### PR TITLE
Support deterministic encoding overrides

### DIFF
--- a/r-package/dtaparser/R/read-dta.R
+++ b/r-package/dtaparser/R/read-dta.R
@@ -11,8 +11,12 @@
 #'   matching `haven::read_dta()`. URLs are fetched at call time; applications
 #'   accepting untrusted `file` values should validate or allowlist sources
 #'   before calling `read_dta()`.
-#' @param encoding Must be `NULL`. Legacy files are decoded as Windows-1252 and
-#'   modern files as UTF-8 according to their storage format.
+#' @param encoding Optional source encoding override. Supported aliases are
+#'   `"UTF-8"`/`"UTF8"`, `"Windows-1252"`/`"CP1252"`, and
+#'   `"ISO-8859-1"`/`"latin1"`, matched case-insensitively. `NULL` uses
+#'   Windows-1252 for legacy files and UTF-8 for modern files. Explicit UTF-8
+#'   replaces malformed input sequences deterministically with U+FFFD. Haven
+#'   2.5.5 may instead omit an affected label.
 #' @param col_select One or more tidyselect expressions. Predicates see Stata
 #'   string storage as character and numeric storage as double. If a source
 #'   variable is selected more than once, its first selection and alias win.
@@ -45,15 +49,13 @@ read_dta <- function(file, encoding = NULL, col_select = NULL, skip = 0,
 
 .read_dta_impl <- function(file, encoding, selection, skip, n_max,
                            .name_repair, materialization) {
-    if (!is.null(encoding)) {
-        stop("`encoding` overrides are not supported; use NULL", call. = FALSE)
-    }
+    encoding <- .validate_dta_encoding(encoding)
     .validate_count(skip, "skip", infinite = FALSE)
     .validate_count(n_max, "n_max", infinite = TRUE)
 
     source <- .resolve_dta_source(file)
     on.exit(.cleanup_dta_source(source), add = TRUE)
-    metadata_names <- .dta_metadata(source$path)
+    metadata_names <- .dta_metadata(source$path, encoding)
 
     if (rlang::quo_is_null(selection)) {
         column_indices <- NULL
@@ -78,7 +80,8 @@ read_dta <- function(file, encoding = NULL, col_select = NULL, skip = 0,
         column_indices,
         as.double(skip),
         as.double(n_max),
-        identical(materialization, "direct")
+        identical(materialization, "direct"),
+        encoding
     )
     if (!is.null(column_indices)) {
         names(native) <- selected_names
@@ -162,8 +165,32 @@ read_dta <- function(file, encoding = NULL, col_select = NULL, skip = 0,
     invisible(NULL)
 }
 
-.dta_metadata <- function(file) {
-    .Call(C_dtaparser_metadata, file)
+.dta_metadata <- function(file, encoding = NULL) {
+    .Call(C_dtaparser_metadata, file, encoding)
+}
+
+.validate_dta_encoding <- function(encoding) {
+    if (is.null(encoding)) return(NULL)
+    if (!is.character(encoding) || length(encoding) != 1L || is.na(encoding)) {
+        stop("`encoding` must be NULL or one non-missing character string",
+             call. = FALSE)
+    }
+    key <- tolower(gsub("[-_ ]", "", encoding))
+    canonical <- switch(key,
+        utf8 = "UTF-8",
+        windows1252 = "Windows-1252",
+        cp1252 = "Windows-1252",
+        iso88591 = "ISO-8859-1",
+        latin1 = "ISO-8859-1",
+        NULL
+    )
+    if (is.null(canonical)) {
+        stop(sprintf(
+            "unsupported `encoding` %s; use UTF-8, Windows-1252, or ISO-8859-1",
+            encodeString(encoding, quote = "\"")
+        ), call. = FALSE)
+    }
+    canonical
 }
 
 .validate_count <- function(value, argument, infinite) {

--- a/r-package/dtaparser/README.md
+++ b/r-package/dtaparser/README.md
@@ -43,6 +43,20 @@ system or `.a`--`.z` missing values. `%td` is converted to `Date`; `%tc` and
 `%tC` are converted to UTC `POSIXct`. Other Stata calendar formats remain
 numeric and retain their `format.stata` attribute.
 
+`encoding = NULL` follows the DTA release convention: Windows-1252 for
+releases 113--115 and UTF-8 for releases 117--119. To recover files whose
+source encoding is recorded incorrectly, pass a case-insensitive UTF-8/UTF8,
+Windows-1252/CP1252, or ISO-8859-1/latin1 alias. The override is deterministic
+across platforms and applies to dataset and variable metadata, fixed strings,
+`strL` payloads, and value-label names and text. ISO-8859-1 remains distinct
+from Windows-1252 at bytes 0x80--0x9f. Other encoding names produce an error
+instead of inheriting platform-dependent `iconv` alias or lossy-conversion
+behavior. Haven 2.5.5 does not apply its override to modern `strL` payloads;
+`dtaparser` deliberately applies the requested encoding consistently there.
+With an explicit UTF-8 override, malformed input sequences are replaced
+deterministically with U+FFFD. Haven 2.5.5 may instead omit or empty an affected
+label.
+
 ## Performance compared with haven
 
 A warm-cache benchmark on an Apple M4 Max compared full reads by
@@ -77,8 +91,6 @@ No repeated 10 GB comparison was completed, so no 10 GB result is reported.
 - Remote bzip2, xz, and zip files have the same limitations as
   `readr::datasource()`; download them locally first when readr cannot expose
   them as a decompressed source.
-- `encoding` must be `NULL`. Legacy files use Windows-1252 and XML-era files
-  use UTF-8 according to the DTA storage format.
 - `col_select` uses tidyselect and is resolved from typed metadata before
   observation data are decoded, so predicates such as `where(is.character)`
   work without reading values. If a source column is selected more than once,

--- a/r-package/dtaparser/man/read_dta.Rd
+++ b/r-package/dtaparser/man/read_dta.Rd
@@ -12,7 +12,13 @@ Character vectors containing literal data are not handled, matching
 \code{haven::read_dta()}. URLs are fetched at call time; applications accepting
 untrusted \code{file} values should validate or allowlist sources before calling
 \code{read_dta()}.}
-\item{encoding}{Must be \code{NULL}; decoding follows the file format.}
+\item{encoding}{Optional source encoding override. Supported aliases are
+\code{"UTF-8"}/\code{"UTF8"}, \code{"Windows-1252"}/\code{"CP1252"}, and
+\code{"ISO-8859-1"}/\code{"latin1"}, matched case-insensitively. \code{NULL}
+uses Windows-1252 for legacy files and UTF-8 for modern files. The override
+applies to metadata, fixed strings, \code{strL} payloads, and value-label
+names and text. Explicit UTF-8 replaces malformed input sequences
+deterministically with U+FFFD. Haven 2.5.5 may instead omit an affected label.}
 \item{col_select}{One or more tidyselect expressions. Predicates treat Stata
 string storage as character and numeric storage as double. If a source
 variable is selected more than once, the first selection and alias win.}

--- a/r-package/dtaparser/src/init.c
+++ b/r-package/dtaparser/src/init.c
@@ -6,9 +6,10 @@
 #include <stdint.h>
 #include <string.h>
 
-extern SEXP dtaparser_metadata_rust(const char *, char **);
+extern SEXP dtaparser_metadata_rust(const char *, const char *, char **);
 extern SEXP dtaparser_read_rust(
-    const char *, const int *, size_t, int, double, double, int, char **
+    const char *, const int *, size_t, int, double, double, int, const char *,
+    char **
 );
 extern void dtaparser_free_error(char *);
 
@@ -123,20 +124,31 @@ static void fail_from_rust(char *message) {
     Rf_error("%s", local);
 }
 
-SEXP C_dtaparser_metadata(SEXP path) {
+static const char *optional_encoding(SEXP encoding) {
+    if (Rf_isNull(encoding)) return NULL;
+    if (TYPEOF(encoding) != STRSXP || XLENGTH(encoding) != 1 ||
+        STRING_ELT(encoding, 0) == NA_STRING) {
+        Rf_error("`encoding` must be NULL or one non-missing character string");
+    }
+    return Rf_translateCharUTF8(STRING_ELT(encoding, 0));
+}
+
+SEXP C_dtaparser_metadata(SEXP path, SEXP encoding) {
     if (TYPEOF(path) != STRSXP || XLENGTH(path) != 1 || STRING_ELT(path, 0) == NA_STRING) {
         Rf_error("`file` must be one non-missing path");
     }
     char *error = NULL;
     SEXP result = dtaparser_metadata_rust(
-        Rf_translateCharUTF8(STRING_ELT(path, 0)), &error
+        Rf_translateCharUTF8(STRING_ELT(path, 0)), optional_encoding(encoding),
+        &error
     );
     if (result == NULL) fail_from_rust(error);
     return result;
 }
 
 SEXP C_dtaparser_read(
-    SEXP path, SEXP columns, SEXP skip, SEXP n_max, SEXP direct_to_r
+    SEXP path, SEXP columns, SEXP skip, SEXP n_max, SEXP direct_to_r,
+    SEXP encoding
 ) {
     if (TYPEOF(path) != STRSXP || XLENGTH(path) != 1 || STRING_ELT(path, 0) == NA_STRING) {
         Rf_error("`file` must be one non-missing path");
@@ -162,6 +174,7 @@ SEXP C_dtaparser_read(
         REAL(skip)[0],
         REAL(n_max)[0],
         LOGICAL(direct_to_r)[0],
+        optional_encoding(encoding),
         &error
     );
     if (result == NULL) fail_from_rust(error);
@@ -169,8 +182,8 @@ SEXP C_dtaparser_read(
 }
 
 static const R_CallMethodDef CallEntries[] = {
-    {"C_dtaparser_metadata", (DL_FUNC) &C_dtaparser_metadata, 1},
-    {"C_dtaparser_read", (DL_FUNC) &C_dtaparser_read, 5},
+    {"C_dtaparser_metadata", (DL_FUNC) &C_dtaparser_metadata, 2},
+    {"C_dtaparser_read", (DL_FUNC) &C_dtaparser_read, 6},
     {NULL, NULL, 0}
 };
 

--- a/r-package/dtaparser/src/rust/src/lib.rs
+++ b/r-package/dtaparser/src/rust/src/lib.rs
@@ -5,7 +5,7 @@ use std::ptr;
 
 use dta_parser::{
     ColumnValues, DtaData, DtaError, DtaFile, DtaMetadata, DtaSink, DtaType, MissingTag,
-    ReadOptions, ValueLabelTable, VariableInfo,
+    ReadOptions, TextEncoding, ValueLabelTable, VariableInfo,
 };
 
 type Sexp = *mut c_void;
@@ -657,8 +657,9 @@ impl DtaSink for RDataFrameSink {
     }
 }
 
-unsafe fn metadata_impl(path: &str) -> Result<Sexp, String> {
-    let file = DtaFile::open(path).map_err(|error| error.to_string())?;
+unsafe fn metadata_impl(path: &str, encoding: TextEncoding) -> Result<Sexp, String> {
+    let file =
+        DtaFile::open_with_encoding(path, encoding).map_err(|error| error.to_string())?;
     let metadata = file.metadata();
     let mut guard = ProtectGuard::new();
     let names = metadata
@@ -709,6 +710,7 @@ unsafe fn read_impl(
     skip: f64,
     n_max: f64,
     direct_to_r: bool,
+    encoding: TextEncoding,
 ) -> Result<Sexp, String> {
     if !skip.is_finite() || skip < 0.0 || skip.fract() != 0.0 || skip > (1_u64 << 53) as f64 {
         return Err("invalid skip value".to_owned());
@@ -725,7 +727,8 @@ unsafe fn read_impl(
     } else {
         Some(n_max as u64)
     };
-    let mut file = DtaFile::open(path).map_err(|error| error.to_string())?;
+    let mut file =
+        DtaFile::open_with_encoding(path, encoding).map_err(|error| error.to_string())?;
     validate_r_row_count(file.metadata().nobs, row_start, row_count)?;
     let options = ReadOptions {
         row_start,
@@ -790,16 +793,31 @@ where
     }
 }
 
+unsafe fn text_encoding(encoding: *const c_char) -> Result<TextEncoding, String> {
+    if encoding.is_null() {
+        return Ok(TextEncoding::Auto);
+    }
+    let label = CStr::from_ptr(encoding)
+        .to_str()
+        .map_err(|_| "encoding name is not valid UTF-8".to_owned())?;
+    TextEncoding::from_label(label).map_err(|error| error.to_string())
+}
+
 #[no_mangle]
 /// Return DTA metadata as an R character vector.
 ///
 /// # Safety
 ///
-/// `path` must point to a valid NUL-terminated string. If non-null, `error`
-/// must point to writable storage for one C string pointer. The caller must run
-/// on R's main thread with an initialized R runtime.
+/// `path` must point to a readable NUL-terminated C byte string for the
+/// duration of this call. `encoding` may be null; otherwise it must likewise
+/// point to a readable NUL-terminated C byte string for the duration of this
+/// call. Neither string's bytes need to be valid UTF-8; invalid UTF-8 is
+/// returned as an ordinary error. If non-null, `error` must point to writable
+/// storage for one C string pointer. The caller must run on R's main thread
+/// with an initialized R runtime.
 pub unsafe extern "C" fn dtaparser_metadata_rust(
     path: *const c_char,
+    encoding: *const c_char,
     error: *mut *mut c_char,
 ) -> Sexp {
     boundary(error, || {
@@ -809,7 +827,7 @@ pub unsafe extern "C" fn dtaparser_metadata_rust(
         let path = CStr::from_ptr(path)
             .to_str()
             .map_err(|_| "file path is not valid UTF-8".to_owned())?;
-        metadata_impl(path)
+        metadata_impl(path, text_encoding(encoding)?)
     })
 }
 
@@ -818,10 +836,14 @@ pub unsafe extern "C" fn dtaparser_metadata_rust(
 ///
 /// # Safety
 ///
-/// `path` must point to a valid NUL-terminated string. Unless `all_columns` is
-/// nonzero, `columns` must address `column_count` readable integers. If
-/// non-null, `error` must point to writable storage for one C string pointer.
-/// The caller must run on R's main thread with an initialized R runtime.
+/// `path` must point to a readable NUL-terminated C byte string for the
+/// duration of this call. `encoding` may be null; otherwise it must likewise
+/// point to a readable NUL-terminated C byte string for the duration of this
+/// call. Neither string's bytes need to be valid UTF-8; invalid UTF-8 is
+/// returned as an ordinary error. Unless `all_columns` is nonzero, `columns`
+/// must address `column_count` readable integers. If non-null, `error` must
+/// point to writable storage for one C string pointer. The caller must run on
+/// R's main thread with an initialized R runtime.
 pub unsafe extern "C" fn dtaparser_read_rust(
     path: *const c_char,
     columns: *const c_int,
@@ -830,6 +852,7 @@ pub unsafe extern "C" fn dtaparser_read_rust(
     skip: f64,
     n_max: f64,
     direct_to_r: c_int,
+    encoding: *const c_char,
     error: *mut *mut c_char,
 ) -> Sexp {
     boundary(error, || {
@@ -859,7 +882,14 @@ pub unsafe extern "C" fn dtaparser_read_rust(
                     .collect::<Result<Vec<_>, _>>()?,
             )
         };
-        read_impl(path, projection, skip, n_max, direct_to_r != 0)
+        read_impl(
+            path,
+            projection,
+            skip,
+            n_max,
+            direct_to_r != 0,
+            text_encoding(encoding)?,
+        )
     })
 }
 

--- a/r-package/dtaparser/src/vendor/dta-parser/README.md
+++ b/r-package/dtaparser/src/vendor/dta-parser/README.md
@@ -42,6 +42,18 @@ Modern fixed strings and `strL` payloads use UTF-8 replacement for malformed
 sequences. Releases 113–115 use Windows-1252 for textual metadata, fixed
 strings, and value labels. All fixed fields stop at their first NUL byte.
 
+Every byte-slice and seekable-file path also accepts a deterministic
+`TextEncoding` override. `Utf8`, `Windows1252`, and true `Iso8859_1` decoding
+apply to dataset and variable metadata, fixed strings, `strL` payloads, and
+value-label names and text; malformed input uses replacement decoding.
+`TextEncoding::Auto` is the default used by the original APIs. Use
+`read_dta_with_encoding`, `read_dta_with_options_and_encoding`,
+`parse_metadata_with_encoding`, `parse_value_labels_with_encoding`,
+`DtaFile::open_with_encoding`, or the corresponding reader constructors for
+an override. `TextEncoding::from_label` accepts case-insensitive UTF-8/UTF8,
+Windows-1252/CP1252, and ISO-8859-1/latin1 aliases and rejects other names;
+ISO-8859-1 is intentionally distinct from Windows-1252 at bytes 0x80--0x9f.
+
 Value-label tables retain their on-disk order and require strictly ascending
 integer keys. Declared lengths, text offsets, NUL terminators, modern wrapper
 tags, legacy table boundaries, and mapped section boundaries are validated.
@@ -50,7 +62,7 @@ For seekable inputs, `DtaFile<R: Read + Seek>` provides bounded-buffer random
 access without loading observation data at construction:
 
 ```rust,no_run
-use dta_parser::{DtaFile, FileOptions, ReadOptions};
+use dta_parser::{DtaFile, FileOptions, ReadOptions, TextEncoding};
 
 let mut file = DtaFile::open("data.dta")?;
 let page = file.read_with_options(&ReadOptions {
@@ -66,7 +78,8 @@ let result = file.read_with_interrupt(&ReadOptions::default(), || {
 });
 
 let configured = FileOptions { max_buffer_bytes: 64 * 1024 };
-# let _ = (page, result, configured);
+let latin1 = DtaFile::open_with_encoding("legacy.dta", TextEncoding::Iso8859_1)?;
+# let _ = (page, result, configured, latin1);
 # Ok::<(), Box<dyn std::error::Error>>(())
 ```
 

--- a/r-package/dtaparser/src/vendor/dta-parser/src/data_reader.rs
+++ b/r-package/dtaparser/src/vendor/dta-parser/src/data_reader.rs
@@ -6,11 +6,12 @@ use crate::endian::{
 };
 use crate::selection::{resolve_columns, row_window};
 use crate::strl::decode_strl_columns;
-use crate::text::{decode_utf8, decode_windows_1252, field_bytes};
+use crate::text::{field_bytes, TextEncoding};
 use crate::{
     classify_byte_missing, classify_double_missing_bits, classify_float_missing_bits,
-    classify_int_missing, classify_long_missing, parse_metadata, parse_value_labels, Column,
-    ColumnValues, DtaData, DtaError, DtaMetadata, DtaType, ReadOptions, VariableInfo,
+    classify_int_missing, classify_long_missing, parse_metadata_with_encoding,
+    parse_value_labels_with_encoding, Column, ColumnValues, DtaData, DtaError, DtaMetadata,
+    DtaType, ReadOptions, VariableInfo,
 };
 
 const DATA_OPEN: &[u8] = b"<data>";
@@ -111,6 +112,7 @@ fn decode_column(
     row_start: u64,
     row_count: u64,
     variable_index: u32,
+    encoding: TextEncoding,
 ) -> Result<Column, DtaError> {
     let index = usize::try_from(variable_index)
         .map_err(|_| DtaError::ArithmeticOverflow("column index"))?;
@@ -203,11 +205,7 @@ fn decode_column(
                 let cell_offset = checked_add_u64(first_offset, row_offset, "cell offset")?;
                 let cell_offset = offset_to_usize(cell_offset, "cell")?;
                 let field = slice_at(bytes, cell_offset, width, "fixed-string observation")?;
-                let value = if metadata.format_version.is_modern() {
-                    decode_utf8(field_bytes(field))
-                } else {
-                    decode_windows_1252(field_bytes(field))
-                };
+                let value = encoding.decode(field_bytes(field));
                 values.push(value);
             }
             ColumnValues::FixedString { values }
@@ -230,12 +228,27 @@ pub fn read_dta(bytes: &[u8]) -> Result<DtaData, DtaError> {
     read_dta_with_options(bytes, &ReadOptions::default())
 }
 
+/// Parse and decode all observations with an explicit source-text encoding.
+pub fn read_dta_with_encoding(bytes: &[u8], encoding: TextEncoding) -> Result<DtaData, DtaError> {
+    read_dta_with_options_and_encoding(bytes, &ReadOptions::default(), encoding)
+}
+
 /// Parse a supported Stata file into a column-oriented, projected result.
 pub fn read_dta_with_options(bytes: &[u8], options: &ReadOptions) -> Result<DtaData, DtaError> {
-    let metadata = parse_metadata(bytes)?;
+    read_dta_with_options_and_encoding(bytes, options, TextEncoding::Auto)
+}
+
+/// Parse a supported Stata file with an explicit source-text encoding.
+pub fn read_dta_with_options_and_encoding(
+    bytes: &[u8],
+    options: &ReadOptions,
+    encoding: TextEncoding,
+) -> Result<DtaData, DtaError> {
+    let metadata = parse_metadata_with_encoding(bytes, encoding)?;
+    let encoding = encoding.resolve(metadata.format_version);
     let payload_start = validate_data_section(bytes, &metadata)?;
     let column_indices = resolve_columns(&metadata, options)?;
-    let value_label_tables = parse_value_labels(bytes, &metadata)?;
+    let value_label_tables = parse_value_labels_with_encoding(bytes, &metadata, encoding)?;
     let (row_start, row_count) = row_window(&metadata, options);
     let mut strl_indices = Vec::new();
     for &index in &column_indices {
@@ -252,6 +265,7 @@ pub fn read_dta_with_options(bytes: &[u8], options: &ReadOptions) -> Result<DtaD
         row_start,
         row_count,
         &strl_indices,
+        encoding,
     )?
     .into_iter()
     .map(|column| (column.variable_index, column))
@@ -269,6 +283,7 @@ pub fn read_dta_with_options(bytes: &[u8], options: &ReadOptions) -> Result<DtaD
                 row_start,
                 row_count,
                 variable_index,
+                encoding,
             )?);
         }
     }

--- a/r-package/dtaparser/src/vendor/dta-parser/src/error.rs
+++ b/r-package/dtaparser/src/vendor/dta-parser/src/error.rs
@@ -40,6 +40,11 @@ pub enum DtaError {
     #[error("invalid Stata release {0:?}")]
     InvalidRelease(String),
 
+    /// A caller requested a text encoding outside the deterministic supported
+    /// set.
+    #[error("unsupported text encoding {0:?}; supported encodings are UTF-8, Windows-1252, and ISO-8859-1")]
+    UnsupportedTextEncoding(String),
+
     /// A legacy header's file-type marker was not the required data-file
     /// marker (`0x01`).
     #[error("invalid legacy file type marker 0x{0:02x}")]

--- a/r-package/dtaparser/src/vendor/dta-parser/src/file.rs
+++ b/r-package/dtaparser/src/vendor/dta-parser/src/file.rs
@@ -3,7 +3,7 @@ use std::fs::File;
 use std::io::{ErrorKind, Read, Seek, SeekFrom};
 use std::path::Path;
 
-use encoding_rs::{CoderResult, Encoding, UTF_8, WINDOWS_1252};
+use encoding_rs::CoderResult;
 
 use crate::endian::{read_i16, read_i32, read_i8, read_u16, read_u32, read_u64};
 use crate::legacy::{
@@ -12,7 +12,7 @@ use crate::legacy::{
 };
 use crate::metadata::{field_widths, resolve_type};
 use crate::selection::{resolve_columns, row_window};
-use crate::text::{decode_utf8, decode_windows_1252, field_bytes, is_utf8_continuation};
+use crate::text::{field_bytes, is_utf8_boundary, TextDecoder, TextEncoding};
 use crate::{
     classify_byte_missing, classify_double_missing_bits, classify_float_missing_bits,
     classify_int_missing, classify_long_missing, ByteOrder, Column, ColumnValues, DtaData,
@@ -482,28 +482,57 @@ pub struct DtaFile<R: Read + Seek> {
     file_length: u64,
     scratch: Scratch,
     value_label_tables: Option<Vec<ValueLabelTable>>,
+    text_encoding: TextEncoding,
 }
 
 impl DtaFile<File> {
     /// Open a path and retain the file handle for subsequent projected reads.
     pub fn open(path: impl AsRef<Path>) -> Result<Self, DtaError> {
+        Self::open_with_encoding(path, TextEncoding::Auto)
+    }
+
+    /// Open a path with an explicit source-text encoding.
+    pub fn open_with_encoding(
+        path: impl AsRef<Path>,
+        encoding: TextEncoding,
+    ) -> Result<Self, DtaError> {
         let file = File::open(path).map_err(|error| DtaError::Io {
             context: "opening file",
             offset: 0,
             kind: error.kind(),
         })?;
-        Self::from_reader(file)
+        Self::from_reader_with_encoding(file, encoding)
     }
 }
 
 impl<R: Read + Seek> DtaFile<R> {
     /// Construct a file-backed reader with the default 8 MiB scratch bound.
     pub fn from_reader(reader: R) -> Result<Self, DtaError> {
-        Self::from_reader_with_options(reader, FileOptions::default())
+        Self::from_reader_with_options_and_encoding(
+            reader,
+            FileOptions::default(),
+            TextEncoding::Auto,
+        )
+    }
+
+    /// Construct a reader with an explicit source-text encoding and the
+    /// default 8 MiB scratch bound.
+    pub fn from_reader_with_encoding(reader: R, encoding: TextEncoding) -> Result<Self, DtaError> {
+        Self::from_reader_with_options_and_encoding(reader, FileOptions::default(), encoding)
     }
 
     /// Construct a file-backed reader with an explicit scratch-read bound.
-    pub fn from_reader_with_options(mut reader: R, options: FileOptions) -> Result<Self, DtaError> {
+    pub fn from_reader_with_options(reader: R, options: FileOptions) -> Result<Self, DtaError> {
+        Self::from_reader_with_options_and_encoding(reader, options, TextEncoding::Auto)
+    }
+
+    /// Construct a file-backed reader with explicit scratch and source-text
+    /// decoding options.
+    pub fn from_reader_with_options_and_encoding(
+        mut reader: R,
+        options: FileOptions,
+        encoding: TextEncoding,
+    ) -> Result<Self, DtaError> {
         if options.max_buffer_bytes < MIN_MAX_BUFFER_BYTES {
             return Err(DtaError::InvalidBufferSize);
         }
@@ -520,7 +549,7 @@ impl<R: Read + Seek> DtaFile<R> {
         }
         let first = read_exact_at(&mut reader, 0, 1, &mut scratch, "reading signature")?;
         let metadata = if matches!(first[0], 113..=115) {
-            read_legacy_metadata(&mut reader, file_length, &mut scratch)?
+            read_legacy_metadata(&mut reader, file_length, &mut scratch, encoding)?
         } else {
             let signature_length = MODERN_SIGNATURE.len();
             if file_length < signature_length as u64
@@ -534,7 +563,7 @@ impl<R: Read + Seek> DtaFile<R> {
             {
                 return Err(DtaError::InvalidSignature);
             }
-            read_modern_metadata(&mut reader, file_length, &mut scratch)?
+            read_modern_metadata(&mut reader, file_length, &mut scratch, encoding)?
         };
         if metadata.section_offsets.end_of_file != file_length {
             return Err(DtaError::MapOffsetMismatch {
@@ -543,12 +572,14 @@ impl<R: Read + Seek> DtaFile<R> {
                 actual: file_length,
             });
         }
+        let text_encoding = encoding.resolve(metadata.format_version);
         Ok(Self {
             reader,
             metadata,
             file_length,
             scratch,
             value_label_tables: None,
+            text_encoding,
         })
     }
 
@@ -653,6 +684,7 @@ impl<R: Read + Seek> DtaFile<R> {
             sink: &mut sink,
             strl_pointers: &mut strl_pointers,
             metadata: &self.metadata,
+            text_encoding: self.text_encoding,
         };
 
         if !indices.is_empty()
@@ -755,16 +787,11 @@ impl<R: Read + Seek> DtaFile<R> {
                     let width = usize::try_from(variable.byte_width)
                         .map_err(|_| DtaError::ArithmeticOverflow("cell width"))?;
                     if matches!(variable.dta_type, DtaType::FixedString(_)) {
-                        let encoding = if self.metadata.format_version.is_modern() {
-                            UTF_8
-                        } else {
-                            WINDOWS_1252
-                        };
                         let (value, _) = decode_range(
                             &mut self.reader,
                             cell_offset,
                             width,
-                            encoding,
+                            self.text_encoding,
                             true,
                             &mut self.scratch,
                             &mut should_interrupt,
@@ -799,6 +826,7 @@ impl<R: Read + Seek> DtaFile<R> {
             &mut strl_pointers,
             &mut sink,
             &mut should_interrupt,
+            self.text_encoding,
         )?;
         check_cancel(&mut should_interrupt)?;
         self.ensure_value_labels(&mut should_interrupt)?;
@@ -832,6 +860,7 @@ impl<R: Read + Seek> DtaFile<R> {
             &self.metadata,
             &mut self.scratch,
             should_interrupt,
+            self.text_encoding,
         )?;
         check_cancel(should_interrupt)?;
         self.value_label_tables = Some(tables);
@@ -911,14 +940,14 @@ fn decode_range<R: Read + Seek, F: FnMut() -> bool>(
     reader: &mut R,
     offset: u64,
     length: usize,
-    encoding: &'static Encoding,
+    encoding: TextEncoding,
     stop_at_nul: bool,
     scratch: &mut Scratch,
     should_interrupt: &mut F,
     context: &'static str,
 ) -> Result<(String, bool), DtaError> {
     let mut output = String::new();
-    let mut decoder = encoding.new_decoder_without_bom_handling();
+    let mut decoder = encoding.new_decoder();
     let mut completed = 0_usize;
     let mut found_nul = false;
 
@@ -958,7 +987,7 @@ fn decode_range<R: Read + Seek, F: FnMut() -> bool>(
         let last = found_nul || completed.saturating_add(chunk_length) == length;
         let mut consumed = 0_usize;
         loop {
-            let (result, read, _) = decoder.decode_to_string(&input[consumed..], &mut output, last);
+            let (result, read) = decoder.decode_to_string(&input[consumed..], &mut output, last);
             consumed = consumed
                 .checked_add(read)
                 .ok_or(DtaError::ArithmeticOverflow("decoded string input"))?;
@@ -984,7 +1013,7 @@ fn decode_range_with_offsets<R: Read + Seek, F: FnMut() -> bool>(
     reader: &mut R,
     offset: u64,
     length: usize,
-    encoding: &'static Encoding,
+    encoding: TextEncoding,
     requested_offsets: &[usize],
     requested_offset_positions: &[usize],
     scratch: &mut Scratch,
@@ -1006,7 +1035,7 @@ fn decode_range_with_offsets<R: Read + Seek, F: FnMut() -> bool>(
     let mut mapped = vec![0; requested_offsets.len()];
     let mut next_mapping = 0;
     let mut output = String::new();
-    let mut decoder = encoding.new_decoder_without_bom_handling();
+    let mut decoder = encoding.new_decoder();
     let mut completed = 0_usize;
     let mut first_invalid_boundary: Option<(usize, usize)> = None;
 
@@ -1033,10 +1062,9 @@ fn decode_range_with_offsets<R: Read + Seek, F: FnMut() -> bool>(
             let boundary = ordered[next_mapping].0;
             let input_end = boundary.saturating_sub(completed).min(bytes.len());
             let original_index = ordered[next_mapping].1;
-            if std::ptr::eq(encoding, UTF_8)
-                && bytes
-                    .get(input_end)
-                    .is_some_and(|byte| is_utf8_continuation(*byte))
+            if encoding.is_utf8()
+                && bytes.get(input_end).is_some_and(|byte| byte & 0xc0 == 0x80)
+                && !utf8_file_boundary(reader, offset, length, boundary, scratch, context)?
                 && match first_invalid_boundary {
                     Some((index, _)) => original_index < index,
                     None => true,
@@ -1055,7 +1083,7 @@ fn decode_range_with_offsets<R: Read + Seek, F: FnMut() -> bool>(
                 mapped[ordered[next_mapping].1] = output.len();
                 next_mapping += 1;
             }
-            decoder = encoding.new_decoder_without_bom_handling();
+            decoder = encoding.new_decoder();
         }
         let last = chunk_end == length;
         decode_into_string(&mut decoder, &bytes[input_start..], last, &mut output)?;
@@ -1075,8 +1103,40 @@ fn decode_range_with_offsets<R: Read + Seek, F: FnMut() -> bool>(
     }
 }
 
+fn utf8_file_boundary<R: Read + Seek>(
+    reader: &mut R,
+    offset: u64,
+    length: usize,
+    boundary: usize,
+    scratch: &mut Scratch,
+    context: &'static str,
+) -> Result<bool, DtaError> {
+    if boundary == 0 || boundary >= length {
+        return Ok(true);
+    }
+    let probe_start = boundary.saturating_sub(3);
+    let probe_end = boundary
+        .checked_add(4)
+        .ok_or(DtaError::ArithmeticOverflow("UTF-8 boundary probe"))?
+        .min(length);
+    let probe_offset = offset
+        .checked_add(
+            u64::try_from(probe_start)
+                .map_err(|_| DtaError::ArithmeticOverflow("UTF-8 boundary probe"))?,
+        )
+        .ok_or(DtaError::ArithmeticOverflow("UTF-8 boundary probe"))?;
+    let probe = read_exact_at(
+        reader,
+        probe_offset,
+        probe_end - probe_start,
+        scratch,
+        context,
+    )?;
+    Ok(is_utf8_boundary(&probe, boundary - probe_start))
+}
+
 fn decode_into_string(
-    decoder: &mut encoding_rs::Decoder,
+    decoder: &mut TextDecoder,
     input: &[u8],
     last: bool,
     output: &mut String,
@@ -1091,7 +1151,7 @@ fn decode_into_string(
         .map_err(|_| DtaError::ArithmeticOverflow("decoded string allocation"))?;
     let mut consumed = 0;
     loop {
-        let (result, read, _) = decoder.decode_to_string(&input[consumed..], output, last);
+        let (result, read) = decoder.decode_to_string(&input[consumed..], output, last);
         consumed = consumed
             .checked_add(read)
             .ok_or(DtaError::ArithmeticOverflow("decoded string input"))?;
@@ -1199,6 +1259,7 @@ fn validate_modern_sortlist<R: Read + Seek>(
 fn read_modern_header_map<R: Read + Seek>(
     reader: &mut R,
     scratch: &mut Scratch,
+    encoding: TextEncoding,
 ) -> Result<FileModernHeaderMap, DtaError> {
     let mut cursor = expect_file_tag(
         reader,
@@ -1215,6 +1276,7 @@ fn read_modern_header_map<R: Read + Seek>(
         .and_then(|release| FormatVersion::try_from(release).ok())
         .filter(|version| version.is_modern())
         .ok_or(DtaError::InvalidRelease(release_text))?;
+    let encoding = encoding.resolve(format_version);
     cursor = checked_add_u64(cursor, 3, "release number")?;
     cursor = expect_file_tag(reader, cursor, b"</release>", "</release>", scratch)?;
     cursor = expect_file_tag(reader, cursor, b"<byteorder>", "<byteorder>", scratch)?;
@@ -1293,7 +1355,7 @@ fn read_modern_header_map<R: Read + Seek>(
         reader,
         cursor,
         label_length,
-        UTF_8,
+        encoding,
         false,
         scratch,
         &mut never_cancel,
@@ -1362,8 +1424,10 @@ fn read_modern_metadata<R: Read + Seek>(
     reader: &mut R,
     file_length: u64,
     scratch: &mut Scratch,
+    encoding: TextEncoding,
 ) -> Result<DtaMetadata, DtaError> {
-    let header = read_modern_header_map(reader, scratch)?;
+    let header = read_modern_header_map(reader, scratch, encoding)?;
+    let encoding = encoding.resolve(header.format_version);
     if header.section_offsets.end_of_file > file_length
         && file_length >= header.section_offsets.stata_data_close
     {
@@ -1489,7 +1553,7 @@ fn read_modern_metadata<R: Read + Seek>(
                 reader,
                 field_offset(start, width, context)?,
                 width,
-                UTF_8,
+                encoding,
                 true,
                 scratch,
                 &mut never_cancel,
@@ -1537,10 +1601,12 @@ fn read_legacy_metadata<R: Read + Seek>(
     reader: &mut R,
     file_length: u64,
     scratch: &mut Scratch,
+    encoding: TextEncoding,
 ) -> Result<DtaMetadata, DtaError> {
     let header = read_exact_at(reader, 0, HEADER_SIZE, scratch, "reading legacy header")?;
     let version = FormatVersion::try_from(u16::from(header[0]))
         .map_err(|_| DtaError::InvalidRelease(header[0].to_string()))?;
+    let encoding = encoding.resolve(version);
     let byte_order = match header[1] {
         1 => ByteOrder::Msf,
         2 => ByteOrder::Lsf,
@@ -1587,7 +1653,7 @@ fn read_legacy_metadata<R: Read + Seek>(
         reader,
         10,
         81,
-        WINDOWS_1252,
+        encoding,
         true,
         scratch,
         &mut never_cancel,
@@ -1628,7 +1694,7 @@ fn read_legacy_metadata<R: Read + Seek>(
                 reader,
                 field_offset(start, width, context)?,
                 width,
-                WINDOWS_1252,
+                encoding,
                 true,
                 scratch,
                 &mut never_cancel,
@@ -1760,6 +1826,7 @@ fn read_value_labels_streaming<R: Read + Seek, F: FnMut() -> bool>(
     metadata: &DtaMetadata,
     scratch: &mut Scratch,
     should_interrupt: &mut F,
+    encoding: TextEncoding,
 ) -> Result<Vec<ValueLabelTable>, DtaError> {
     const RESERVED_WIDTH: usize = 3;
     let modern = metadata.format_version.is_modern();
@@ -1767,7 +1834,6 @@ fn read_value_labels_streaming<R: Read + Seek, F: FnMut() -> bool>(
         FormatVersion::V113 | FormatVersion::V114 | FormatVersion::V115 | FormatVersion::V117 => 33,
         FormatVersion::V118 | FormatVersion::V119 => 129,
     };
-    let encoding = if modern { UTF_8 } else { WINDOWS_1252 };
     let section_end = if modern {
         metadata.section_offsets.stata_data_close
     } else {
@@ -2223,6 +2289,7 @@ struct CellDecoder<'a, S> {
     sink: &'a mut S,
     strl_pointers: &'a mut [Option<Vec<Option<FileGsoKey>>>],
     metadata: &'a DtaMetadata,
+    text_encoding: TextEncoding,
 }
 
 impl<S: DtaSink> CellDecoder<'_, S> {
@@ -2236,11 +2303,7 @@ impl<S: DtaSink> CellDecoder<'_, S> {
         variable: &VariableInfo,
     ) -> Result<(), DtaError> {
         if matches!(variable.dta_type, DtaType::FixedString(_)) {
-            let mut value = if self.metadata.format_version.is_modern() {
-                decode_utf8(field_bytes(cell))
-            } else {
-                decode_windows_1252(field_bytes(cell))
-            };
+            let mut value = self.text_encoding.decode(field_bytes(cell));
             value.shrink_to_fit();
             return self
                 .sink
@@ -2333,6 +2396,7 @@ fn resolve_file_strls<R: Read + Seek, F: FnMut() -> bool, S: DtaSink>(
     pointers: &mut [Option<Vec<Option<FileGsoKey>>>],
     sink: &mut S,
     should_interrupt: &mut F,
+    encoding: TextEncoding,
 ) -> Result<(), DtaError> {
     if !pointers.iter().any(Option::is_some) {
         return Ok(());
@@ -2471,7 +2535,15 @@ fn resolve_file_strls<R: Read + Seek, F: FnMut() -> bool, S: DtaSink>(
         });
     }
 
-    materialize_file_strls(reader, scratch, &entries, pointers, sink, should_interrupt)
+    materialize_file_strls(
+        reader,
+        scratch,
+        &entries,
+        pointers,
+        sink,
+        should_interrupt,
+        encoding,
+    )
 }
 
 fn materialize_file_strls<R: Read + Seek, F: FnMut() -> bool, S: DtaSink>(
@@ -2481,6 +2553,7 @@ fn materialize_file_strls<R: Read + Seek, F: FnMut() -> bool, S: DtaSink>(
     pointers: &mut [Option<Vec<Option<FileGsoKey>>>],
     sink: &mut S,
     should_interrupt: &mut F,
+    encoding: TextEncoding,
 ) -> Result<(), DtaError> {
     let mut decoded = HashMap::<FileGsoKey, String>::new();
     let mut pointer_count = 0_usize;
@@ -2517,7 +2590,7 @@ fn materialize_file_strls<R: Read + Seek, F: FnMut() -> bool, S: DtaSink>(
                 reader,
                 entry.content_offset,
                 decoded_length,
-                UTF_8,
+                encoding,
                 false,
                 scratch,
                 should_interrupt,
@@ -2602,6 +2675,7 @@ mod tests {
                     null_checks += 1;
                     null_checks >= 2
                 },
+                TextEncoding::Utf8,
             ),
             Err(DtaError::Cancelled)
         );
@@ -2641,6 +2715,7 @@ mod tests {
                     repeated_checks += 1;
                     repeated_checks >= 4
                 },
+                TextEncoding::Utf8,
             ),
             Err(DtaError::Cancelled)
         );

--- a/r-package/dtaparser/src/vendor/dta-parser/src/legacy.rs
+++ b/r-package/dtaparser/src/vendor/dta-parser/src/legacy.rs
@@ -1,5 +1,5 @@
 use crate::endian::{checked_add, checked_mul, read_i32, read_u16, slice_at};
-use crate::text::{decode_windows_1252, field_bytes};
+use crate::text::{field_bytes, TextEncoding};
 use crate::{
     ByteOrder, DtaError, DtaMetadata, DtaType, FormatVersion, SectionOffsets, VariableInfo,
 };
@@ -18,8 +18,8 @@ pub(crate) fn format_width(version: FormatVersion) -> usize {
     }
 }
 
-fn decode_field(bytes: &[u8]) -> String {
-    decode_windows_1252(field_bytes(bytes))
+fn decode_field(bytes: &[u8], encoding: TextEncoding) -> String {
+    encoding.decode(field_bytes(bytes))
 }
 
 pub(crate) fn legacy_type(code: u8, version: FormatVersion) -> Result<(DtaType, u32), DtaError> {
@@ -138,6 +138,7 @@ fn scan_expansion_fields_ordered(
 pub(crate) fn parse_legacy_metadata(
     bytes: &[u8],
     file_length: u64,
+    encoding: TextEncoding,
 ) -> Result<DtaMetadata, DtaError> {
     slice_at(bytes, 0, HEADER_SIZE, "legacy header")?;
     let version = FormatVersion::try_from(u16::from(bytes[0]))
@@ -174,6 +175,7 @@ pub(crate) fn parse_legacy_metadata(
         byte_order,
         nvar,
         nobs,
+        encoding.resolve(version),
     )
 }
 
@@ -186,6 +188,7 @@ pub(crate) fn parse_legacy_metadata_layout(
     byte_order: ByteOrder,
     nvar: u32,
     nobs: u64,
+    encoding: TextEncoding,
 ) -> Result<DtaMetadata, DtaError> {
     let nvar_usize =
         usize::try_from(nvar).map_err(|_| DtaError::ArithmeticOverflow("legacy variable count"))?;
@@ -196,7 +199,7 @@ pub(crate) fn parse_legacy_metadata_layout(
     }
     slice_at(bytes, 0, expansion_start, "legacy fixed metadata sections")?;
 
-    let dataset_label = decode_field(slice_at(bytes, 10, 81, "legacy dataset label")?);
+    let dataset_label = decode_field(slice_at(bytes, 10, 81, "legacy dataset label")?, encoding);
     let type_codes = slice_at(
         bytes,
         fixed.variable_types,
@@ -232,27 +235,39 @@ pub(crate) fn parse_legacy_metadata_layout(
         )?;
         let (dta_type, byte_width) = legacy_type(code, version)?;
         variables.push(VariableInfo {
-            name: decode_field(slice_at(bytes, name_at, VARNAME_WIDTH, "legacy varname")?),
+            name: decode_field(
+                slice_at(bytes, name_at, VARNAME_WIDTH, "legacy varname")?,
+                encoding,
+            ),
             dta_type,
             type_code: u16::from(code),
-            format: decode_field(slice_at(
-                bytes,
-                format_at,
-                format_width(version),
-                "legacy display format",
-            )?),
-            label: decode_field(slice_at(
-                bytes,
-                label_at,
-                VARIABLE_LABEL_WIDTH,
-                "legacy variable label",
-            )?),
-            value_label_name: decode_field(slice_at(
-                bytes,
-                value_label_at,
-                VALUE_LABEL_NAME_WIDTH,
-                "legacy value-label name",
-            )?),
+            format: decode_field(
+                slice_at(
+                    bytes,
+                    format_at,
+                    format_width(version),
+                    "legacy display format",
+                )?,
+                encoding,
+            ),
+            label: decode_field(
+                slice_at(
+                    bytes,
+                    label_at,
+                    VARIABLE_LABEL_WIDTH,
+                    "legacy variable label",
+                )?,
+                encoding,
+            ),
+            value_label_name: decode_field(
+                slice_at(
+                    bytes,
+                    value_label_at,
+                    VALUE_LABEL_NAME_WIDTH,
+                    "legacy value-label name",
+                )?,
+                encoding,
+            ),
             byte_width,
             byte_offset,
         });

--- a/r-package/dtaparser/src/vendor/dta-parser/src/lib.rs
+++ b/r-package/dtaparser/src/vendor/dta-parser/src/lib.rs
@@ -18,18 +18,21 @@ mod text;
 mod types;
 mod value_labels;
 
-pub use data_reader::{read_dta, read_dta_with_options};
+pub use data_reader::{
+    read_dta, read_dta_with_encoding, read_dta_with_options, read_dta_with_options_and_encoding,
+};
 pub use error::DtaError;
 pub use file::{DtaFile, DtaSink, FileOptions};
-pub use metadata::parse_metadata;
+pub use metadata::{parse_metadata, parse_metadata_with_encoding};
 pub use missing::{
     classify_byte_missing, classify_double_missing_bits, classify_float_missing_bits,
     classify_int_missing, classify_long_missing, MissingTag, DOUBLE_MISSING_DOT_BITS,
     DOUBLE_MISSING_STEP_BITS, DOUBLE_MISSING_Z_BITS, FLOAT_MISSING_DOT_BITS,
     FLOAT_MISSING_STEP_BITS, FLOAT_MISSING_Z_BITS,
 };
+pub use text::TextEncoding;
 pub use types::{
     ByteOrder, Column, ColumnValues, DtaData, DtaMetadata, DtaType, FormatVersion, ReadOptions,
     SectionOffsets, ValueLabelEntry, ValueLabelTable, VariableInfo,
 };
-pub use value_labels::parse_value_labels;
+pub use value_labels::{parse_value_labels, parse_value_labels_with_encoding};

--- a/r-package/dtaparser/src/vendor/dta-parser/src/metadata.rs
+++ b/r-package/dtaparser/src/vendor/dta-parser/src/metadata.rs
@@ -3,6 +3,7 @@ use crate::endian::{
     read_u64, read_u8, slice_at,
 };
 use crate::legacy::parse_legacy_metadata;
+use crate::text::TextEncoding;
 use crate::{
     ByteOrder, DtaError, DtaMetadata, DtaType, FormatVersion, SectionOffsets, VariableInfo,
 };
@@ -141,6 +142,7 @@ fn parse_length_prefixed_text(
     version: FormatVersion,
     byte_order: ByteOrder,
     mut cursor: usize,
+    encoding: TextEncoding,
 ) -> Result<(String, usize), DtaError> {
     cursor = expect_at(bytes, cursor, LABEL_OPEN, "<label>")?;
     let (length, length_width) = if version == FormatVersion::V117 {
@@ -155,8 +157,7 @@ fn parse_length_prefixed_text(
         )
     };
     cursor = checked_add(cursor, length_width, "dataset label length")?;
-    let label =
-        String::from_utf8_lossy(slice_at(bytes, cursor, length, "dataset label")?).into_owned();
+    let label = encoding.decode(slice_at(bytes, cursor, length, "dataset label")?);
     cursor = checked_add(cursor, length, "dataset label")?;
     cursor = expect_at(bytes, cursor, LABEL_CLOSE, "</label>")?;
 
@@ -262,6 +263,7 @@ fn parse_fixed_string_section(
     bytes: &[u8],
     nvar: usize,
     section: StringSection,
+    encoding: TextEncoding,
 ) -> Result<Vec<String>, DtaError> {
     let start = offset_to_usize(section.offset, section.open_name)?;
     let mut cursor = expect_at(bytes, start, section.open, section.open_name)?;
@@ -274,7 +276,7 @@ fn parse_fixed_string_section(
             .iter()
             .position(|byte| *byte == 0)
             .unwrap_or(field.len());
-        strings.push(String::from_utf8_lossy(&field[..nul]).into_owned());
+        strings.push(encoding.decode(&field[..nul]));
     }
 
     cursor = checked_add(cursor, payload_length, "string section length")?;
@@ -340,17 +342,28 @@ pub(crate) fn resolve_type(code: u16, version: FormatVersion) -> Result<(DtaType
 /// sequential layout requires scanning expansion fields and observation
 /// geometry to establish the value-label and end-of-file offsets.
 pub fn parse_metadata(bytes: &[u8]) -> Result<DtaMetadata, DtaError> {
+    parse_metadata_with_encoding(bytes, TextEncoding::Auto)
+}
+
+/// Parse metadata while overriding the source encoding of every textual
+/// field. [`TextEncoding::Auto`] preserves the release-specific default.
+pub fn parse_metadata_with_encoding(
+    bytes: &[u8],
+    encoding: TextEncoding,
+) -> Result<DtaMetadata, DtaError> {
     if matches!(bytes.first(), Some(113..=115)) {
         return parse_legacy_metadata(
             bytes,
             u64::try_from(bytes.len()).map_err(|_| DtaError::ArithmeticOverflow("file length"))?,
+            encoding,
         );
     }
     let (format_version, cursor) = parse_release(bytes)?;
+    let encoding = encoding.resolve(format_version);
     let (byte_order, cursor) = parse_byte_order(bytes, cursor)?;
     let (nvar, nobs, cursor) = parse_counts(bytes, format_version, byte_order, cursor)?;
     let (dataset_label, map_start) =
-        parse_length_prefixed_text(bytes, format_version, byte_order, cursor)?;
+        parse_length_prefixed_text(bytes, format_version, byte_order, cursor, encoding)?;
     let (section_offsets, _) = parse_section_map(bytes, byte_order, map_start)?;
 
     let nvar_usize = usize::try_from(nvar).map_err(|_| DtaError::ArithmeticOverflow("nvar"))?;
@@ -369,6 +382,7 @@ pub fn parse_metadata(bytes: &[u8]) -> Result<DtaMetadata, DtaError> {
             close_name: "</varnames>",
             field_width: widths.varname,
         },
+        encoding,
     )?;
     validate_sortlist(bytes, format_version, &section_offsets, nvar_usize)?;
     let formats = parse_fixed_string_section(
@@ -384,6 +398,7 @@ pub fn parse_metadata(bytes: &[u8]) -> Result<DtaMetadata, DtaError> {
             close_name: "</formats>",
             field_width: widths.format,
         },
+        encoding,
     )?;
     let value_label_names = parse_fixed_string_section(
         bytes,
@@ -398,6 +413,7 @@ pub fn parse_metadata(bytes: &[u8]) -> Result<DtaMetadata, DtaError> {
             close_name: "</value_label_names>",
             field_width: widths.value_label_name,
         },
+        encoding,
     )?;
     let variable_labels = parse_fixed_string_section(
         bytes,
@@ -412,6 +428,7 @@ pub fn parse_metadata(bytes: &[u8]) -> Result<DtaMetadata, DtaError> {
             close_name: "</variable_labels>",
             field_width: widths.variable_label,
         },
+        encoding,
     )?;
 
     let mut byte_offset = 0_u64;

--- a/r-package/dtaparser/src/vendor/dta-parser/src/strl.rs
+++ b/r-package/dtaparser/src/vendor/dta-parser/src/strl.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use crate::endian::{
     checked_add, checked_sub, expect_at, offset_to_usize, read_u16, read_u32, read_u64, slice_at,
 };
-use crate::text::decode_utf8;
+use crate::text::TextEncoding;
 use crate::{Column, ColumnValues, DtaError, DtaMetadata, DtaType, FormatVersion, VariableInfo};
 
 const STRLS_OPEN: &[u8] = b"<strls>";
@@ -252,6 +252,7 @@ pub(crate) fn decode_strl_columns(
     row_start: u64,
     row_count: u64,
     variable_indices: &[u32],
+    encoding: TextEncoding,
 ) -> Result<Vec<Column>, DtaError> {
     if variable_indices.is_empty() {
         return Ok(Vec::new());
@@ -300,7 +301,7 @@ pub(crate) fn decode_strl_columns(
             } else {
                 content
             };
-            let value = decode_utf8(string_bytes);
+            let value = encoding.decode(string_bytes);
             decoded.insert(key, value.clone());
             values.push(value);
         }

--- a/r-package/dtaparser/src/vendor/dta-parser/src/text.rs
+++ b/r-package/dtaparser/src/vendor/dta-parser/src/text.rs
@@ -1,24 +1,194 @@
-use encoding_rs::WINDOWS_1252;
+use encoding_rs::{CoderResult, Decoder, UTF_8, WINDOWS_1252};
 
-pub(crate) fn decode_utf8(bytes: &[u8]) -> String {
-    String::from_utf8_lossy(bytes).into_owned()
+use crate::{DtaError, FormatVersion};
+
+/// Source encoding used for textual fields in a Stata file.
+///
+/// [`TextEncoding::Auto`] follows the DTA release: UTF-8 for releases 117--119
+/// and Windows-1252 for releases 113--115. Explicit modes override that
+/// convention for every textual field decoded by the parser.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
+pub enum TextEncoding {
+    #[default]
+    Auto,
+    Utf8,
+    Windows1252,
+    Iso8859_1,
 }
 
-pub(crate) fn decode_windows_1252(bytes: &[u8]) -> String {
-    WINDOWS_1252
-        .decode_without_bom_handling(bytes)
-        .0
-        .into_owned()
+impl TextEncoding {
+    /// Resolve a deterministic, case-insensitive encoding label.
+    ///
+    /// ASCII hyphens, underscores, and spaces are ignored. Supported labels
+    /// are `UTF-8`/`UTF8`, `Windows-1252`/`CP1252`, and
+    /// `ISO-8859-1`/`latin1`.
+    pub fn from_label(label: &str) -> Result<Self, DtaError> {
+        let normalized = label
+            .bytes()
+            .filter(|byte| !matches!(byte, b'-' | b'_' | b' '))
+            .map(|byte| byte.to_ascii_lowercase())
+            .collect::<Vec<_>>();
+        match normalized.as_slice() {
+            b"utf8" => Ok(Self::Utf8),
+            b"windows1252" | b"cp1252" => Ok(Self::Windows1252),
+            b"iso88591" | b"latin1" => Ok(Self::Iso8859_1),
+            _ => Err(DtaError::UnsupportedTextEncoding(label.to_owned())),
+        }
+    }
+
+    pub(crate) fn resolve(self, version: FormatVersion) -> Self {
+        match self {
+            Self::Auto if version.is_modern() => Self::Utf8,
+            Self::Auto => Self::Windows1252,
+            explicit => explicit,
+        }
+    }
+
+    pub(crate) fn decode(self, bytes: &[u8]) -> String {
+        match self {
+            Self::Utf8 => String::from_utf8_lossy(bytes).into_owned(),
+            Self::Windows1252 => WINDOWS_1252
+                .decode_without_bom_handling(bytes)
+                .0
+                .into_owned(),
+            Self::Iso8859_1 => decode_iso_8859_1(bytes),
+            Self::Auto => unreachable!("text encoding must be resolved before decoding"),
+        }
+    }
+
+    pub(crate) fn is_utf8(self) -> bool {
+        matches!(self, Self::Utf8)
+    }
+
+    pub(crate) fn new_decoder(self) -> TextDecoder {
+        match self {
+            Self::Utf8 => TextDecoder::EncodingRs(UTF_8.new_decoder_without_bom_handling()),
+            Self::Windows1252 => {
+                TextDecoder::EncodingRs(WINDOWS_1252.new_decoder_without_bom_handling())
+            }
+            Self::Iso8859_1 => TextDecoder::Iso8859_1,
+            Self::Auto => unreachable!("text encoding must be resolved before decoding"),
+        }
+    }
+}
+
+pub(crate) enum TextDecoder {
+    EncodingRs(Decoder),
+    Iso8859_1,
+}
+
+impl TextDecoder {
+    pub(crate) fn decode_to_string(
+        &mut self,
+        input: &[u8],
+        output: &mut String,
+        last: bool,
+    ) -> (CoderResult, usize) {
+        match self {
+            Self::EncodingRs(decoder) => {
+                let (result, read, _) = decoder.decode_to_string(input, output, last);
+                (result, read)
+            }
+            Self::Iso8859_1 => {
+                for &byte in input {
+                    output.push(char::from(byte));
+                }
+                (CoderResult::InputEmpty, input.len())
+            }
+        }
+    }
+}
+
+fn decode_iso_8859_1(bytes: &[u8]) -> String {
+    let mut output = String::with_capacity(bytes.len());
+    for &byte in bytes {
+        output.push(char::from(byte));
+    }
+    output
+}
+
+pub(crate) fn field_bytes(bytes: &[u8]) -> &[u8] {
+    let end = bytes
+        .iter()
+        .position(|byte| *byte == 0)
+        .unwrap_or(bytes.len());
+    &bytes[..end]
 }
 
 pub(crate) fn is_utf8_continuation(byte: u8) -> bool {
     byte & 0xc0 == 0x80
 }
 
-pub(crate) fn field_bytes(field: &[u8]) -> &[u8] {
-    let end = field
-        .iter()
-        .position(|byte| *byte == 0)
-        .unwrap_or(field.len());
-    &field[..end]
+/// Whether `offset` lies between decoded UTF-8 code points. Malformed bytes
+/// are replacement characters of their own, so an offset before a standalone
+/// continuation byte remains a valid boundary.
+pub(crate) fn is_utf8_boundary(bytes: &[u8], offset: usize) -> bool {
+    if offset == 0 || offset >= bytes.len() || !is_utf8_continuation(bytes[offset]) {
+        return true;
+    }
+    let mut start = offset;
+    while start > 0 && is_utf8_continuation(bytes[start]) {
+        start -= 1;
+    }
+    let width = match bytes[start] {
+        0xc2..=0xdf => 2,
+        0xe0..=0xef => 3,
+        0xf0..=0xf4 => 4,
+        _ => return true,
+    };
+    let Some(end) = start.checked_add(width) else {
+        return true;
+    };
+    if offset >= end || end > bytes.len() {
+        return true;
+    }
+    std::str::from_utf8(&bytes[start..end]).is_err()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolves_only_the_documented_aliases() {
+        assert_eq!(
+            TextEncoding::from_label("UTF-8").unwrap(),
+            TextEncoding::Utf8
+        );
+        assert_eq!(
+            TextEncoding::from_label("utf_8").unwrap(),
+            TextEncoding::Utf8
+        );
+        assert_eq!(
+            TextEncoding::from_label("CP1252").unwrap(),
+            TextEncoding::Windows1252
+        );
+        assert_eq!(
+            TextEncoding::from_label("iso 8859-1").unwrap(),
+            TextEncoding::Iso8859_1
+        );
+        assert!(matches!(
+            TextEncoding::from_label("native.enc"),
+            Err(DtaError::UnsupportedTextEncoding(_))
+        ));
+    }
+
+    #[test]
+    fn latin1_and_windows_1252_are_distinct() {
+        assert_eq!(TextEncoding::Windows1252.decode(&[0x80]), "\u{20ac}");
+        assert_eq!(TextEncoding::Iso8859_1.decode(&[0x80]), "\u{80}");
+    }
+
+    #[test]
+    fn malformed_utf8_uses_replacement_decoding() {
+        assert_eq!(TextEncoding::Utf8.decode(&[0xff]), "\u{fffd}");
+    }
+
+    #[test]
+    fn utf8_boundaries_distinguish_valid_codepoints_from_malformed_bytes() {
+        assert!(!is_utf8_boundary("é".as_bytes(), 1));
+        assert!(!is_utf8_boundary("€".as_bytes(), 2));
+        assert!(is_utf8_boundary(&[b'x', 0x80], 1));
+        assert!(is_utf8_boundary(&[0x80], 0));
+    }
 }

--- a/r-package/dtaparser/src/vendor/dta-parser/src/value_labels.rs
+++ b/r-package/dtaparser/src/vendor/dta-parser/src/value_labels.rs
@@ -1,5 +1,5 @@
 use crate::endian::{checked_add, checked_mul, expect_at, offset_to_usize, read_i32, slice_at};
-use crate::text::{decode_utf8, decode_windows_1252, field_bytes, is_utf8_continuation};
+use crate::text::{field_bytes, is_utf8_boundary, TextEncoding};
 use crate::{
     classify_long_missing, DtaError, DtaMetadata, FormatVersion, ValueLabelEntry, ValueLabelTable,
 };
@@ -25,6 +25,7 @@ fn parse_table(
     table_start: usize,
     name_width: usize,
     wrapped: bool,
+    encoding: TextEncoding,
 ) -> Result<(ValueLabelTable, usize), DtaError> {
     let mut cursor = if wrapped {
         expect_at(bytes, table_start, LABEL_OPEN, "<lbl>")?
@@ -62,11 +63,7 @@ fn parse_table(
     } else {
         field_bytes(name_field)
     };
-    let name = if metadata.format_version.is_modern() {
-        decode_utf8(name_bytes)
-    } else {
-        decode_windows_1252(name_bytes)
-    };
+    let name = encoding.decode(name_bytes);
     cursor = checked_add(cursor, name_width, "value-label table name")?;
 
     // The format reserves these bytes but does not assign them semantics.
@@ -175,8 +172,8 @@ fn parse_table(
                 text_length,
             });
         };
-        if metadata.format_version.is_modern()
-            && is_utf8_continuation(payload[text_start + text_offset_usize])
+        if encoding.is_utf8()
+            && !is_utf8_boundary(&payload[text_start..text_end], text_offset_usize)
         {
             return Err(DtaError::InvalidValueLabelTextOffset {
                 entry_index,
@@ -222,11 +219,7 @@ fn parse_table(
                     context: "value-label text",
                     offset: checked_add(payload_start, label_start, "value-label text")?,
                 })?;
-        let label = if metadata.format_version.is_modern() {
-            decode_utf8(&remaining[..nul])
-        } else {
-            decode_windows_1252(&remaining[..nul])
-        };
+        let label = encoding.decode(&remaining[..nul]);
         entries.push(ValueLabelEntry {
             value,
             missing_tag: classify_long_missing(value),
@@ -249,7 +242,21 @@ pub fn parse_value_labels(
     bytes: &[u8],
     metadata: &DtaMetadata,
 ) -> Result<Vec<ValueLabelTable>, DtaError> {
-    parse_value_labels_section(bytes, metadata, 0)
+    parse_value_labels_with_encoding(bytes, metadata, TextEncoding::Auto)
+}
+
+/// Parse value-label tables with an explicit source-text encoding.
+pub fn parse_value_labels_with_encoding(
+    bytes: &[u8],
+    metadata: &DtaMetadata,
+    encoding: TextEncoding,
+) -> Result<Vec<ValueLabelTable>, DtaError> {
+    parse_value_labels_section(
+        bytes,
+        metadata,
+        0,
+        encoding.resolve(metadata.format_version),
+    )
 }
 
 fn local_offset(absolute: u64, base_offset: u64, context: &'static str) -> Result<usize, DtaError> {
@@ -286,6 +293,7 @@ pub(crate) fn parse_value_labels_section(
     bytes: &[u8],
     metadata: &DtaMetadata,
     base_offset: u64,
+    encoding: TextEncoding,
 ) -> Result<Vec<ValueLabelTable>, DtaError> {
     let name_width = name_width(metadata.format_version)?;
     let start = local_offset(
@@ -309,7 +317,7 @@ pub(crate) fn parse_value_labels_section(
         let mut cursor = start;
         let mut tables = Vec::new();
         while cursor < end {
-            let (table, next) = parse_table(bytes, metadata, cursor, name_width, false)?;
+            let (table, next) = parse_table(bytes, metadata, cursor, name_width, false, encoding)?;
             if next <= cursor {
                 return Err(DtaError::ArithmeticOverflow("legacy value-label cursor"));
             }
@@ -336,7 +344,7 @@ pub(crate) fn parse_value_labels_section(
             cursor = expect_at(bytes, cursor, VALUE_LABELS_CLOSE, "</value_labels>")?;
             break;
         }
-        let (table, next) = parse_table(bytes, metadata, cursor, name_width, true)?;
+        let (table, next) = parse_table(bytes, metadata, cursor, name_width, true, encoding)?;
         tables.push(table);
         cursor = next;
     }

--- a/r-package/dtaparser/tests/testthat/test-input-sources.R
+++ b/r-package/dtaparser/tests/testthat/test-input-sources.R
@@ -250,7 +250,7 @@ test_that("temporary sources are cleaned when an interrupt unwinds the read", {
                     path <<- source$path
                     source
                 },
-                .dta_metadata = function(file) rlang::interrupt(),
+                .dta_metadata = function(file, encoding = NULL) rlang::interrupt(),
                 .package = "dtaparser"
             )
             interrupted <- tryCatch(

--- a/r-package/dtaparser/tests/testthat/test-read-dta.R
+++ b/r-package/dtaparser/tests/testthat/test-read-dta.R
@@ -2,6 +2,17 @@ fixture <- function(name) {
     system.file("extdata", name, package = "dtaparser", mustWork = TRUE)
 }
 
+replace_first_byte <- function(bytes, text, replacement) {
+    needle <- charToRaw(text)
+    starts <- seq_len(length(bytes) - length(needle) + 1L)
+    matches <- vapply(starts, function(start) {
+        identical(bytes[start:(start + length(needle) - 1L)], needle)
+    }, logical(1))
+    stopifnot(any(matches))
+    bytes[starts[which(matches)[[1L]]]] <- as.raw(replacement)
+    bytes
+}
+
 test_that("read_dta has the haven-compatible public signature", {
     expected <- c("file", "encoding", "col_select", "skip", "n_max", ".name_repair")
     expect_identical(names(formals(read_dta)), expected)
@@ -166,9 +177,96 @@ test_that("date and datetime storage become native R temporal vectors", {
     expect_identical(attr(actual$instant, "tzone"), "UTC")
 })
 
+test_that("explicit encodings match haven across ordinary textual surfaces", {
+    skip_if_not_installed("haven")
+    for (version in c(115L, 118L)) {
+        source <- fixture(sprintf("auto_v%d.dta", version))
+        bytes <- readBin(source, "raw", file.info(source)$size)
+        for (text in c(
+            "1978 automobile data", "Make and model", "AMC Concord", "Domestic"
+        )) {
+            bytes <- replace_first_byte(bytes, text, 0x80)
+        }
+        path <- tempfile(fileext = ".dta")
+        on.exit(unlink(path), add = TRUE)
+        writeBin(bytes, path)
+
+        for (encoding in c("Windows-1252", "ISO-8859-1")) {
+            actual <- read_dta(path, encoding = encoding)
+            rust_vectors <- dtaparser:::.read_dta_rust_vectors(
+                path, encoding = encoding
+            )
+            expected <- haven::read_dta(path, encoding = encoding)
+            info <- paste("release", version, encoding)
+
+            expect_identical(actual, rust_vectors,
+                             info = paste(info, "materialization"))
+            expect_identical(actual$make, expected$make,
+                             info = paste(info, "fixed string"))
+            expect_identical(attr(actual, "label"), attr(expected, "label"),
+                             info = paste(info, "dataset label"))
+            expect_identical(attr(actual$make, "label"),
+                             attr(expected$make, "label"),
+                             info = paste(info, "variable label"))
+            expect_identical(attr(actual$foreign, "labels"),
+                             attr(expected$foreign, "labels"),
+                             info = paste(info, "value labels"))
+        }
+    }
+
+    modern <- fixture("auto_v118.dta")
+    expect_identical(read_dta(modern, encoding = "utf_8"),
+                     read_dta(modern, encoding = "UTF8"))
+    expect_identical(read_dta(modern, encoding = "UTF-8")$make,
+                     haven::read_dta(modern, encoding = "UTF-8")$make)
+})
+
+test_that("explicit encodings apply consistently to strL text", {
+    source <- fixture("strl_test_v118.dta")
+    bytes <- readBin(source, "raw", file.info(source)$size)
+    bytes <- replace_first_byte(bytes, "This is observation 1", 0x80)
+    path <- tempfile(fileext = ".dta")
+    on.exit(unlink(path), add = TRUE)
+    writeBin(bytes, path)
+
+    cp1252 <- read_dta(path, encoding = "CP1252")
+    latin1 <- read_dta(path, encoding = "latin-1")
+    expect_identical(cp1252, dtaparser:::.read_dta_rust_vectors(
+        path, encoding = "windows_1252"
+    ))
+    expect_identical(latin1, dtaparser:::.read_dta_rust_vectors(
+        path, encoding = "ISO 8859 1"
+    ))
+    expect_true(startsWith(cp1252$long_text[[1L]], "\u20ac"))
+    expect_true(startsWith(latin1$long_text[[1L]], "\u0080"))
+})
+
+test_that("explicit UTF-8 replaces malformed sequences in both collectors", {
+    source <- fixture("auto_v118.dta")
+    bytes <- readBin(source, "raw", file.info(source)$size)
+    bytes <- replace_first_byte(bytes, "1978 automobile data", 0xff)
+    bytes <- replace_first_byte(bytes, "AMC Concord", 0xff)
+    path <- tempfile(fileext = ".dta")
+    on.exit(unlink(path), add = TRUE)
+    writeBin(bytes, path)
+
+    direct <- read_dta(path, encoding = "UTF-8")
+    rust_vectors <- dtaparser:::.read_dta_rust_vectors(
+        path, encoding = "UTF8"
+    )
+    expect_identical(direct, rust_vectors)
+    expect_true(startsWith(attr(direct, "label"), "\ufffd"))
+    expect_true(startsWith(direct$make[[1L]], "\ufffd"))
+})
+
 test_that("argument and native parse failures are ordinary R errors", {
     path <- fixture("auto_v118.dta")
-    expect_error(read_dta(path, encoding = "latin1"), "not supported")
+    expect_error(read_dta(path, encoding = "KOI8-R"), "unsupported.*encoding")
+    expect_error(read_dta(path, encoding = NA_character_), "non-missing")
+    expect_error(read_dta(path, encoding = character()), "one non-missing")
+    expect_error(read_dta(path, encoding = c("UTF-8", "latin1")),
+                 "one non-missing")
+    expect_error(read_dta(path, encoding = 1), "one non-missing")
     expect_error(read_dta(path, skip = -1), "non-negative")
     expect_error(read_dta(path, skip = 1.5), "whole number")
     expect_error(read_dta(path, n_max = NA_real_), "non-negative")

--- a/r-package/dtaparser/tests/testthat/test-read-dta.R
+++ b/r-package/dtaparser/tests/testthat/test-read-dta.R
@@ -179,7 +179,7 @@ test_that("date and datetime storage become native R temporal vectors", {
 
 test_that("explicit encodings match haven across ordinary textual surfaces", {
     skip_if_not_installed("haven")
-    for (version in c(115L, 118L)) {
+    for (version in c(115L, 118L)) local({
         source <- fixture(sprintf("auto_v%d.dta", version))
         bytes <- readBin(source, "raw", file.info(source)$size)
         for (text in c(
@@ -212,7 +212,7 @@ test_that("explicit encodings match haven across ordinary textual surfaces", {
                              attr(expected$foreign, "labels"),
                              info = paste(info, "value labels"))
         }
-    }
+    })
 
     modern <- fixture("auto_v118.dta")
     expect_identical(read_dta(modern, encoding = "utf_8"),

--- a/rust/dta-parser/README.md
+++ b/rust/dta-parser/README.md
@@ -42,6 +42,18 @@ Modern fixed strings and `strL` payloads use UTF-8 replacement for malformed
 sequences. Releases 113–115 use Windows-1252 for textual metadata, fixed
 strings, and value labels. All fixed fields stop at their first NUL byte.
 
+Every byte-slice and seekable-file path also accepts a deterministic
+`TextEncoding` override. `Utf8`, `Windows1252`, and true `Iso8859_1` decoding
+apply to dataset and variable metadata, fixed strings, `strL` payloads, and
+value-label names and text; malformed input uses replacement decoding.
+`TextEncoding::Auto` is the default used by the original APIs. Use
+`read_dta_with_encoding`, `read_dta_with_options_and_encoding`,
+`parse_metadata_with_encoding`, `parse_value_labels_with_encoding`,
+`DtaFile::open_with_encoding`, or the corresponding reader constructors for
+an override. `TextEncoding::from_label` accepts case-insensitive UTF-8/UTF8,
+Windows-1252/CP1252, and ISO-8859-1/latin1 aliases and rejects other names;
+ISO-8859-1 is intentionally distinct from Windows-1252 at bytes 0x80--0x9f.
+
 Value-label tables retain their on-disk order and require strictly ascending
 integer keys. Declared lengths, text offsets, NUL terminators, modern wrapper
 tags, legacy table boundaries, and mapped section boundaries are validated.
@@ -50,7 +62,7 @@ For seekable inputs, `DtaFile<R: Read + Seek>` provides bounded-buffer random
 access without loading observation data at construction:
 
 ```rust,no_run
-use dta_parser::{DtaFile, FileOptions, ReadOptions};
+use dta_parser::{DtaFile, FileOptions, ReadOptions, TextEncoding};
 
 let mut file = DtaFile::open("data.dta")?;
 let page = file.read_with_options(&ReadOptions {
@@ -66,7 +78,8 @@ let result = file.read_with_interrupt(&ReadOptions::default(), || {
 });
 
 let configured = FileOptions { max_buffer_bytes: 64 * 1024 };
-# let _ = (page, result, configured);
+let latin1 = DtaFile::open_with_encoding("legacy.dta", TextEncoding::Iso8859_1)?;
+# let _ = (page, result, configured, latin1);
 # Ok::<(), Box<dyn std::error::Error>>(())
 ```
 

--- a/rust/dta-parser/src/data_reader.rs
+++ b/rust/dta-parser/src/data_reader.rs
@@ -6,11 +6,12 @@ use crate::endian::{
 };
 use crate::selection::{resolve_columns, row_window};
 use crate::strl::decode_strl_columns;
-use crate::text::{decode_utf8, decode_windows_1252, field_bytes};
+use crate::text::{field_bytes, TextEncoding};
 use crate::{
     classify_byte_missing, classify_double_missing_bits, classify_float_missing_bits,
-    classify_int_missing, classify_long_missing, parse_metadata, parse_value_labels, Column,
-    ColumnValues, DtaData, DtaError, DtaMetadata, DtaType, ReadOptions, VariableInfo,
+    classify_int_missing, classify_long_missing, parse_metadata_with_encoding,
+    parse_value_labels_with_encoding, Column, ColumnValues, DtaData, DtaError, DtaMetadata,
+    DtaType, ReadOptions, VariableInfo,
 };
 
 const DATA_OPEN: &[u8] = b"<data>";
@@ -111,6 +112,7 @@ fn decode_column(
     row_start: u64,
     row_count: u64,
     variable_index: u32,
+    encoding: TextEncoding,
 ) -> Result<Column, DtaError> {
     let index = usize::try_from(variable_index)
         .map_err(|_| DtaError::ArithmeticOverflow("column index"))?;
@@ -203,11 +205,7 @@ fn decode_column(
                 let cell_offset = checked_add_u64(first_offset, row_offset, "cell offset")?;
                 let cell_offset = offset_to_usize(cell_offset, "cell")?;
                 let field = slice_at(bytes, cell_offset, width, "fixed-string observation")?;
-                let value = if metadata.format_version.is_modern() {
-                    decode_utf8(field_bytes(field))
-                } else {
-                    decode_windows_1252(field_bytes(field))
-                };
+                let value = encoding.decode(field_bytes(field));
                 values.push(value);
             }
             ColumnValues::FixedString { values }
@@ -230,12 +228,27 @@ pub fn read_dta(bytes: &[u8]) -> Result<DtaData, DtaError> {
     read_dta_with_options(bytes, &ReadOptions::default())
 }
 
+/// Parse and decode all observations with an explicit source-text encoding.
+pub fn read_dta_with_encoding(bytes: &[u8], encoding: TextEncoding) -> Result<DtaData, DtaError> {
+    read_dta_with_options_and_encoding(bytes, &ReadOptions::default(), encoding)
+}
+
 /// Parse a supported Stata file into a column-oriented, projected result.
 pub fn read_dta_with_options(bytes: &[u8], options: &ReadOptions) -> Result<DtaData, DtaError> {
-    let metadata = parse_metadata(bytes)?;
+    read_dta_with_options_and_encoding(bytes, options, TextEncoding::Auto)
+}
+
+/// Parse a supported Stata file with an explicit source-text encoding.
+pub fn read_dta_with_options_and_encoding(
+    bytes: &[u8],
+    options: &ReadOptions,
+    encoding: TextEncoding,
+) -> Result<DtaData, DtaError> {
+    let metadata = parse_metadata_with_encoding(bytes, encoding)?;
+    let encoding = encoding.resolve(metadata.format_version);
     let payload_start = validate_data_section(bytes, &metadata)?;
     let column_indices = resolve_columns(&metadata, options)?;
-    let value_label_tables = parse_value_labels(bytes, &metadata)?;
+    let value_label_tables = parse_value_labels_with_encoding(bytes, &metadata, encoding)?;
     let (row_start, row_count) = row_window(&metadata, options);
     let mut strl_indices = Vec::new();
     for &index in &column_indices {
@@ -252,6 +265,7 @@ pub fn read_dta_with_options(bytes: &[u8], options: &ReadOptions) -> Result<DtaD
         row_start,
         row_count,
         &strl_indices,
+        encoding,
     )?
     .into_iter()
     .map(|column| (column.variable_index, column))
@@ -269,6 +283,7 @@ pub fn read_dta_with_options(bytes: &[u8], options: &ReadOptions) -> Result<DtaD
                 row_start,
                 row_count,
                 variable_index,
+                encoding,
             )?);
         }
     }

--- a/rust/dta-parser/src/error.rs
+++ b/rust/dta-parser/src/error.rs
@@ -40,6 +40,11 @@ pub enum DtaError {
     #[error("invalid Stata release {0:?}")]
     InvalidRelease(String),
 
+    /// A caller requested a text encoding outside the deterministic supported
+    /// set.
+    #[error("unsupported text encoding {0:?}; supported encodings are UTF-8, Windows-1252, and ISO-8859-1")]
+    UnsupportedTextEncoding(String),
+
     /// A legacy header's file-type marker was not the required data-file
     /// marker (`0x01`).
     #[error("invalid legacy file type marker 0x{0:02x}")]

--- a/rust/dta-parser/src/file.rs
+++ b/rust/dta-parser/src/file.rs
@@ -3,7 +3,7 @@ use std::fs::File;
 use std::io::{ErrorKind, Read, Seek, SeekFrom};
 use std::path::Path;
 
-use encoding_rs::{CoderResult, Encoding, UTF_8, WINDOWS_1252};
+use encoding_rs::CoderResult;
 
 use crate::endian::{read_i16, read_i32, read_i8, read_u16, read_u32, read_u64};
 use crate::legacy::{
@@ -12,7 +12,7 @@ use crate::legacy::{
 };
 use crate::metadata::{field_widths, resolve_type};
 use crate::selection::{resolve_columns, row_window};
-use crate::text::{decode_utf8, decode_windows_1252, field_bytes, is_utf8_continuation};
+use crate::text::{field_bytes, is_utf8_boundary, TextDecoder, TextEncoding};
 use crate::{
     classify_byte_missing, classify_double_missing_bits, classify_float_missing_bits,
     classify_int_missing, classify_long_missing, ByteOrder, Column, ColumnValues, DtaData,
@@ -482,28 +482,57 @@ pub struct DtaFile<R: Read + Seek> {
     file_length: u64,
     scratch: Scratch,
     value_label_tables: Option<Vec<ValueLabelTable>>,
+    text_encoding: TextEncoding,
 }
 
 impl DtaFile<File> {
     /// Open a path and retain the file handle for subsequent projected reads.
     pub fn open(path: impl AsRef<Path>) -> Result<Self, DtaError> {
+        Self::open_with_encoding(path, TextEncoding::Auto)
+    }
+
+    /// Open a path with an explicit source-text encoding.
+    pub fn open_with_encoding(
+        path: impl AsRef<Path>,
+        encoding: TextEncoding,
+    ) -> Result<Self, DtaError> {
         let file = File::open(path).map_err(|error| DtaError::Io {
             context: "opening file",
             offset: 0,
             kind: error.kind(),
         })?;
-        Self::from_reader(file)
+        Self::from_reader_with_encoding(file, encoding)
     }
 }
 
 impl<R: Read + Seek> DtaFile<R> {
     /// Construct a file-backed reader with the default 8 MiB scratch bound.
     pub fn from_reader(reader: R) -> Result<Self, DtaError> {
-        Self::from_reader_with_options(reader, FileOptions::default())
+        Self::from_reader_with_options_and_encoding(
+            reader,
+            FileOptions::default(),
+            TextEncoding::Auto,
+        )
+    }
+
+    /// Construct a reader with an explicit source-text encoding and the
+    /// default 8 MiB scratch bound.
+    pub fn from_reader_with_encoding(reader: R, encoding: TextEncoding) -> Result<Self, DtaError> {
+        Self::from_reader_with_options_and_encoding(reader, FileOptions::default(), encoding)
     }
 
     /// Construct a file-backed reader with an explicit scratch-read bound.
-    pub fn from_reader_with_options(mut reader: R, options: FileOptions) -> Result<Self, DtaError> {
+    pub fn from_reader_with_options(reader: R, options: FileOptions) -> Result<Self, DtaError> {
+        Self::from_reader_with_options_and_encoding(reader, options, TextEncoding::Auto)
+    }
+
+    /// Construct a file-backed reader with explicit scratch and source-text
+    /// decoding options.
+    pub fn from_reader_with_options_and_encoding(
+        mut reader: R,
+        options: FileOptions,
+        encoding: TextEncoding,
+    ) -> Result<Self, DtaError> {
         if options.max_buffer_bytes < MIN_MAX_BUFFER_BYTES {
             return Err(DtaError::InvalidBufferSize);
         }
@@ -520,7 +549,7 @@ impl<R: Read + Seek> DtaFile<R> {
         }
         let first = read_exact_at(&mut reader, 0, 1, &mut scratch, "reading signature")?;
         let metadata = if matches!(first[0], 113..=115) {
-            read_legacy_metadata(&mut reader, file_length, &mut scratch)?
+            read_legacy_metadata(&mut reader, file_length, &mut scratch, encoding)?
         } else {
             let signature_length = MODERN_SIGNATURE.len();
             if file_length < signature_length as u64
@@ -534,7 +563,7 @@ impl<R: Read + Seek> DtaFile<R> {
             {
                 return Err(DtaError::InvalidSignature);
             }
-            read_modern_metadata(&mut reader, file_length, &mut scratch)?
+            read_modern_metadata(&mut reader, file_length, &mut scratch, encoding)?
         };
         if metadata.section_offsets.end_of_file != file_length {
             return Err(DtaError::MapOffsetMismatch {
@@ -543,12 +572,14 @@ impl<R: Read + Seek> DtaFile<R> {
                 actual: file_length,
             });
         }
+        let text_encoding = encoding.resolve(metadata.format_version);
         Ok(Self {
             reader,
             metadata,
             file_length,
             scratch,
             value_label_tables: None,
+            text_encoding,
         })
     }
 
@@ -653,6 +684,7 @@ impl<R: Read + Seek> DtaFile<R> {
             sink: &mut sink,
             strl_pointers: &mut strl_pointers,
             metadata: &self.metadata,
+            text_encoding: self.text_encoding,
         };
 
         if !indices.is_empty()
@@ -755,16 +787,11 @@ impl<R: Read + Seek> DtaFile<R> {
                     let width = usize::try_from(variable.byte_width)
                         .map_err(|_| DtaError::ArithmeticOverflow("cell width"))?;
                     if matches!(variable.dta_type, DtaType::FixedString(_)) {
-                        let encoding = if self.metadata.format_version.is_modern() {
-                            UTF_8
-                        } else {
-                            WINDOWS_1252
-                        };
                         let (value, _) = decode_range(
                             &mut self.reader,
                             cell_offset,
                             width,
-                            encoding,
+                            self.text_encoding,
                             true,
                             &mut self.scratch,
                             &mut should_interrupt,
@@ -799,6 +826,7 @@ impl<R: Read + Seek> DtaFile<R> {
             &mut strl_pointers,
             &mut sink,
             &mut should_interrupt,
+            self.text_encoding,
         )?;
         check_cancel(&mut should_interrupt)?;
         self.ensure_value_labels(&mut should_interrupt)?;
@@ -832,6 +860,7 @@ impl<R: Read + Seek> DtaFile<R> {
             &self.metadata,
             &mut self.scratch,
             should_interrupt,
+            self.text_encoding,
         )?;
         check_cancel(should_interrupt)?;
         self.value_label_tables = Some(tables);
@@ -911,14 +940,14 @@ fn decode_range<R: Read + Seek, F: FnMut() -> bool>(
     reader: &mut R,
     offset: u64,
     length: usize,
-    encoding: &'static Encoding,
+    encoding: TextEncoding,
     stop_at_nul: bool,
     scratch: &mut Scratch,
     should_interrupt: &mut F,
     context: &'static str,
 ) -> Result<(String, bool), DtaError> {
     let mut output = String::new();
-    let mut decoder = encoding.new_decoder_without_bom_handling();
+    let mut decoder = encoding.new_decoder();
     let mut completed = 0_usize;
     let mut found_nul = false;
 
@@ -958,7 +987,7 @@ fn decode_range<R: Read + Seek, F: FnMut() -> bool>(
         let last = found_nul || completed.saturating_add(chunk_length) == length;
         let mut consumed = 0_usize;
         loop {
-            let (result, read, _) = decoder.decode_to_string(&input[consumed..], &mut output, last);
+            let (result, read) = decoder.decode_to_string(&input[consumed..], &mut output, last);
             consumed = consumed
                 .checked_add(read)
                 .ok_or(DtaError::ArithmeticOverflow("decoded string input"))?;
@@ -984,7 +1013,7 @@ fn decode_range_with_offsets<R: Read + Seek, F: FnMut() -> bool>(
     reader: &mut R,
     offset: u64,
     length: usize,
-    encoding: &'static Encoding,
+    encoding: TextEncoding,
     requested_offsets: &[usize],
     requested_offset_positions: &[usize],
     scratch: &mut Scratch,
@@ -1006,7 +1035,7 @@ fn decode_range_with_offsets<R: Read + Seek, F: FnMut() -> bool>(
     let mut mapped = vec![0; requested_offsets.len()];
     let mut next_mapping = 0;
     let mut output = String::new();
-    let mut decoder = encoding.new_decoder_without_bom_handling();
+    let mut decoder = encoding.new_decoder();
     let mut completed = 0_usize;
     let mut first_invalid_boundary: Option<(usize, usize)> = None;
 
@@ -1033,10 +1062,9 @@ fn decode_range_with_offsets<R: Read + Seek, F: FnMut() -> bool>(
             let boundary = ordered[next_mapping].0;
             let input_end = boundary.saturating_sub(completed).min(bytes.len());
             let original_index = ordered[next_mapping].1;
-            if std::ptr::eq(encoding, UTF_8)
-                && bytes
-                    .get(input_end)
-                    .is_some_and(|byte| is_utf8_continuation(*byte))
+            if encoding.is_utf8()
+                && bytes.get(input_end).is_some_and(|byte| byte & 0xc0 == 0x80)
+                && !utf8_file_boundary(reader, offset, length, boundary, scratch, context)?
                 && match first_invalid_boundary {
                     Some((index, _)) => original_index < index,
                     None => true,
@@ -1055,7 +1083,7 @@ fn decode_range_with_offsets<R: Read + Seek, F: FnMut() -> bool>(
                 mapped[ordered[next_mapping].1] = output.len();
                 next_mapping += 1;
             }
-            decoder = encoding.new_decoder_without_bom_handling();
+            decoder = encoding.new_decoder();
         }
         let last = chunk_end == length;
         decode_into_string(&mut decoder, &bytes[input_start..], last, &mut output)?;
@@ -1075,8 +1103,40 @@ fn decode_range_with_offsets<R: Read + Seek, F: FnMut() -> bool>(
     }
 }
 
+fn utf8_file_boundary<R: Read + Seek>(
+    reader: &mut R,
+    offset: u64,
+    length: usize,
+    boundary: usize,
+    scratch: &mut Scratch,
+    context: &'static str,
+) -> Result<bool, DtaError> {
+    if boundary == 0 || boundary >= length {
+        return Ok(true);
+    }
+    let probe_start = boundary.saturating_sub(3);
+    let probe_end = boundary
+        .checked_add(4)
+        .ok_or(DtaError::ArithmeticOverflow("UTF-8 boundary probe"))?
+        .min(length);
+    let probe_offset = offset
+        .checked_add(
+            u64::try_from(probe_start)
+                .map_err(|_| DtaError::ArithmeticOverflow("UTF-8 boundary probe"))?,
+        )
+        .ok_or(DtaError::ArithmeticOverflow("UTF-8 boundary probe"))?;
+    let probe = read_exact_at(
+        reader,
+        probe_offset,
+        probe_end - probe_start,
+        scratch,
+        context,
+    )?;
+    Ok(is_utf8_boundary(&probe, boundary - probe_start))
+}
+
 fn decode_into_string(
-    decoder: &mut encoding_rs::Decoder,
+    decoder: &mut TextDecoder,
     input: &[u8],
     last: bool,
     output: &mut String,
@@ -1091,7 +1151,7 @@ fn decode_into_string(
         .map_err(|_| DtaError::ArithmeticOverflow("decoded string allocation"))?;
     let mut consumed = 0;
     loop {
-        let (result, read, _) = decoder.decode_to_string(&input[consumed..], output, last);
+        let (result, read) = decoder.decode_to_string(&input[consumed..], output, last);
         consumed = consumed
             .checked_add(read)
             .ok_or(DtaError::ArithmeticOverflow("decoded string input"))?;
@@ -1199,6 +1259,7 @@ fn validate_modern_sortlist<R: Read + Seek>(
 fn read_modern_header_map<R: Read + Seek>(
     reader: &mut R,
     scratch: &mut Scratch,
+    encoding: TextEncoding,
 ) -> Result<FileModernHeaderMap, DtaError> {
     let mut cursor = expect_file_tag(
         reader,
@@ -1215,6 +1276,7 @@ fn read_modern_header_map<R: Read + Seek>(
         .and_then(|release| FormatVersion::try_from(release).ok())
         .filter(|version| version.is_modern())
         .ok_or(DtaError::InvalidRelease(release_text))?;
+    let encoding = encoding.resolve(format_version);
     cursor = checked_add_u64(cursor, 3, "release number")?;
     cursor = expect_file_tag(reader, cursor, b"</release>", "</release>", scratch)?;
     cursor = expect_file_tag(reader, cursor, b"<byteorder>", "<byteorder>", scratch)?;
@@ -1293,7 +1355,7 @@ fn read_modern_header_map<R: Read + Seek>(
         reader,
         cursor,
         label_length,
-        UTF_8,
+        encoding,
         false,
         scratch,
         &mut never_cancel,
@@ -1362,8 +1424,10 @@ fn read_modern_metadata<R: Read + Seek>(
     reader: &mut R,
     file_length: u64,
     scratch: &mut Scratch,
+    encoding: TextEncoding,
 ) -> Result<DtaMetadata, DtaError> {
-    let header = read_modern_header_map(reader, scratch)?;
+    let header = read_modern_header_map(reader, scratch, encoding)?;
+    let encoding = encoding.resolve(header.format_version);
     if header.section_offsets.end_of_file > file_length
         && file_length >= header.section_offsets.stata_data_close
     {
@@ -1489,7 +1553,7 @@ fn read_modern_metadata<R: Read + Seek>(
                 reader,
                 field_offset(start, width, context)?,
                 width,
-                UTF_8,
+                encoding,
                 true,
                 scratch,
                 &mut never_cancel,
@@ -1537,10 +1601,12 @@ fn read_legacy_metadata<R: Read + Seek>(
     reader: &mut R,
     file_length: u64,
     scratch: &mut Scratch,
+    encoding: TextEncoding,
 ) -> Result<DtaMetadata, DtaError> {
     let header = read_exact_at(reader, 0, HEADER_SIZE, scratch, "reading legacy header")?;
     let version = FormatVersion::try_from(u16::from(header[0]))
         .map_err(|_| DtaError::InvalidRelease(header[0].to_string()))?;
+    let encoding = encoding.resolve(version);
     let byte_order = match header[1] {
         1 => ByteOrder::Msf,
         2 => ByteOrder::Lsf,
@@ -1587,7 +1653,7 @@ fn read_legacy_metadata<R: Read + Seek>(
         reader,
         10,
         81,
-        WINDOWS_1252,
+        encoding,
         true,
         scratch,
         &mut never_cancel,
@@ -1628,7 +1694,7 @@ fn read_legacy_metadata<R: Read + Seek>(
                 reader,
                 field_offset(start, width, context)?,
                 width,
-                WINDOWS_1252,
+                encoding,
                 true,
                 scratch,
                 &mut never_cancel,
@@ -1760,6 +1826,7 @@ fn read_value_labels_streaming<R: Read + Seek, F: FnMut() -> bool>(
     metadata: &DtaMetadata,
     scratch: &mut Scratch,
     should_interrupt: &mut F,
+    encoding: TextEncoding,
 ) -> Result<Vec<ValueLabelTable>, DtaError> {
     const RESERVED_WIDTH: usize = 3;
     let modern = metadata.format_version.is_modern();
@@ -1767,7 +1834,6 @@ fn read_value_labels_streaming<R: Read + Seek, F: FnMut() -> bool>(
         FormatVersion::V113 | FormatVersion::V114 | FormatVersion::V115 | FormatVersion::V117 => 33,
         FormatVersion::V118 | FormatVersion::V119 => 129,
     };
-    let encoding = if modern { UTF_8 } else { WINDOWS_1252 };
     let section_end = if modern {
         metadata.section_offsets.stata_data_close
     } else {
@@ -2223,6 +2289,7 @@ struct CellDecoder<'a, S> {
     sink: &'a mut S,
     strl_pointers: &'a mut [Option<Vec<Option<FileGsoKey>>>],
     metadata: &'a DtaMetadata,
+    text_encoding: TextEncoding,
 }
 
 impl<S: DtaSink> CellDecoder<'_, S> {
@@ -2236,11 +2303,7 @@ impl<S: DtaSink> CellDecoder<'_, S> {
         variable: &VariableInfo,
     ) -> Result<(), DtaError> {
         if matches!(variable.dta_type, DtaType::FixedString(_)) {
-            let mut value = if self.metadata.format_version.is_modern() {
-                decode_utf8(field_bytes(cell))
-            } else {
-                decode_windows_1252(field_bytes(cell))
-            };
+            let mut value = self.text_encoding.decode(field_bytes(cell));
             value.shrink_to_fit();
             return self
                 .sink
@@ -2333,6 +2396,7 @@ fn resolve_file_strls<R: Read + Seek, F: FnMut() -> bool, S: DtaSink>(
     pointers: &mut [Option<Vec<Option<FileGsoKey>>>],
     sink: &mut S,
     should_interrupt: &mut F,
+    encoding: TextEncoding,
 ) -> Result<(), DtaError> {
     if !pointers.iter().any(Option::is_some) {
         return Ok(());
@@ -2471,7 +2535,15 @@ fn resolve_file_strls<R: Read + Seek, F: FnMut() -> bool, S: DtaSink>(
         });
     }
 
-    materialize_file_strls(reader, scratch, &entries, pointers, sink, should_interrupt)
+    materialize_file_strls(
+        reader,
+        scratch,
+        &entries,
+        pointers,
+        sink,
+        should_interrupt,
+        encoding,
+    )
 }
 
 fn materialize_file_strls<R: Read + Seek, F: FnMut() -> bool, S: DtaSink>(
@@ -2481,6 +2553,7 @@ fn materialize_file_strls<R: Read + Seek, F: FnMut() -> bool, S: DtaSink>(
     pointers: &mut [Option<Vec<Option<FileGsoKey>>>],
     sink: &mut S,
     should_interrupt: &mut F,
+    encoding: TextEncoding,
 ) -> Result<(), DtaError> {
     let mut decoded = HashMap::<FileGsoKey, String>::new();
     let mut pointer_count = 0_usize;
@@ -2517,7 +2590,7 @@ fn materialize_file_strls<R: Read + Seek, F: FnMut() -> bool, S: DtaSink>(
                 reader,
                 entry.content_offset,
                 decoded_length,
-                UTF_8,
+                encoding,
                 false,
                 scratch,
                 should_interrupt,
@@ -2602,6 +2675,7 @@ mod tests {
                     null_checks += 1;
                     null_checks >= 2
                 },
+                TextEncoding::Utf8,
             ),
             Err(DtaError::Cancelled)
         );
@@ -2641,6 +2715,7 @@ mod tests {
                     repeated_checks += 1;
                     repeated_checks >= 4
                 },
+                TextEncoding::Utf8,
             ),
             Err(DtaError::Cancelled)
         );

--- a/rust/dta-parser/src/legacy.rs
+++ b/rust/dta-parser/src/legacy.rs
@@ -1,5 +1,5 @@
 use crate::endian::{checked_add, checked_mul, read_i32, read_u16, slice_at};
-use crate::text::{decode_windows_1252, field_bytes};
+use crate::text::{field_bytes, TextEncoding};
 use crate::{
     ByteOrder, DtaError, DtaMetadata, DtaType, FormatVersion, SectionOffsets, VariableInfo,
 };
@@ -18,8 +18,8 @@ pub(crate) fn format_width(version: FormatVersion) -> usize {
     }
 }
 
-fn decode_field(bytes: &[u8]) -> String {
-    decode_windows_1252(field_bytes(bytes))
+fn decode_field(bytes: &[u8], encoding: TextEncoding) -> String {
+    encoding.decode(field_bytes(bytes))
 }
 
 pub(crate) fn legacy_type(code: u8, version: FormatVersion) -> Result<(DtaType, u32), DtaError> {
@@ -138,6 +138,7 @@ fn scan_expansion_fields_ordered(
 pub(crate) fn parse_legacy_metadata(
     bytes: &[u8],
     file_length: u64,
+    encoding: TextEncoding,
 ) -> Result<DtaMetadata, DtaError> {
     slice_at(bytes, 0, HEADER_SIZE, "legacy header")?;
     let version = FormatVersion::try_from(u16::from(bytes[0]))
@@ -174,6 +175,7 @@ pub(crate) fn parse_legacy_metadata(
         byte_order,
         nvar,
         nobs,
+        encoding.resolve(version),
     )
 }
 
@@ -186,6 +188,7 @@ pub(crate) fn parse_legacy_metadata_layout(
     byte_order: ByteOrder,
     nvar: u32,
     nobs: u64,
+    encoding: TextEncoding,
 ) -> Result<DtaMetadata, DtaError> {
     let nvar_usize =
         usize::try_from(nvar).map_err(|_| DtaError::ArithmeticOverflow("legacy variable count"))?;
@@ -196,7 +199,7 @@ pub(crate) fn parse_legacy_metadata_layout(
     }
     slice_at(bytes, 0, expansion_start, "legacy fixed metadata sections")?;
 
-    let dataset_label = decode_field(slice_at(bytes, 10, 81, "legacy dataset label")?);
+    let dataset_label = decode_field(slice_at(bytes, 10, 81, "legacy dataset label")?, encoding);
     let type_codes = slice_at(
         bytes,
         fixed.variable_types,
@@ -232,27 +235,39 @@ pub(crate) fn parse_legacy_metadata_layout(
         )?;
         let (dta_type, byte_width) = legacy_type(code, version)?;
         variables.push(VariableInfo {
-            name: decode_field(slice_at(bytes, name_at, VARNAME_WIDTH, "legacy varname")?),
+            name: decode_field(
+                slice_at(bytes, name_at, VARNAME_WIDTH, "legacy varname")?,
+                encoding,
+            ),
             dta_type,
             type_code: u16::from(code),
-            format: decode_field(slice_at(
-                bytes,
-                format_at,
-                format_width(version),
-                "legacy display format",
-            )?),
-            label: decode_field(slice_at(
-                bytes,
-                label_at,
-                VARIABLE_LABEL_WIDTH,
-                "legacy variable label",
-            )?),
-            value_label_name: decode_field(slice_at(
-                bytes,
-                value_label_at,
-                VALUE_LABEL_NAME_WIDTH,
-                "legacy value-label name",
-            )?),
+            format: decode_field(
+                slice_at(
+                    bytes,
+                    format_at,
+                    format_width(version),
+                    "legacy display format",
+                )?,
+                encoding,
+            ),
+            label: decode_field(
+                slice_at(
+                    bytes,
+                    label_at,
+                    VARIABLE_LABEL_WIDTH,
+                    "legacy variable label",
+                )?,
+                encoding,
+            ),
+            value_label_name: decode_field(
+                slice_at(
+                    bytes,
+                    value_label_at,
+                    VALUE_LABEL_NAME_WIDTH,
+                    "legacy value-label name",
+                )?,
+                encoding,
+            ),
             byte_width,
             byte_offset,
         });

--- a/rust/dta-parser/src/lib.rs
+++ b/rust/dta-parser/src/lib.rs
@@ -18,18 +18,21 @@ mod text;
 mod types;
 mod value_labels;
 
-pub use data_reader::{read_dta, read_dta_with_options};
+pub use data_reader::{
+    read_dta, read_dta_with_encoding, read_dta_with_options, read_dta_with_options_and_encoding,
+};
 pub use error::DtaError;
 pub use file::{DtaFile, DtaSink, FileOptions};
-pub use metadata::parse_metadata;
+pub use metadata::{parse_metadata, parse_metadata_with_encoding};
 pub use missing::{
     classify_byte_missing, classify_double_missing_bits, classify_float_missing_bits,
     classify_int_missing, classify_long_missing, MissingTag, DOUBLE_MISSING_DOT_BITS,
     DOUBLE_MISSING_STEP_BITS, DOUBLE_MISSING_Z_BITS, FLOAT_MISSING_DOT_BITS,
     FLOAT_MISSING_STEP_BITS, FLOAT_MISSING_Z_BITS,
 };
+pub use text::TextEncoding;
 pub use types::{
     ByteOrder, Column, ColumnValues, DtaData, DtaMetadata, DtaType, FormatVersion, ReadOptions,
     SectionOffsets, ValueLabelEntry, ValueLabelTable, VariableInfo,
 };
-pub use value_labels::parse_value_labels;
+pub use value_labels::{parse_value_labels, parse_value_labels_with_encoding};

--- a/rust/dta-parser/src/metadata.rs
+++ b/rust/dta-parser/src/metadata.rs
@@ -3,6 +3,7 @@ use crate::endian::{
     read_u64, read_u8, slice_at,
 };
 use crate::legacy::parse_legacy_metadata;
+use crate::text::TextEncoding;
 use crate::{
     ByteOrder, DtaError, DtaMetadata, DtaType, FormatVersion, SectionOffsets, VariableInfo,
 };
@@ -141,6 +142,7 @@ fn parse_length_prefixed_text(
     version: FormatVersion,
     byte_order: ByteOrder,
     mut cursor: usize,
+    encoding: TextEncoding,
 ) -> Result<(String, usize), DtaError> {
     cursor = expect_at(bytes, cursor, LABEL_OPEN, "<label>")?;
     let (length, length_width) = if version == FormatVersion::V117 {
@@ -155,8 +157,7 @@ fn parse_length_prefixed_text(
         )
     };
     cursor = checked_add(cursor, length_width, "dataset label length")?;
-    let label =
-        String::from_utf8_lossy(slice_at(bytes, cursor, length, "dataset label")?).into_owned();
+    let label = encoding.decode(slice_at(bytes, cursor, length, "dataset label")?);
     cursor = checked_add(cursor, length, "dataset label")?;
     cursor = expect_at(bytes, cursor, LABEL_CLOSE, "</label>")?;
 
@@ -262,6 +263,7 @@ fn parse_fixed_string_section(
     bytes: &[u8],
     nvar: usize,
     section: StringSection,
+    encoding: TextEncoding,
 ) -> Result<Vec<String>, DtaError> {
     let start = offset_to_usize(section.offset, section.open_name)?;
     let mut cursor = expect_at(bytes, start, section.open, section.open_name)?;
@@ -274,7 +276,7 @@ fn parse_fixed_string_section(
             .iter()
             .position(|byte| *byte == 0)
             .unwrap_or(field.len());
-        strings.push(String::from_utf8_lossy(&field[..nul]).into_owned());
+        strings.push(encoding.decode(&field[..nul]));
     }
 
     cursor = checked_add(cursor, payload_length, "string section length")?;
@@ -340,17 +342,28 @@ pub(crate) fn resolve_type(code: u16, version: FormatVersion) -> Result<(DtaType
 /// sequential layout requires scanning expansion fields and observation
 /// geometry to establish the value-label and end-of-file offsets.
 pub fn parse_metadata(bytes: &[u8]) -> Result<DtaMetadata, DtaError> {
+    parse_metadata_with_encoding(bytes, TextEncoding::Auto)
+}
+
+/// Parse metadata while overriding the source encoding of every textual
+/// field. [`TextEncoding::Auto`] preserves the release-specific default.
+pub fn parse_metadata_with_encoding(
+    bytes: &[u8],
+    encoding: TextEncoding,
+) -> Result<DtaMetadata, DtaError> {
     if matches!(bytes.first(), Some(113..=115)) {
         return parse_legacy_metadata(
             bytes,
             u64::try_from(bytes.len()).map_err(|_| DtaError::ArithmeticOverflow("file length"))?,
+            encoding,
         );
     }
     let (format_version, cursor) = parse_release(bytes)?;
+    let encoding = encoding.resolve(format_version);
     let (byte_order, cursor) = parse_byte_order(bytes, cursor)?;
     let (nvar, nobs, cursor) = parse_counts(bytes, format_version, byte_order, cursor)?;
     let (dataset_label, map_start) =
-        parse_length_prefixed_text(bytes, format_version, byte_order, cursor)?;
+        parse_length_prefixed_text(bytes, format_version, byte_order, cursor, encoding)?;
     let (section_offsets, _) = parse_section_map(bytes, byte_order, map_start)?;
 
     let nvar_usize = usize::try_from(nvar).map_err(|_| DtaError::ArithmeticOverflow("nvar"))?;
@@ -369,6 +382,7 @@ pub fn parse_metadata(bytes: &[u8]) -> Result<DtaMetadata, DtaError> {
             close_name: "</varnames>",
             field_width: widths.varname,
         },
+        encoding,
     )?;
     validate_sortlist(bytes, format_version, &section_offsets, nvar_usize)?;
     let formats = parse_fixed_string_section(
@@ -384,6 +398,7 @@ pub fn parse_metadata(bytes: &[u8]) -> Result<DtaMetadata, DtaError> {
             close_name: "</formats>",
             field_width: widths.format,
         },
+        encoding,
     )?;
     let value_label_names = parse_fixed_string_section(
         bytes,
@@ -398,6 +413,7 @@ pub fn parse_metadata(bytes: &[u8]) -> Result<DtaMetadata, DtaError> {
             close_name: "</value_label_names>",
             field_width: widths.value_label_name,
         },
+        encoding,
     )?;
     let variable_labels = parse_fixed_string_section(
         bytes,
@@ -412,6 +428,7 @@ pub fn parse_metadata(bytes: &[u8]) -> Result<DtaMetadata, DtaError> {
             close_name: "</variable_labels>",
             field_width: widths.variable_label,
         },
+        encoding,
     )?;
 
     let mut byte_offset = 0_u64;

--- a/rust/dta-parser/src/strl.rs
+++ b/rust/dta-parser/src/strl.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use crate::endian::{
     checked_add, checked_sub, expect_at, offset_to_usize, read_u16, read_u32, read_u64, slice_at,
 };
-use crate::text::decode_utf8;
+use crate::text::TextEncoding;
 use crate::{Column, ColumnValues, DtaError, DtaMetadata, DtaType, FormatVersion, VariableInfo};
 
 const STRLS_OPEN: &[u8] = b"<strls>";
@@ -252,6 +252,7 @@ pub(crate) fn decode_strl_columns(
     row_start: u64,
     row_count: u64,
     variable_indices: &[u32],
+    encoding: TextEncoding,
 ) -> Result<Vec<Column>, DtaError> {
     if variable_indices.is_empty() {
         return Ok(Vec::new());
@@ -300,7 +301,7 @@ pub(crate) fn decode_strl_columns(
             } else {
                 content
             };
-            let value = decode_utf8(string_bytes);
+            let value = encoding.decode(string_bytes);
             decoded.insert(key, value.clone());
             values.push(value);
         }

--- a/rust/dta-parser/src/text.rs
+++ b/rust/dta-parser/src/text.rs
@@ -1,24 +1,194 @@
-use encoding_rs::WINDOWS_1252;
+use encoding_rs::{CoderResult, Decoder, UTF_8, WINDOWS_1252};
 
-pub(crate) fn decode_utf8(bytes: &[u8]) -> String {
-    String::from_utf8_lossy(bytes).into_owned()
+use crate::{DtaError, FormatVersion};
+
+/// Source encoding used for textual fields in a Stata file.
+///
+/// [`TextEncoding::Auto`] follows the DTA release: UTF-8 for releases 117--119
+/// and Windows-1252 for releases 113--115. Explicit modes override that
+/// convention for every textual field decoded by the parser.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
+pub enum TextEncoding {
+    #[default]
+    Auto,
+    Utf8,
+    Windows1252,
+    Iso8859_1,
 }
 
-pub(crate) fn decode_windows_1252(bytes: &[u8]) -> String {
-    WINDOWS_1252
-        .decode_without_bom_handling(bytes)
-        .0
-        .into_owned()
+impl TextEncoding {
+    /// Resolve a deterministic, case-insensitive encoding label.
+    ///
+    /// ASCII hyphens, underscores, and spaces are ignored. Supported labels
+    /// are `UTF-8`/`UTF8`, `Windows-1252`/`CP1252`, and
+    /// `ISO-8859-1`/`latin1`.
+    pub fn from_label(label: &str) -> Result<Self, DtaError> {
+        let normalized = label
+            .bytes()
+            .filter(|byte| !matches!(byte, b'-' | b'_' | b' '))
+            .map(|byte| byte.to_ascii_lowercase())
+            .collect::<Vec<_>>();
+        match normalized.as_slice() {
+            b"utf8" => Ok(Self::Utf8),
+            b"windows1252" | b"cp1252" => Ok(Self::Windows1252),
+            b"iso88591" | b"latin1" => Ok(Self::Iso8859_1),
+            _ => Err(DtaError::UnsupportedTextEncoding(label.to_owned())),
+        }
+    }
+
+    pub(crate) fn resolve(self, version: FormatVersion) -> Self {
+        match self {
+            Self::Auto if version.is_modern() => Self::Utf8,
+            Self::Auto => Self::Windows1252,
+            explicit => explicit,
+        }
+    }
+
+    pub(crate) fn decode(self, bytes: &[u8]) -> String {
+        match self {
+            Self::Utf8 => String::from_utf8_lossy(bytes).into_owned(),
+            Self::Windows1252 => WINDOWS_1252
+                .decode_without_bom_handling(bytes)
+                .0
+                .into_owned(),
+            Self::Iso8859_1 => decode_iso_8859_1(bytes),
+            Self::Auto => unreachable!("text encoding must be resolved before decoding"),
+        }
+    }
+
+    pub(crate) fn is_utf8(self) -> bool {
+        matches!(self, Self::Utf8)
+    }
+
+    pub(crate) fn new_decoder(self) -> TextDecoder {
+        match self {
+            Self::Utf8 => TextDecoder::EncodingRs(UTF_8.new_decoder_without_bom_handling()),
+            Self::Windows1252 => {
+                TextDecoder::EncodingRs(WINDOWS_1252.new_decoder_without_bom_handling())
+            }
+            Self::Iso8859_1 => TextDecoder::Iso8859_1,
+            Self::Auto => unreachable!("text encoding must be resolved before decoding"),
+        }
+    }
+}
+
+pub(crate) enum TextDecoder {
+    EncodingRs(Decoder),
+    Iso8859_1,
+}
+
+impl TextDecoder {
+    pub(crate) fn decode_to_string(
+        &mut self,
+        input: &[u8],
+        output: &mut String,
+        last: bool,
+    ) -> (CoderResult, usize) {
+        match self {
+            Self::EncodingRs(decoder) => {
+                let (result, read, _) = decoder.decode_to_string(input, output, last);
+                (result, read)
+            }
+            Self::Iso8859_1 => {
+                for &byte in input {
+                    output.push(char::from(byte));
+                }
+                (CoderResult::InputEmpty, input.len())
+            }
+        }
+    }
+}
+
+fn decode_iso_8859_1(bytes: &[u8]) -> String {
+    let mut output = String::with_capacity(bytes.len());
+    for &byte in bytes {
+        output.push(char::from(byte));
+    }
+    output
+}
+
+pub(crate) fn field_bytes(bytes: &[u8]) -> &[u8] {
+    let end = bytes
+        .iter()
+        .position(|byte| *byte == 0)
+        .unwrap_or(bytes.len());
+    &bytes[..end]
 }
 
 pub(crate) fn is_utf8_continuation(byte: u8) -> bool {
     byte & 0xc0 == 0x80
 }
 
-pub(crate) fn field_bytes(field: &[u8]) -> &[u8] {
-    let end = field
-        .iter()
-        .position(|byte| *byte == 0)
-        .unwrap_or(field.len());
-    &field[..end]
+/// Whether `offset` lies between decoded UTF-8 code points. Malformed bytes
+/// are replacement characters of their own, so an offset before a standalone
+/// continuation byte remains a valid boundary.
+pub(crate) fn is_utf8_boundary(bytes: &[u8], offset: usize) -> bool {
+    if offset == 0 || offset >= bytes.len() || !is_utf8_continuation(bytes[offset]) {
+        return true;
+    }
+    let mut start = offset;
+    while start > 0 && is_utf8_continuation(bytes[start]) {
+        start -= 1;
+    }
+    let width = match bytes[start] {
+        0xc2..=0xdf => 2,
+        0xe0..=0xef => 3,
+        0xf0..=0xf4 => 4,
+        _ => return true,
+    };
+    let Some(end) = start.checked_add(width) else {
+        return true;
+    };
+    if offset >= end || end > bytes.len() {
+        return true;
+    }
+    std::str::from_utf8(&bytes[start..end]).is_err()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolves_only_the_documented_aliases() {
+        assert_eq!(
+            TextEncoding::from_label("UTF-8").unwrap(),
+            TextEncoding::Utf8
+        );
+        assert_eq!(
+            TextEncoding::from_label("utf_8").unwrap(),
+            TextEncoding::Utf8
+        );
+        assert_eq!(
+            TextEncoding::from_label("CP1252").unwrap(),
+            TextEncoding::Windows1252
+        );
+        assert_eq!(
+            TextEncoding::from_label("iso 8859-1").unwrap(),
+            TextEncoding::Iso8859_1
+        );
+        assert!(matches!(
+            TextEncoding::from_label("native.enc"),
+            Err(DtaError::UnsupportedTextEncoding(_))
+        ));
+    }
+
+    #[test]
+    fn latin1_and_windows_1252_are_distinct() {
+        assert_eq!(TextEncoding::Windows1252.decode(&[0x80]), "\u{20ac}");
+        assert_eq!(TextEncoding::Iso8859_1.decode(&[0x80]), "\u{80}");
+    }
+
+    #[test]
+    fn malformed_utf8_uses_replacement_decoding() {
+        assert_eq!(TextEncoding::Utf8.decode(&[0xff]), "\u{fffd}");
+    }
+
+    #[test]
+    fn utf8_boundaries_distinguish_valid_codepoints_from_malformed_bytes() {
+        assert!(!is_utf8_boundary("é".as_bytes(), 1));
+        assert!(!is_utf8_boundary("€".as_bytes(), 2));
+        assert!(is_utf8_boundary(&[b'x', 0x80], 1));
+        assert!(is_utf8_boundary(&[0x80], 0));
+    }
 }

--- a/rust/dta-parser/src/value_labels.rs
+++ b/rust/dta-parser/src/value_labels.rs
@@ -1,5 +1,5 @@
 use crate::endian::{checked_add, checked_mul, expect_at, offset_to_usize, read_i32, slice_at};
-use crate::text::{decode_utf8, decode_windows_1252, field_bytes, is_utf8_continuation};
+use crate::text::{field_bytes, is_utf8_boundary, TextEncoding};
 use crate::{
     classify_long_missing, DtaError, DtaMetadata, FormatVersion, ValueLabelEntry, ValueLabelTable,
 };
@@ -25,6 +25,7 @@ fn parse_table(
     table_start: usize,
     name_width: usize,
     wrapped: bool,
+    encoding: TextEncoding,
 ) -> Result<(ValueLabelTable, usize), DtaError> {
     let mut cursor = if wrapped {
         expect_at(bytes, table_start, LABEL_OPEN, "<lbl>")?
@@ -62,11 +63,7 @@ fn parse_table(
     } else {
         field_bytes(name_field)
     };
-    let name = if metadata.format_version.is_modern() {
-        decode_utf8(name_bytes)
-    } else {
-        decode_windows_1252(name_bytes)
-    };
+    let name = encoding.decode(name_bytes);
     cursor = checked_add(cursor, name_width, "value-label table name")?;
 
     // The format reserves these bytes but does not assign them semantics.
@@ -175,8 +172,8 @@ fn parse_table(
                 text_length,
             });
         };
-        if metadata.format_version.is_modern()
-            && is_utf8_continuation(payload[text_start + text_offset_usize])
+        if encoding.is_utf8()
+            && !is_utf8_boundary(&payload[text_start..text_end], text_offset_usize)
         {
             return Err(DtaError::InvalidValueLabelTextOffset {
                 entry_index,
@@ -222,11 +219,7 @@ fn parse_table(
                     context: "value-label text",
                     offset: checked_add(payload_start, label_start, "value-label text")?,
                 })?;
-        let label = if metadata.format_version.is_modern() {
-            decode_utf8(&remaining[..nul])
-        } else {
-            decode_windows_1252(&remaining[..nul])
-        };
+        let label = encoding.decode(&remaining[..nul]);
         entries.push(ValueLabelEntry {
             value,
             missing_tag: classify_long_missing(value),
@@ -249,7 +242,21 @@ pub fn parse_value_labels(
     bytes: &[u8],
     metadata: &DtaMetadata,
 ) -> Result<Vec<ValueLabelTable>, DtaError> {
-    parse_value_labels_section(bytes, metadata, 0)
+    parse_value_labels_with_encoding(bytes, metadata, TextEncoding::Auto)
+}
+
+/// Parse value-label tables with an explicit source-text encoding.
+pub fn parse_value_labels_with_encoding(
+    bytes: &[u8],
+    metadata: &DtaMetadata,
+    encoding: TextEncoding,
+) -> Result<Vec<ValueLabelTable>, DtaError> {
+    parse_value_labels_section(
+        bytes,
+        metadata,
+        0,
+        encoding.resolve(metadata.format_version),
+    )
 }
 
 fn local_offset(absolute: u64, base_offset: u64, context: &'static str) -> Result<usize, DtaError> {
@@ -286,6 +293,7 @@ pub(crate) fn parse_value_labels_section(
     bytes: &[u8],
     metadata: &DtaMetadata,
     base_offset: u64,
+    encoding: TextEncoding,
 ) -> Result<Vec<ValueLabelTable>, DtaError> {
     let name_width = name_width(metadata.format_version)?;
     let start = local_offset(
@@ -309,7 +317,7 @@ pub(crate) fn parse_value_labels_section(
         let mut cursor = start;
         let mut tables = Vec::new();
         while cursor < end {
-            let (table, next) = parse_table(bytes, metadata, cursor, name_width, false)?;
+            let (table, next) = parse_table(bytes, metadata, cursor, name_width, false, encoding)?;
             if next <= cursor {
                 return Err(DtaError::ArithmeticOverflow("legacy value-label cursor"));
             }
@@ -336,7 +344,7 @@ pub(crate) fn parse_value_labels_section(
             cursor = expect_at(bytes, cursor, VALUE_LABELS_CLOSE, "</value_labels>")?;
             break;
         }
-        let (table, next) = parse_table(bytes, metadata, cursor, name_width, true)?;
+        let (table, next) = parse_table(bytes, metadata, cursor, name_width, true, encoding)?;
         tables.push(table);
         cursor = next;
     }

--- a/rust/dta-parser/tests/encoding.rs
+++ b/rust/dta-parser/tests/encoding.rs
@@ -1,0 +1,79 @@
+use std::fs;
+use std::io::Cursor;
+use std::path::{Path, PathBuf};
+
+use dta_parser::{read_dta_with_encoding, ColumnValues, DtaFile, TextEncoding};
+
+fn fixture_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("../../tests/fixtures/dta")
+}
+
+fn fixture(name: &str) -> Vec<u8> {
+    fs::read(fixture_dir().join(name)).unwrap()
+}
+
+fn replace_first(bytes: &mut [u8], needle: &[u8], replacement: u8) {
+    let offset = bytes
+        .windows(needle.len())
+        .position(|window| window == needle)
+        .unwrap_or_else(|| {
+            panic!(
+                "fixture does not contain {:?}",
+                String::from_utf8_lossy(needle)
+            )
+        });
+    bytes[offset] = replacement;
+}
+
+#[test]
+fn override_reaches_modern_metadata_fixed_strings_and_value_labels() {
+    let mut bytes = fixture("auto_v118.dta");
+    replace_first(&mut bytes, b"1978 automobile data", 0x80);
+    replace_first(&mut bytes, b"Make and model", 0x80);
+    replace_first(&mut bytes, b"AMC Concord", 0x80);
+    replace_first(&mut bytes, b"Domestic", 0x80);
+
+    let cp1252 = read_dta_with_encoding(&bytes, TextEncoding::Windows1252).unwrap();
+    assert!(cp1252.metadata.dataset_label.starts_with('\u{20ac}'));
+    assert!(cp1252.metadata.variables[0].label.starts_with('\u{20ac}'));
+    let ColumnValues::FixedString { values } = &cp1252.columns[0].values else {
+        panic!("make must be a fixed string");
+    };
+    assert!(values[0].starts_with('\u{20ac}'));
+    assert!(cp1252.value_label_table("origin").unwrap().entries[0]
+        .label
+        .starts_with('\u{20ac}'));
+
+    let latin1 = read_dta_with_encoding(&bytes, TextEncoding::Iso8859_1).unwrap();
+    assert!(latin1.metadata.dataset_label.starts_with('\u{80}'));
+    assert!(latin1.metadata.variables[0].label.starts_with('\u{80}'));
+    let ColumnValues::FixedString { values } = &latin1.columns[0].values else {
+        panic!("make must be a fixed string");
+    };
+    assert!(values[0].starts_with('\u{80}'));
+    assert!(latin1.value_label_table("origin").unwrap().entries[0]
+        .label
+        .starts_with('\u{80}'));
+
+    let mut file =
+        DtaFile::from_reader_with_encoding(Cursor::new(bytes), TextEncoding::Iso8859_1).unwrap();
+    assert_eq!(file.read().unwrap(), latin1);
+}
+
+#[test]
+fn override_reaches_modern_strl_payloads() {
+    let mut bytes = fixture("strl_test_v118.dta");
+    replace_first(&mut bytes, b"This is observation 1", 0x80);
+
+    let cp1252 = read_dta_with_encoding(&bytes, TextEncoding::Windows1252).unwrap();
+    let ColumnValues::StrL { values } = &cp1252.columns[0].values else {
+        panic!("long_text must be strL");
+    };
+    assert!(values[0].starts_with('\u{20ac}'));
+
+    let latin1 = read_dta_with_encoding(&bytes, TextEncoding::Iso8859_1).unwrap();
+    let ColumnValues::StrL { values } = &latin1.columns[0].values else {
+        panic!("long_text must be strL");
+    };
+    assert!(values[0].starts_with('\u{80}'));
+}

--- a/rust/dta-parser/tests/legacy.rs
+++ b/rust/dta-parser/tests/legacy.rs
@@ -2,8 +2,10 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use dta_parser::{
-    parse_metadata, read_dta, ByteOrder, ColumnValues, DtaError, FormatVersion, MissingTag,
+    parse_metadata, read_dta, read_dta_with_encoding, ByteOrder, ColumnValues, DtaError, DtaFile,
+    FormatVersion, MissingTag, TextEncoding,
 };
+use std::io::Cursor;
 
 fn fixture_dir() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join("../../tests/fixtures/dta")
@@ -155,6 +157,35 @@ fn decodes_true_big_endian_v113_and_windows_1252() {
             .label,
         "é"
     );
+}
+
+#[test]
+fn explicit_encoding_overrides_every_legacy_text_surface() {
+    let bytes = synthetic_v113_msf();
+    let latin1 = read_dta_with_encoding(&bytes, TextEncoding::Iso8859_1).unwrap();
+    assert_eq!(latin1.metadata.dataset_label, "Café");
+    assert_eq!(latin1.metadata.variables[0].label, "naïve");
+    let ColumnValues::FixedString { values } = &latin1.columns[1].values else {
+        panic!("text must be a fixed string");
+    };
+    assert_eq!(values, &["\u{93}h\u{94}"]);
+    assert_eq!(
+        latin1
+            .value_label_table("num_lbl")
+            .unwrap()
+            .entry(321)
+            .unwrap()
+            .label,
+        "é"
+    );
+
+    let utf8 = read_dta_with_encoding(&bytes, TextEncoding::Utf8).unwrap();
+    assert_eq!(utf8.metadata.dataset_label, "Caf\u{fffd}");
+    assert_eq!(utf8.metadata.variables[0].label, "na\u{fffd}ve");
+
+    let mut file =
+        DtaFile::from_reader_with_encoding(Cursor::new(bytes), TextEncoding::Iso8859_1).unwrap();
+    assert_eq!(file.read().unwrap(), latin1);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- add reusable Rust text-decoding options for automatic, UTF-8, Windows-1252, and ISO-8859-1 decoding
- honor explicit R `encoding` overrides across metadata, fixed strings, `strL`, and value-label names/text in both materialization paths
- document deterministic aliases, malformed-byte replacement, and narrow evidence-backed differences from haven
- preserve the existing `encoding = NULL` default path and keep notes parsing deferred to #17

## Compatibility decisions

The R API aligns with `haven::read_dta()` for the supported deterministic encodings. It deliberately does not inherit platform-dependent arbitrary `iconv` aliases. Unknown encodings fail clearly.

Unlike haven 2.5.5, which ignores explicit encodings for modern `strL`, this implementation applies the override consistently so incorrectly recorded `strL` text can be recovered. Explicit malformed UTF-8 is decoded deterministically with U+FFFD replacement rather than haven's platform-dependent omission behavior.

## Validation

- independent iterative review: CLEAN
- stable Rust and Rust 1.74 fmt, clippy, tests, and docs
- root/vendor byte synchronization and archive integrity
- direct-R and Rust-vector differential tests
- `DTA_REQUIRE_R_CONFORMANCE=1 scripts/conformance.sh`
- `R CMD check`: Status OK
- R/haven conformance: PASS
- `git diff --check`

Closes #16

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional `encoding` override for `read_dta()` and encoding-aware reading paths.
  * Supports UTF-8, Windows-1252, and ISO-8859-1 (including supported aliases) with consistent decoding across metadata, fixed strings, `strL` long text, and value labels.
  * Added deterministic replacement behavior for malformed UTF-8 input; automatic defaults remain based on file release.
* **Bug Fixes**
  * Improved robustness when decoding incorrectly recorded or ambiguous text encodings.
* **Documentation**
  * Updated R and Rust docs to detail aliases, defaults, and malformed-input behavior.
* **Tests**
  * Expanded coverage for encoding overrides and cross-surface consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->