### PR TITLE
Reduce R materialization memory

### DIFF
--- a/benchmarks/r-materialization/README.md
+++ b/benchmarks/r-materialization/README.md
@@ -9,11 +9,23 @@ This benchmark compares the two output collectors built into the same package:
 
 The timing runner checks exact output identity, warms both paths, alternates
 execution order, runs garbage collection outside the timed region, and writes
-every observation to TSV:
+every observation to TSV. Build the package from the current checkout and
+install it into a fresh benchmark-only library before starting a benchmark
+session:
 
 ```sh
+R CMD build r-package/dtaparser
+mkdir -p "$PWD/target"
+benchmark_lib="$(mktemp -d "$PWD/target/r-benchmark-library.XXXXXX")"
+R CMD INSTALL --library="$benchmark_lib" dtaparser_0.1.0.tar.gz
+export DTAPARSER_BENCH_LIB="$benchmark_lib"
 Rscript benchmarks/r-materialization/run.R input.dta timings.tsv 21
 ```
+
+Both runners require `DTAPARSER_BENCH_LIB` and verify that `dtaparser` was
+loaded from that checkout-local library, preventing a global or stale
+installation from being benchmarked accidentally. Install before the timed
+process so package installation is excluded from the memory measurements.
 
 Peak memory must be measured in fresh processes. On macOS:
 

--- a/benchmarks/r-materialization/README.md
+++ b/benchmarks/r-materialization/README.md
@@ -1,0 +1,27 @@
+# R materialization benchmark
+
+This benchmark compares the two output collectors built into the same package:
+
+- `direct-r`: numeric cells are decoded into their final R vectors; strings are
+  retained only until they can be batch-materialized into R.
+- `rust-vectors`: the reference path builds a complete `DtaData` value before
+  converting it into R vectors.
+
+The timing runner checks exact output identity, warms both paths, alternates
+execution order, runs garbage collection outside the timed region, and writes
+every observation to TSV:
+
+```sh
+Rscript benchmarks/r-materialization/run.R input.dta timings.tsv 21
+```
+
+Peak memory must be measured in fresh processes. On macOS:
+
+```sh
+/usr/bin/time -l Rscript benchmarks/r-materialization/memory-worker.R input.dta direct-r
+/usr/bin/time -l Rscript benchmarks/r-materialization/memory-worker.R input.dta rust-vectors
+```
+
+Compare both `maximum resident set size` and `peak memory footprint`. The final
+R object is intentionally retained until process exit so it is included in the
+measurement.

--- a/benchmarks/r-materialization/memory-worker.R
+++ b/benchmarks/r-materialization/memory-worker.R
@@ -5,8 +5,24 @@ if (length(args) != 2L || !args[[2L]] %in% c("direct-r", "rust-vectors")) {
 
 path <- normalizePath(args[[1L]])
 materialization <- args[[2L]]
+script_argument <- grep("^--file=", commandArgs(trailingOnly = FALSE), value = TRUE)[[1L]]
+script_path <- normalizePath(sub("^--file=", "", script_argument), winslash = "/")
+checkout_root <- normalizePath(file.path(dirname(script_path), "..", ".."), winslash = "/")
+benchmark_library <- Sys.getenv("DTAPARSER_BENCH_LIB")
+if (!nzchar(benchmark_library)) {
+    stop("set DTAPARSER_BENCH_LIB to a library containing dtaparser built from this checkout")
+}
+benchmark_library <- normalizePath(benchmark_library, winslash = "/")
+if (!startsWith(benchmark_library, paste0(checkout_root, "/"))) {
+    stop("DTAPARSER_BENCH_LIB must point to a library inside this checkout")
+}
+.libPaths(c(benchmark_library, .libPaths()))
 if (!requireNamespace("dtaparser", quietly = TRUE)) {
-    stop("dtaparser is required")
+    stop("DTAPARSER_BENCH_LIB does not contain a loadable dtaparser installation")
+}
+loaded_library <- normalizePath(dirname(find.package("dtaparser")), winslash = "/")
+if (!identical(loaded_library, benchmark_library)) {
+    stop("dtaparser was not loaded from DTAPARSER_BENCH_LIB")
 }
 
 result <- if (identical(materialization, "direct-r")) {

--- a/benchmarks/r-materialization/memory-worker.R
+++ b/benchmarks/r-materialization/memory-worker.R
@@ -1,0 +1,21 @@
+args <- commandArgs(trailingOnly = TRUE)
+if (length(args) != 2L || !args[[2L]] %in% c("direct-r", "rust-vectors")) {
+    stop("usage: Rscript memory-worker.R INPUT_DTA direct-r|rust-vectors")
+}
+
+path <- normalizePath(args[[1L]])
+materialization <- args[[2L]]
+if (!requireNamespace("dtaparser", quietly = TRUE)) {
+    stop("dtaparser is required")
+}
+
+result <- if (identical(materialization, "direct-r")) {
+    dtaparser::read_dta(path)
+} else {
+    dtaparser:::.read_dta_rust_vectors(path)
+}
+cat(sprintf(
+    "%s: %d rows, %d columns, %.3f MB final R object\n",
+    materialization, nrow(result), ncol(result),
+    as.numeric(utils::object.size(result)) / 1e6
+))

--- a/benchmarks/r-materialization/results-2026-07-26.md
+++ b/benchmarks/r-materialization/results-2026-07-26.md
@@ -1,0 +1,44 @@
+# Direct-R materialization results (2026-07-26)
+
+Environment: Apple M4 Max, 128 GB RAM, macOS 26.5.2, R 4.6.1. The package was
+built in Cargo release mode. Both collectors were compiled into the same
+package and read the same warm-cache, mixed-type, 40-column synthetic DTA
+files. Every timing run first required exact collector output identity, warmed
+both paths, alternated execution order, and ran garbage collection outside the
+timed interval.
+
+| Input | Collector | Iterations | Median | p05 | p95 |
+| --- | --- | ---: | ---: | ---: | ---: |
+| 100 MB | direct-R | 21 | 0.263 s | 0.218 s | 0.287 s |
+| 100 MB | Rust vectors | 21 | 0.275 s | 0.226 s | 0.300 s |
+| 1 GB | direct-R | 7 | 2.057 s | 2.039 s | 2.071 s |
+| 1 GB | Rust vectors | 7 | 2.226 s | 2.180 s | 2.240 s |
+
+Direct-R was 4.4% faster at 100 MB and 7.6% faster at 1 GB by median elapsed
+time.
+
+Peak memory was measured in fresh processes with `/usr/bin/time -l`. The
+reported values include R, the loaded package, and the retained final data
+frame.
+
+| Input | Collector | Runs | Median maximum RSS | Median peak footprint |
+| --- | --- | ---: | ---: | ---: |
+| 100 MB | direct-R | 3 | 394.1 MB | 326.1 MB |
+| 100 MB | Rust vectors | 3 | 391.9 MB | 375.8 MB |
+| 1 GB | direct-R | 2 | 2.213 GB | 2.087 GB |
+| 1 GB | Rust vectors | 2 | 2.612 GB | 2.597 GB |
+
+At 1 GB, direct-R reduced maximum RSS by 15.3% and peak footprint by 19.6%.
+The 100 MB maximum-RSS result was 0.6% higher for direct-R even though its peak
+footprint was 13.2% lower; fixed process overhead and allocator accounting
+dominate that smaller case. The 1 GB result shows the expected scaling from
+removing numeric Rust value and missing-tag vectors.
+
+The direct collector writes numeric cells into protected final R vectors.
+Strings remain temporarily batched in Rust because fully interleaving R string
+allocation with parsing was slower on the mixed workload; they are drained
+into final R character vectors after decoding. The retained Rust-vector path
+continues to return the reusable `DtaData` model and is available internally to
+the R package as an A/B and differential-testing baseline.
+
+No 10 GB materialization benchmark was run for this change.

--- a/benchmarks/r-materialization/run.R
+++ b/benchmarks/r-materialization/run.R
@@ -1,0 +1,69 @@
+args <- commandArgs(trailingOnly = TRUE)
+if (length(args) < 2L) {
+    stop("usage: Rscript run.R INPUT_DTA OUTPUT_TSV [ITERATIONS]")
+}
+
+path <- normalizePath(args[[1L]])
+output <- normalizePath(args[[2L]], mustWork = FALSE)
+iterations <- if (length(args) >= 3L) as.integer(args[[3L]]) else 21L
+stopifnot(is.finite(iterations), iterations >= 1L)
+
+if (!requireNamespace("dtaparser", quietly = TRUE)) {
+    stop("dtaparser is required")
+}
+
+read_one <- function(materialization) {
+    if (identical(materialization, "direct-r")) {
+        dtaparser::read_dta(path)
+    } else {
+        dtaparser:::.read_dta_rust_vectors(path)
+    }
+}
+
+direct <- read_one("direct-r")
+rust_vectors <- read_one("rust-vectors")
+stopifnot(identical(direct, rust_vectors))
+expected_dim <- dim(direct)
+rm(direct, rust_vectors)
+invisible(gc())
+
+rows <- vector("list", iterations * 2L)
+position <- 1L
+for (iteration in seq_len(iterations)) {
+    order <- if (iteration %% 2L) {
+        c("direct-r", "rust-vectors")
+    } else {
+        c("rust-vectors", "direct-r")
+    }
+    for (materialization in order) {
+        invisible(gc())
+        started <- proc.time()[["elapsed"]]
+        result <- read_one(materialization)
+        elapsed <- proc.time()[["elapsed"]] - started
+        stopifnot(identical(dim(result), expected_dim))
+        rows[[position]] <- data.frame(
+            materialization = materialization,
+            iteration = iteration,
+            elapsed_s = elapsed
+        )
+        position <- position + 1L
+        rm(result)
+    }
+}
+
+raw <- do.call(rbind, rows)
+dir.create(dirname(output), recursive = TRUE, showWarnings = FALSE)
+write.table(raw, output, sep = "\t", row.names = FALSE, quote = FALSE)
+
+summary <- do.call(rbind, lapply(split(raw$elapsed_s, raw$materialization), function(x) {
+    data.frame(
+        iterations = length(x),
+        median_s = median(x),
+        p05_s = unname(quantile(x, 0.05)),
+        p95_s = unname(quantile(x, 0.95))
+    )
+}))
+summary$materialization <- row.names(summary)
+row.names(summary) <- NULL
+summary <- summary[c("materialization", "iterations", "median_s", "p05_s", "p95_s")]
+print(summary, row.names = FALSE)

--- a/benchmarks/r-materialization/run.R
+++ b/benchmarks/r-materialization/run.R
@@ -8,8 +8,24 @@ output <- normalizePath(args[[2L]], mustWork = FALSE)
 iterations <- if (length(args) >= 3L) as.integer(args[[3L]]) else 21L
 stopifnot(is.finite(iterations), iterations >= 1L)
 
+script_argument <- grep("^--file=", commandArgs(trailingOnly = FALSE), value = TRUE)[[1L]]
+script_path <- normalizePath(sub("^--file=", "", script_argument), winslash = "/")
+checkout_root <- normalizePath(file.path(dirname(script_path), "..", ".."), winslash = "/")
+benchmark_library <- Sys.getenv("DTAPARSER_BENCH_LIB")
+if (!nzchar(benchmark_library)) {
+    stop("set DTAPARSER_BENCH_LIB to a library containing dtaparser built from this checkout")
+}
+benchmark_library <- normalizePath(benchmark_library, winslash = "/")
+if (!startsWith(benchmark_library, paste0(checkout_root, "/"))) {
+    stop("DTAPARSER_BENCH_LIB must point to a library inside this checkout")
+}
+.libPaths(c(benchmark_library, .libPaths()))
 if (!requireNamespace("dtaparser", quietly = TRUE)) {
-    stop("dtaparser is required")
+    stop("DTAPARSER_BENCH_LIB does not contain a loadable dtaparser installation")
+}
+loaded_library <- normalizePath(dirname(find.package("dtaparser")), winslash = "/")
+if (!identical(loaded_library, benchmark_library)) {
+    stop("dtaparser was not loaded from DTAPARSER_BENCH_LIB")
 }
 
 read_one <- function(materialization) {

--- a/r-package/dtaparser/R/read-dta.R
+++ b/r-package/dtaparser/R/read-dta.R
@@ -22,6 +22,25 @@
 #' @export
 read_dta <- function(file, encoding = NULL, col_select = NULL, skip = 0,
                      n_max = Inf, .name_repair = "unique") {
+    .read_dta_impl(
+        file, encoding, rlang::enquo(col_select), skip, n_max, .name_repair,
+        materialization = "direct"
+    )
+}
+
+# Internal A/B baseline. This deliberately retains the former two-stage path
+# so direct-to-R materialization can be benchmarked and checked independently.
+.read_dta_rust_vectors <- function(file, encoding = NULL, col_select = NULL,
+                                   skip = 0, n_max = Inf,
+                                   .name_repair = "unique") {
+    .read_dta_impl(
+        file, encoding, rlang::enquo(col_select), skip, n_max, .name_repair,
+        materialization = "rust-vectors"
+    )
+}
+
+.read_dta_impl <- function(file, encoding, selection, skip, n_max,
+                           .name_repair, materialization) {
     if (!is.character(file) || length(file) != 1L || is.na(file)) {
         stop("`file` must be one non-missing path", call. = FALSE)
     }
@@ -32,7 +51,6 @@ read_dta <- function(file, encoding = NULL, col_select = NULL, skip = 0,
     .validate_count(n_max, "n_max", infinite = TRUE)
 
     file <- normalizePath(file, mustWork = TRUE)
-    selection <- rlang::enquo(col_select)
     metadata_names <- .dta_metadata(file)
 
     if (rlang::quo_is_null(selection)) {
@@ -57,7 +75,8 @@ read_dta <- function(file, encoding = NULL, col_select = NULL, skip = 0,
         file,
         column_indices,
         as.double(skip),
-        as.double(n_max)
+        as.double(n_max),
+        identical(materialization, "direct")
     )
     if (!is.null(column_indices)) {
         names(native) <- selected_names

--- a/r-package/dtaparser/README.md
+++ b/r-package/dtaparser/README.md
@@ -3,7 +3,9 @@
 `dtaparser` is the native R interface to this repository's bounded Rust DTA
 reader. Its exported `read_dta()` function deliberately mirrors the formal
 arguments of `haven::read_dta()`, while observation storage is decoded by Rust
-and copied directly into R vectors.
+and materialized through an R-specific collector. Numeric values are written
+into their final R vectors during decoding; strings are batch-materialized to
+avoid interleaving R allocation with the parser's hot loop.
 
 ```r
 library(dtaparser)
@@ -54,12 +56,15 @@ haven. Missing R dependencies produce an explicit `SKIP`; CI sets
 `DTA_REQUIRE_R_CONFORMANCE=1` and checks Linux, macOS, and Windows. Only
 nonmissing floating values permit `1e-7` relative tolerance; missing tags,
 labels, formats, value-label tables, strings, names, dimensions, projections,
-and row windows are otherwise exact.
+and row windows are otherwise exact. Package tests also require the direct-R
+collector to be identical to the retained `DtaData`/Rust-vector collector on
+every bundled fixture.
 
 ```sh
 DTA_REQUIRE_R_CONFORMANCE=1 bun run conformance
 R CMD build r-package/dtaparser
 R CMD check --no-manual dtaparser_0.1.0.tar.gz
+Rscript benchmarks/r-materialization/run.R input.dta timings.tsv 21
 ```
 
 The native source of truth is `rust/dta-parser`. After a root-first change,

--- a/r-package/dtaparser/README.md
+++ b/r-package/dtaparser/README.md
@@ -64,8 +64,16 @@ every bundled fixture.
 DTA_REQUIRE_R_CONFORMANCE=1 bun run conformance
 R CMD build r-package/dtaparser
 R CMD check --no-manual dtaparser_0.1.0.tar.gz
+mkdir -p "$PWD/target"
+benchmark_lib="$(mktemp -d "$PWD/target/r-benchmark-library.XXXXXX")"
+R CMD INSTALL --library="$benchmark_lib" dtaparser_0.1.0.tar.gz
+export DTAPARSER_BENCH_LIB="$benchmark_lib"
 Rscript benchmarks/r-materialization/run.R input.dta timings.tsv 21
 ```
+
+The materialization benchmark runners require `DTAPARSER_BENCH_LIB` and verify
+that the package is loaded from that freshly populated, checkout-local library
+rather than an unrelated global installation.
 
 The native source of truth is `rust/dta-parser`. After a root-first change,
 mirror it here and run `scripts/check-rust-sync.sh`; the check also verifies the

--- a/r-package/dtaparser/src/init.c
+++ b/r-package/dtaparser/src/init.c
@@ -8,7 +8,7 @@
 
 extern SEXP dtaparser_metadata_rust(const char *, char **);
 extern SEXP dtaparser_read_rust(
-    const char *, const int *, size_t, int, double, double, char **
+    const char *, const int *, size_t, int, double, double, int, char **
 );
 extern void dtaparser_free_error(char *);
 
@@ -135,7 +135,9 @@ SEXP C_dtaparser_metadata(SEXP path) {
     return result;
 }
 
-SEXP C_dtaparser_read(SEXP path, SEXP columns, SEXP skip, SEXP n_max) {
+SEXP C_dtaparser_read(
+    SEXP path, SEXP columns, SEXP skip, SEXP n_max, SEXP direct_to_r
+) {
     if (TYPEOF(path) != STRSXP || XLENGTH(path) != 1 || STRING_ELT(path, 0) == NA_STRING) {
         Rf_error("`file` must be one non-missing path");
     }
@@ -147,6 +149,10 @@ SEXP C_dtaparser_read(SEXP path, SEXP columns, SEXP skip, SEXP n_max) {
         TYPEOF(n_max) != REALSXP || XLENGTH(n_max) != 1) {
         Rf_error("internal row bounds must be numeric scalars");
     }
+    if (TYPEOF(direct_to_r) != LGLSXP || XLENGTH(direct_to_r) != 1 ||
+        LOGICAL(direct_to_r)[0] == NA_LOGICAL) {
+        Rf_error("internal materialization selector must be logical");
+    }
     char *error = NULL;
     SEXP result = dtaparser_read_rust(
         Rf_translateCharUTF8(STRING_ELT(path, 0)),
@@ -155,6 +161,7 @@ SEXP C_dtaparser_read(SEXP path, SEXP columns, SEXP skip, SEXP n_max) {
         all_columns,
         REAL(skip)[0],
         REAL(n_max)[0],
+        LOGICAL(direct_to_r)[0],
         &error
     );
     if (result == NULL) fail_from_rust(error);
@@ -163,7 +170,7 @@ SEXP C_dtaparser_read(SEXP path, SEXP columns, SEXP skip, SEXP n_max) {
 
 static const R_CallMethodDef CallEntries[] = {
     {"C_dtaparser_metadata", (DL_FUNC) &C_dtaparser_metadata, 1},
-    {"C_dtaparser_read", (DL_FUNC) &C_dtaparser_read, 4},
+    {"C_dtaparser_read", (DL_FUNC) &C_dtaparser_read, 5},
     {NULL, NULL, 0}
 };
 

--- a/r-package/dtaparser/src/rust/src/lib.rs
+++ b/r-package/dtaparser/src/rust/src/lib.rs
@@ -366,6 +366,9 @@ enum RColumn {
     },
     String {
         vector: Sexp,
+        // Delaying R string allocation until after decoding is measurably
+        // faster than interleaving it with the parser's hot loop. Insertions
+        // still validate the DtaSink row-order contract below.
         values: Vec<String>,
     },
 }
@@ -471,9 +474,20 @@ impl RDataFrameSink {
     }
 
     #[inline(always)]
-    fn push_string_value(&mut self, column: usize, value: String) -> Result<(), DtaError> {
+    fn push_string_value(
+        &mut self,
+        column: usize,
+        row: usize,
+        value: String,
+    ) -> Result<(), DtaError> {
         match self.columns.get_mut(column) {
             Some(RColumn::String { values, .. }) => {
+                if values.len() != row {
+                    return Err(DtaError::Output(format!(
+                        "string output row mismatch: expected {}, got {row}",
+                        values.len()
+                    )));
+                }
                 values.push(value);
                 Ok(())
             }
@@ -544,15 +558,15 @@ impl DtaSink for RDataFrameSink {
     fn push_fixed_string(
         &mut self,
         column: usize,
-        _row: usize,
+        row: usize,
         value: String,
     ) -> Result<(), DtaError> {
-        self.push_string_value(column, value)
+        self.push_string_value(column, row, value)
     }
 
     #[inline(always)]
-    fn push_strl(&mut self, column: usize, _row: usize, value: &str) -> Result<(), DtaError> {
-        self.push_string_value(column, value.to_owned())
+    fn push_strl(&mut self, column: usize, row: usize, value: &str) -> Result<(), DtaError> {
+        self.push_string_value(column, row, value.to_owned())
     }
 
     fn finish(
@@ -562,11 +576,19 @@ impl DtaSink for RDataFrameSink {
         row_count: u64,
         value_label_tables: Vec<ValueLabelTable>,
     ) -> Result<Self::Output, DtaError> {
+        let expected_string_rows = usize::try_from(row_count)
+            .map_err(|_| DtaError::Output("R vector is too long".to_owned()))?;
         unsafe {
             for column in &mut self.columns {
                 let RColumn::String { vector, values } = column else {
                     continue;
                 };
+                if values.len() != expected_string_rows {
+                    return Err(DtaError::Output(format!(
+                        "string output row count mismatch: expected {expected_string_rows}, got {}",
+                        values.len()
+                    )));
+                }
                 for (row, value) in values.drain(..).enumerate() {
                     poll_interrupt(row).map_err(DtaError::Output)?;
                     SET_STRING_ELT(

--- a/r-package/dtaparser/src/rust/src/lib.rs
+++ b/r-package/dtaparser/src/rust/src/lib.rs
@@ -4,7 +4,8 @@ use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::ptr;
 
 use dta_parser::{
-    ColumnValues, DtaData, DtaFile, DtaType, MissingTag, ReadOptions, ValueLabelTable, VariableInfo,
+    ColumnValues, DtaData, DtaError, DtaFile, DtaMetadata, DtaSink, DtaType, MissingTag,
+    ReadOptions, ValueLabelTable, VariableInfo,
 };
 
 type Sexp = *mut c_void;
@@ -357,6 +358,283 @@ unsafe fn build_data_frame(data: &DtaData) -> Result<Sexp, String> {
     Ok(result)
 }
 
+enum RColumn {
+    Numeric {
+        vector: Sexp,
+        output: *mut f64,
+        temporal: TemporalKind,
+    },
+    String {
+        vector: Sexp,
+        values: Vec<String>,
+    },
+}
+
+struct RDataFrameSink {
+    result: Sexp,
+    columns: Vec<RColumn>,
+    source_indices: Vec<u32>,
+    _guard: ProtectGuard,
+}
+
+impl RDataFrameSink {
+    unsafe fn new(
+        metadata: &DtaMetadata,
+        row_count: u64,
+        source_indices: &[u32],
+    ) -> Result<Self, DtaError> {
+        let capacity = usize::try_from(row_count)
+            .map_err(|_| DtaError::Output("R vector is too long".to_owned()))?;
+        let length = RLen::try_from(row_count)
+            .map_err(|_| DtaError::Output("R vector is too long".to_owned()))?;
+        let column_count = RLen::try_from(source_indices.len())
+            .map_err(|_| DtaError::Output("too many columns".to_owned()))?;
+        let mut guard = ProtectGuard::new();
+        let result = guard
+            .alloc(VECSXP, column_count)
+            .map_err(DtaError::Output)?;
+        let names = guard
+            .alloc(STRSXP, column_count)
+            .map_err(DtaError::Output)?;
+        let mut columns = Vec::new();
+        columns
+            .try_reserve_exact(source_indices.len())
+            .map_err(|_| DtaError::Output("could not track R output columns".to_owned()))?;
+
+        for (output_index, &source_index) in source_indices.iter().enumerate() {
+            let variable = metadata
+                .variables
+                .get(source_index as usize)
+                .ok_or(DtaError::ArithmeticOverflow("output source column"))?;
+            let column = match variable.dta_type {
+                DtaType::FixedString(_) | DtaType::StrL => RColumn::String {
+                    vector: guard.alloc(STRSXP, length).map_err(DtaError::Output)?,
+                    values: Vec::with_capacity(capacity),
+                },
+                _ => {
+                    let vector = guard.alloc(REALSXP, length).map_err(DtaError::Output)?;
+                    RColumn::Numeric {
+                        vector,
+                        output: REAL(vector),
+                        temporal: temporal_kind(&variable.format),
+                    }
+                }
+            };
+            let vector = match &column {
+                RColumn::Numeric { vector, .. } | RColumn::String { vector, .. } => *vector,
+            };
+            SET_VECTOR_ELT(result, output_index as RLen, vector);
+            SET_STRING_ELT(
+                names,
+                output_index as RLen,
+                r_char(&variable.name).map_err(DtaError::Output)?,
+            );
+            columns.push(column);
+        }
+        set_symbol_attr(result, R_NamesSymbol, names).map_err(DtaError::Output)?;
+
+        Ok(Self {
+            result,
+            columns,
+            source_indices: source_indices.to_vec(),
+            _guard: guard,
+        })
+    }
+
+    #[inline(always)]
+    fn numeric_column(&self, column: usize) -> Result<(*mut f64, TemporalKind), DtaError> {
+        match self.columns.get(column) {
+            Some(RColumn::Numeric {
+                output, temporal, ..
+            }) => Ok((*output, *temporal)),
+            _ => Err(DtaError::Output(
+                "numeric output column mismatch".to_owned(),
+            )),
+        }
+    }
+
+    #[inline(always)]
+    fn write_numeric(
+        &mut self,
+        column: usize,
+        row: usize,
+        value: f64,
+        missing: Option<MissingTag>,
+    ) -> Result<(), DtaError> {
+        let (output, temporal) = self.numeric_column(column)?;
+        unsafe {
+            *output.add(row) = missing
+                .map(r_missing)
+                .unwrap_or_else(|| observed_value(value, temporal));
+        }
+        Ok(())
+    }
+
+    #[inline(always)]
+    fn push_string_value(&mut self, column: usize, value: String) -> Result<(), DtaError> {
+        match self.columns.get_mut(column) {
+            Some(RColumn::String { values, .. }) => {
+                values.push(value);
+                Ok(())
+            }
+            _ => Err(DtaError::Output("string output column mismatch".to_owned())),
+        }
+    }
+}
+
+impl DtaSink for RDataFrameSink {
+    type Output = Sexp;
+
+    #[inline(always)]
+    fn push_byte(
+        &mut self,
+        column: usize,
+        row: usize,
+        value: i8,
+        missing: Option<MissingTag>,
+    ) -> Result<(), DtaError> {
+        self.write_numeric(column, row, f64::from(value), missing)
+    }
+
+    #[inline(always)]
+    fn push_int(
+        &mut self,
+        column: usize,
+        row: usize,
+        value: i16,
+        missing: Option<MissingTag>,
+    ) -> Result<(), DtaError> {
+        self.write_numeric(column, row, f64::from(value), missing)
+    }
+
+    #[inline(always)]
+    fn push_long(
+        &mut self,
+        column: usize,
+        row: usize,
+        value: i32,
+        missing: Option<MissingTag>,
+    ) -> Result<(), DtaError> {
+        self.write_numeric(column, row, f64::from(value), missing)
+    }
+
+    #[inline(always)]
+    fn push_float(
+        &mut self,
+        column: usize,
+        row: usize,
+        value: f32,
+        missing: Option<MissingTag>,
+    ) -> Result<(), DtaError> {
+        self.write_numeric(column, row, f64::from(value), missing)
+    }
+
+    #[inline(always)]
+    fn push_double(
+        &mut self,
+        column: usize,
+        row: usize,
+        value: f64,
+        missing: Option<MissingTag>,
+    ) -> Result<(), DtaError> {
+        self.write_numeric(column, row, value, missing)
+    }
+
+    #[inline(always)]
+    fn push_fixed_string(
+        &mut self,
+        column: usize,
+        _row: usize,
+        value: String,
+    ) -> Result<(), DtaError> {
+        self.push_string_value(column, value)
+    }
+
+    #[inline(always)]
+    fn push_strl(&mut self, column: usize, _row: usize, value: &str) -> Result<(), DtaError> {
+        self.push_string_value(column, value.to_owned())
+    }
+
+    fn finish(
+        mut self,
+        metadata: DtaMetadata,
+        _row_start: u64,
+        row_count: u64,
+        value_label_tables: Vec<ValueLabelTable>,
+    ) -> Result<Self::Output, DtaError> {
+        unsafe {
+            for column in &mut self.columns {
+                let RColumn::String { vector, values } = column else {
+                    continue;
+                };
+                for (row, value) in values.drain(..).enumerate() {
+                    poll_interrupt(row).map_err(DtaError::Output)?;
+                    SET_STRING_ELT(
+                        *vector,
+                        row as RLen,
+                        r_char(&value).map_err(DtaError::Output)?,
+                    );
+                }
+            }
+
+            for (output_index, &source_index) in self.source_indices.iter().enumerate() {
+                check_interrupt().map_err(DtaError::Output)?;
+                let variable = metadata
+                    .variables
+                    .get(source_index as usize)
+                    .ok_or(DtaError::ArithmeticOverflow("output source column"))?;
+                let table = if variable.value_label_name.is_empty() {
+                    None
+                } else {
+                    value_label_tables
+                        .iter()
+                        .find(|table| table.name == variable.value_label_name)
+                };
+                let vector = match &self.columns[output_index] {
+                    RColumn::Numeric { vector, .. } | RColumn::String { vector, .. } => *vector,
+                };
+                let mut attribute_guard = ProtectGuard::new();
+                attach_variable_attributes(vector, variable, table, &mut attribute_guard)
+                    .map_err(DtaError::Output)?;
+            }
+
+            let row_count = c_int::try_from(row_count).map_err(|_| {
+                DtaError::Output("R data frames cannot contain more than 2^31-1 rows".to_owned())
+            })?;
+            {
+                let mut attribute_guard = ProtectGuard::new();
+                let row_names = attribute_guard.alloc(INTSXP, 2).map_err(DtaError::Output)?;
+                *INTEGER(row_names) = R_NaInt;
+                *INTEGER(row_names).add(1) = -row_count;
+                set_symbol_attr(self.result, R_RowNamesSymbol, row_names)
+                    .map_err(DtaError::Output)?;
+            }
+            {
+                let mut attribute_guard = ProtectGuard::new();
+                set_class(self.result, &["data.frame"], &mut attribute_guard)
+                    .map_err(DtaError::Output)?;
+            }
+            if !metadata.dataset_label.is_empty() {
+                let mut attribute_guard = ProtectGuard::new();
+                let label = scalar_string(&metadata.dataset_label, &mut attribute_guard)
+                    .map_err(DtaError::Output)?;
+                set_attr(self.result, "label", label).map_err(DtaError::Output)?;
+            }
+            {
+                let mut attribute_guard = ProtectGuard::new();
+                let version = scalar_integer(
+                    metadata.format_version.as_u16().into(),
+                    &mut attribute_guard,
+                )
+                .map_err(DtaError::Output)?;
+                set_attr(self.result, "dta_format_version", version).map_err(DtaError::Output)?;
+            }
+        }
+        let result = self.result;
+        Ok(result)
+    }
+}
+
 unsafe fn metadata_impl(path: &str) -> Result<Sexp, String> {
     let file = DtaFile::open(path).map_err(|error| error.to_string())?;
     let metadata = file.metadata();
@@ -408,6 +686,7 @@ unsafe fn read_impl(
     columns: Option<Vec<u32>>,
     skip: f64,
     n_max: f64,
+    direct_to_r: bool,
 ) -> Result<Sexp, String> {
     if !skip.is_finite() || skip < 0.0 || skip.fract() != 0.0 || skip > (1_u64 << 53) as f64 {
         return Err("invalid skip value".to_owned());
@@ -431,10 +710,21 @@ unsafe fn read_impl(
         row_count,
         column_indices: columns,
     };
-    let data = file
-        .read_with_interrupt(&options, || unsafe { dtaparser_check_interrupt() != 0 })
-        .map_err(|error| error.to_string())?;
-    build_data_frame(&data)
+    if direct_to_r {
+        file.read_with_sink_and_interrupt(
+            &options,
+            |metadata, _row_start, row_count, indices| unsafe {
+                RDataFrameSink::new(metadata, row_count, indices)
+            },
+            || unsafe { dtaparser_check_interrupt() != 0 },
+        )
+        .map_err(|error| error.to_string())
+    } else {
+        let data = file
+            .read_with_interrupt(&options, || unsafe { dtaparser_check_interrupt() != 0 })
+            .map_err(|error| error.to_string())?;
+        build_data_frame(&data)
+    }
 }
 
 fn panic_message(payload: Box<dyn Any + Send>) -> String {
@@ -517,6 +807,7 @@ pub unsafe extern "C" fn dtaparser_read_rust(
     all_columns: c_int,
     skip: f64,
     n_max: f64,
+    direct_to_r: c_int,
     error: *mut *mut c_char,
 ) -> Sexp {
     boundary(error, || {
@@ -546,7 +837,7 @@ pub unsafe extern "C" fn dtaparser_read_rust(
                     .collect::<Result<Vec<_>, _>>()?,
             )
         };
-        read_impl(path, projection, skip, n_max)
+        read_impl(path, projection, skip, n_max, direct_to_r != 0)
     })
 }
 

--- a/r-package/dtaparser/src/vendor/dta-parser/README.md
+++ b/r-package/dtaparser/src/vendor/dta-parser/README.md
@@ -77,9 +77,15 @@ capped. Row windows seek directly to selected observations, and only selected
 cells are decoded. GSO headers are scanned without retaining unrequested
 payloads, selected payloads are streamed and cached per read, and value-label
 tables are streamed and cached lazily. The cooperative callback is checked
-between chunks and returns
-`DtaError::Cancelled` without a partial `DtaData` or partially initialized
-label cache.
+between chunks and returns `DtaError::Cancelled` without exposing a partial
+output or partially initialized label cache.
+
+`DtaFile::read_with_sink_and_interrupt` runs the same validation, I/O, typed
+cell decoding, `strL`, and value-label pipeline through a caller-provided
+`DtaSink`. The built-in sink retains the public `DtaData`/`ColumnValues` model;
+foreign-runtime adapters can instead materialize their own column store. The
+generic sink is statically dispatched, avoiding a dynamic callback boundary in
+the per-cell loop.
 
 `DtaMetadata` and its nested types implement `serde::Serialize` and
 `serde::Deserialize`; the observation and value-label models do as well. Their

--- a/r-package/dtaparser/src/vendor/dta-parser/src/error.rs
+++ b/r-package/dtaparser/src/vendor/dta-parser/src/error.rs
@@ -149,6 +149,12 @@ pub enum DtaError {
     #[error("read cancelled")]
     Cancelled,
 
+    /// A caller-provided output collector could not materialize a decoded
+    /// value. Keeping collector failures in the parser's ordinary error path
+    /// ensures partially built outputs are dropped without being exposed.
+    #[error("output materialization failed: {0}")]
+    Output(String),
+
     /// A seek or read failed while accessing a file-backed source.
     #[error("I/O error while {context} at byte offset {offset}: {kind:?}")]
     Io {

--- a/r-package/dtaparser/src/vendor/dta-parser/src/file.rs
+++ b/r-package/dtaparser/src/vendor/dta-parser/src/file.rs
@@ -121,9 +121,72 @@ enum ColumnBuilder {
     },
     StrL {
         index: u32,
-        pointers: Vec<Option<FileGsoKey>>,
         values: Vec<String>,
     },
+}
+
+/// Destination for typed cells decoded by [`DtaFile`].
+///
+/// Implementations can retain ordinary Rust vectors, write directly into a
+/// foreign column store, or stream values elsewhere. Calls are monomorphized,
+/// so the shared decoder does not add a dynamic callback boundary per cell.
+pub trait DtaSink: Sized {
+    type Output;
+
+    fn push_byte(
+        &mut self,
+        column: usize,
+        row: usize,
+        value: i8,
+        missing: Option<crate::MissingTag>,
+    ) -> Result<(), DtaError>;
+    fn push_int(
+        &mut self,
+        column: usize,
+        row: usize,
+        value: i16,
+        missing: Option<crate::MissingTag>,
+    ) -> Result<(), DtaError>;
+    fn push_long(
+        &mut self,
+        column: usize,
+        row: usize,
+        value: i32,
+        missing: Option<crate::MissingTag>,
+    ) -> Result<(), DtaError>;
+    fn push_float(
+        &mut self,
+        column: usize,
+        row: usize,
+        value: f32,
+        missing: Option<crate::MissingTag>,
+    ) -> Result<(), DtaError>;
+    fn push_double(
+        &mut self,
+        column: usize,
+        row: usize,
+        value: f64,
+        missing: Option<crate::MissingTag>,
+    ) -> Result<(), DtaError>;
+    fn push_fixed_string(
+        &mut self,
+        column: usize,
+        row: usize,
+        value: String,
+    ) -> Result<(), DtaError>;
+    fn push_strl(&mut self, column: usize, row: usize, value: &str) -> Result<(), DtaError>;
+
+    fn finish(
+        self,
+        metadata: DtaMetadata,
+        row_start: u64,
+        row_count: u64,
+        value_label_tables: Vec<ValueLabelTable>,
+    ) -> Result<Self::Output, DtaError>;
+}
+
+struct VecSink {
+    columns: Vec<ColumnBuilder>,
 }
 
 impl ColumnBuilder {
@@ -160,7 +223,6 @@ impl ColumnBuilder {
             },
             DtaType::StrL => Self::StrL {
                 index,
-                pointers: Vec::with_capacity(capacity),
                 values: Vec::with_capacity(capacity),
             },
         }
@@ -227,11 +289,183 @@ impl ColumnBuilder {
                 variable_index: index,
                 values: ColumnValues::FixedString { values },
             },
-            Self::StrL { index, values, .. } => Column {
+            Self::StrL { index, values } => Column {
                 variable_index: index,
                 values: ColumnValues::StrL { values },
             },
         }
+    }
+}
+
+impl VecSink {
+    fn new(metadata: &DtaMetadata, indices: &[u32], capacity: usize) -> Self {
+        let columns = indices
+            .iter()
+            .map(|index| {
+                let variable = &metadata.variables[*index as usize];
+                ColumnBuilder::new(*index, &variable.dta_type, capacity)
+            })
+            .collect();
+        Self { columns }
+    }
+
+    #[inline(always)]
+    fn column(&mut self, index: usize) -> Result<&mut ColumnBuilder, DtaError> {
+        self.columns
+            .get_mut(index)
+            .ok_or(DtaError::ArithmeticOverflow("output column index"))
+    }
+}
+
+impl DtaSink for VecSink {
+    type Output = DtaData;
+
+    #[inline(always)]
+    fn push_byte(
+        &mut self,
+        column: usize,
+        _row: usize,
+        value: i8,
+        missing: Option<crate::MissingTag>,
+    ) -> Result<(), DtaError> {
+        let ColumnBuilder::Byte {
+            values,
+            missing_tags,
+            ..
+        } = self.column(column)?
+        else {
+            return Err(DtaError::ArithmeticOverflow("output column type"));
+        };
+        values.push(value);
+        missing_tags.push(missing);
+        Ok(())
+    }
+
+    #[inline(always)]
+    fn push_int(
+        &mut self,
+        column: usize,
+        _row: usize,
+        value: i16,
+        missing: Option<crate::MissingTag>,
+    ) -> Result<(), DtaError> {
+        let ColumnBuilder::Int {
+            values,
+            missing_tags,
+            ..
+        } = self.column(column)?
+        else {
+            return Err(DtaError::ArithmeticOverflow("output column type"));
+        };
+        values.push(value);
+        missing_tags.push(missing);
+        Ok(())
+    }
+
+    #[inline(always)]
+    fn push_long(
+        &mut self,
+        column: usize,
+        _row: usize,
+        value: i32,
+        missing: Option<crate::MissingTag>,
+    ) -> Result<(), DtaError> {
+        let ColumnBuilder::Long {
+            values,
+            missing_tags,
+            ..
+        } = self.column(column)?
+        else {
+            return Err(DtaError::ArithmeticOverflow("output column type"));
+        };
+        values.push(value);
+        missing_tags.push(missing);
+        Ok(())
+    }
+
+    #[inline(always)]
+    fn push_float(
+        &mut self,
+        column: usize,
+        _row: usize,
+        value: f32,
+        missing: Option<crate::MissingTag>,
+    ) -> Result<(), DtaError> {
+        let ColumnBuilder::Float {
+            values,
+            missing_tags,
+            ..
+        } = self.column(column)?
+        else {
+            return Err(DtaError::ArithmeticOverflow("output column type"));
+        };
+        values.push(value);
+        missing_tags.push(missing);
+        Ok(())
+    }
+
+    #[inline(always)]
+    fn push_double(
+        &mut self,
+        column: usize,
+        _row: usize,
+        value: f64,
+        missing: Option<crate::MissingTag>,
+    ) -> Result<(), DtaError> {
+        let ColumnBuilder::Double {
+            values,
+            missing_tags,
+            ..
+        } = self.column(column)?
+        else {
+            return Err(DtaError::ArithmeticOverflow("output column type"));
+        };
+        values.push(value);
+        missing_tags.push(missing);
+        Ok(())
+    }
+
+    #[inline(always)]
+    fn push_fixed_string(
+        &mut self,
+        column: usize,
+        _row: usize,
+        value: String,
+    ) -> Result<(), DtaError> {
+        let ColumnBuilder::FixedString { values, .. } = self.column(column)? else {
+            return Err(DtaError::ArithmeticOverflow("output column type"));
+        };
+        values.push(value);
+        Ok(())
+    }
+
+    #[inline(always)]
+    fn push_strl(&mut self, column: usize, _row: usize, value: &str) -> Result<(), DtaError> {
+        let ColumnBuilder::StrL { values, .. } = self.column(column)? else {
+            return Err(DtaError::ArithmeticOverflow("output column type"));
+        };
+        values.push(value.to_owned());
+        Ok(())
+    }
+
+    fn finish(
+        self,
+        metadata: DtaMetadata,
+        row_start: u64,
+        row_count: u64,
+        value_label_tables: Vec<ValueLabelTable>,
+    ) -> Result<Self::Output, DtaError> {
+        Ok(DtaData {
+            metadata,
+            row_start,
+            row_count,
+            columns: self
+                .columns
+                .into_iter()
+                .map(ColumnBuilder::finish)
+                .collect(),
+            value_label_tables,
+        })
     }
 }
 
@@ -351,9 +585,37 @@ impl<R: Read + Seek> DtaFile<R> {
     pub fn read_with_interrupt<F>(
         &mut self,
         options: &ReadOptions,
-        mut should_interrupt: F,
+        should_interrupt: F,
     ) -> Result<DtaData, DtaError>
     where
+        F: FnMut() -> bool,
+    {
+        self.read_with_sink_and_interrupt(
+            options,
+            |metadata, _row_start, row_count, indices| {
+                let capacity = usize::try_from(row_count)
+                    .map_err(|_| DtaError::ArithmeticOverflow("projected row count"))?;
+                Ok(VecSink::new(metadata, indices, capacity))
+            },
+            should_interrupt,
+        )
+    }
+
+    /// Decode through a caller-provided typed output collector.
+    ///
+    /// The collector is constructed after metadata, projection, and row bounds
+    /// are resolved but before observation data are read. Both the built-in
+    /// [`DtaData`] path and foreign-runtime adapters therefore share the same
+    /// validation, I/O, cell decoding, `strL`, and value-label logic.
+    pub fn read_with_sink_and_interrupt<S, B, F>(
+        &mut self,
+        options: &ReadOptions,
+        build_sink: B,
+        mut should_interrupt: F,
+    ) -> Result<S::Output, DtaError>
+    where
+        S: DtaSink,
+        B: FnOnce(&DtaMetadata, u64, u64, &[u32]) -> Result<S, DtaError>,
         F: FnMut() -> bool,
     {
         check_cancel(&mut should_interrupt)?;
@@ -367,11 +629,16 @@ impl<R: Read + Seek> DtaFile<R> {
         let (row_start, row_count) = row_window(&self.metadata, options);
         let capacity = usize::try_from(row_count)
             .map_err(|_| DtaError::ArithmeticOverflow("projected row count"))?;
-        let mut builders = indices
+        let mut sink = build_sink(&self.metadata, row_start, row_count, &indices)?;
+        let mut strl_pointers = indices
             .iter()
             .map(|index| {
                 let variable = &self.metadata.variables[*index as usize];
-                ColumnBuilder::new(*index, &variable.dta_type, capacity)
+                if variable.dta_type == DtaType::StrL {
+                    Some(Vec::with_capacity(capacity))
+                } else {
+                    None
+                }
             })
             .collect::<Vec<_>>();
         let payload_start = if self.metadata.format_version.is_modern() {
@@ -379,8 +646,13 @@ impl<R: Read + Seek> DtaFile<R> {
         } else {
             self.metadata.section_offsets.data
         };
+        let mut cell_decoder = CellDecoder {
+            sink: &mut sink,
+            strl_pointers: &mut strl_pointers,
+            metadata: &self.metadata,
+        };
 
-        if !builders.is_empty()
+        if !indices.is_empty()
             && self.metadata.obs_length > 0
             && self.metadata.obs_length <= self.scratch.limit as u64
         {
@@ -420,7 +692,11 @@ impl<R: Read + Seek> DtaFile<R> {
                     let row_at = local_row
                         .checked_mul(obs_length)
                         .ok_or(DtaError::ArithmeticOverflow("staged row offset"))?;
-                    for (builder, &index) in builders.iter_mut().zip(&indices) {
+                    let output_row = usize::try_from(row)
+                        .map_err(|_| DtaError::ArithmeticOverflow("output row"))?
+                        .checked_add(local_row)
+                        .ok_or(DtaError::ArithmeticOverflow("output row"))?;
+                    for (output_column, &index) in indices.iter().enumerate() {
                         let variable = &self.metadata.variables[index as usize];
                         let width = usize::try_from(variable.byte_width)
                             .map_err(|_| DtaError::ArithmeticOverflow("cell width"))?;
@@ -443,7 +719,13 @@ impl<R: Read + Seek> DtaFile<R> {
                             needed: width,
                             available: staged.len().saturating_sub(cell_at),
                         })?;
-                        push_staged_cell(builder, cell, absolute_offset, &self.metadata, variable)?;
+                        cell_decoder.push_staged_cell(
+                            output_column,
+                            output_row,
+                            cell,
+                            absolute_offset,
+                            variable,
+                        )?;
                     }
                 }
                 row = row
@@ -453,13 +735,15 @@ impl<R: Read + Seek> DtaFile<R> {
         } else {
             for row in 0..row_count {
                 check_cancel(&mut should_interrupt)?;
+                let output_row =
+                    usize::try_from(row).map_err(|_| DtaError::ArithmeticOverflow("output row"))?;
                 let source_row = row_start
                     .checked_add(row)
                     .ok_or(DtaError::ArithmeticOverflow("source row"))?;
                 let row_offset = source_row
                     .checked_mul(self.metadata.obs_length)
                     .ok_or(DtaError::ArithmeticOverflow("row offset"))?;
-                for (builder, &index) in builders.iter_mut().zip(&indices) {
+                for (output_column, &index) in indices.iter().enumerate() {
                     let variable = &self.metadata.variables[index as usize];
                     let cell_offset = payload_start
                         .checked_add(row_offset)
@@ -483,10 +767,9 @@ impl<R: Read + Seek> DtaFile<R> {
                             &mut should_interrupt,
                             "reading fixed-string observation",
                         )?;
-                        let ColumnBuilder::FixedString { values, .. } = builder else {
-                            return Err(DtaError::ArithmeticOverflow("column builder type"));
-                        };
-                        values.push(value);
+                        cell_decoder
+                            .sink
+                            .push_fixed_string(output_column, output_row, value)?;
                         continue;
                     }
                     let cell = read_exact_at(
@@ -496,22 +779,22 @@ impl<R: Read + Seek> DtaFile<R> {
                         &mut self.scratch,
                         "reading observation cell",
                     )?;
-                    push_cell(
-                        builder,
+                    cell_decoder.push_cell(
+                        output_column,
+                        output_row,
                         &cell,
                         cell_offset,
-                        &self.metadata,
                         &variable.dta_type,
                     )?;
                 }
             }
         }
-
         resolve_file_strls(
             &mut self.reader,
             &self.metadata,
             &mut self.scratch,
-            &mut builders,
+            &mut strl_pointers,
+            &mut sink,
             &mut should_interrupt,
         )?;
         check_cancel(&mut should_interrupt)?;
@@ -520,14 +803,12 @@ impl<R: Read + Seek> DtaFile<R> {
             .value_label_tables
             .clone()
             .expect("value-label cache was initialized");
-        let columns = builders.into_iter().map(ColumnBuilder::finish).collect();
-        Ok(DtaData {
-            metadata: self.metadata.clone(),
+        sink.finish(
+            self.metadata.clone(),
             row_start,
             row_count,
-            columns,
             value_label_tables,
-        })
+        )
     }
 
     /// Return ownership of the underlying reader.
@@ -1935,115 +2216,128 @@ fn validate_gso_key(
     }
 }
 
-fn push_staged_cell(
-    builder: &mut ColumnBuilder,
-    cell: &[u8],
-    absolute_offset: u64,
-    metadata: &DtaMetadata,
-    variable: &VariableInfo,
-) -> Result<(), DtaError> {
-    if matches!(variable.dta_type, DtaType::FixedString(_)) {
-        let mut value = if metadata.format_version.is_modern() {
-            decode_utf8(field_bytes(cell))
-        } else {
-            decode_windows_1252(field_bytes(cell))
-        };
-        value.shrink_to_fit();
-        let ColumnBuilder::FixedString { values, .. } = builder else {
-            return Err(DtaError::ArithmeticOverflow("column builder type"));
-        };
-        values.push(value);
-        return Ok(());
-    }
-    push_cell(builder, cell, absolute_offset, metadata, &variable.dta_type)
+struct CellDecoder<'a, S> {
+    sink: &'a mut S,
+    strl_pointers: &'a mut [Option<Vec<Option<FileGsoKey>>>],
+    metadata: &'a DtaMetadata,
 }
 
-fn push_cell(
-    builder: &mut ColumnBuilder,
-    cell: &[u8],
-    absolute_offset: u64,
-    metadata: &DtaMetadata,
-    dta_type: &DtaType,
-) -> Result<(), DtaError> {
-    match builder {
-        ColumnBuilder::Byte {
-            values,
-            missing_tags,
-            ..
-        } => {
-            let value = read_i8(cell, 0, "byte observation")?;
-            values.push(value);
-            missing_tags.push(classify_byte_missing(value));
+impl<S: DtaSink> CellDecoder<'_, S> {
+    #[inline(always)]
+    fn push_staged_cell(
+        &mut self,
+        output_column: usize,
+        output_row: usize,
+        cell: &[u8],
+        absolute_offset: u64,
+        variable: &VariableInfo,
+    ) -> Result<(), DtaError> {
+        if matches!(variable.dta_type, DtaType::FixedString(_)) {
+            let mut value = if self.metadata.format_version.is_modern() {
+                decode_utf8(field_bytes(cell))
+            } else {
+                decode_windows_1252(field_bytes(cell))
+            };
+            value.shrink_to_fit();
+            return self
+                .sink
+                .push_fixed_string(output_column, output_row, value);
         }
-        ColumnBuilder::Int {
-            values,
-            missing_tags,
-            ..
-        } => {
-            let value = read_i16(cell, 0, metadata.byte_order, "int observation")?;
-            values.push(value);
-            missing_tags.push(classify_int_missing(value));
-        }
-        ColumnBuilder::Long {
-            values,
-            missing_tags,
-            ..
-        } => {
-            let value = read_i32(cell, 0, metadata.byte_order, "long observation")?;
-            values.push(value);
-            missing_tags.push(classify_long_missing(value));
-        }
-        ColumnBuilder::Float {
-            values,
-            missing_tags,
-            ..
-        } => {
-            let bits = read_u32(cell, 0, metadata.byte_order, "float observation")?;
-            values.push(f32::from_bits(bits));
-            missing_tags.push(classify_float_missing_bits(bits));
-        }
-        ColumnBuilder::Double {
-            values,
-            missing_tags,
-            ..
-        } => {
-            let bits = read_u64(cell, 0, metadata.byte_order, "double observation")?;
-            values.push(f64::from_bits(bits));
-            missing_tags.push(classify_double_missing_bits(bits));
-        }
-        ColumnBuilder::FixedString { .. } => {
-            return Err(DtaError::ArithmeticOverflow("fixed string streaming path"));
-        }
-        ColumnBuilder::StrL { pointers, .. } => {
-            if *dta_type != DtaType::StrL {
-                return Err(DtaError::ArithmeticOverflow("column builder type"));
+        self.push_cell(
+            output_column,
+            output_row,
+            cell,
+            absolute_offset,
+            &variable.dta_type,
+        )
+    }
+
+    #[inline(always)]
+    fn push_cell(
+        &mut self,
+        output_column: usize,
+        output_row: usize,
+        cell: &[u8],
+        absolute_offset: u64,
+        dta_type: &DtaType,
+    ) -> Result<(), DtaError> {
+        match dta_type {
+            DtaType::Byte => {
+                let value = read_i8(cell, 0, "byte observation")?;
+                self.sink.push_byte(
+                    output_column,
+                    output_row,
+                    value,
+                    classify_byte_missing(value),
+                )?;
             }
-            pointers.push(parse_pointer(cell, absolute_offset, metadata)?);
+            DtaType::Int => {
+                let value = read_i16(cell, 0, self.metadata.byte_order, "int observation")?;
+                self.sink.push_int(
+                    output_column,
+                    output_row,
+                    value,
+                    classify_int_missing(value),
+                )?;
+            }
+            DtaType::Long => {
+                let value = read_i32(cell, 0, self.metadata.byte_order, "long observation")?;
+                self.sink.push_long(
+                    output_column,
+                    output_row,
+                    value,
+                    classify_long_missing(value),
+                )?;
+            }
+            DtaType::Float => {
+                let bits = read_u32(cell, 0, self.metadata.byte_order, "float observation")?;
+                self.sink.push_float(
+                    output_column,
+                    output_row,
+                    f32::from_bits(bits),
+                    classify_float_missing_bits(bits),
+                )?;
+            }
+            DtaType::Double => {
+                let bits = read_u64(cell, 0, self.metadata.byte_order, "double observation")?;
+                self.sink.push_double(
+                    output_column,
+                    output_row,
+                    f64::from_bits(bits),
+                    classify_double_missing_bits(bits),
+                )?;
+            }
+            DtaType::FixedString(_) => {
+                return Err(DtaError::ArithmeticOverflow("fixed string streaming path"));
+            }
+            DtaType::StrL => {
+                let pointers = self
+                    .strl_pointers
+                    .get_mut(output_column)
+                    .and_then(Option::as_mut)
+                    .ok_or(DtaError::ArithmeticOverflow("strL output column"))?;
+                pointers.push(parse_pointer(cell, absolute_offset, self.metadata)?);
+            }
         }
+        Ok(())
     }
-    Ok(())
 }
 
-fn resolve_file_strls<R: Read + Seek, F: FnMut() -> bool>(
+fn resolve_file_strls<R: Read + Seek, F: FnMut() -> bool, S: DtaSink>(
     reader: &mut R,
     metadata: &DtaMetadata,
     scratch: &mut Scratch,
-    builders: &mut [ColumnBuilder],
+    pointers: &mut [Option<Vec<Option<FileGsoKey>>>],
+    sink: &mut S,
     should_interrupt: &mut F,
 ) -> Result<(), DtaError> {
-    if !builders
-        .iter()
-        .any(|builder| matches!(builder, ColumnBuilder::StrL { .. }))
-    {
+    if !pointers.iter().any(Option::is_some) {
         return Ok(());
     }
-    let requested = builders
+    let requested = pointers
         .iter()
-        .filter_map(|builder| match builder {
-            ColumnBuilder::StrL { pointers, .. } => Some(pointers.iter().flatten().copied()),
-            _ => None,
-        })
-        .flatten()
+        .filter_map(Option::as_ref)
+        .flat_map(|column| column.iter().flatten().copied())
         .collect::<HashSet<_>>();
 
     let mut entries = HashMap::new();
@@ -2174,26 +2468,24 @@ fn resolve_file_strls<R: Read + Seek, F: FnMut() -> bool>(
         });
     }
 
-    materialize_file_strls(reader, scratch, &entries, builders, should_interrupt)
+    materialize_file_strls(reader, scratch, &entries, pointers, sink, should_interrupt)
 }
 
-fn materialize_file_strls<R: Read + Seek, F: FnMut() -> bool>(
+fn materialize_file_strls<R: Read + Seek, F: FnMut() -> bool, S: DtaSink>(
     reader: &mut R,
     scratch: &mut Scratch,
     entries: &HashMap<FileGsoKey, FileGsoEntry>,
-    builders: &mut [ColumnBuilder],
+    pointers: &mut [Option<Vec<Option<FileGsoKey>>>],
+    sink: &mut S,
     should_interrupt: &mut F,
 ) -> Result<(), DtaError> {
     let mut decoded = HashMap::<FileGsoKey, String>::new();
     let mut pointer_count = 0_usize;
-    for builder in builders {
-        let ColumnBuilder::StrL {
-            pointers, values, ..
-        } = builder
-        else {
+    for (column_index, column_pointers) in pointers.iter_mut().enumerate() {
+        let Some(column_pointers) = column_pointers else {
             continue;
         };
-        for pointer in pointers.iter().copied() {
+        for (row_index, pointer) in column_pointers.iter().copied().enumerate() {
             if pointer_count % STRL_CANCEL_CHECK_INTERVAL == 0 {
                 check_cancel(should_interrupt)?;
             }
@@ -2201,11 +2493,11 @@ fn materialize_file_strls<R: Read + Seek, F: FnMut() -> bool>(
                 .checked_add(1)
                 .ok_or(DtaError::ArithmeticOverflow("strL pointer count"))?;
             let Some(key) = pointer else {
-                values.push(String::new());
+                sink.push_strl(column_index, row_index, "")?;
                 continue;
             };
             if let Some(value) = decoded.get(&key) {
-                values.push(value.clone());
+                sink.push_strl(column_index, row_index, value)?;
                 continue;
             }
             let entry = entries.get(&key).ok_or(DtaError::DanglingStrlPointer {
@@ -2229,8 +2521,8 @@ fn materialize_file_strls<R: Read + Seek, F: FnMut() -> bool>(
                 "reading selected GSO content",
             )?
             .0;
-            decoded.insert(key, value.clone());
-            values.push(value);
+            sink.push_strl(column_index, row_index, &value)?;
+            decoded.insert(key, value);
         }
     }
     Ok(())
@@ -2288,18 +2580,21 @@ mod tests {
     #[test]
     fn strl_materialization_polls_during_long_null_and_cache_hit_runs() {
         let pointer_count = STRL_CANCEL_CHECK_INTERVAL * 3;
-        let mut null_builders = vec![ColumnBuilder::StrL {
-            index: 0,
-            pointers: vec![None; pointer_count],
-            values: Vec::with_capacity(pointer_count),
-        }];
+        let mut null_pointers = vec![Some(vec![None; pointer_count])];
+        let mut null_sink = VecSink {
+            columns: vec![ColumnBuilder::StrL {
+                index: 0,
+                values: Vec::with_capacity(pointer_count),
+            }],
+        };
         let mut null_checks = 0;
         assert_eq!(
             materialize_file_strls(
                 &mut Cursor::new(Vec::<u8>::new()),
                 &mut Scratch::new(1024),
                 &HashMap::new(),
-                &mut null_builders,
+                &mut null_pointers,
+                &mut null_sink,
                 &mut || {
                     null_checks += 1;
                     null_checks >= 2
@@ -2307,7 +2602,7 @@ mod tests {
             ),
             Err(DtaError::Cancelled)
         );
-        let ColumnBuilder::StrL { values, .. } = &null_builders[0] else {
+        let ColumnBuilder::StrL { values, .. } = &null_sink.columns[0] else {
             unreachable!()
         };
         assert_eq!(values.len(), STRL_CANCEL_CHECK_INTERVAL);
@@ -2324,18 +2619,21 @@ mod tests {
                 gso_type: 130,
             },
         )]);
-        let mut repeated_builders = vec![ColumnBuilder::StrL {
-            index: 0,
-            pointers: vec![Some(key); pointer_count],
-            values: Vec::with_capacity(pointer_count),
-        }];
+        let mut repeated_pointers = vec![Some(vec![Some(key); pointer_count])];
+        let mut repeated_sink = VecSink {
+            columns: vec![ColumnBuilder::StrL {
+                index: 0,
+                values: Vec::with_capacity(pointer_count),
+            }],
+        };
         let mut repeated_checks = 0;
         assert_eq!(
             materialize_file_strls(
                 &mut Cursor::new(b"x\0".to_vec()),
                 &mut Scratch::new(1024),
                 &entries,
-                &mut repeated_builders,
+                &mut repeated_pointers,
+                &mut repeated_sink,
                 &mut || {
                     repeated_checks += 1;
                     repeated_checks >= 4
@@ -2343,7 +2641,7 @@ mod tests {
             ),
             Err(DtaError::Cancelled)
         );
-        let ColumnBuilder::StrL { values, .. } = &repeated_builders[0] else {
+        let ColumnBuilder::StrL { values, .. } = &repeated_sink.columns[0] else {
             unreachable!()
         };
         assert_eq!(values.len(), STRL_CANCEL_CHECK_INTERVAL);

--- a/r-package/dtaparser/src/vendor/dta-parser/src/file.rs
+++ b/r-package/dtaparser/src/vendor/dta-parser/src/file.rs
@@ -130,6 +130,9 @@ enum ColumnBuilder {
 /// Implementations can retain ordinary Rust vectors, write directly into a
 /// foreign column store, or stream values elsewhere. Calls are monomorphized,
 /// so the shared decoder does not add a dynamic callback boundary per cell.
+/// On a successful read, each selected `(column, row)` pair is written exactly
+/// once, rows ascend within each column, and `StrL` pushes are deferred until
+/// after all other cells.
 pub trait DtaSink: Sized {
     type Output;
 

--- a/r-package/dtaparser/src/vendor/dta-parser/src/lib.rs
+++ b/r-package/dtaparser/src/vendor/dta-parser/src/lib.rs
@@ -20,7 +20,7 @@ mod value_labels;
 
 pub use data_reader::{read_dta, read_dta_with_options};
 pub use error::DtaError;
-pub use file::{DtaFile, FileOptions};
+pub use file::{DtaFile, DtaSink, FileOptions};
 pub use metadata::parse_metadata;
 pub use missing::{
     classify_byte_missing, classify_double_missing_bits, classify_float_missing_bits,

--- a/r-package/dtaparser/tests/testthat/test-read-dta.R
+++ b/r-package/dtaparser/tests/testthat/test-read-dta.R
@@ -23,6 +23,7 @@ test_that("all bundled fixtures agree with haven", {
 
     for (path in paths) {
         actual <- read_dta(path)
+        rust_vectors <- dtaparser:::.read_dta_rust_vectors(path)
         expected <- haven::read_dta(path)
         info <- basename(path)
         metadata <- dtaparser:::.dta_metadata(normalizePath(path))
@@ -31,6 +32,8 @@ test_that("all bundled fixtures agree with haven", {
             as.character(metadata)
         )
 
+        expect_identical(actual, rust_vectors,
+                         info = paste(info, "direct and Rust-vector collectors"))
         expect_identical(dim(actual), dim(expected), info = info)
         expect_identical(names(actual), names(expected), info = info)
         expect_identical(attr(actual, "label", exact = TRUE),
@@ -68,8 +71,15 @@ test_that("projection, renaming, and row bounds match haven", {
         skip = 5,
         n_max = 4
     )
+    rust_vectors <- dtaparser:::.read_dta_rust_vectors(
+        path,
+        col_select = c(origin = foreign, make, price),
+        skip = 5,
+        n_max = 4
+    )
     expected <- haven::read_dta(path, skip = 5, n_max = 4)
 
+    expect_identical(actual, rust_vectors)
     expect_identical(names(actual), c("origin", "make", "price"))
     expect_equal(actual$origin, expected$foreign)
     expect_equal(actual$make, expected$make)
@@ -80,6 +90,10 @@ test_that("projection, renaming, and row bounds match haven", {
 test_that("an empty projection retains the selected row count", {
     path <- fixture("auto_v118.dta")
     result <- read_dta(path, col_select = character(), skip = 2, n_max = 3)
+    rust_vectors <- dtaparser:::.read_dta_rust_vectors(
+        path, col_select = character(), skip = 2, n_max = 3
+    )
+    expect_identical(result, rust_vectors)
     expect_identical(dim(result), c(3L, 0L))
 })
 
@@ -165,4 +179,6 @@ test_that("argument and native parse failures are ordinary R errors", {
     on.exit(unlink(corrupt), add = TRUE)
     writeBin(as.raw(1:8), corrupt)
     expect_error(read_dta(corrupt), "header|format|small|read|I/O", ignore.case = TRUE)
+    expect_error(dtaparser:::.read_dta_rust_vectors(corrupt),
+                 "header|format|small|read|I/O", ignore.case = TRUE)
 })

--- a/rust/dta-parser/README.md
+++ b/rust/dta-parser/README.md
@@ -77,9 +77,15 @@ capped. Row windows seek directly to selected observations, and only selected
 cells are decoded. GSO headers are scanned without retaining unrequested
 payloads, selected payloads are streamed and cached per read, and value-label
 tables are streamed and cached lazily. The cooperative callback is checked
-between chunks and returns
-`DtaError::Cancelled` without a partial `DtaData` or partially initialized
-label cache.
+between chunks and returns `DtaError::Cancelled` without exposing a partial
+output or partially initialized label cache.
+
+`DtaFile::read_with_sink_and_interrupt` runs the same validation, I/O, typed
+cell decoding, `strL`, and value-label pipeline through a caller-provided
+`DtaSink`. The built-in sink retains the public `DtaData`/`ColumnValues` model;
+foreign-runtime adapters can instead materialize their own column store. The
+generic sink is statically dispatched, avoiding a dynamic callback boundary in
+the per-cell loop.
 
 `DtaMetadata` and its nested types implement `serde::Serialize` and
 `serde::Deserialize`; the observation and value-label models do as well. Their

--- a/rust/dta-parser/src/error.rs
+++ b/rust/dta-parser/src/error.rs
@@ -149,6 +149,12 @@ pub enum DtaError {
     #[error("read cancelled")]
     Cancelled,
 
+    /// A caller-provided output collector could not materialize a decoded
+    /// value. Keeping collector failures in the parser's ordinary error path
+    /// ensures partially built outputs are dropped without being exposed.
+    #[error("output materialization failed: {0}")]
+    Output(String),
+
     /// A seek or read failed while accessing a file-backed source.
     #[error("I/O error while {context} at byte offset {offset}: {kind:?}")]
     Io {

--- a/rust/dta-parser/src/file.rs
+++ b/rust/dta-parser/src/file.rs
@@ -121,9 +121,72 @@ enum ColumnBuilder {
     },
     StrL {
         index: u32,
-        pointers: Vec<Option<FileGsoKey>>,
         values: Vec<String>,
     },
+}
+
+/// Destination for typed cells decoded by [`DtaFile`].
+///
+/// Implementations can retain ordinary Rust vectors, write directly into a
+/// foreign column store, or stream values elsewhere. Calls are monomorphized,
+/// so the shared decoder does not add a dynamic callback boundary per cell.
+pub trait DtaSink: Sized {
+    type Output;
+
+    fn push_byte(
+        &mut self,
+        column: usize,
+        row: usize,
+        value: i8,
+        missing: Option<crate::MissingTag>,
+    ) -> Result<(), DtaError>;
+    fn push_int(
+        &mut self,
+        column: usize,
+        row: usize,
+        value: i16,
+        missing: Option<crate::MissingTag>,
+    ) -> Result<(), DtaError>;
+    fn push_long(
+        &mut self,
+        column: usize,
+        row: usize,
+        value: i32,
+        missing: Option<crate::MissingTag>,
+    ) -> Result<(), DtaError>;
+    fn push_float(
+        &mut self,
+        column: usize,
+        row: usize,
+        value: f32,
+        missing: Option<crate::MissingTag>,
+    ) -> Result<(), DtaError>;
+    fn push_double(
+        &mut self,
+        column: usize,
+        row: usize,
+        value: f64,
+        missing: Option<crate::MissingTag>,
+    ) -> Result<(), DtaError>;
+    fn push_fixed_string(
+        &mut self,
+        column: usize,
+        row: usize,
+        value: String,
+    ) -> Result<(), DtaError>;
+    fn push_strl(&mut self, column: usize, row: usize, value: &str) -> Result<(), DtaError>;
+
+    fn finish(
+        self,
+        metadata: DtaMetadata,
+        row_start: u64,
+        row_count: u64,
+        value_label_tables: Vec<ValueLabelTable>,
+    ) -> Result<Self::Output, DtaError>;
+}
+
+struct VecSink {
+    columns: Vec<ColumnBuilder>,
 }
 
 impl ColumnBuilder {
@@ -160,7 +223,6 @@ impl ColumnBuilder {
             },
             DtaType::StrL => Self::StrL {
                 index,
-                pointers: Vec::with_capacity(capacity),
                 values: Vec::with_capacity(capacity),
             },
         }
@@ -227,11 +289,183 @@ impl ColumnBuilder {
                 variable_index: index,
                 values: ColumnValues::FixedString { values },
             },
-            Self::StrL { index, values, .. } => Column {
+            Self::StrL { index, values } => Column {
                 variable_index: index,
                 values: ColumnValues::StrL { values },
             },
         }
+    }
+}
+
+impl VecSink {
+    fn new(metadata: &DtaMetadata, indices: &[u32], capacity: usize) -> Self {
+        let columns = indices
+            .iter()
+            .map(|index| {
+                let variable = &metadata.variables[*index as usize];
+                ColumnBuilder::new(*index, &variable.dta_type, capacity)
+            })
+            .collect();
+        Self { columns }
+    }
+
+    #[inline(always)]
+    fn column(&mut self, index: usize) -> Result<&mut ColumnBuilder, DtaError> {
+        self.columns
+            .get_mut(index)
+            .ok_or(DtaError::ArithmeticOverflow("output column index"))
+    }
+}
+
+impl DtaSink for VecSink {
+    type Output = DtaData;
+
+    #[inline(always)]
+    fn push_byte(
+        &mut self,
+        column: usize,
+        _row: usize,
+        value: i8,
+        missing: Option<crate::MissingTag>,
+    ) -> Result<(), DtaError> {
+        let ColumnBuilder::Byte {
+            values,
+            missing_tags,
+            ..
+        } = self.column(column)?
+        else {
+            return Err(DtaError::ArithmeticOverflow("output column type"));
+        };
+        values.push(value);
+        missing_tags.push(missing);
+        Ok(())
+    }
+
+    #[inline(always)]
+    fn push_int(
+        &mut self,
+        column: usize,
+        _row: usize,
+        value: i16,
+        missing: Option<crate::MissingTag>,
+    ) -> Result<(), DtaError> {
+        let ColumnBuilder::Int {
+            values,
+            missing_tags,
+            ..
+        } = self.column(column)?
+        else {
+            return Err(DtaError::ArithmeticOverflow("output column type"));
+        };
+        values.push(value);
+        missing_tags.push(missing);
+        Ok(())
+    }
+
+    #[inline(always)]
+    fn push_long(
+        &mut self,
+        column: usize,
+        _row: usize,
+        value: i32,
+        missing: Option<crate::MissingTag>,
+    ) -> Result<(), DtaError> {
+        let ColumnBuilder::Long {
+            values,
+            missing_tags,
+            ..
+        } = self.column(column)?
+        else {
+            return Err(DtaError::ArithmeticOverflow("output column type"));
+        };
+        values.push(value);
+        missing_tags.push(missing);
+        Ok(())
+    }
+
+    #[inline(always)]
+    fn push_float(
+        &mut self,
+        column: usize,
+        _row: usize,
+        value: f32,
+        missing: Option<crate::MissingTag>,
+    ) -> Result<(), DtaError> {
+        let ColumnBuilder::Float {
+            values,
+            missing_tags,
+            ..
+        } = self.column(column)?
+        else {
+            return Err(DtaError::ArithmeticOverflow("output column type"));
+        };
+        values.push(value);
+        missing_tags.push(missing);
+        Ok(())
+    }
+
+    #[inline(always)]
+    fn push_double(
+        &mut self,
+        column: usize,
+        _row: usize,
+        value: f64,
+        missing: Option<crate::MissingTag>,
+    ) -> Result<(), DtaError> {
+        let ColumnBuilder::Double {
+            values,
+            missing_tags,
+            ..
+        } = self.column(column)?
+        else {
+            return Err(DtaError::ArithmeticOverflow("output column type"));
+        };
+        values.push(value);
+        missing_tags.push(missing);
+        Ok(())
+    }
+
+    #[inline(always)]
+    fn push_fixed_string(
+        &mut self,
+        column: usize,
+        _row: usize,
+        value: String,
+    ) -> Result<(), DtaError> {
+        let ColumnBuilder::FixedString { values, .. } = self.column(column)? else {
+            return Err(DtaError::ArithmeticOverflow("output column type"));
+        };
+        values.push(value);
+        Ok(())
+    }
+
+    #[inline(always)]
+    fn push_strl(&mut self, column: usize, _row: usize, value: &str) -> Result<(), DtaError> {
+        let ColumnBuilder::StrL { values, .. } = self.column(column)? else {
+            return Err(DtaError::ArithmeticOverflow("output column type"));
+        };
+        values.push(value.to_owned());
+        Ok(())
+    }
+
+    fn finish(
+        self,
+        metadata: DtaMetadata,
+        row_start: u64,
+        row_count: u64,
+        value_label_tables: Vec<ValueLabelTable>,
+    ) -> Result<Self::Output, DtaError> {
+        Ok(DtaData {
+            metadata,
+            row_start,
+            row_count,
+            columns: self
+                .columns
+                .into_iter()
+                .map(ColumnBuilder::finish)
+                .collect(),
+            value_label_tables,
+        })
     }
 }
 
@@ -351,9 +585,37 @@ impl<R: Read + Seek> DtaFile<R> {
     pub fn read_with_interrupt<F>(
         &mut self,
         options: &ReadOptions,
-        mut should_interrupt: F,
+        should_interrupt: F,
     ) -> Result<DtaData, DtaError>
     where
+        F: FnMut() -> bool,
+    {
+        self.read_with_sink_and_interrupt(
+            options,
+            |metadata, _row_start, row_count, indices| {
+                let capacity = usize::try_from(row_count)
+                    .map_err(|_| DtaError::ArithmeticOverflow("projected row count"))?;
+                Ok(VecSink::new(metadata, indices, capacity))
+            },
+            should_interrupt,
+        )
+    }
+
+    /// Decode through a caller-provided typed output collector.
+    ///
+    /// The collector is constructed after metadata, projection, and row bounds
+    /// are resolved but before observation data are read. Both the built-in
+    /// [`DtaData`] path and foreign-runtime adapters therefore share the same
+    /// validation, I/O, cell decoding, `strL`, and value-label logic.
+    pub fn read_with_sink_and_interrupt<S, B, F>(
+        &mut self,
+        options: &ReadOptions,
+        build_sink: B,
+        mut should_interrupt: F,
+    ) -> Result<S::Output, DtaError>
+    where
+        S: DtaSink,
+        B: FnOnce(&DtaMetadata, u64, u64, &[u32]) -> Result<S, DtaError>,
         F: FnMut() -> bool,
     {
         check_cancel(&mut should_interrupt)?;
@@ -367,11 +629,16 @@ impl<R: Read + Seek> DtaFile<R> {
         let (row_start, row_count) = row_window(&self.metadata, options);
         let capacity = usize::try_from(row_count)
             .map_err(|_| DtaError::ArithmeticOverflow("projected row count"))?;
-        let mut builders = indices
+        let mut sink = build_sink(&self.metadata, row_start, row_count, &indices)?;
+        let mut strl_pointers = indices
             .iter()
             .map(|index| {
                 let variable = &self.metadata.variables[*index as usize];
-                ColumnBuilder::new(*index, &variable.dta_type, capacity)
+                if variable.dta_type == DtaType::StrL {
+                    Some(Vec::with_capacity(capacity))
+                } else {
+                    None
+                }
             })
             .collect::<Vec<_>>();
         let payload_start = if self.metadata.format_version.is_modern() {
@@ -379,8 +646,13 @@ impl<R: Read + Seek> DtaFile<R> {
         } else {
             self.metadata.section_offsets.data
         };
+        let mut cell_decoder = CellDecoder {
+            sink: &mut sink,
+            strl_pointers: &mut strl_pointers,
+            metadata: &self.metadata,
+        };
 
-        if !builders.is_empty()
+        if !indices.is_empty()
             && self.metadata.obs_length > 0
             && self.metadata.obs_length <= self.scratch.limit as u64
         {
@@ -420,7 +692,11 @@ impl<R: Read + Seek> DtaFile<R> {
                     let row_at = local_row
                         .checked_mul(obs_length)
                         .ok_or(DtaError::ArithmeticOverflow("staged row offset"))?;
-                    for (builder, &index) in builders.iter_mut().zip(&indices) {
+                    let output_row = usize::try_from(row)
+                        .map_err(|_| DtaError::ArithmeticOverflow("output row"))?
+                        .checked_add(local_row)
+                        .ok_or(DtaError::ArithmeticOverflow("output row"))?;
+                    for (output_column, &index) in indices.iter().enumerate() {
                         let variable = &self.metadata.variables[index as usize];
                         let width = usize::try_from(variable.byte_width)
                             .map_err(|_| DtaError::ArithmeticOverflow("cell width"))?;
@@ -443,7 +719,13 @@ impl<R: Read + Seek> DtaFile<R> {
                             needed: width,
                             available: staged.len().saturating_sub(cell_at),
                         })?;
-                        push_staged_cell(builder, cell, absolute_offset, &self.metadata, variable)?;
+                        cell_decoder.push_staged_cell(
+                            output_column,
+                            output_row,
+                            cell,
+                            absolute_offset,
+                            variable,
+                        )?;
                     }
                 }
                 row = row
@@ -453,13 +735,15 @@ impl<R: Read + Seek> DtaFile<R> {
         } else {
             for row in 0..row_count {
                 check_cancel(&mut should_interrupt)?;
+                let output_row =
+                    usize::try_from(row).map_err(|_| DtaError::ArithmeticOverflow("output row"))?;
                 let source_row = row_start
                     .checked_add(row)
                     .ok_or(DtaError::ArithmeticOverflow("source row"))?;
                 let row_offset = source_row
                     .checked_mul(self.metadata.obs_length)
                     .ok_or(DtaError::ArithmeticOverflow("row offset"))?;
-                for (builder, &index) in builders.iter_mut().zip(&indices) {
+                for (output_column, &index) in indices.iter().enumerate() {
                     let variable = &self.metadata.variables[index as usize];
                     let cell_offset = payload_start
                         .checked_add(row_offset)
@@ -483,10 +767,9 @@ impl<R: Read + Seek> DtaFile<R> {
                             &mut should_interrupt,
                             "reading fixed-string observation",
                         )?;
-                        let ColumnBuilder::FixedString { values, .. } = builder else {
-                            return Err(DtaError::ArithmeticOverflow("column builder type"));
-                        };
-                        values.push(value);
+                        cell_decoder
+                            .sink
+                            .push_fixed_string(output_column, output_row, value)?;
                         continue;
                     }
                     let cell = read_exact_at(
@@ -496,22 +779,22 @@ impl<R: Read + Seek> DtaFile<R> {
                         &mut self.scratch,
                         "reading observation cell",
                     )?;
-                    push_cell(
-                        builder,
+                    cell_decoder.push_cell(
+                        output_column,
+                        output_row,
                         &cell,
                         cell_offset,
-                        &self.metadata,
                         &variable.dta_type,
                     )?;
                 }
             }
         }
-
         resolve_file_strls(
             &mut self.reader,
             &self.metadata,
             &mut self.scratch,
-            &mut builders,
+            &mut strl_pointers,
+            &mut sink,
             &mut should_interrupt,
         )?;
         check_cancel(&mut should_interrupt)?;
@@ -520,14 +803,12 @@ impl<R: Read + Seek> DtaFile<R> {
             .value_label_tables
             .clone()
             .expect("value-label cache was initialized");
-        let columns = builders.into_iter().map(ColumnBuilder::finish).collect();
-        Ok(DtaData {
-            metadata: self.metadata.clone(),
+        sink.finish(
+            self.metadata.clone(),
             row_start,
             row_count,
-            columns,
             value_label_tables,
-        })
+        )
     }
 
     /// Return ownership of the underlying reader.
@@ -1935,115 +2216,128 @@ fn validate_gso_key(
     }
 }
 
-fn push_staged_cell(
-    builder: &mut ColumnBuilder,
-    cell: &[u8],
-    absolute_offset: u64,
-    metadata: &DtaMetadata,
-    variable: &VariableInfo,
-) -> Result<(), DtaError> {
-    if matches!(variable.dta_type, DtaType::FixedString(_)) {
-        let mut value = if metadata.format_version.is_modern() {
-            decode_utf8(field_bytes(cell))
-        } else {
-            decode_windows_1252(field_bytes(cell))
-        };
-        value.shrink_to_fit();
-        let ColumnBuilder::FixedString { values, .. } = builder else {
-            return Err(DtaError::ArithmeticOverflow("column builder type"));
-        };
-        values.push(value);
-        return Ok(());
-    }
-    push_cell(builder, cell, absolute_offset, metadata, &variable.dta_type)
+struct CellDecoder<'a, S> {
+    sink: &'a mut S,
+    strl_pointers: &'a mut [Option<Vec<Option<FileGsoKey>>>],
+    metadata: &'a DtaMetadata,
 }
 
-fn push_cell(
-    builder: &mut ColumnBuilder,
-    cell: &[u8],
-    absolute_offset: u64,
-    metadata: &DtaMetadata,
-    dta_type: &DtaType,
-) -> Result<(), DtaError> {
-    match builder {
-        ColumnBuilder::Byte {
-            values,
-            missing_tags,
-            ..
-        } => {
-            let value = read_i8(cell, 0, "byte observation")?;
-            values.push(value);
-            missing_tags.push(classify_byte_missing(value));
+impl<S: DtaSink> CellDecoder<'_, S> {
+    #[inline(always)]
+    fn push_staged_cell(
+        &mut self,
+        output_column: usize,
+        output_row: usize,
+        cell: &[u8],
+        absolute_offset: u64,
+        variable: &VariableInfo,
+    ) -> Result<(), DtaError> {
+        if matches!(variable.dta_type, DtaType::FixedString(_)) {
+            let mut value = if self.metadata.format_version.is_modern() {
+                decode_utf8(field_bytes(cell))
+            } else {
+                decode_windows_1252(field_bytes(cell))
+            };
+            value.shrink_to_fit();
+            return self
+                .sink
+                .push_fixed_string(output_column, output_row, value);
         }
-        ColumnBuilder::Int {
-            values,
-            missing_tags,
-            ..
-        } => {
-            let value = read_i16(cell, 0, metadata.byte_order, "int observation")?;
-            values.push(value);
-            missing_tags.push(classify_int_missing(value));
-        }
-        ColumnBuilder::Long {
-            values,
-            missing_tags,
-            ..
-        } => {
-            let value = read_i32(cell, 0, metadata.byte_order, "long observation")?;
-            values.push(value);
-            missing_tags.push(classify_long_missing(value));
-        }
-        ColumnBuilder::Float {
-            values,
-            missing_tags,
-            ..
-        } => {
-            let bits = read_u32(cell, 0, metadata.byte_order, "float observation")?;
-            values.push(f32::from_bits(bits));
-            missing_tags.push(classify_float_missing_bits(bits));
-        }
-        ColumnBuilder::Double {
-            values,
-            missing_tags,
-            ..
-        } => {
-            let bits = read_u64(cell, 0, metadata.byte_order, "double observation")?;
-            values.push(f64::from_bits(bits));
-            missing_tags.push(classify_double_missing_bits(bits));
-        }
-        ColumnBuilder::FixedString { .. } => {
-            return Err(DtaError::ArithmeticOverflow("fixed string streaming path"));
-        }
-        ColumnBuilder::StrL { pointers, .. } => {
-            if *dta_type != DtaType::StrL {
-                return Err(DtaError::ArithmeticOverflow("column builder type"));
+        self.push_cell(
+            output_column,
+            output_row,
+            cell,
+            absolute_offset,
+            &variable.dta_type,
+        )
+    }
+
+    #[inline(always)]
+    fn push_cell(
+        &mut self,
+        output_column: usize,
+        output_row: usize,
+        cell: &[u8],
+        absolute_offset: u64,
+        dta_type: &DtaType,
+    ) -> Result<(), DtaError> {
+        match dta_type {
+            DtaType::Byte => {
+                let value = read_i8(cell, 0, "byte observation")?;
+                self.sink.push_byte(
+                    output_column,
+                    output_row,
+                    value,
+                    classify_byte_missing(value),
+                )?;
             }
-            pointers.push(parse_pointer(cell, absolute_offset, metadata)?);
+            DtaType::Int => {
+                let value = read_i16(cell, 0, self.metadata.byte_order, "int observation")?;
+                self.sink.push_int(
+                    output_column,
+                    output_row,
+                    value,
+                    classify_int_missing(value),
+                )?;
+            }
+            DtaType::Long => {
+                let value = read_i32(cell, 0, self.metadata.byte_order, "long observation")?;
+                self.sink.push_long(
+                    output_column,
+                    output_row,
+                    value,
+                    classify_long_missing(value),
+                )?;
+            }
+            DtaType::Float => {
+                let bits = read_u32(cell, 0, self.metadata.byte_order, "float observation")?;
+                self.sink.push_float(
+                    output_column,
+                    output_row,
+                    f32::from_bits(bits),
+                    classify_float_missing_bits(bits),
+                )?;
+            }
+            DtaType::Double => {
+                let bits = read_u64(cell, 0, self.metadata.byte_order, "double observation")?;
+                self.sink.push_double(
+                    output_column,
+                    output_row,
+                    f64::from_bits(bits),
+                    classify_double_missing_bits(bits),
+                )?;
+            }
+            DtaType::FixedString(_) => {
+                return Err(DtaError::ArithmeticOverflow("fixed string streaming path"));
+            }
+            DtaType::StrL => {
+                let pointers = self
+                    .strl_pointers
+                    .get_mut(output_column)
+                    .and_then(Option::as_mut)
+                    .ok_or(DtaError::ArithmeticOverflow("strL output column"))?;
+                pointers.push(parse_pointer(cell, absolute_offset, self.metadata)?);
+            }
         }
+        Ok(())
     }
-    Ok(())
 }
 
-fn resolve_file_strls<R: Read + Seek, F: FnMut() -> bool>(
+fn resolve_file_strls<R: Read + Seek, F: FnMut() -> bool, S: DtaSink>(
     reader: &mut R,
     metadata: &DtaMetadata,
     scratch: &mut Scratch,
-    builders: &mut [ColumnBuilder],
+    pointers: &mut [Option<Vec<Option<FileGsoKey>>>],
+    sink: &mut S,
     should_interrupt: &mut F,
 ) -> Result<(), DtaError> {
-    if !builders
-        .iter()
-        .any(|builder| matches!(builder, ColumnBuilder::StrL { .. }))
-    {
+    if !pointers.iter().any(Option::is_some) {
         return Ok(());
     }
-    let requested = builders
+    let requested = pointers
         .iter()
-        .filter_map(|builder| match builder {
-            ColumnBuilder::StrL { pointers, .. } => Some(pointers.iter().flatten().copied()),
-            _ => None,
-        })
-        .flatten()
+        .filter_map(Option::as_ref)
+        .flat_map(|column| column.iter().flatten().copied())
         .collect::<HashSet<_>>();
 
     let mut entries = HashMap::new();
@@ -2174,26 +2468,24 @@ fn resolve_file_strls<R: Read + Seek, F: FnMut() -> bool>(
         });
     }
 
-    materialize_file_strls(reader, scratch, &entries, builders, should_interrupt)
+    materialize_file_strls(reader, scratch, &entries, pointers, sink, should_interrupt)
 }
 
-fn materialize_file_strls<R: Read + Seek, F: FnMut() -> bool>(
+fn materialize_file_strls<R: Read + Seek, F: FnMut() -> bool, S: DtaSink>(
     reader: &mut R,
     scratch: &mut Scratch,
     entries: &HashMap<FileGsoKey, FileGsoEntry>,
-    builders: &mut [ColumnBuilder],
+    pointers: &mut [Option<Vec<Option<FileGsoKey>>>],
+    sink: &mut S,
     should_interrupt: &mut F,
 ) -> Result<(), DtaError> {
     let mut decoded = HashMap::<FileGsoKey, String>::new();
     let mut pointer_count = 0_usize;
-    for builder in builders {
-        let ColumnBuilder::StrL {
-            pointers, values, ..
-        } = builder
-        else {
+    for (column_index, column_pointers) in pointers.iter_mut().enumerate() {
+        let Some(column_pointers) = column_pointers else {
             continue;
         };
-        for pointer in pointers.iter().copied() {
+        for (row_index, pointer) in column_pointers.iter().copied().enumerate() {
             if pointer_count % STRL_CANCEL_CHECK_INTERVAL == 0 {
                 check_cancel(should_interrupt)?;
             }
@@ -2201,11 +2493,11 @@ fn materialize_file_strls<R: Read + Seek, F: FnMut() -> bool>(
                 .checked_add(1)
                 .ok_or(DtaError::ArithmeticOverflow("strL pointer count"))?;
             let Some(key) = pointer else {
-                values.push(String::new());
+                sink.push_strl(column_index, row_index, "")?;
                 continue;
             };
             if let Some(value) = decoded.get(&key) {
-                values.push(value.clone());
+                sink.push_strl(column_index, row_index, value)?;
                 continue;
             }
             let entry = entries.get(&key).ok_or(DtaError::DanglingStrlPointer {
@@ -2229,8 +2521,8 @@ fn materialize_file_strls<R: Read + Seek, F: FnMut() -> bool>(
                 "reading selected GSO content",
             )?
             .0;
-            decoded.insert(key, value.clone());
-            values.push(value);
+            sink.push_strl(column_index, row_index, &value)?;
+            decoded.insert(key, value);
         }
     }
     Ok(())
@@ -2288,18 +2580,21 @@ mod tests {
     #[test]
     fn strl_materialization_polls_during_long_null_and_cache_hit_runs() {
         let pointer_count = STRL_CANCEL_CHECK_INTERVAL * 3;
-        let mut null_builders = vec![ColumnBuilder::StrL {
-            index: 0,
-            pointers: vec![None; pointer_count],
-            values: Vec::with_capacity(pointer_count),
-        }];
+        let mut null_pointers = vec![Some(vec![None; pointer_count])];
+        let mut null_sink = VecSink {
+            columns: vec![ColumnBuilder::StrL {
+                index: 0,
+                values: Vec::with_capacity(pointer_count),
+            }],
+        };
         let mut null_checks = 0;
         assert_eq!(
             materialize_file_strls(
                 &mut Cursor::new(Vec::<u8>::new()),
                 &mut Scratch::new(1024),
                 &HashMap::new(),
-                &mut null_builders,
+                &mut null_pointers,
+                &mut null_sink,
                 &mut || {
                     null_checks += 1;
                     null_checks >= 2
@@ -2307,7 +2602,7 @@ mod tests {
             ),
             Err(DtaError::Cancelled)
         );
-        let ColumnBuilder::StrL { values, .. } = &null_builders[0] else {
+        let ColumnBuilder::StrL { values, .. } = &null_sink.columns[0] else {
             unreachable!()
         };
         assert_eq!(values.len(), STRL_CANCEL_CHECK_INTERVAL);
@@ -2324,18 +2619,21 @@ mod tests {
                 gso_type: 130,
             },
         )]);
-        let mut repeated_builders = vec![ColumnBuilder::StrL {
-            index: 0,
-            pointers: vec![Some(key); pointer_count],
-            values: Vec::with_capacity(pointer_count),
-        }];
+        let mut repeated_pointers = vec![Some(vec![Some(key); pointer_count])];
+        let mut repeated_sink = VecSink {
+            columns: vec![ColumnBuilder::StrL {
+                index: 0,
+                values: Vec::with_capacity(pointer_count),
+            }],
+        };
         let mut repeated_checks = 0;
         assert_eq!(
             materialize_file_strls(
                 &mut Cursor::new(b"x\0".to_vec()),
                 &mut Scratch::new(1024),
                 &entries,
-                &mut repeated_builders,
+                &mut repeated_pointers,
+                &mut repeated_sink,
                 &mut || {
                     repeated_checks += 1;
                     repeated_checks >= 4
@@ -2343,7 +2641,7 @@ mod tests {
             ),
             Err(DtaError::Cancelled)
         );
-        let ColumnBuilder::StrL { values, .. } = &repeated_builders[0] else {
+        let ColumnBuilder::StrL { values, .. } = &repeated_sink.columns[0] else {
             unreachable!()
         };
         assert_eq!(values.len(), STRL_CANCEL_CHECK_INTERVAL);

--- a/rust/dta-parser/src/file.rs
+++ b/rust/dta-parser/src/file.rs
@@ -130,6 +130,9 @@ enum ColumnBuilder {
 /// Implementations can retain ordinary Rust vectors, write directly into a
 /// foreign column store, or stream values elsewhere. Calls are monomorphized,
 /// so the shared decoder does not add a dynamic callback boundary per cell.
+/// On a successful read, each selected `(column, row)` pair is written exactly
+/// once, rows ascend within each column, and `StrL` pushes are deferred until
+/// after all other cells.
 pub trait DtaSink: Sized {
     type Output;
 

--- a/rust/dta-parser/src/lib.rs
+++ b/rust/dta-parser/src/lib.rs
@@ -20,7 +20,7 @@ mod value_labels;
 
 pub use data_reader::{read_dta, read_dta_with_options};
 pub use error::DtaError;
-pub use file::{DtaFile, FileOptions};
+pub use file::{DtaFile, DtaSink, FileOptions};
 pub use metadata::parse_metadata;
 pub use missing::{
     classify_byte_missing, classify_double_missing_bits, classify_float_missing_bits,


### PR DESCRIPTION
## Summary

- add a statically dispatched `DtaSink` collector to the shared Rust reader
- materialize numeric columns directly into protected R vectors while retaining batched Rust string materialization
- preserve the existing Rust-vector/`DtaData` path for non-R consumers and differential benchmarking
- add direct-vs-vector parity tests and a reproducible timing/memory benchmark harness

## Benchmark results

| Input | Iterations | Direct R median | Rust vectors median | Direct R change |
| --- | ---: | ---: | ---: | ---: |
| 100 MB | 21 | 0.263 s | 0.275 s | 4.4% faster |
| 1 GB | 7 | 2.057 s | 2.226 s | 7.6% faster |

For the 1 GB fresh-process memory runs, direct materialization reduced median maximum RSS from about 2.612 GB to 2.213 GB (15.3%) and median macOS peak footprint from about 2.597 GB to 2.087 GB (19.6%).

The benchmark report records methodology and raw summaries. No 10 GB run was performed for this change.

## Validation

- `DTA_REQUIRE_R_CONFORMANCE=1 bun run conformance`
- `R CMD check` — status OK
- Rust 1.74 core and R-bridge test suites
- clippy with warnings denied for the core and R bridge
- `scripts/check-rust-sync.sh`
- `git diff --check`

All direct-vs-Rust-vector differential fixture, projection, empty-selection, and corrupt-input tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optimized R materialization path that streams numeric values directly while batch-materializing strings.
  * Introduced a flexible output-collection mechanism used for alternate materialization.
  * Added an R benchmark runner plus fresh timing and memory result documents for comparing materialization approaches.
* **Bug Fixes**
  * Improved error messages when output materialization fails.
  * Ensured cancellation continues to avoid exposing partial results.
* **Documentation**
  * Expanded the R package README with updated materialization/conformance instructions and benchmark procedure.  
* **Tests**
  * Extended test coverage to validate alternate materialization outputs match.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->