### PR TITLE
ci: publish to npm on version tag (Trusted Publishing)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,7 @@ name: Publish to npm
 #     - Organization or user: jbearak
 #     - Repository:           dta-parser
 #     - Workflow filename:    publish.yml
-#     - Environment:          (leave blank)
+#     - Environment:          release   (must match the job's environment)
 #   That links this exact workflow to the package; GitHub's OIDC token is
 #   exchanged for a short-lived publish token at run time. Provenance is
 #   attached automatically. Nothing to store or rotate.
@@ -33,6 +33,12 @@ permissions:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    # Publishing runs through the "release" environment. Bind the npm
+    # trusted publisher to this same environment name, and add protection
+    # rules on GitHub (Settings → Environments → release): require a
+    # reviewer to approve each publish, and/or restrict deployments to
+    # v*.*.* tags. Only runs that clear those rules can mint a publish token.
+    environment: release
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,84 @@
+name: Publish to npm
+
+# Publishes @jbearak/dta-parser when a version tag is pushed (e.g. v0.2.1),
+# using npm Trusted Publishing (OIDC) — no NPM_TOKEN secret required.
+# Also runnable manually from the Actions tab.
+#
+# Setup required once, on npmjs.com:
+#   Package page → Settings → "Trusted Publisher" → add a GitHub Actions
+#   publisher with:
+#     - Organization or user: jbearak
+#     - Repository:           dta-parser
+#     - Workflow filename:    publish.yml
+#     - Environment:          (leave blank)
+#   That links this exact workflow to the package; GitHub's OIDC token is
+#   exchanged for a short-lived publish token at run time. Provenance is
+#   attached automatically. Nothing to store or rotate.
+#
+# Release flow:
+#   - bump "version" in package.json, commit to main
+#   - git tag vX.Y.Z && git push origin vX.Y.Z
+# The tag must match package.json's version or the job fails before publish.
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  id-token: write # required for npm Trusted Publishing (OIDC)
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Typecheck
+        run: bun run typecheck
+
+      - name: Test
+        run: bun test ./tests
+
+      - name: Build
+        run: bun run build
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: 'https://registry.npmjs.org'
+
+      # Trusted Publishing (OIDC) requires npm >= 11.5.1; the npm bundled
+      # with Node 20 is older, so upgrade before publishing.
+      - name: Upgrade npm for trusted publishing
+        run: npm install -g npm@latest
+
+      # On a tag push, fail fast if the tag doesn't match package.json's
+      # version (prevents publishing a mismatched version). Skipped for
+      # manual workflow_dispatch runs.
+      - name: Verify tag matches package version
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          tag_version="${GITHUB_REF_NAME#v}"
+          pkg_version="$(node -p "require('./package.json').version")"
+          if [ "$tag_version" != "$pkg_version" ]; then
+            echo "Tag $GITHUB_REF_NAME ($tag_version) does not match package.json version ($pkg_version)" >&2
+            exit 1
+          fi
+
+      # No token: authentication is via OIDC (the id-token permission above
+      # plus the trusted publisher configured on npm). dist is already built;
+      # --ignore-scripts keeps the "prepare" hook from rebuilding under npm
+      # so we ship exactly what we tested. Provenance is attached automatically.
+      - name: Publish
+        run: npm publish --ignore-scripts --access public


### PR DESCRIPTION
## Summary

Adds `.github/workflows/publish.yml` to publish `@jbearak/dta-parser` to npm when a `vX.Y.Z` tag is pushed (also runnable via workflow_dispatch).

Pipeline: `bun install --frozen-lockfile` → `typecheck` → `test` → `build`, then `npm publish`. On a tag push it first fails if the tag doesn't match `package.json`'s version.

## Authentication: Trusted Publishing (OIDC) — no secret

Uses npm **Trusted Publishing** rather than a stored `NPM_TOKEN`: GitHub's OIDC token (`id-token: write`) is exchanged for a short-lived publish token at run time, and provenance is attached automatically. Nothing to store or rotate, and no 2FA-bypass token.

The publish job runs through a **`release`** environment so GitHub environment protection rules (required reviewer / tag restrictions) can gate each publish.

## One-time setup before this can publish

1. **npm** (package page → Settings → Trusted Publisher → GitHub Actions):
   - user `jbearak`, repo `dta-parser`, workflow `publish.yml`, environment `release`.
2. **GitHub** (repo Settings → Environments → `release`): optionally add a required reviewer and/or restrict deployments to `v*.*.*` tags.

## Release flow

bump `version` in `package.json` → commit to `main` → `git tag vX.Y.Z && git push origin vX.Y.Z`.

Note: this only triggers on *future* tags; the existing 0.2.0 needs a one-time manual publish (or a `v0.2.0` tag once the above is set up).

https://claude.ai/code/session_01Ap5k2Q5tHt1Z5V4QM9trEN