### PR TITLE
ci: pin all workflow actions to full-length SHAs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,10 +41,10 @@ jobs:
     environment: release
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -59,7 +59,7 @@ jobs:
         run: bun run build
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/pullfrog.yml
+++ b/.github/workflows/pullfrog.yml
@@ -22,11 +22,11 @@ jobs:
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 1
       - name: Run agent
-        uses: pullfrog/pullfrog@v0
+        uses: pullfrog/pullfrog@3beaa0fb16f67a689055eac8df88e71024e423b2 # v0
         with:
           prompt: ${{ inputs.prompt }}
         env:


### PR DESCRIPTION
The jbearak account requires GitHub Actions to be pinned to a full-length commit SHA; tag refs are rejected by policy. Pins every external action in both workflows to the SHA its tag points to, version preserved as a trailing comment.

**publish.yml**
- `actions/checkout` → `34e1148…` (v4)
- `oven-sh/setup-bun` → `0c5077e…` (v2)
- `actions/setup-node` → `49933ea…` (v4)

**pullfrog.yml**
- `actions/checkout` → `df4cb1c…` (v6)
- `pullfrog/pullfrog` → `3beaa0f…` (v0)

https://claude.ai/code/session_01Ap5k2Q5tHt1Z5V4QM9trEN