### PR TITLE
Add reproducible haven benchmark

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+/benchmark-results

--- a/README.md
+++ b/README.md
@@ -352,3 +352,11 @@ npm run build
 npm run typecheck
 npm test
 ```
+
+For cross-language correctness and performance comparisons against R's
+`haven::read_dta()`, see [Benchmarking against haven](docs/benchmarking.md).
+The opt-in reproducibility check covers every checked-in `.dta` fixture:
+
+```sh
+npm run test:reproducibility
+```

--- a/benchmarks/dta-vs-haven/generate.R
+++ b/benchmarks/dta-vs-haven/generate.R
@@ -1,0 +1,52 @@
+suppressPackageStartupMessages(library(haven))
+
+args <- commandArgs(trailingOnly = TRUE)
+if (length(args) != 2) {
+    stop("usage: generate.R <output-directory> <rows>")
+}
+
+output_dir <- args[[1]]
+rows <- as.integer(args[[2]])
+if (is.na(rows) || rows < 1) stop("rows must be a positive integer")
+dir.create(output_dir, recursive = TRUE, showWarnings = FALSE)
+
+set.seed(20260724)
+
+numeric_data <- as.data.frame(replicate(
+    20, stats::runif(rows), simplify = FALSE
+))
+names(numeric_data) <- sprintf("num%02d", seq_len(20))
+attr(numeric_data, "label") <- "Deterministic numeric benchmark"
+write_dta(
+    numeric_data,
+    file.path(output_dir, "numeric-v118.dta"),
+    version = 14
+)
+
+group <- labelled(
+    as.double((seq_len(rows) - 1L) %% 5L),
+    c(control = 0, alpha = 1, beta = 2, gamma = 3, delta = 4),
+    label = "Study group"
+)
+tagged <- as.double(seq_len(rows)) / 10
+tagged[seq.int(1L, rows, by = 101L)] <- tagged_na("a")
+tagged[seq.int(51L, rows, by = 103L)] <- NA_real_
+mixed_data <- data.frame(
+    id = as.double(seq_len(rows)),
+    measure = stats::rnorm(rows),
+    fraction = stats::runif(rows),
+    group = group,
+    tagged = tagged,
+    text_short = sprintf("s%07d", seq_len(rows)),
+    text_repeated = rep(c("north", "south", "east", "west"),
+                        length.out = rows),
+    stringsAsFactors = FALSE
+)
+attr(mixed_data, "label") <- "Deterministic mixed benchmark"
+attr(mixed_data$id, "label") <- "Row identifier"
+attr(mixed_data$measure, "label") <- "Normal measurement"
+write_dta(
+    mixed_data,
+    file.path(output_dir, "mixed-v118.dta"),
+    version = 14
+)

--- a/benchmarks/dta-vs-haven/haven.R
+++ b/benchmarks/dta-vs-haven/haven.R
@@ -1,0 +1,197 @@
+suppressPackageStartupMessages(library(haven))
+
+args <- commandArgs(trailingOnly = TRUE)
+if (length(args) < 2) {
+    stop("usage: haven.R <snapshot|benchmark> <output.json> [arguments ...]")
+}
+if (!requireNamespace("jsonlite", quietly = TRUE)) {
+    stop("the R package 'jsonlite' is required")
+}
+
+mode <- args[[1]]
+output_path <- args[[2]]
+
+canonical_cell <- function(value) {
+    if (is.na(value)) {
+        tag <- haven::na_tag(value)
+        missing <- if (is.na(tag)) "." else paste0(".", tag)
+        return(list(missing = missing))
+    }
+    if (is.character(value)) as.character(value) else as.double(value)
+}
+
+snapshot_file <- function(file_path) {
+    data <- haven::read_dta(file_path)
+    variables <- lapply(names(data), function(name) {
+        column <- data[[name]]
+        labels <- attr(column, "labels", exact = TRUE)
+        label_entries <- if (is.null(labels)) {
+            list()
+        } else {
+            lapply(seq_along(labels), function(index) {
+                list(
+                    value = canonical_cell(unname(labels[[index]])),
+                    label = unname(names(labels)[[index]])
+                )
+            })
+        }
+        list(
+            name = name,
+            label = attr(column, "label", exact = TRUE) %||% "",
+            format = attr(column, "format.stata", exact = TRUE) %||% "",
+            labels = label_entries
+        )
+    })
+    rows <- lapply(seq_len(nrow(data)), function(row_index) {
+        unname(lapply(
+            data,
+            function(column) canonical_cell(column[[row_index]])
+        ))
+    })
+    list(
+        file = basename(file_path),
+        dataset_label = attr(data, "label", exact = TRUE) %||% "",
+        nrow = nrow(data),
+        ncol = ncol(data),
+        variables = variables,
+        rows = rows
+    )
+}
+
+`%||%` <- function(left, right) {
+    if (is.null(left)) right else left
+}
+
+elapsed_samples <- function(read_once, warmup, iterations) {
+    for (index in seq_len(warmup)) read_once()
+    vapply(seq_len(iterations), function(index) {
+        start <- as.numeric(Sys.time())
+        read_once()
+        (as.numeric(Sys.time()) - start) * 1000
+    }, numeric(1))
+}
+
+observe_dimensions <- function(data) {
+    invisible(nrow(data) + ncol(data))
+}
+
+benchmark_file <- function(file_path, warmup, iterations) {
+    metadata <- haven::read_dta(file_path, n_max = 0)
+    row_count <- nrow(haven::read_dta(file_path, col_select = 1))
+    selected <- c(1L, 2L, min(5L, length(names(metadata))))
+    selected <- unique(selected)
+    file_size <- file.info(file_path)$size
+    raw_data <- readBin(file_path, what = "raw", n = file_size)
+    file_spec <- readr::datasource(file_path)
+    raw_spec <- readr::datasource(raw_data)
+    native_file <- function(n_max = -1L) {
+        data <- haven:::df_parse_dta_file(
+            file_spec, "", character(), n_max, 0L,
+            name_repair = "unique"
+        )
+        observe_dimensions(data)
+    }
+    native_raw <- function() {
+        data <- haven:::df_parse_dta_raw(
+            raw_spec, "", character(), -1L, 0L,
+            name_repair = "unique"
+        )
+        observe_dimensions(data)
+    }
+    raw_file_read <- function() {
+        data <- readBin(file_path, what = "raw", n = file_size)
+        invisible(length(data))
+    }
+    synthetic_result_shape <- function() {
+        columns <- lapply(metadata, function(template) {
+            column <- if (is.character(template)) {
+                character(row_count)
+            } else {
+                numeric(row_count)
+            }
+            for (attribute in c(
+                "label", "format.stata", "class", "labels", "units", "tzone"
+            )) {
+                value <- attr(template, attribute, exact = TRUE)
+                if (!is.null(value)) attr(column, attribute) <- value
+            }
+            column
+        })
+        names(columns) <- names(metadata)
+        data <- tibble::as_tibble(columns, .name_repair = "minimal")
+        label <- attr(metadata, "label", exact = TRUE)
+        if (!is.null(label)) attr(data, "label") <- label
+        assign(".haven_decomposition_sink", data, envir = .GlobalEnv)
+        observe_dimensions(data)
+    }
+    full_read <- function() {
+        data <- haven::read_dta(file_path)
+        observe_dimensions(data)
+    }
+    selected_read <- function() {
+        data <- haven::read_dta(
+            file_path,
+            col_select = tidyselect::all_of(selected)
+        )
+        observe_dimensions(data)
+    }
+    full_samples <- elapsed_samples(full_read, warmup, iterations)
+    selected_samples <- elapsed_samples(
+        selected_read, warmup, iterations
+    )
+    list(
+        file = basename(file_path),
+        full = as.list(full_samples),
+        selected = as.list(selected_samples),
+        selected_indices = as.list(selected - 1L),
+        decomposition = list(
+            end_to_end_file = as.list(full_samples),
+            native_file = as.list(elapsed_samples(
+                native_file, warmup, iterations
+            )),
+            native_preloaded_raw = as.list(elapsed_samples(
+                native_raw, warmup, iterations
+            )),
+            native_metadata_file = as.list(elapsed_samples(
+                function() native_file(0L), warmup, iterations
+            )),
+            raw_file_read = as.list(elapsed_samples(
+                raw_file_read, warmup, iterations
+            )),
+            synthetic_result_shape = as.list(elapsed_samples(
+                synthetic_result_shape, warmup, iterations
+            ))
+        )
+    )
+}
+
+if (mode == "snapshot") {
+    files <- args[-c(1, 2)]
+    result <- list(
+        haven_version = as.character(utils::packageVersion("haven")),
+        r_version = R.version.string,
+        datasets = lapply(files, snapshot_file)
+    )
+} else if (mode == "benchmark") {
+    if (length(args) < 5) {
+        stop("benchmark mode requires <warmup> <iterations> <files ...>")
+    }
+    warmup <- as.integer(args[[3]])
+    iterations <- as.integer(args[[4]])
+    files <- args[-c(1, 2, 3, 4)]
+    result <- list(
+        haven_version = as.character(utils::packageVersion("haven")),
+        r_version = R.version.string,
+        datasets = lapply(
+            files, benchmark_file,
+            warmup = warmup, iterations = iterations
+        )
+    )
+} else {
+    stop(paste("unknown mode:", mode))
+}
+
+jsonlite::write_json(
+    result, output_path,
+    auto_unbox = TRUE, null = "null", digits = NA, pretty = TRUE
+)

--- a/benchmarks/dta-vs-haven/run.ts
+++ b/benchmarks/dta-vs-haven/run.ts
@@ -1,0 +1,568 @@
+import { execFileSync } from 'node:child_process';
+import {
+    closeSync,
+    mkdtempSync,
+    mkdirSync,
+    openSync,
+    readFileSync,
+    readSync,
+    readdirSync,
+    rmSync,
+    statSync,
+    writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { DtaFile } from '../../src/node';
+import { parse_metadata } from '../../src/header';
+import { read_rows_from_data_buffer } from '../../src/data-reader';
+import { parse_value_labels } from '../../src/value-labels';
+import { is_missing_value_object } from '../../src/missing-values';
+import { is_legacy_format, type RowCell } from '../../src/types';
+
+type JsonValue = null | boolean | number | string
+    | JsonValue[] | { [key: string]: JsonValue };
+
+interface Options {
+    correctness: boolean;
+    benchmark: boolean;
+    rows: number;
+    warmup: number;
+    iterations: number;
+    json?: string;
+}
+
+interface TimingDataset {
+    file: string;
+    nvar: number;
+    full: number[];
+    selected: number[];
+    selected_indices: number[];
+    decomposition?: Record<string, number[]>;
+}
+
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
+const ROOT_DIR = path.resolve(SCRIPT_DIR, '../..');
+const FIXTURE_DIR = path.join(ROOT_DIR, 'tests/fixtures/dta');
+
+function parse_positive(value: string | undefined, flag: string): number {
+    const parsed = Number(value);
+    if (!Number.isInteger(parsed) || parsed < 1) {
+        throw new Error(`${flag} requires a positive integer`);
+    }
+    return parsed;
+}
+
+function parse_options(argv: string[]): Options {
+    const options: Options = {
+        correctness: true,
+        benchmark: true,
+        rows: 100_000,
+        warmup: 2,
+        iterations: 5,
+    };
+    for (let index = 0; index < argv.length; index++) {
+        const argument = argv[index];
+        if (argument === '--correctness-only') options.benchmark = false;
+        else if (argument === '--benchmark-only') options.correctness = false;
+        else if (argument === '--rows') {
+            options.rows = parse_positive(argv[++index], argument);
+        } else if (argument === '--warmup') {
+            options.warmup = parse_positive(argv[++index], argument);
+        } else if (argument === '--iterations') {
+            options.iterations = parse_positive(argv[++index], argument);
+        } else if (argument === '--json') {
+            options.json = argv[++index];
+            if (!options.json) throw new Error('--json requires a path');
+        } else if (argument === '--help') {
+            console.log(`Usage: bun run benchmarks/dta-vs-haven/run.ts [options]
+
+  --correctness-only  compare checked-in fixtures without timing
+  --benchmark-only    run generated performance workloads only
+  --rows N            rows per generated dataset (default: 100000)
+  --warmup N          untimed reads per implementation (default: 2)
+  --iterations N      timed reads per implementation (default: 5)
+  --json PATH         also write machine-readable results`);
+            process.exit(0);
+        } else {
+            throw new Error(`unknown argument: ${argument}`);
+        }
+    }
+    return options;
+}
+
+function run_r(arguments_: string[]): void {
+    execFileSync('Rscript', arguments_, { stdio: 'inherit' });
+}
+
+function r_json(mode: string, arguments_: string[]): any {
+    const directory = mkdtempSync(path.join(tmpdir(), 'dta-haven-r-'));
+    const output = path.join(directory, 'result.json');
+    try {
+        run_r([path.join(SCRIPT_DIR, 'haven.R'), mode, output, ...arguments_]);
+        return JSON.parse(readFileSync(output, 'utf8'));
+    } finally {
+        rmSync(directory, { recursive: true, force: true });
+    }
+}
+
+function canonical_cell(cell: RowCell): JsonValue {
+    return is_missing_value_object(cell)
+        ? { missing: cell.missing_type }
+        : cell;
+}
+
+async function snapshot_file(file_path: string): Promise<JsonValue> {
+    const file = await DtaFile.open(file_path);
+    try {
+        const rows = await file.read_rows(0, file.nobs);
+        return {
+            file: path.basename(file_path),
+            dataset_label: file.dataset_label,
+            nrow: file.nobs,
+            ncol: file.nvar,
+            variables: file.variables.map(variable => {
+                const table = file.value_label_tables.get(
+                    variable.value_label_name
+                );
+                return {
+                    name: variable.name,
+                    label: variable.label,
+                    format: variable.format,
+                    labels: table
+                        ? [...table].map(([value, label]) => ({
+                            value: canonical_cell(value), label,
+                        }))
+                        : [],
+                };
+            }),
+            rows: rows.map(row => row.map(canonical_cell)),
+        };
+    } finally {
+        file.close();
+    }
+}
+
+function compare_values(
+    actual: any,
+    expected: any,
+    location: string,
+    failures: string[],
+): void {
+    if (typeof actual === 'number' && typeof expected === 'number') {
+        const scale = Math.max(1, Math.abs(actual), Math.abs(expected));
+        if (Math.abs(actual - expected) > 1e-7 * scale) {
+            failures.push(`${location}: ${actual} !== ${expected}`);
+        }
+        return;
+    }
+    if (Array.isArray(actual) && Array.isArray(expected)) {
+        if (actual.length !== expected.length) {
+            failures.push(
+                `${location}: length ${actual.length} !== ${expected.length}`
+            );
+            return;
+        }
+        for (let index = 0; index < actual.length; index++) {
+            compare_values(
+                actual[index], expected[index],
+                `${location}[${index}]`, failures
+            );
+        }
+        return;
+    }
+    if (actual && expected
+        && typeof actual === 'object' && typeof expected === 'object') {
+        const keys = new Set([
+            ...Object.keys(actual), ...Object.keys(expected),
+        ]);
+        for (const key of keys) {
+            compare_values(
+                actual[key], expected[key],
+                `${location}.${key}`, failures
+            );
+        }
+        return;
+    }
+    if (actual !== expected) {
+        failures.push(
+            `${location}: ${JSON.stringify(actual)} !== `
+            + JSON.stringify(expected)
+        );
+    }
+}
+
+async function run_correctness(): Promise<any> {
+    const files = readdirSync(FIXTURE_DIR)
+        .filter(file => file.endsWith('.dta'))
+        .sort()
+        .map(file => path.join(FIXTURE_DIR, file));
+    const haven = r_json('snapshot', files);
+    const parser = [];
+    for (const file of files) parser.push(await snapshot_file(file));
+    const failures: string[] = [];
+    compare_values(
+        parser, haven.datasets, 'datasets', failures
+    );
+    if (failures.length > 0) {
+        const shown = failures.slice(0, 20).join('\n');
+        throw new Error(
+            `reproducibility comparison failed (${failures.length} `
+            + `differences):\n${shown}`
+        );
+    }
+    console.log(
+        `Correctness: PASS — ${files.length} files match haven `
+        + `(tolerance 1e-7).`
+    );
+    return {
+        status: 'pass', files: files.length,
+        tolerance: 1e-7,
+        haven_version: haven.haven_version,
+        r_version: haven.r_version,
+    };
+}
+
+async function elapsed_samples(
+    read_once: () => Promise<number>,
+    warmup: number,
+    iterations: number,
+): Promise<number[]> {
+    for (let index = 0; index < warmup; index++) await read_once();
+    const samples: number[] = [];
+    for (let index = 0; index < iterations; index++) {
+        const start = performance.now();
+        await read_once();
+        samples.push(performance.now() - start);
+    }
+    return samples;
+}
+
+async function benchmark_file(
+    file_path: string,
+    selected_indices: number[],
+    options: Options,
+): Promise<TimingDataset> {
+    const full_read = async (): Promise<number> => {
+        const file = await DtaFile.open(file_path);
+        try {
+            const rows = await file.read_rows(0, file.nobs);
+            return rows.length;
+        } finally {
+            file.close();
+        }
+    };
+    const selected_read = async (): Promise<number> => {
+        const file = await DtaFile.open(file_path);
+        try {
+            const columns = await file.read_columns(selected_indices);
+            return Array.from(columns.values()).reduce(
+                (total, column) => total + column.length,
+                columns.size,
+            );
+        } finally {
+            file.close();
+        }
+    };
+    const file_bytes = readFileSync(file_path);
+    const file_buffer = file_bytes.buffer.slice(
+        file_bytes.byteOffset,
+        file_bytes.byteOffset + file_bytes.byteLength,
+    ) as ArrayBuffer;
+    const metadata = parse_metadata(file_buffer);
+    const data_tag_length = is_legacy_format(metadata.format_version)
+        ? 0 : '<data>'.length;
+    const data_start = metadata.section_offsets.data + data_tag_length;
+    const data_length = metadata.nobs * metadata.obs_length;
+    const data_buffer = file_buffer.slice(
+        data_start, data_start + data_length
+    );
+    const descriptor = openSync(file_path, 'r');
+    const open_only = async (): Promise<number> => {
+        const file = await DtaFile.open(file_path);
+        try {
+            return file.nobs + file.nvar;
+        } finally {
+            file.close();
+        }
+    };
+    const observation_read = async (): Promise<number> => {
+        const buffer = Buffer.allocUnsafe(data_length);
+        let total = 0;
+        while (total < data_length) {
+            const count = readSync(
+                descriptor, buffer, total,
+                data_length - total, data_start + total,
+            );
+            if (count === 0) throw new Error('unexpected EOF');
+            total += count;
+        }
+        return total;
+    };
+    const decode_preloaded = async (): Promise<number> => {
+        const rows = read_rows_from_data_buffer(
+            data_buffer, metadata, 0, metadata.nobs
+        );
+        return rows.length;
+    };
+    const metadata_preloaded = async (): Promise<number> => {
+        const parsed = parse_metadata(file_buffer);
+        return parsed.nobs + parsed.nvar;
+    };
+    const labels_preloaded = async (): Promise<number> => {
+        return parse_value_labels(file_buffer, metadata).size;
+    };
+    let synthetic_rows_sink: unknown;
+    const synthetic_row_shape = async (): Promise<number> => {
+        const rows = Array.from(
+            { length: metadata.nobs },
+            () => new Array(metadata.nvar),
+        );
+        synthetic_rows_sink = rows;
+        return (synthetic_rows_sink as unknown[]).length;
+    };
+    try {
+        const full = await elapsed_samples(
+            full_read, options.warmup, options.iterations
+        );
+        const selected = await elapsed_samples(
+            selected_read, options.warmup, options.iterations
+        );
+        return {
+            file: path.basename(file_path),
+            nvar: metadata.nvar,
+            full,
+            selected,
+            selected_indices,
+            decomposition: {
+                end_to_end_file: full,
+                open_metadata_labels: await elapsed_samples(
+                    open_only, options.warmup, options.iterations
+                ),
+                observation_read: await elapsed_samples(
+                    observation_read, options.warmup, options.iterations
+                ),
+                decode_preloaded: await elapsed_samples(
+                    decode_preloaded, options.warmup, options.iterations
+                ),
+                metadata_parse_preloaded: await elapsed_samples(
+                    metadata_preloaded, options.warmup, options.iterations
+                ),
+                labels_parse_preloaded: await elapsed_samples(
+                    labels_preloaded, options.warmup, options.iterations
+                ),
+                synthetic_row_shape: await elapsed_samples(
+                    synthetic_row_shape, options.warmup, options.iterations
+                ),
+            },
+        };
+    } finally {
+        closeSync(descriptor);
+    }
+}
+
+function median(values: number[]): number {
+    const sorted = [...values].sort((left, right) => left - right);
+    const middle = Math.floor(sorted.length / 2);
+    return sorted.length % 2
+        ? sorted[middle]
+        : (sorted[middle - 1] + sorted[middle]) / 2;
+}
+
+async function run_benchmark(options: Options): Promise<any> {
+    const directory = mkdtempSync(path.join(tmpdir(), 'dta-benchmark-'));
+    try {
+        run_r([
+            path.join(SCRIPT_DIR, 'generate.R'),
+            directory, String(options.rows),
+        ]);
+        const files = ['numeric-v118.dta', 'mixed-v118.dta']
+            .map(file => path.join(directory, file));
+        const haven = r_json('benchmark', [
+            String(options.warmup), String(options.iterations), ...files,
+        ]);
+        const parser: TimingDataset[] = [];
+        for (const dataset of haven.datasets as TimingDataset[]) {
+            parser.push(await benchmark_file(
+                path.join(directory, dataset.file),
+                dataset.selected_indices,
+                options,
+            ));
+        }
+        console.log('\nPerformance (median milliseconds; lower is better)');
+        console.log('dataset\tread\tdta-parser\thaven\tdta-parser throughput');
+        const comparisons = [];
+        const attribution = [];
+        for (let index = 0; index < parser.length; index++) {
+            const file_size = statSync(files[index]).size;
+            for (const read of ['full', 'selected'] as const) {
+                const dta_ms = median(parser[index][read]);
+                const haven_ms = median(haven.datasets[index][read]);
+                const relative = haven_ms / dta_ms;
+                console.log(
+                    `${parser[index].file}\t${read}\t${dta_ms.toFixed(1)}`
+                    + `\t${haven_ms.toFixed(1)}\t${relative.toFixed(2)}x`
+                );
+                comparisons.push({
+                    file: parser[index].file,
+                    bytes: file_size,
+                    read,
+                    dta_parser_ms: parser[index][read],
+                    haven_ms: haven.datasets[index][read],
+                    dta_parser_median_ms: dta_ms,
+                    haven_median_ms: haven_ms,
+                    dta_parser_throughput_relative_to_haven: relative,
+                });
+            }
+
+            const dta_stages = parser[index].decomposition!;
+            const haven_stages = (
+                haven.datasets[index].decomposition
+            ) as Record<string, number[]>;
+            const dta_total = median(dta_stages.end_to_end_file);
+            const dta_open = median(dta_stages.open_metadata_labels);
+            const dta_read = median(dta_stages.observation_read);
+            const dta_decode = median(dta_stages.decode_preloaded);
+            const dta_residual = dta_total
+                - dta_open - dta_read - dta_decode;
+            const haven_total = median(haven_stages.end_to_end_file);
+            const haven_native = median(haven_stages.native_file);
+            const haven_metadata = median(
+                haven_stages.native_metadata_file
+            );
+            const haven_native_data_output = haven_native - haven_metadata;
+            const haven_wrapper = haven_total - haven_native;
+            const decoded_cells = options.rows * parser[index].nvar;
+            const percent = (value: number, total: number): number =>
+                total === 0 ? 0 : value / total * 100;
+
+            console.log(`\nAttribution: ${parser[index].file}`);
+            console.log('implementation\tfactor\tmedian ms\t% of end-to-end');
+            for (const [implementation, factor, milliseconds, total] of [
+                ['dta-parser', 'open + metadata + labels', dta_open, dta_total],
+                ['dta-parser', 'observation-section read', dta_read, dta_total],
+                ['dta-parser', 'decode + JS result allocation', dta_decode, dta_total],
+                ['dta-parser', 'composition/noise residual', dta_residual, dta_total],
+                ['haven', 'native metadata/setup', haven_metadata, haven_total],
+                ['haven', 'native data + decode + R result',
+                    haven_native_data_output, haven_total],
+                ['haven', 'R wrapper/datasource residual', haven_wrapper, haven_total],
+            ] as Array<[string, string, number, number]>) {
+                console.log(
+                    `${implementation}\t${factor}\t${milliseconds.toFixed(2)}`
+                    + `\t${percent(milliseconds, total).toFixed(1)}%`
+                );
+            }
+            console.log('diagnostic\tmedian ms');
+            console.log(`decoded cells\t${decoded_cells}`);
+            console.log(
+                `dta decode + result ns/cell\t${(
+                    dta_decode * 1e6 / decoded_cells
+                ).toFixed(2)}`
+            );
+            console.log(
+                `haven native data + decode + result ns/cell\t${(
+                    haven_native_data_output * 1e6 / decoded_cells
+                ).toFixed(2)}`
+            );
+            console.log(
+                `dta metadata parse, preloaded\t${median(
+                    dta_stages.metadata_parse_preloaded
+                ).toFixed(2)}`
+            );
+            console.log(
+                `dta value-label parse, preloaded\t${median(
+                    dta_stages.labels_parse_preloaded
+                ).toFixed(2)}`
+            );
+            console.log(
+                `dta empty row-container allocation lower bound\t${median(
+                    dta_stages.synthetic_row_shape
+                ).toFixed(2)}`
+            );
+            console.log(
+                `haven raw file read only\t${median(
+                    haven_stages.raw_file_read
+                ).toFixed(2)}`
+            );
+            console.log(
+                `haven native parse from preloaded raw\t${median(
+                    haven_stages.native_preloaded_raw
+                ).toFixed(2)}`
+            );
+            console.log(
+                `haven empty typed-result allocation lower bound\t${median(
+                    haven_stages.synthetic_result_shape
+                ).toFixed(2)}`
+            );
+
+            attribution.push({
+                file: parser[index].file,
+                decoded_cells,
+                dta_parser: {
+                    end_to_end_ms: dta_total,
+                    open_metadata_labels_ms: dta_open,
+                    observation_read_ms: dta_read,
+                    decode_and_result_ms: dta_decode,
+                    composition_residual_ms: dta_residual,
+                    metadata_parse_preloaded_ms: median(
+                        dta_stages.metadata_parse_preloaded
+                    ),
+                    labels_parse_preloaded_ms: median(
+                        dta_stages.labels_parse_preloaded
+                    ),
+                    empty_row_container_allocation_lower_bound_ms: median(
+                        dta_stages.synthetic_row_shape
+                    ),
+                    raw_samples: dta_stages,
+                },
+                haven: {
+                    end_to_end_ms: haven_total,
+                    native_file_ms: haven_native,
+                    native_metadata_setup_ms: haven_metadata,
+                    native_data_decode_result_ms: haven_native_data_output,
+                    r_wrapper_datasource_residual_ms: haven_wrapper,
+                    raw_file_read_ms: median(haven_stages.raw_file_read),
+                    native_preloaded_raw_ms: median(
+                        haven_stages.native_preloaded_raw
+                    ),
+                    empty_typed_result_allocation_lower_bound_ms: median(
+                        haven_stages.synthetic_result_shape
+                    ),
+                    raw_samples: haven_stages,
+                },
+            });
+        }
+        return {
+            rows: options.rows,
+            warmup: options.warmup,
+            iterations: options.iterations,
+            haven_version: haven.haven_version,
+            r_version: haven.r_version,
+            comparisons,
+            attribution,
+        };
+    } finally {
+        rmSync(directory, { recursive: true, force: true });
+    }
+}
+
+const options = parse_options(process.argv.slice(2));
+const result: any = {
+    generated_at: new Date().toISOString(),
+    environment: {
+        platform: `${os.platform()} ${os.release()} ${os.arch()}`,
+        cpu: os.cpus()[0]?.model ?? 'unknown',
+        bun: Bun.version,
+    },
+};
+if (options.benchmark) result.performance = await run_benchmark(options);
+if (options.correctness) result.correctness = await run_correctness();
+if (options.json) {
+    const output = path.resolve(options.json);
+    mkdirSync(path.dirname(output), { recursive: true });
+    writeFileSync(output, `${JSON.stringify(result, null, 2)}\n`);
+    console.log(`\nWrote ${output}`);
+}

--- a/docs/benchmark-results/2026-07-24-apple-m4-max.md
+++ b/docs/benchmark-results/2026-07-24-apple-m4-max.md
@@ -1,0 +1,72 @@
+# dta-parser versus haven: Apple M4 Max, 2026-07-24
+
+This is one recorded run of the reproducible benchmark described in
+[Benchmarking against haven](../benchmarking.md). It is an observation from a
+specific machine and software stack, not a universal performance claim.
+
+## Environment
+
+| Component | Version |
+| --- | --- |
+| CPU | Apple M4 Max |
+| Platform | macOS/Darwin 25.5.0 arm64 |
+| Bun | 1.3.14 |
+| R | 4.6.1 |
+| haven | 2.5.5 |
+
+The run used 100,000 rows per generated dataset, three untimed warmups, and ten
+timed iterations:
+
+```sh
+bun run benchmarks/dta-vs-haven/run.ts \
+  --benchmark-only \
+  --rows 100000 \
+  --warmup 3 \
+  --iterations 10 \
+  --json benchmark-results/decomposition.json
+```
+
+## End-to-end results
+
+Median elapsed milliseconds; lower is better. Relative throughput is haven's
+median divided by dta-parser's median.
+
+| Dataset | Read | dta-parser | haven | Relative throughput |
+| --- | --- | ---: | ---: | ---: |
+| Numeric v118 | Full, 20 columns | 17.2 ms | 74.4 ms | 4.33x |
+| Numeric v118 | Three columns | 3.8 ms | 16.6 ms | 4.42x |
+| Mixed v118 | Full, seven columns | 21.4 ms | 75.5 ms | 3.53x |
+| Mixed v118 | Three columns | 5.5 ms | 13.9 ms | 2.54x |
+
+## Full-read attribution
+
+The percentages use independently measured stage medians, so small negative or
+greater-than-100% residuals represent timer/JIT/garbage-collection noise rather
+than negative work.
+
+| Dataset and implementation | Setup/metadata | Warm data read | Decode + result | Composition/wrapper residual |
+| --- | ---: | ---: | ---: | ---: |
+| Numeric, dta-parser | 0.05 ms (0.3%) | 0.60 ms (3.5%) | 15.98 ms (93.1%) | 0.54 ms (3.2%) |
+| Numeric, haven | 0.18 ms (0.2%) | Included in native stage | 76.69 ms (103.1%) | -2.48 ms (-3.3%) |
+| Mixed, dta-parser | 0.03 ms (0.2%) | 0.20 ms (1.0%) | 21.53 ms (100.7%) | -0.39 ms (-1.8%) |
+| Mixed, haven | 0.13 ms (0.2%) | Included in native stage | 73.95 ms (97.9%) | 1.43 ms (1.9%) |
+
+| Diagnostic | Numeric | Mixed |
+| --- | ---: | ---: |
+| dta-parser decode + result | 7.99 ns/cell | 30.76 ns/cell |
+| haven native data + decode + result | 38.34 ns/cell | 105.64 ns/cell |
+| Haven raw file read only | 1.62 ms | 0.58 ms |
+| Haven native parse from preloaded raw | 74.82 ms | 72.47 ms |
+| dta-parser empty result-container lower bound | 1.03 ms | 0.65 ms |
+| haven empty typed-result lower bound | 0.40 ms | 0.11 ms |
+
+For these warm-cache workloads, metadata, file access, and the R wrapper are
+minor. Most elapsed time is in each implementation's combined decode and
+result-materialization path. Haven's ReadStat decoding and per-cell R-vector
+population share one native callback pipeline, so this external harness does
+not claim to divide that combined stage further.
+
+## Correctness result
+
+The companion reproducibility suite passed all 29 checked-in `.dta` fixtures
+against haven with the documented `1e-7` numeric tolerance.

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -1,0 +1,189 @@
+# Benchmarking against haven
+
+The repository includes an opt-in, reproducible comparison with
+[`haven::read_dta()`](https://haven.tidyverse.org/reference/read_dta.html).
+It has two deliberately separate parts:
+
+1. a correctness suite over every checked-in Stata fixture; and
+2. a performance benchmark over deterministic, generated datasets, including
+   stage-level attribution.
+
+The suite is opt-in because the regular TypeScript tests should not require an
+R installation. It does not download data or packages and does not retain the
+generated `.dta` files.
+
+## Requirements
+
+- the repository's normal JavaScript dependencies (`npm install`);
+- R available as `Rscript`; and
+- the R packages `haven` and `jsonlite`.
+
+Install the R dependencies once if needed:
+
+```r
+install.packages(c("haven", "jsonlite"))
+```
+
+## Correctness suite
+
+Run:
+
+```sh
+npm run test:reproducibility
+```
+
+The suite asks both readers to decode all checked-in `.dta` files and compares
+canonical representations. The corpus currently exercises formats 114, 115,
+117, 118, and 119; numeric storage types; fixed and long strings; empty and
+wide datasets; dataset and variable labels; display formats; value labels;
+and ordinary plus extended missing values (`.`, `.a` through `.z`).
+
+For every file, the comparison includes:
+
+- row and column counts and variable order;
+- dataset labels, variable labels, and Stata display formats;
+- each variable's value-to-label mapping; and
+- every decoded cell, with tagged missing values kept distinct.
+
+Numbers use a relative tolerance of `1e-7` so values stored as Stata `float`
+are not rejected due to insignificant language-level formatting differences.
+All other values and metadata are exact. Stata storage type names are not part
+of the cross-reader assertion because haven exposes the decoded R vector type,
+not the original byte/int/long/float distinction. The parser's storage-type
+handling remains covered by the TypeScript unit suite.
+
+The command exits nonzero on the first run containing a difference and prints
+up to 20 paths to mismatched values. A successful run resembles:
+
+```text
+Correctness: PASS — 29 files match haven (tolerance 1e-7).
+```
+
+## Performance benchmark
+
+Run the correctness suite and performance benchmark together:
+
+```sh
+npm run benchmark
+```
+
+Or run only the timings:
+
+```sh
+bun run benchmarks/dta-vs-haven/run.ts --benchmark-only
+```
+
+The default workload uses 100,000 rows, two untimed warmups, and five measured
+iterations. Options make a run easy to scale or repeat:
+
+```sh
+bun run benchmarks/dta-vs-haven/run.ts \
+  --rows 250000 \
+  --warmup 3 \
+  --iterations 10 \
+  --json benchmark-results/dta-vs-haven.json
+```
+
+The JSON artifact contains environment and package versions, file sizes, all
+raw timing samples, medians, and relative throughput. `benchmark-results/` is
+gitignored so machine-specific measurements are not accidentally presented as
+universal package claims.
+
+### Workloads and timing
+
+The generator uses a fixed random seed and haven's Stata 14 writer to create
+v118 files in a fresh temporary directory:
+
+| Dataset | Shape | Purpose |
+| --- | --- | --- |
+| `numeric-v118.dta` | 20 numeric columns | Dense numeric decoding |
+| `mixed-v118.dta` | 7 numeric/labelled/string columns | Labels, strings, and tagged missing values |
+
+Each file is measured in two modes: a full read and a three-column projection.
+Each sample includes opening the `.dta` file, parsing its metadata, decoding
+the requested data, and closing it. R and Bun process startup, fixture
+generation, warmups, and result serialization are outside the timed region.
+Both readers eagerly materialize the requested data before a sample completes;
+the harness only inspects result dimensions, so downstream traversal is not
+part of the measurement.
+
+### Stage attribution
+
+After the headline timings, the harness prints an attribution table for each
+dataset. These measurements answer a narrower question than the headline:
+where does each implementation spend its end-to-end time on a warm file?
+
+For dta-parser, the boundaries are directly exposed by its implementation:
+
+| Stage | Measurement |
+| --- | --- |
+| Open + metadata + labels | `DtaFile.open()` followed by `close()` |
+| Observation read | One positional read of the exact observation byte range into a newly allocated buffer |
+| Decode + JS result | `read_rows_from_data_buffer()` over an already loaded observation buffer |
+| Composition/noise residual | End-to-end median minus the three independently measured medians above |
+
+The metadata parser and value-label parser are also timed against preloaded
+bytes as diagnostics. An empty row-container allocation supplies a lower bound
+on JS result allocation; it does not populate cells, so it must not be
+subtracted as though it were the complete result-construction cost.
+The diagnostic output also normalizes each combined decode/result stage to
+nanoseconds per requested cell, making differently shaped datasets easier to
+compare.
+
+Haven has a coarser observable boundary. `read_dta()` calls ReadStat's C parser,
+and haven's C++ value callback writes each decoded cell into its R vector during
+that same native call. Without rebuilding haven with internal timers, binary
+decoding and R result population cannot be measured independently. The harness
+therefore reports them honestly as a combined stage:
+
+| Stage | Measurement |
+| --- | --- |
+| Native metadata/setup | Haven's native file entrypoint with `n_max = 0` (internally it may parse one row before returning zero) |
+| Native data + decode + R result | Full native-file median minus native metadata/setup |
+| R wrapper/datasource residual | `read_dta()` median minus the preconfigured native-file median |
+
+Two further diagnostics constrain the interpretation. A base-R raw file read
+shows the warm file-I/O scale, while haven's native parser over a preloaded raw
+vector shows whether its file input path explains material time. A synthetic
+typed tibble with the correct dimensions and attributes gives a lower bound on
+R result allocation, but not the cost of populating cells, allocating actual
+strings, or crossing ReadStat's per-value callback.
+
+The percentages are calculated from medians of separate sample sets. They are
+useful attribution estimates, not an accounting identity. A negative or large
+`composition/noise residual` indicates timer noise, garbage collection, JIT
+state, or interactions between stages; increase `--rows`, warmups, and
+iterations before drawing conclusions. All raw samples are retained in the
+optional JSON result.
+
+Because generated files are written and repeatedly warmed immediately before
+measurement, the default suite characterizes warm-cache parsing. It does not
+claim to measure cold physical-disk latency. Re-run with larger `--rows` values
+to test how allocation and garbage collection change with scale.
+
+The displayed value `dta-parser throughput` is:
+
+```text
+haven median elapsed time / dta-parser median elapsed time
+```
+
+Thus `2.00x` means dta-parser completed that workload in half haven's median
+time; `0.50x` means it took twice as long. Lower millisecond values are always
+better. Compare results only on the same machine and workload: filesystem
+cache, CPU, R/Bun versions, data shape, and iteration count can materially
+change timings.
+
+This harness measures elapsed read performance, not peak memory. It also does
+not claim feature parity between the libraries: haven returns a tibble with R
+classes, while dta-parser returns JavaScript rows or selected columns and
+preserves Stata missing tags as explicit objects.
+
+## Implementation files
+
+- `benchmarks/dta-vs-haven/run.ts` orchestrates comparison, timing, and output.
+- `benchmarks/dta-vs-haven/haven.R` provides haven snapshots and timed reads.
+- `benchmarks/dta-vs-haven/generate.R` creates deterministic performance data.
+
+## Recorded runs
+
+- [Apple M4 Max, 2026-07-24](benchmark-results/2026-07-24-apple-m4-max.md)

--- a/package.json
+++ b/package.json
@@ -48,7 +48,9 @@
     "build": "npm run clean && npm run build:types && npm run build:esm && npm run build:cjs",
     "prepare": "npm run build",
     "typecheck": "tsc -p tsconfig.types.json --noEmit",
-    "test": "bun test ./tests"
+    "test": "bun test ./tests",
+    "test:reproducibility": "bun run benchmarks/dta-vs-haven/run.ts --correctness-only",
+    "benchmark": "bun run benchmarks/dta-vs-haven/run.ts"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",


### PR DESCRIPTION
## What changed

- add an opt-in cross-language reproducibility suite comparing all checked-in `.dta` fixtures with `haven::read_dta()`
- add deterministic numeric and mixed performance workloads
- decompose warm-cache timings into setup, observation I/O, decode/materialization, wrapper, and residual stages
- document methodology, limitations, commands, and interpretation
- record a machine-qualified Apple M4 Max result rather than presenting it as a universal claim

## Why

The parser needs a repeatable way to verify semantic parity with a mature Stata reader and to understand where performance differences arise. The stage-level benchmark shows whether changes affect metadata, I/O, decoding, or result construction instead of relying only on a single elapsed-time number.

## Impact

Regular TypeScript tests remain unchanged and do not require R. Contributors with R, haven, and jsonlite can run `npm run test:reproducibility` or `npm run benchmark`; generated files and machine-local JSON results are temporary or gitignored.

## Validation

- `npm test` — 211 passed
- `npm run typecheck`
- `npm run build`
- strict TypeScript check of `benchmarks/dta-vs-haven/run.ts`
- `npm run test:reproducibility` — 29 fixtures matched haven
- 100,000-row decomposition benchmark with 3 warmups and 10 measured iterations
