### PR TITLE
Document the multi-language repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,23 @@
-# `@jbearak/dta-parser`
+# dta-parser
 
-TypeScript parser for Stata `.dta` files.
+This repository contains three libraries for reading Stata `.dta` files,
+built around two independent parser implementations:
 
-This package was first written inside
+| Library | Location | Parser implementation | Primary interface |
+| --- | --- | --- | --- |
+| TypeScript/npm package | Repository root | TypeScript | `@jbearak/dta-parser` and `@jbearak/dta-parser/node` |
+| Rust crate | [`rust/dta-parser`](rust/dta-parser) | Rust | `dta_parser::{read_dta, DtaFile}` |
+| R package | [`r-package/dtaparser`](r-package/dtaparser) | Rust | `dtaparser::read_dta()` |
+
+The TypeScript and Rust parsers are separate implementations checked against
+the same fixtures and compatibility contract. The R package is a language
+binding around the Rust parser, not a third parser. The TypeScript package
+currently occupies the repository root; the Rust crate and R package each
+live in their own subdirectory.
+
+## TypeScript library
+
+The `@jbearak/dta-parser` package was first written inside
 [Sight](https://github.com/jbearak/sight), then extracted so the same parser
 could be used by Sight and
 [manuscript-markdown](https://github.com/jbearak/manuscript-markdown).
@@ -56,7 +71,7 @@ want portable parsing utilities. Use `@jbearak/dta-parser/node` when you want
 `DtaFile` to open a `.dta` file from disk and read rows or columns with
 filesystem-backed random access.
 
-This repository also contains the native Rust core in `rust/dta-parser`. Its
+This repository also contains the Rust parser in `rust/dta-parser`. Its
 public byte-slice and bounded `Read + Seek` APIs read releases 113–115 and
 117–119 into storage-preserving, column-oriented vectors, with row/column
 projection, exact missing tags, Windows-1252 legacy text, value-label
@@ -64,7 +79,7 @@ associations, cooperative cancellation, and strict `strL`/GSO resolution. Rust
 callers should see the [crate README](rust/dta-parser/README.md) for examples
 and the precise I/O contract.
 
-The native R package lives in [`r-package/dtaparser`](r-package/dtaparser).
+The R package lives in [`r-package/dtaparser`](r-package/dtaparser).
 It exports a haven-shaped `read_dta()` interface backed by the bounded Rust
 reader, with tidyselect projection, row windows, labels and formats, tagged
 missings, long strings, and R date/time classes. Its locked dependency archive
@@ -313,7 +328,8 @@ is provided. `read_columns()` accepts the same cancellation options.
 
 ## Implementation and parity maintenance
 
-The three public surfaces share one compatibility contract but have distinct
+The three libraries expose four public surfaces. The two parser
+implementations share one compatibility contract but have distinct
 entrypoints:
 
 | Surface | Entrypoint | I/O model | Supported releases |
@@ -323,10 +339,11 @@ entrypoints:
 | Rust | `dta_parser::{read_dta, DtaFile}` | slice or bounded `Read + Seek` | 113--115, 117--119 |
 | R | `dtaparser::read_dta()` | local path through the bounded Rust core | 113--115, 117--119 |
 
-The Rust crate under `rust/dta-parser` is the native source of truth. The R
-package mirrors it under `r-package/dtaparser/src/vendor/dta-parser`; never edit
-only the mirror. `scripts/check-rust-sync.sh` checks source equality, Cargo
-locks, and the normalized offline dependency archive. Run
+The Rust crate under `rust/dta-parser` is the source of truth for the Rust
+parser and its R binding; it is independent of the TypeScript parser. The R
+package mirrors the crate under `r-package/dtaparser/src/vendor/dta-parser`;
+never edit only the mirror. `scripts/check-rust-sync.sh` checks source equality,
+Cargo locks, and the normalized offline dependency archive. Run
 `scripts/rebuild-r-vendor.sh` only when the locked dependency archive changes,
 then update its checked SHA-256 intentionally.
 
@@ -361,7 +378,7 @@ Before merging parser or packaging changes:
 
 1. Run the Bun tests, typecheck, build, conformance, Rust fmt/clippy/tests/docs,
    deterministic fuzz smoke, and source/archive sync check.
-2. If the native core changed, mirror it into the R vendor tree and add a
+2. If the Rust parser changed, mirror it into the R vendor tree and add a
    regression at the root first.
 3. Run `R CMD build` and `R CMD check` with haven installed; confirm the GNU
    Rust target is actually used with Rtools on Windows.
@@ -370,7 +387,7 @@ Before merging parser or packaging changes:
 5. Confirm lockfiles, archive identity, support matrix, limitations, package
    docs, and changelog/release notes describe the same source.
 
-Issue #8 is complete across the sequential native-core, observation, legacy
+Issue #8 is complete across the sequential Rust-core, observation, legacy
 and bounded-file, R bridge, and conformance/CI slices. Publishing releases is a
 separate maintainer action.
 

--- a/r-package/dtaparser/README.md
+++ b/r-package/dtaparser/README.md
@@ -1,6 +1,6 @@
 # dtaparser
 
-`dtaparser` is the native R interface to this repository's bounded Rust DTA
+`dtaparser` is the R interface to this repository's bounded Rust DTA
 reader. Its exported `read_dta()` function deliberately mirrors the formal
 arguments of `haven::read_dta()`, while observation storage is decoded by Rust
 and materialized through an R-specific collector. Numeric values are written
@@ -23,6 +23,35 @@ and variable labels, display formats, value-label tables, `strL` values, and
 system or `.a`--`.z` missing values. `%td` is converted to `Date`; `%tc` and
 `%tC` are converted to UTC `POSIXct`. Other Stata calendar formats remain
 numeric and retain their `format.stata` attribute.
+
+## Performance compared with haven
+
+A warm-cache benchmark on an Apple M4 Max compared full reads by
+`dtaparser::read_dta()` and `haven::read_dta()` on deterministic, mixed-type
+Stata 15 files. Each file contained 40 columns spanning numeric, labelled,
+date/time, and string data. The run warmed each implementation, alternated
+their execution order, and ran garbage collection outside the timed intervals.
+
+| Input | Rows | Iterations | dtaparser median | haven median | Relative throughput |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| 100 MB | 222,656 | 101 | 0.236 s | 1.122 s | 4.754x |
+| 1 GB | 2,227,111 | 101 | 2.187 s | 11.045 s | 5.050x |
+
+Relative throughput is the haven median divided by the dtaparser median, so
+higher is faster for dtaparser. Before timing, eight representative columns in
+32-row samples from the start, middle, and end of each file were compared with
+haven after removing dtaparser's additional top-level `dta_format_version`
+attribute. The remaining attributes and values matched, subject to the
+conformance suite's `1e-7` tolerance for nonmissing floating-point values.
+
+These are machine- and workload-specific measurements, not performance
+guarantees or CI thresholds. The haven comparison used the Rust-vector
+materialization path that is now retained as an internal differential-testing
+baseline. The current direct-R collector was benchmarked separately and was
+faster than that retained path, but haven was not measured in the same run, so
+the ratios above are not extrapolated; see the
+[direct-R materialization results](../../benchmarks/r-materialization/results-2026-07-26.md).
+No repeated 10 GB comparison was completed, so no 10 GB result is reported.
 
 ## Scope and limitations
 
@@ -75,7 +104,7 @@ The materialization benchmark runners require `DTAPARSER_BENCH_LIB` and verify
 that the package is loaded from that freshly populated, checkout-local library
 rather than an unrelated global installation.
 
-The native source of truth is `rust/dta-parser`. After a root-first change,
+The Rust source of truth is `rust/dta-parser`. After a root-first change,
 mirror it here and run `scripts/check-rust-sync.sh`; the check also verifies the
 Cargo locks and deterministic offline `vendor.tar.gz` identity. Windows CI
 installs and selects `stable-x86_64-pc-windows-gnu`, confirms the rustc host,


### PR DESCRIPTION
## Summary

- describe the repository as three libraries backed by two independent parsers
- clarify that the TypeScript and Rust parsers are separate and the R package wraps Rust
- document completed `dtaparser::read_dta()` versus `haven::read_dta()` results for 100 MB and 1 GB synthetic mixed-type full reads
- qualify the benchmark as machine- and workload-specific, distinguish the retained Rust-vector path from the current direct-R collector, and avoid extrapolating to 10 GB

## Benchmark evidence

The documented cohorts were completed on an Apple M4 Max with 101 iterations per implementation and workload:

| Input | Rows | dtaparser median | haven median | Relative throughput |
| --- | ---: | ---: | ---: | ---: |
| 100 MB | 222,656 | 0.236 s | 1.122 s | 4.754x |
| 1 GB | 2,227,111 | 2.187 s | 11.045 s | 5.050x |

The README records the warm-cache, alternating-order methodology; sampled parity validation; the removed extra `dta_format_version` attribute; and the absence of a completed repeated 10 GB comparison.

## Scope

Documentation only:

- `README.md`
- `r-package/dtaparser/README.md`

The untracked large-scale benchmark working files are intentionally excluded. TypeScript relocation is reserved for a separate follow-up PR.

## Validation

- independent planner/implementer/reviewer cycle; final reviewer verdict: CLEAN
- `git diff --check`
- relative Markdown link verification for both changed READMEs
- tracked diff contains only the two documented README files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the repository structure, parser implementations, library interfaces, and compatibility contracts.
  * Standardized terminology for the Rust parser and R package.
  * Added performance comparisons between `dtaparser` and `haven`, including benchmark results and measurement notes.
  * Updated contribution, release, conformance, and source-of-truth guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->