### PR TITLE
Support haven-compatible R input sources

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,7 @@ jobs:
         run: rustup toolchain install stable --profile minimal
       - name: Install R dependencies
         shell: Rscript {0}
-        run: install.packages(c("rlang", "tibble", "tidyselect", "testthat", "haven"))
+        run: install.packages(c("readr", "rlang", "tibble", "tidyselect", "testthat", "haven", "callr", "httpuv"))
       - name: Build package from offline Cargo archive
         if: runner.os != 'Linux'
         shell: bash

--- a/r-package/dtaparser/DESCRIPTION
+++ b/r-package/dtaparser/DESCRIPTION
@@ -11,7 +11,7 @@ License: GPL-3
 Encoding: UTF-8
 Depends: R (>= 4.1.0)
 Imports:
-    readr,
+    readr (>= 2.2.0),
     rlang,
     tibble,
     tidyselect

--- a/r-package/dtaparser/DESCRIPTION
+++ b/r-package/dtaparser/DESCRIPTION
@@ -11,12 +11,15 @@ License: GPL-3
 Encoding: UTF-8
 Depends: R (>= 4.1.0)
 Imports:
+    readr,
     rlang,
     tibble,
     tidyselect
 Suggests:
+    callr,
     haven,
-    testthat (>= 3.0.0)
+    httpuv,
+    testthat (>= 3.1.7)
 Config/testthat/edition: 3
 SystemRequirements: Cargo and Rust >= 1.74; on Windows, the
     x86_64-pc-windows-gnu toolchain matching 64-bit R

--- a/r-package/dtaparser/R/read-dta.R
+++ b/r-package/dtaparser/R/read-dta.R
@@ -8,7 +8,9 @@
 #' @param file A path, URL, raw vector, or binary connection. Local and remote
 #'   gzip files and local bzip2, xz, and zip files are decompressed
 #'   automatically. Character vectors containing literal data are not handled,
-#'   matching `haven::read_dta()`.
+#'   matching `haven::read_dta()`. URLs are fetched at call time; applications
+#'   accepting untrusted `file` values should validate or allowlist sources
+#'   before calling `read_dta()`.
 #' @param encoding Must be `NULL`. Legacy files are decoded as Windows-1252 and
 #'   modern files as UTF-8 according to their storage format.
 #' @param col_select One or more tidyselect expressions. Predicates see Stata
@@ -94,25 +96,29 @@ read_dta <- function(file, encoding = NULL, col_select = NULL, skip = 0,
 
 .resolve_dta_source <- function(file) {
     caller_supplied_source <- inherits(file, "source")
+    caller_path <- .caller_dta_source_path(file)
     datasource <- readr::datasource(file)
     source_type <- class(datasource)[[1L]]
 
     if (identical(source_type, "source_file")) {
         path <- normalizePath(datasource[[1L]], winslash = "/", mustWork = TRUE)
-        # readr adds an environment with a finalizer when it copied a
-        # connection, compressed file, or URL into a temporary file. Retain
-        # the datasource for both native passes and eagerly clean the path.
+        # Delete only a direct child of tempdir() that differs from a canonical
+        # caller-owned path. Ownership never depends on datasource internals,
+        # and a caller-supplied source object is always left to its caller.
         temporary_parent <- dirname(path)
         temporary_root <- normalizePath(
             tempdir(), winslash = "/", mustWork = TRUE
         )
+        comparison_path <- path
         if (identical(.Platform$OS.type, "windows")) {
             temporary_parent <- tolower(temporary_parent)
             temporary_root <- tolower(temporary_root)
+            comparison_path <- tolower(comparison_path)
+            if (!is.null(caller_path)) caller_path <- tolower(caller_path)
         }
         temporary <- !caller_supplied_source &&
-            "env" %in% names(datasource) &&
-            identical(temporary_parent, temporary_root)
+            identical(temporary_parent, temporary_root) &&
+            (is.null(caller_path) || !identical(comparison_path, caller_path))
         return(list(
             path = path,
             temporary = temporary,
@@ -130,6 +136,23 @@ read_dta <- function(file, encoding = NULL, col_select = NULL, skip = 0,
     }
 
     stop("This kind of input is not handled.", call. = FALSE)
+}
+
+.caller_dta_source_path <- function(file) {
+    path <- NULL
+    if (is.character(file) && length(file) == 1L && !is.na(file) &&
+        file.exists(file)) {
+        path <- file
+    } else if (inherits(file, "connection")) {
+        description <- summary(file)$description
+        if (is.character(description) && length(description) == 1L &&
+            !is.na(description) && file.exists(description)) {
+            path <- description
+        }
+    }
+
+    if (is.null(path)) return(NULL)
+    normalizePath(path, winslash = "/", mustWork = TRUE)
 }
 
 .cleanup_dta_source <- function(source) {

--- a/r-package/dtaparser/R/read-dta.R
+++ b/r-package/dtaparser/R/read-dta.R
@@ -5,8 +5,10 @@
 #' and variable labels, Stata display formats, value labels, `strL` content,
 #' and Stata system/extended missing values are retained.
 #'
-#' @param file A single path to a `.dta` file. Connections, URLs, and compressed
-#'   paths are not supported.
+#' @param file A path, URL, raw vector, or binary connection. Local and remote
+#'   gzip files and local bzip2, xz, and zip files are decompressed
+#'   automatically. Character vectors containing literal data are not handled,
+#'   matching `haven::read_dta()`.
 #' @param encoding Must be `NULL`. Legacy files are decoded as Windows-1252 and
 #'   modern files as UTF-8 according to their storage format.
 #' @param col_select One or more tidyselect expressions. Predicates see Stata
@@ -41,17 +43,15 @@ read_dta <- function(file, encoding = NULL, col_select = NULL, skip = 0,
 
 .read_dta_impl <- function(file, encoding, selection, skip, n_max,
                            .name_repair, materialization) {
-    if (!is.character(file) || length(file) != 1L || is.na(file)) {
-        stop("`file` must be one non-missing path", call. = FALSE)
-    }
     if (!is.null(encoding)) {
         stop("`encoding` overrides are not supported; use NULL", call. = FALSE)
     }
     .validate_count(skip, "skip", infinite = FALSE)
     .validate_count(n_max, "n_max", infinite = TRUE)
 
-    file <- normalizePath(file, mustWork = TRUE)
-    metadata_names <- .dta_metadata(file)
+    source <- .resolve_dta_source(file)
+    on.exit(.cleanup_dta_source(source), add = TRUE)
+    metadata_names <- .dta_metadata(source$path)
 
     if (rlang::quo_is_null(selection)) {
         column_indices <- NULL
@@ -72,7 +72,7 @@ read_dta <- function(file, encoding = NULL, col_select = NULL, skip = 0,
 
     native <- .Call(
         C_dtaparser_read,
-        file,
+        source$path,
         column_indices,
         as.double(skip),
         as.double(n_max),
@@ -90,6 +90,45 @@ read_dta <- function(file, encoding = NULL, col_select = NULL, skip = 0,
         attr(result, "dta_format_version") <- format_version
     }
     result
+}
+
+.resolve_dta_source <- function(file) {
+    caller_supplied_source <- inherits(file, "source")
+    datasource <- readr::datasource(file)
+    source_type <- class(datasource)[[1L]]
+
+    if (identical(source_type, "source_file")) {
+        path <- normalizePath(datasource[[1L]], mustWork = TRUE)
+        # readr adds an environment with a finalizer when it copied a
+        # connection, compressed file, or URL into a temporary file. Retain
+        # the datasource for both native passes and eagerly clean the path.
+        temporary <- !caller_supplied_source &&
+            "env" %in% names(datasource) &&
+            identical(dirname(path), normalizePath(tempdir(), mustWork = TRUE))
+        return(list(
+            path = path,
+            temporary = temporary,
+            datasource = datasource
+        ))
+    }
+
+    if (identical(source_type, "source_raw")) {
+        path <- tempfile(pattern = "dtaparser-", fileext = ".dta")
+        complete <- FALSE
+        on.exit(if (!complete) unlink(path), add = TRUE)
+        writeBin(datasource[[1L]], path)
+        complete <- TRUE
+        return(list(path = path, temporary = TRUE, datasource = datasource))
+    }
+
+    stop("This kind of input is not handled.", call. = FALSE)
+}
+
+.cleanup_dta_source <- function(source) {
+    if (isTRUE(source$temporary)) {
+        unlink(source$path)
+    }
+    invisible(NULL)
 }
 
 .dta_metadata <- function(file) {

--- a/r-package/dtaparser/R/read-dta.R
+++ b/r-package/dtaparser/R/read-dta.R
@@ -98,13 +98,21 @@ read_dta <- function(file, encoding = NULL, col_select = NULL, skip = 0,
     source_type <- class(datasource)[[1L]]
 
     if (identical(source_type, "source_file")) {
-        path <- normalizePath(datasource[[1L]], mustWork = TRUE)
+        path <- normalizePath(datasource[[1L]], winslash = "/", mustWork = TRUE)
         # readr adds an environment with a finalizer when it copied a
         # connection, compressed file, or URL into a temporary file. Retain
         # the datasource for both native passes and eagerly clean the path.
+        temporary_parent <- dirname(path)
+        temporary_root <- normalizePath(
+            tempdir(), winslash = "/", mustWork = TRUE
+        )
+        if (identical(.Platform$OS.type, "windows")) {
+            temporary_parent <- tolower(temporary_parent)
+            temporary_root <- tolower(temporary_root)
+        }
         temporary <- !caller_supplied_source &&
             "env" %in% names(datasource) &&
-            identical(dirname(path), normalizePath(tempdir(), mustWork = TRUE))
+            identical(temporary_parent, temporary_root)
         return(list(
             path = path,
             temporary = temporary,

--- a/r-package/dtaparser/README.md
+++ b/r-package/dtaparser/README.md
@@ -26,6 +26,10 @@ decompressed automatically. Source resolution is delegated to
 vectors containing literal text are rejected because haven does not handle
 the resulting `source_string` for DTA input.
 
+URLs are fetched at call time. Applications that pass untrusted values to
+`file` should validate or allowlist acceptable sources before calling
+`read_dta()`; the reader does not impose a network allowlist.
+
 Source resolution remains an R-layer concern. An ordinary uncompressed local
 file is passed straight to the path-based Rust reader without copying its
 contents. Raw bytes and readr-resolved connections, compressed inputs, and

--- a/r-package/dtaparser/README.md
+++ b/r-package/dtaparser/README.md
@@ -18,6 +18,21 @@ cars <- read_dta(
 )
 ```
 
+`file` accepts the same practical input sources as `haven::read_dta()`:
+local paths, raw DTA bytes, binary connections, and URLs. Gzip files are
+decompressed locally or over a URL; local bzip2, xz, and zip files are also
+decompressed automatically. Source resolution is delegated to
+`readr::datasource()`, the same interface used by haven 2.5.5. Character
+vectors containing literal text are rejected because haven does not handle
+the resulting `source_string` for DTA input.
+
+Source resolution remains an R-layer concern. An ordinary uncompressed local
+file is passed straight to the path-based Rust reader without copying its
+contents. Raw bytes and readr-resolved connections, compressed inputs, and
+URLs use temporary files that are removed when the read succeeds, errors, or
+is interrupted. This keeps network and decompression dependencies out of the
+reusable Rust parser.
+
 The reader supports Stata releases 113--115 and 117--119. It retains dataset
 and variable labels, display formats, value-label tables, `strL` values, and
 system or `.a`--`.z` missing values. `%td` is converted to `Date`; `%tc` and
@@ -55,8 +70,9 @@ No repeated 10 GB comparison was completed, so no 10 GB result is reported.
 
 ## Scope and limitations
 
-- `file` must be a local, uncompressed file path. Connections and URLs are not
-  supported.
+- Remote bzip2, xz, and zip files have the same limitations as
+  `readr::datasource()`; download them locally first when readr cannot expose
+  them as a decompressed source.
 - `encoding` must be `NULL`. Legacy files use Windows-1252 and XML-era files
   use UTF-8 according to the DTA storage format.
 - `col_select` uses tidyselect and is resolved from typed metadata before

--- a/r-package/dtaparser/man/read_dta.Rd
+++ b/r-package/dtaparser/man/read_dta.Rd
@@ -6,7 +6,10 @@ read_dta(file, encoding = NULL, col_select = NULL, skip = 0,
   n_max = Inf, .name_repair = "unique")
 }
 \arguments{
-\item{file}{A single path to a DTA file.}
+\item{file}{A path, URL, raw vector, or binary connection. Local and remote
+gzip files and local bzip2, xz, and zip files are decompressed automatically.
+Character vectors containing literal data are not handled, matching
+\code{haven::read_dta()}.}
 \item{encoding}{Must be \code{NULL}; decoding follows the file format.}
 \item{col_select}{One or more tidyselect expressions. Predicates treat Stata
 string storage as character and numeric storage as double. If a source

--- a/r-package/dtaparser/man/read_dta.Rd
+++ b/r-package/dtaparser/man/read_dta.Rd
@@ -9,7 +9,9 @@ read_dta(file, encoding = NULL, col_select = NULL, skip = 0,
 \item{file}{A path, URL, raw vector, or binary connection. Local and remote
 gzip files and local bzip2, xz, and zip files are decompressed automatically.
 Character vectors containing literal data are not handled, matching
-\code{haven::read_dta()}.}
+\code{haven::read_dta()}. URLs are fetched at call time; applications accepting
+untrusted \code{file} values should validate or allowlist sources before calling
+\code{read_dta()}.}
 \item{encoding}{Must be \code{NULL}; decoding follows the file format.}
 \item{col_select}{One or more tidyselect expressions. Predicates treat Stata
 string storage as character and numeric storage as double. If a source

--- a/r-package/dtaparser/tests/testthat/test-input-sources.R
+++ b/r-package/dtaparser/tests/testthat/test-input-sources.R
@@ -1,0 +1,271 @@
+input_fixture <- function() {
+    system.file("extdata", "auto_v118.dta", package = "dtaparser",
+                mustWork = TRUE)
+}
+
+read_fixture_bytes <- function() {
+    path <- input_fixture()
+    readBin(path, "raw", n = file.info(path)$size)
+}
+
+expect_source_parity <- function(actual, expected) {
+    expect_identical(dim(actual), dim(expected))
+    expect_identical(names(actual), names(expected))
+    expect_identical(attr(actual, "label", exact = TRUE),
+                     attr(expected, "label", exact = TRUE))
+    for (name in names(actual)) {
+        expect_equal(actual[[name]], expected[[name]], tolerance = 1e-7,
+                     info = name)
+    }
+}
+
+write_compressed_fixture <- function(kind) {
+    input <- input_fixture()
+    output <- tempfile(fileext = paste0(".", kind))
+    bytes <- read_fixture_bytes()
+
+    if (identical(kind, "zip")) {
+        if (!nzchar(Sys.which("zip"))) {
+            testthat::skip("a zip executable is required")
+        }
+        directory <- tempfile(pattern = "dtaparser-zip-")
+        dir.create(directory)
+        copied <- file.path(directory, basename(input))
+        file.copy(input, copied)
+        old <- setwd(directory)
+        on.exit({
+            setwd(old)
+            unlink(directory, recursive = TRUE)
+        }, add = TRUE)
+        utils::zip(output, basename(copied))
+        if (!file.exists(output) || file.info(output)$size == 0) {
+            stop("failed to create zip fixture", call. = FALSE)
+        }
+        return(output)
+    }
+
+    connection <- switch(kind,
+        gz = gzfile(output, "wb"),
+        bz2 = bzfile(output, "wb"),
+        xz = xzfile(output, "wb")
+    )
+    on.exit(close(connection), add = TRUE)
+    writeBin(bytes, connection)
+    output
+}
+
+start_fixture_server <- function(path) {
+    port <- tryCatch(httpuv::randomPort(), error = function(error) {
+        testthat::skip("this environment does not permit a loopback server")
+    })
+    ready <- tempfile(pattern = "dtaparser-http-ready-")
+    process <- callr::r_bg(
+        function(path, port, ready) {
+            bytes <- readBin(path, "raw", n = file.info(path)$size)
+            app <- list(call = function(request) {
+                list(
+                    status = 200L,
+                    headers = list("Content-Type" = "application/octet-stream"),
+                    body = bytes
+                )
+            })
+            server <- httpuv::startServer("127.0.0.1", port, app)
+            on.exit(httpuv::stopServer(server), add = TRUE)
+            file.create(ready)
+            repeat httpuv::service(100)
+        },
+        args = list(normalizePath(path), port, ready),
+        supervise = TRUE
+    )
+
+    deadline <- Sys.time() + 10
+    while (!file.exists(ready) && process$is_alive() && Sys.time() < deadline) {
+        Sys.sleep(0.02)
+    }
+    if (!file.exists(ready)) {
+        process$kill()
+        stop("local HTTP fixture server did not start", call. = FALSE)
+    }
+
+    list(
+        url = sprintf("http://127.0.0.1:%d/%s", port, basename(path)),
+        process = process,
+        ready = ready
+    )
+}
+
+test_that("plain local paths retain the direct path fast path", {
+    path <- normalizePath(input_fixture())
+    source <- dtaparser:::.resolve_dta_source(path)
+    on.exit(dtaparser:::.cleanup_dta_source(source), add = TRUE)
+
+    expect_identical(source$path, path)
+    expect_false(source$temporary)
+})
+
+test_that("caller-supplied datasource paths are never deleted", {
+    path <- tempfile(fileext = ".dta")
+    file.copy(input_fixture(), path)
+    on.exit(unlink(path), add = TRUE)
+    datasource <- readr::datasource(path)
+    datasource$env <- new.env(parent = emptyenv())
+
+    source <- dtaparser:::.resolve_dta_source(datasource)
+    expect_false(source$temporary)
+    dtaparser:::.cleanup_dta_source(source)
+    expect_true(file.exists(path))
+})
+
+test_that("raw bytes and binary connections match haven", {
+    skip_if_not_installed("haven")
+    bytes <- read_fixture_bytes()
+
+    actual_raw <- read_dta(
+        bytes, col_select = c(make, price), skip = 3, n_max = 5
+    )
+    expected_raw <- haven::read_dta(
+        bytes, col_select = c(make, price), skip = 3, n_max = 5
+    )
+    expect_source_parity(actual_raw, expected_raw)
+
+    actual_connection <- rawConnection(bytes, "rb")
+    expected_connection <- rawConnection(bytes, "rb")
+    on.exit(close(actual_connection), add = TRUE)
+    on.exit(close(expected_connection), add = TRUE)
+    actual <- read_dta(actual_connection, skip = 3, n_max = 5)
+    expected <- haven::read_dta(expected_connection, skip = 3, n_max = 5)
+    expect_source_parity(actual, expected)
+
+    # haven 2.5.5 resolves a connection twice when col_select is supplied,
+    # exhausting a non-rewindable connection before its data pass. Resolve it
+    # once so selection remains useful while retaining haven's selected values.
+    selected_connection <- rawConnection(bytes, "rb")
+    on.exit(close(selected_connection), add = TRUE)
+    selected <- read_dta(
+        selected_connection, col_select = c(make, price),
+        skip = 3, n_max = 5
+    )
+    expect_source_parity(selected, expected[c("make", "price")])
+})
+
+test_that("local compressed sources match haven", {
+    skip_if_not_installed("haven")
+
+    for (kind in c("gz", "bz2", "xz", "zip")) {
+        path <- write_compressed_fixture(kind)
+        on.exit(unlink(path), add = TRUE)
+        actual <- read_dta(
+            path, col_select = c(make, price), skip = 3, n_max = 5
+        )
+        expected <- haven::read_dta(
+            path, col_select = c(make, price), skip = 3, n_max = 5
+        )
+        expect_source_parity(actual, expected)
+    }
+})
+
+test_that("URL sources match haven over a hermetic loopback server", {
+    skip_if_not_installed("haven")
+    skip_if_not_installed("callr")
+    skip_if_not_installed("httpuv")
+
+    gzip <- write_compressed_fixture("gz")
+    on.exit(unlink(gzip), add = TRUE)
+
+    for (path in c(input_fixture(), gzip)) {
+        server <- start_fixture_server(path)
+        actual <- read_dta(
+            server$url, col_select = c(make, price), skip = 3, n_max = 5
+        )
+        expected <- haven::read_dta(
+            server$url, col_select = c(make, price), skip = 3, n_max = 5
+        )
+        server$process$kill()
+        unlink(server$ready)
+        expect_source_parity(actual, expected)
+    }
+})
+
+test_that("temporary sources are cleaned automatically after reads and errors", {
+    bytes <- read_fixture_bytes()
+    resolved <- list()
+    original_resolver <- dtaparser:::.resolve_dta_source
+    local_mocked_bindings(
+        .resolve_dta_source = function(file) {
+            source <- original_resolver(file)
+            resolved[[length(resolved) + 1L]] <<- list(
+                path = source$path,
+                temporary = source$temporary
+            )
+            source
+        },
+        .package = "dtaparser"
+    )
+
+    expect_silent(read_dta(bytes, n_max = 1))
+    expect_true(resolved[[1L]]$temporary)
+    expect_false(file.exists(resolved[[1L]]$path))
+    expect_error(read_dta(as.raw(1:8)), "header|format|small|read|I/O",
+                 ignore.case = TRUE)
+    expect_true(resolved[[2L]]$temporary)
+    expect_false(file.exists(resolved[[2L]]$path))
+
+    connection <- rawConnection(bytes, "rb")
+    on.exit(close(connection), add = TRUE)
+    expect_silent(read_dta(connection, n_max = 1))
+    expect_true(resolved[[3L]]$temporary)
+    expect_false(file.exists(resolved[[3L]]$path))
+
+    malformed_connection <- rawConnection(as.raw(1:8), "rb")
+    on.exit(close(malformed_connection), add = TRUE)
+    expect_error(
+        read_dta(malformed_connection),
+        "header|format|small|read|I/O",
+        ignore.case = TRUE
+    )
+    expect_true(resolved[[4L]]$temporary)
+    expect_false(file.exists(resolved[[4L]]$path))
+})
+
+test_that("temporary sources are cleaned when an interrupt unwinds the read", {
+    skip_if_not_installed("callr")
+    result <- callr::r(
+        function(library, bytes) {
+            .libPaths(c(library, .libPaths()))
+            library(dtaparser)
+            path <- NULL
+            original_resolver <- dtaparser:::.resolve_dta_source
+            testthat::local_mocked_bindings(
+                .resolve_dta_source = function(file) {
+                    source <- original_resolver(file)
+                    path <<- source$path
+                    source
+                },
+                .dta_metadata = function(file) rlang::interrupt(),
+                .package = "dtaparser"
+            )
+            interrupted <- tryCatch(
+                {
+                    dtaparser::read_dta(bytes)
+                    FALSE
+                },
+                interrupt = function(condition) TRUE
+            )
+            list(interrupted = interrupted, temporary_exists = file.exists(path))
+        },
+        args = list(
+            dirname(find.package("dtaparser")),
+            read_fixture_bytes()
+        )
+    )
+
+    expect_true(result$interrupted)
+    expect_false(result$temporary_exists)
+})
+
+test_that("unsupported literal character data matches haven's error", {
+    skip_if_not_installed("haven")
+    literal <- c("not", "DTA bytes")
+    expect_error(read_dta(literal), "kind of input is not handled")
+    expect_error(haven::read_dta(literal), "kind of input is not handled")
+})

--- a/r-package/dtaparser/tests/testthat/test-input-sources.R
+++ b/r-package/dtaparser/tests/testthat/test-input-sources.R
@@ -82,8 +82,9 @@ start_fixture_server <- function(path) {
     while (!file.exists(ready) && process$is_alive() && Sys.time() < deadline) {
         Sys.sleep(0.02)
     }
-    if (!file.exists(ready)) {
-        process$kill()
+    if (!file.exists(ready) || !process$is_alive()) {
+        if (process$is_alive()) process$kill()
+        unlink(ready)
         stop("local HTTP fixture server did not start", call. = FALSE)
     }
 
@@ -179,15 +180,18 @@ test_that("URL sources match haven over a hermetic loopback server", {
 
     for (path in c(input_fixture(), gzip)) {
         server <- start_fixture_server(path)
-        actual <- read_dta(
-            server$url, col_select = c(make, price), skip = 3, n_max = 5
-        )
-        expected <- haven::read_dta(
-            server$url, col_select = c(make, price), skip = 3, n_max = 5
-        )
-        server$process$kill()
-        unlink(server$ready)
-        expect_source_parity(actual, expected)
+        tryCatch({
+            actual <- read_dta(
+                server$url, col_select = c(make, price), skip = 3, n_max = 5
+            )
+            expected <- haven::read_dta(
+                server$url, col_select = c(make, price), skip = 3, n_max = 5
+            )
+            expect_source_parity(actual, expected)
+        }, finally = {
+            if (server$process$is_alive()) server$process$kill()
+            unlink(server$ready)
+        })
     }
 })
 
@@ -271,6 +275,9 @@ test_that("temporary sources are cleaned when an interrupt unwinds the read", {
 test_that("unsupported literal character data matches haven's error", {
     skip_if_not_installed("haven")
     literal <- c("not", "DTA bytes")
-    expect_error(read_dta(literal), "kind of input is not handled")
-    expect_error(haven::read_dta(literal), "kind of input is not handled")
+    actual <- tryCatch(read_dta(literal), error = identity)
+    expected <- tryCatch(haven::read_dta(literal), error = identity)
+    expect_s3_class(actual, "error")
+    expect_s3_class(expected, "error")
+    expect_identical(conditionMessage(actual), conditionMessage(expected))
 })

--- a/r-package/dtaparser/tests/testthat/test-input-sources.R
+++ b/r-package/dtaparser/tests/testthat/test-input-sources.R
@@ -95,7 +95,7 @@ start_fixture_server <- function(path) {
 }
 
 test_that("plain local paths retain the direct path fast path", {
-    path <- normalizePath(input_fixture())
+    path <- normalizePath(input_fixture(), winslash = "/")
     source <- dtaparser:::.resolve_dta_source(path)
     on.exit(dtaparser:::.cleanup_dta_source(source), add = TRUE)
 
@@ -107,6 +107,11 @@ test_that("caller-supplied datasource paths are never deleted", {
     path <- tempfile(fileext = ".dta")
     file.copy(input_fixture(), path)
     on.exit(unlink(path), add = TRUE)
+    direct_source <- dtaparser:::.resolve_dta_source(path)
+    expect_false(direct_source$temporary)
+    dtaparser:::.cleanup_dta_source(direct_source)
+    expect_true(file.exists(path))
+
     datasource <- readr::datasource(path)
     datasource$env <- new.env(parent = emptyenv())
 


### PR DESCRIPTION
## Summary

- resolve `read_dta()` inputs through the same exported `readr::datasource()` interface used by haven 2.5.5
- support raw DTA bytes, binary connections, local gzip/bzip2/xz/zip files, plain URLs, and remote gzip while retaining the unchanged direct local-path native path
- keep network, decompression, connection, and temporary-file lifecycle concerns in R rather than the reusable Rust parser
- clean owned temporary files after success, parse errors, and interrupt unwinding without deleting caller-owned datasource paths
- document the supported sources and add hermetic differential tests against haven

## Compatibility decision

The target is haven 2.5.5 with readr 2.2.0. User-visible input categories align with haven. Character literal `source_string` input remains rejected because haven 2.5.5 does not handle it for DTA parsing. One intentional improvement is retained: dtaparser resolves a connection once, so `col_select` remains usable on non-rewindable connections instead of exhausting the connection during a separate metadata pass.

Adding readr increases the R dependency footprint, but avoids maintaining a second, drifting URL/compression/connection resolver. Ordinary local files are not copied or materialized in R, and the Rust API remains path-based and reusable.

## Validation

- independent iterative review: CLEAN after all findings were addressed
- focused source tests, including hermetic loopback plain and gzip URLs: pass
- `R CMD check --no-manual`: Status OK
- `DTA_REQUIRE_R_CONFORMANCE=1 scripts/conformance.sh`: pass
- `scripts/check-rust-sync.sh`: pass
- `git diff --check`: pass

Closes #15

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced `read_dta()` to accept local paths, URLs, raw DTA bytes, binary connections, and common compressed inputs, with automatic decompression where supported.
  * Improves handling of intermediate sources and reliably cleans up temporary files after success, failure, or interruption.
* **Documentation**
  * Updated `read_dta()` docs (README and manual) to clarify supported input types, decompression behavior, and scope/limitations.
* **Bug Fixes**
  * Tightened validation for `encoding`, `skip`, and row-range inputs; improved error behavior for unsupported literal character data.
* **Tests**
  * Added thorough parity and lifecycle tests versus `haven`, including hermetic URL fetching and cleanup-on-interrupt checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->