### PR TITLE
Match haven dataset notes

### DIFF
--- a/r-package/dtaparser/R/read-dta.R
+++ b/r-package/dtaparser/R/read-dta.R
@@ -2,8 +2,8 @@
 #'
 #' Reads releases 113--115 and 117--119 through the native Rust parser.
 #' Numeric and character columns are created directly by native code. Dataset
-#' and variable labels, Stata display formats, value labels, `strL` content,
-#' and Stata system/extended missing values are retained.
+#' and variable labels, dataset notes, Stata display formats, value labels,
+#' `strL` content, and Stata system/extended missing values are retained.
 #'
 #' @param file A path, URL, raw vector, or binary connection. Local and remote
 #'   gzip files and local bzip2, xz, and zip files are decompressed
@@ -88,12 +88,10 @@ read_dta <- function(file, encoding = NULL, col_select = NULL, skip = 0,
     }
 
     dataset_label <- attr(native, "label", exact = TRUE)
-    format_version <- attr(native, "dta_format_version", exact = TRUE)
+    dataset_notes <- attr(native, "notes", exact = TRUE)
     result <- tibble::as_tibble(native, .name_repair = .name_repair)
     if (!is.null(dataset_label)) attr(result, "label") <- dataset_label
-    if (!is.null(format_version)) {
-        attr(result, "dta_format_version") <- format_version
-    }
+    if (!is.null(dataset_notes)) attr(result, "notes") <- dataset_notes
     result
 }
 

--- a/r-package/dtaparser/README.md
+++ b/r-package/dtaparser/README.md
@@ -38,10 +38,10 @@ is interrupted. This keeps network and decompression dependencies out of the
 reusable Rust parser.
 
 The reader supports Stata releases 113--115 and 117--119. It retains dataset
-and variable labels, display formats, value-label tables, `strL` values, and
-system or `.a`--`.z` missing values. `%td` is converted to `Date`; `%tc` and
-`%tC` are converted to UTC `POSIXct`. Other Stata calendar formats remain
-numeric and retain their `format.stata` attribute.
+and variable labels, dataset notes, display formats, value-label tables,
+`strL` values, and system or `.a`--`.z` missing values. `%td` is converted to
+`Date`; `%tc` and `%tC` are converted to UTC `POSIXct`. Other Stata calendar
+formats remain numeric and retain their `format.stata` attribute.
 
 `encoding = NULL` follows the DTA release convention: Windows-1252 for
 releases 113--115 and UTF-8 for releases 117--119. To recover files whose

--- a/r-package/dtaparser/README.md
+++ b/r-package/dtaparser/README.md
@@ -73,9 +73,8 @@ their execution order, and ran garbage collection outside the timed intervals.
 Relative throughput is the haven median divided by the dtaparser median, so
 higher is faster for dtaparser. Before timing, eight representative columns in
 32-row samples from the start, middle, and end of each file were compared with
-haven after removing dtaparser's additional top-level `dta_format_version`
-attribute. The remaining attributes and values matched, subject to the
-conformance suite's `1e-7` tolerance for nonmissing floating-point values.
+haven. The attributes and values matched, subject to the conformance suite's
+`1e-7` tolerance for nonmissing floating-point values.
 
 These are machine- and workload-specific measurements, not performance
 guarantees or CI thresholds. The haven comparison used the Rust-vector

--- a/r-package/dtaparser/man/read_dta.Rd
+++ b/r-package/dtaparser/man/read_dta.Rd
@@ -29,6 +29,6 @@ variable is selected more than once, the first selection and alias win.}
 \value{A tibble containing native numeric and character vectors.}
 \description{
 Reads Stata releases 113--115 and 117--119 through the native Rust parser,
-retaining labels, formats, value labels, long strings, temporal classes, and
-Stata tagged missing values.
+retaining dataset and variable labels, dataset notes, formats, value labels,
+long strings, temporal classes, and Stata tagged missing values.
 }

--- a/r-package/dtaparser/src/rust/src/lib.rs
+++ b/r-package/dtaparser/src/rust/src/lib.rs
@@ -309,6 +309,22 @@ unsafe fn build_column(
     Ok(vector)
 }
 
+unsafe fn attach_dataset_attributes(result: Sexp, metadata: &DtaMetadata) -> Result<(), String> {
+    if !metadata.dataset_label.is_empty() {
+        check_interrupt()?;
+        let mut guard = ProtectGuard::new();
+        let label = scalar_string(&metadata.dataset_label, &mut guard)?;
+        set_attr(result, "label", label)?;
+    }
+    if !metadata.notes.is_empty() {
+        check_interrupt()?;
+        let mut guard = ProtectGuard::new();
+        let notes = string_vector(&metadata.notes, &mut guard)?;
+        set_attr(result, "notes", notes)?;
+    }
+    Ok(())
+}
+
 unsafe fn build_data_frame(data: &DtaData) -> Result<Sexp, String> {
     let mut result_guard = ProtectGuard::new();
     let column_count = RLen::try_from(data.columns.len()).map_err(|_| "too many columns")?;
@@ -341,20 +357,7 @@ unsafe fn build_data_frame(data: &DtaData) -> Result<Sexp, String> {
         set_class(result, &["data.frame"], &mut attribute_guard)?;
     }
 
-    if !data.metadata.dataset_label.is_empty() {
-        check_interrupt()?;
-        let mut attribute_guard = ProtectGuard::new();
-        let label = scalar_string(&data.metadata.dataset_label, &mut attribute_guard)?;
-        set_attr(result, "label", label)?;
-    }
-    {
-        let mut attribute_guard = ProtectGuard::new();
-        let version = scalar_integer(
-            data.metadata.format_version.as_u16().into(),
-            &mut attribute_guard,
-        )?;
-        set_attr(result, "dta_format_version", version)?;
-    }
+    attach_dataset_attributes(result, &data.metadata)?;
     Ok(result)
 }
 
@@ -636,21 +639,7 @@ impl DtaSink for RDataFrameSink {
                 set_class(self.result, &["data.frame"], &mut attribute_guard)
                     .map_err(DtaError::Output)?;
             }
-            if !metadata.dataset_label.is_empty() {
-                let mut attribute_guard = ProtectGuard::new();
-                let label = scalar_string(&metadata.dataset_label, &mut attribute_guard)
-                    .map_err(DtaError::Output)?;
-                set_attr(self.result, "label", label).map_err(DtaError::Output)?;
-            }
-            {
-                let mut attribute_guard = ProtectGuard::new();
-                let version = scalar_integer(
-                    metadata.format_version.as_u16().into(),
-                    &mut attribute_guard,
-                )
-                .map_err(DtaError::Output)?;
-                set_attr(self.result, "dta_format_version", version).map_err(DtaError::Output)?;
-            }
+            attach_dataset_attributes(self.result, &metadata).map_err(DtaError::Output)?;
         }
         let result = self.result;
         Ok(result)
@@ -658,8 +647,7 @@ impl DtaSink for RDataFrameSink {
 }
 
 unsafe fn metadata_impl(path: &str, encoding: TextEncoding) -> Result<Sexp, String> {
-    let file =
-        DtaFile::open_with_encoding(path, encoding).map_err(|error| error.to_string())?;
+    let file = DtaFile::open_with_encoding(path, encoding).map_err(|error| error.to_string())?;
     let metadata = file.metadata();
     let mut guard = ProtectGuard::new();
     let names = metadata

--- a/r-package/dtaparser/src/vendor/dta-parser/src/file.rs
+++ b/r-package/dtaparser/src/vendor/dta-parser/src/file.rs
@@ -12,7 +12,7 @@ use crate::legacy::{
 };
 use crate::metadata::{field_widths, resolve_type};
 use crate::selection::{resolve_columns, row_window};
-use crate::text::{field_bytes, is_utf8_boundary, TextDecoder, TextEncoding};
+use crate::text::{field_bytes, is_dataset_note, is_utf8_boundary, TextDecoder, TextEncoding};
 use crate::{
     classify_byte_missing, classify_double_missing_bits, classify_float_missing_bits,
     classify_int_missing, classify_long_missing, ByteOrder, Column, ColumnValues, DtaData,
@@ -1256,6 +1256,118 @@ fn validate_modern_sortlist<R: Read + Seek>(
     ensure_absolute("formats", after_close, header.section_offsets.formats)
 }
 
+fn read_modern_notes<R: Read + Seek>(
+    reader: &mut R,
+    header: &FileModernHeaderMap,
+    encoding: TextEncoding,
+    scratch: &mut Scratch,
+) -> Result<Vec<String>, DtaError> {
+    let width = if header.format_version == FormatVersion::V117 {
+        33_usize
+    } else {
+        129_usize
+    };
+    let names_length = width
+        .checked_mul(2)
+        .ok_or(DtaError::ArithmeticOverflow("characteristic names length"))?;
+    let mut cursor = expect_file_tag(
+        reader,
+        header.section_offsets.characteristics,
+        b"<characteristics>",
+        "<characteristics>",
+        scratch,
+    )?;
+    let mut notes = Vec::new();
+
+    loop {
+        let marker = read_exact_at(reader, cursor, 4, scratch, "reading characteristic tag")?;
+        if marker == b"</ch" {
+            cursor = expect_file_tag(
+                reader,
+                cursor,
+                b"</characteristics>",
+                "</characteristics>",
+                scratch,
+            )?;
+            ensure_absolute("data", cursor, header.section_offsets.data)?;
+            return Ok(notes);
+        }
+        if marker != b"<ch>" {
+            return Err(DtaError::UnexpectedTag {
+                expected: "<ch> or </characteristics>",
+                offset: error_offset(cursor),
+            });
+        }
+        cursor = checked_add_u64(cursor, 4, "characteristic opening tag")?;
+        let length_bytes =
+            read_exact_at(reader, cursor, 4, scratch, "reading characteristic length")?;
+        let payload_length = usize::try_from(read_u32(
+            &length_bytes,
+            0,
+            header.byte_order,
+            "characteristic length",
+        )?)
+        .map_err(|_| DtaError::ArithmeticOverflow("characteristic length"))?;
+        cursor = checked_add_u64(cursor, 4, "characteristic length")?;
+        if payload_length < names_length {
+            return Err(DtaError::Truncated {
+                context: "characteristic names",
+                offset: error_offset(cursor),
+                needed: names_length,
+                available: payload_length,
+            });
+        }
+        let close = checked_add_u64(
+            cursor,
+            u64::try_from(payload_length)
+                .map_err(|_| DtaError::ArithmeticOverflow("characteristic payload length"))?,
+            "characteristic payload",
+        )?;
+        let after_close = checked_add_u64(close, 5, "characteristic closing tag")?;
+        if after_close > header.section_offsets.data {
+            return Err(DtaError::Truncated {
+                context: "characteristic payload",
+                offset: error_offset(cursor),
+                needed: payload_length.saturating_add(5),
+                available: usize::try_from(header.section_offsets.data.saturating_sub(cursor))
+                    .unwrap_or(usize::MAX),
+            });
+        }
+        let names = read_exact_at(
+            reader,
+            cursor,
+            names_length,
+            scratch,
+            "reading characteristic names",
+        )?;
+        if is_dataset_note(&names[..width], &names[width..]) {
+            let value_offset = checked_add_u64(
+                cursor,
+                u64::try_from(names_length)
+                    .map_err(|_| DtaError::ArithmeticOverflow("characteristic value offset"))?,
+                "characteristic value offset",
+            )?;
+            let value_length = payload_length - names_length;
+            let mut never_cancel = || false;
+            let note = decode_range(
+                reader,
+                value_offset,
+                value_length,
+                encoding,
+                true,
+                scratch,
+                &mut never_cancel,
+                "reading characteristic value",
+            )?
+            .0;
+            if !note.is_empty() {
+                notes.push(note);
+            }
+        }
+        cursor = expect_file_tag(reader, close, b"</ch>", "</ch>", scratch)?;
+    }
+}
+
 fn read_modern_header_map<R: Read + Seek>(
     reader: &mut R,
     scratch: &mut Scratch,
@@ -1522,6 +1634,7 @@ fn read_modern_metadata<R: Read + Seek>(
         "variable_labels",
         scratch,
     )?;
+    let notes = read_modern_notes(reader, &header, encoding, scratch)?;
 
     let mut byte_offset = 0_u64;
     let mut variables = Vec::with_capacity(nvar);
@@ -1591,6 +1704,7 @@ fn read_modern_metadata<R: Read + Seek>(
         nvar: header.nvar,
         nobs: header.nobs,
         dataset_label: header.dataset_label,
+        notes,
         variables,
         section_offsets: header.section_offsets,
         obs_length: byte_offset,
@@ -1733,6 +1847,7 @@ fn read_legacy_metadata<R: Read + Seek>(
 
     let mut cursor = u64::try_from(fixed_end)
         .map_err(|_| DtaError::ArithmeticOverflow("legacy expansion offset"))?;
+    let mut notes = Vec::new();
     loop {
         let expansion =
             read_exact_at(reader, cursor, 5, scratch, "reading legacy expansion field")?;
@@ -1755,19 +1870,55 @@ fn read_legacy_metadata<R: Read + Seek>(
             });
         }
         cursor = checked_add_u64(cursor, 5, "legacy expansion header")?;
-        cursor = checked_add_u64(
+        let payload_length = usize::try_from(length)
+            .map_err(|_| DtaError::ArithmeticOverflow("legacy expansion length"))?;
+        let payload_end = checked_add_u64(
             cursor,
-            u64::try_from(length)
+            u64::try_from(payload_length)
                 .map_err(|_| DtaError::ArithmeticOverflow("legacy expansion length"))?,
             "legacy expansion payload",
         )?;
-        if cursor > file_length {
+        if payload_end > file_length {
             return Err(DtaError::Io {
                 context: "reading legacy expansion field",
-                offset: cursor,
+                offset: payload_end,
                 kind: ErrorKind::UnexpectedEof,
             });
         }
+        if data_type == 1 && payload_length >= 2 * VARNAME_WIDTH {
+            let names = read_exact_at(
+                reader,
+                cursor,
+                2 * VARNAME_WIDTH,
+                scratch,
+                "reading legacy characteristic names",
+            )?;
+            if is_dataset_note(&names[..VARNAME_WIDTH], &names[VARNAME_WIDTH..]) {
+                let value_offset = checked_add_u64(
+                    cursor,
+                    u64::try_from(2 * VARNAME_WIDTH).map_err(|_| {
+                        DtaError::ArithmeticOverflow("legacy characteristic value offset")
+                    })?,
+                    "legacy characteristic value offset",
+                )?;
+                let value_length = payload_length - 2 * VARNAME_WIDTH;
+                let note = decode_range(
+                    reader,
+                    value_offset,
+                    value_length,
+                    encoding,
+                    true,
+                    scratch,
+                    &mut never_cancel,
+                    "reading legacy characteristic value",
+                )?
+                .0;
+                if !note.is_empty() {
+                    notes.push(note);
+                }
+            }
+        }
+        cursor = payload_end;
     }
     let observation_bytes = nobs
         .checked_mul(byte_offset)
@@ -1789,6 +1940,7 @@ fn read_legacy_metadata<R: Read + Seek>(
         nvar,
         nobs,
         dataset_label,
+        notes,
         variables,
         section_offsets: SectionOffsets {
             stata_data: 0,
@@ -2617,6 +2769,7 @@ mod tests {
             nvar: 1,
             nobs: 1,
             dataset_label: String::new(),
+            notes: Vec::new(),
             variables: vec![VariableInfo {
                 name: "text".to_owned(),
                 dta_type: DtaType::StrL,

--- a/r-package/dtaparser/src/vendor/dta-parser/src/file.rs
+++ b/r-package/dtaparser/src/vendor/dta-parser/src/file.rs
@@ -1879,10 +1879,12 @@ fn read_legacy_metadata<R: Read + Seek>(
             "legacy expansion payload",
         )?;
         if payload_end > file_length {
-            return Err(DtaError::Io {
-                context: "reading legacy expansion field",
-                offset: payload_end,
-                kind: ErrorKind::UnexpectedEof,
+            return Err(DtaError::Truncated {
+                context: "legacy expansion-field payload",
+                offset: error_offset(cursor),
+                needed: payload_length,
+                available: usize::try_from(file_length.saturating_sub(cursor))
+                    .unwrap_or(usize::MAX),
             });
         }
         if data_type == 1 && payload_length >= 2 * VARNAME_WIDTH {

--- a/r-package/dtaparser/src/vendor/dta-parser/src/legacy.rs
+++ b/r-package/dtaparser/src/vendor/dta-parser/src/legacy.rs
@@ -1,5 +1,5 @@
 use crate::endian::{checked_add, checked_mul, read_i32, read_u16, slice_at};
-use crate::text::{field_bytes, TextEncoding};
+use crate::text::{field_bytes, is_dataset_note, TextEncoding};
 use crate::{
     ByteOrder, DtaError, DtaMetadata, DtaType, FormatVersion, SectionOffsets, VariableInfo,
 };
@@ -101,8 +101,10 @@ fn scan_expansion_fields_ordered(
     bytes: &[u8],
     start: usize,
     byte_order: ByteOrder,
-) -> Result<usize, DtaError> {
+    encoding: TextEncoding,
+) -> Result<(usize, Vec<String>), DtaError> {
     let mut cursor = start;
+    let mut notes = Vec::new();
     loop {
         let data_type = slice_at(bytes, cursor, 1, "legacy expansion-field type")?[0];
         let length_offset = checked_add(cursor, 1, "legacy expansion-field length")?;
@@ -113,7 +115,10 @@ fn scan_expansion_fields_ordered(
             "legacy expansion-field length",
         )?;
         if data_type == 0 && value == 0 {
-            return checked_add(cursor, 5, "legacy expansion-field terminator");
+            return Ok((
+                checked_add(cursor, 5, "legacy expansion-field terminator")?,
+                notes,
+            ));
         }
         if value < 0 {
             return Err(DtaError::NegativeExpansionLength {
@@ -130,7 +135,17 @@ fn scan_expansion_fields_ordered(
         let length = usize::try_from(value)
             .map_err(|_| DtaError::ArithmeticOverflow("legacy expansion-field length"))?;
         cursor = checked_add(cursor, 5, "legacy expansion-field header")?;
-        slice_at(bytes, cursor, length, "legacy expansion-field payload")?;
+        let payload = slice_at(bytes, cursor, length, "legacy expansion-field payload")?;
+        if data_type == 1 && payload.len() >= 2 * VARNAME_WIDTH {
+            let (variable, remainder) = payload.split_at(VARNAME_WIDTH);
+            let (characteristic, value) = remainder.split_at(VARNAME_WIDTH);
+            if is_dataset_note(variable, characteristic) {
+                let note = encoding.decode(field_bytes(value));
+                if !note.is_empty() {
+                    notes.push(note);
+                }
+            }
+        }
         cursor = checked_add(cursor, length, "legacy expansion-field payload")?;
     }
 }
@@ -166,7 +181,9 @@ pub(crate) fn parse_legacy_metadata(
     let fixed = legacy_fixed_offsets(nvar_usize, version)?;
     let expansion_start = fixed.end;
     slice_at(bytes, 0, expansion_start, "legacy fixed metadata sections")?;
-    let data_offset = scan_expansion_fields_ordered(bytes, expansion_start, byte_order)?;
+    let resolved_encoding = encoding.resolve(version);
+    let (data_offset, notes) =
+        scan_expansion_fields_ordered(bytes, expansion_start, byte_order, resolved_encoding)?;
     parse_legacy_metadata_layout(
         bytes,
         file_length,
@@ -175,7 +192,8 @@ pub(crate) fn parse_legacy_metadata(
         byte_order,
         nvar,
         nobs,
-        encoding.resolve(version),
+        resolved_encoding,
+        notes,
     )
 }
 
@@ -189,6 +207,7 @@ pub(crate) fn parse_legacy_metadata_layout(
     nvar: u32,
     nobs: u64,
     encoding: TextEncoding,
+    notes: Vec<String>,
 ) -> Result<DtaMetadata, DtaError> {
     let nvar_usize =
         usize::try_from(nvar).map_err(|_| DtaError::ArithmeticOverflow("legacy variable count"))?;
@@ -307,6 +326,7 @@ pub(crate) fn parse_legacy_metadata_layout(
         nvar,
         nobs,
         dataset_label,
+        notes,
         variables,
         section_offsets: SectionOffsets {
             stata_data: 0,

--- a/r-package/dtaparser/src/vendor/dta-parser/src/metadata.rs
+++ b/r-package/dtaparser/src/vendor/dta-parser/src/metadata.rs
@@ -3,7 +3,7 @@ use crate::endian::{
     read_u64, read_u8, slice_at,
 };
 use crate::legacy::parse_legacy_metadata;
-use crate::text::TextEncoding;
+use crate::text::{field_bytes, is_dataset_note, TextEncoding};
 use crate::{
     ByteOrder, DtaError, DtaMetadata, DtaType, FormatVersion, SectionOffsets, VariableInfo,
 };
@@ -35,6 +35,10 @@ const VALUE_LABEL_NAMES_OPEN: &[u8] = b"<value_label_names>";
 const VALUE_LABEL_NAMES_CLOSE: &[u8] = b"</value_label_names>";
 const VARIABLE_LABELS_OPEN: &[u8] = b"<variable_labels>";
 const VARIABLE_LABELS_CLOSE: &[u8] = b"</variable_labels>";
+const CHARACTERISTICS_OPEN: &[u8] = b"<characteristics>";
+const CHARACTERISTICS_CLOSE: &[u8] = b"</characteristics>";
+const CHARACTERISTIC_OPEN: &[u8] = b"<ch>";
+const CHARACTERISTIC_CLOSE: &[u8] = b"</ch>";
 
 const SECTION_MAP_ENTRIES: usize = 14;
 
@@ -302,6 +306,89 @@ fn validate_sortlist(
     ensure_map_offset("formats", cursor, offsets.formats)
 }
 
+fn parse_characteristics(
+    bytes: &[u8],
+    version: FormatVersion,
+    byte_order: ByteOrder,
+    offsets: &SectionOffsets,
+    encoding: TextEncoding,
+) -> Result<Vec<String>, DtaError> {
+    let start = offset_to_usize(offsets.characteristics, "characteristics")?;
+    if bytes.len() == start {
+        return Ok(Vec::new());
+    }
+    let data = offset_to_usize(offsets.data, "data")?;
+    let width = if version == FormatVersion::V117 {
+        33
+    } else {
+        129
+    };
+    let names_length = checked_mul(width, 2, "characteristic names length")?;
+    let mut cursor = expect_at(bytes, start, CHARACTERISTICS_OPEN, "<characteristics>")?;
+    let mut notes = Vec::new();
+
+    loop {
+        if bytes.get(cursor..cursor.saturating_add(CHARACTERISTICS_CLOSE.len()))
+            == Some(CHARACTERISTICS_CLOSE)
+        {
+            cursor = expect_at(bytes, cursor, CHARACTERISTICS_CLOSE, "</characteristics>")?;
+            ensure_map_offset("data", cursor, offsets.data)?;
+            return Ok(notes);
+        }
+
+        cursor = expect_at(bytes, cursor, CHARACTERISTIC_OPEN, "<ch>")?;
+        let payload_length = usize::try_from(read_u32(
+            bytes,
+            cursor,
+            byte_order,
+            "characteristic length",
+        )?)
+        .map_err(|_| DtaError::ArithmeticOverflow("characteristic length"))?;
+        cursor = checked_add(cursor, 4, "characteristic length")?;
+        if payload_length < names_length {
+            return Err(DtaError::Truncated {
+                context: "characteristic names",
+                offset: cursor,
+                needed: names_length,
+                available: payload_length,
+            });
+        }
+        let payload_end = checked_add(cursor, payload_length, "characteristic payload")?;
+        let record_end = checked_add(
+            payload_end,
+            CHARACTERISTIC_CLOSE.len(),
+            "characteristic closing tag",
+        )?;
+        if record_end > data {
+            return Err(DtaError::Truncated {
+                context: "characteristic payload",
+                offset: cursor,
+                needed: payload_length.saturating_add(CHARACTERISTIC_CLOSE.len()),
+                available: data.saturating_sub(cursor),
+            });
+        }
+        let payload = slice_at(bytes, cursor, payload_length, "characteristic payload")?;
+        let (variable, remainder) = payload.split_at(width);
+        let (characteristic, value) = remainder.split_at(width);
+        if is_dataset_note(variable, characteristic) {
+            let note = encoding.decode(field_bytes(value));
+            if !note.is_empty() {
+                notes.push(note);
+            }
+        }
+        cursor = payload_end;
+        cursor = expect_at(bytes, cursor, CHARACTERISTIC_CLOSE, "</ch>")?;
+        if cursor > data {
+            return Err(DtaError::MapOffsetMismatch {
+                section: "data",
+                expected: offsets.data,
+                actual: u64::try_from(cursor)
+                    .map_err(|_| DtaError::ArithmeticOverflow("characteristics end"))?,
+            });
+        }
+    }
+}
+
 pub(crate) fn resolve_type(code: u16, version: FormatVersion) -> Result<(DtaType, u32), DtaError> {
     let numeric = match code {
         65530 => Some((DtaType::Byte, 1)),
@@ -430,6 +517,13 @@ pub fn parse_metadata_with_encoding(
         },
         encoding,
     )?;
+    let notes = parse_characteristics(
+        bytes,
+        format_version,
+        byte_order,
+        &section_offsets,
+        encoding,
+    )?;
 
     let mut byte_offset = 0_u64;
     let mut variables = Vec::with_capacity(nvar_usize);
@@ -457,6 +551,7 @@ pub fn parse_metadata_with_encoding(
         nvar,
         nobs,
         dataset_label,
+        notes,
         variables,
         section_offsets,
         obs_length: byte_offset,

--- a/r-package/dtaparser/src/vendor/dta-parser/src/selection.rs
+++ b/r-package/dtaparser/src/vendor/dta-parser/src/selection.rs
@@ -45,6 +45,7 @@ mod tests {
             nvar,
             nobs,
             dataset_label: String::new(),
+            notes: Vec::new(),
             variables: Vec::new(),
             section_offsets: SectionOffsets::from_array([0; 14]),
             obs_length: 0,

--- a/r-package/dtaparser/src/vendor/dta-parser/src/strl.rs
+++ b/r-package/dtaparser/src/vendor/dta-parser/src/strl.rs
@@ -325,6 +325,7 @@ mod tests {
             nvar: 1,
             nobs,
             dataset_label: String::new(),
+            notes: Vec::new(),
             variables: vec![VariableInfo {
                 name: "long".into(),
                 dta_type: DtaType::StrL,

--- a/r-package/dtaparser/src/vendor/dta-parser/src/text.rs
+++ b/r-package/dtaparser/src/vendor/dta-parser/src/text.rs
@@ -115,6 +115,17 @@ pub(crate) fn field_bytes(bytes: &[u8]) -> &[u8] {
     &bytes[..end]
 }
 
+pub(crate) fn is_dataset_note(variable: &[u8], characteristic: &[u8]) -> bool {
+    if field_bytes(variable) != b"_dta" {
+        return false;
+    }
+    let name = field_bytes(characteristic);
+    let Some(index) = name.strip_prefix(b"note") else {
+        return false;
+    };
+    !index.is_empty() && index.iter().all(u8::is_ascii_digit)
+}
+
 pub(crate) fn is_utf8_continuation(byte: u8) -> bool {
     byte & 0xc0 == 0x80
 }

--- a/r-package/dtaparser/src/vendor/dta-parser/src/types.rs
+++ b/r-package/dtaparser/src/vendor/dta-parser/src/types.rs
@@ -316,6 +316,8 @@ pub struct DtaMetadata {
     #[serde(with = "decimal_u64")]
     pub nobs: u64,
     pub dataset_label: String,
+    #[serde(default)]
+    pub notes: Vec<String>,
     pub variables: Vec<VariableInfo>,
     pub section_offsets: SectionOffsets,
     #[serde(with = "decimal_u64")]
@@ -471,6 +473,7 @@ mod tests {
             nvar: 1,
             nobs: 9_007_199_254_740_993,
             dataset_label: "fixture".into(),
+            notes: vec!["first note".into()],
             variables: vec![VariableInfo {
                 name: "x".into(),
                 dta_type: DtaType::FixedString(12),
@@ -489,6 +492,7 @@ mod tests {
         assert_eq!(value["format_version"], 119);
         assert_eq!(value["byte_order"], "MSF");
         assert_eq!(value["nobs"], "9007199254740993");
+        assert_eq!(value["notes"][0], "first note");
         assert_eq!(value["variables"][0]["type"], "str12");
         assert_eq!(value["variables"][0]["byte_offset"], "0");
         assert_eq!(value["section_offsets"]["data"], "0");

--- a/r-package/dtaparser/tests/testthat/test-read-dta.R
+++ b/r-package/dtaparser/tests/testthat/test-read-dta.R
@@ -49,7 +49,11 @@ test_that("all bundled fixtures agree with haven", {
         expect_identical(names(actual), names(expected), info = info)
         expect_identical(attr(actual, "label", exact = TRUE),
                          attr(expected, "label", exact = TRUE), info = info)
-        expect_true(attr(actual, "dta_format_version", exact = TRUE) %in%
+        expect_identical(attr(actual, "notes", exact = TRUE),
+                         attr(expected, "notes", exact = TRUE), info = info)
+        expect_null(attr(actual, "dta_format_version", exact = TRUE), info = info)
+        expect_identical(attributes(actual), attributes(expected), info = info)
+        expect_true(attr(metadata, "dta_format_version", exact = TRUE) %in%
                     c(113L, 114L, 115L, 117L, 118L, 119L), info = info)
 
         for (name in names(actual)) {
@@ -70,6 +74,34 @@ test_that("all bundled fixtures agree with haven", {
                 )
             }
         }
+    }
+})
+
+test_that("dataset-note cardinality, ordering, and empty values match haven", {
+    skip_if_not_installed("haven")
+    source <- fixture("auto_v118.dta")
+    multiple <- readBin(source, "raw", file.info(source)$size)
+    one <- replace_first_byte(multiple, "note0", utf8ToInt("x"))
+    empty <- replace_first_byte(
+        multiple, "From Consumer Reports with permission", 0
+    )
+    zero <- replace_first_byte(one, "note1", utf8ToInt("x"))
+
+    for (variant in list(multiple = multiple, one = one, empty = empty,
+                         zero = zero)) {
+        expected <- haven::read_dta(
+            variant, col_select = make, skip = 2, n_max = 3
+        )
+        actual <- read_dta(
+            variant, col_select = make, skip = 2, n_max = 3
+        )
+        rust_vectors <- dtaparser:::.read_dta_rust_vectors(
+            variant, col_select = make, skip = 2, n_max = 3
+        )
+
+        expect_identical(actual, rust_vectors)
+        expect_identical(attr(actual, "notes", exact = TRUE),
+                         attr(expected, "notes", exact = TRUE))
     }
 })
 
@@ -96,6 +128,8 @@ test_that("projection, renaming, and row bounds match haven", {
     expect_equal(actual$make, expected$make)
     expect_equal(actual$price, expected$price)
     expect_identical(attr(actual, "label"), attr(expected, "label"))
+    expect_identical(attr(actual, "notes"), attr(expected, "notes"))
+    expect_null(attr(actual, "dta_format_version", exact = TRUE))
 })
 
 test_that("an empty projection retains the selected row count", {
@@ -219,6 +253,21 @@ test_that("explicit encodings match haven across ordinary textual surfaces", {
                      read_dta(modern, encoding = "UTF8"))
     expect_identical(read_dta(modern, encoding = "UTF-8")$make,
                      haven::read_dta(modern, encoding = "UTF-8")$make)
+
+    note_bytes <- readBin(modern, "raw", file.info(modern)$size)
+    note_bytes <- replace_first_byte(
+        note_bytes, "From Consumer Reports with permission", 0x80
+    )
+    cp1252 <- read_dta(note_bytes, encoding = "Windows-1252")
+    latin1 <- read_dta(note_bytes, encoding = "ISO-8859-1")
+    expect_identical(cp1252, dtaparser:::.read_dta_rust_vectors(
+        note_bytes, encoding = "CP1252"
+    ))
+    expect_identical(latin1, dtaparser:::.read_dta_rust_vectors(
+        note_bytes, encoding = "latin1"
+    ))
+    expect_true(startsWith(attr(cp1252, "notes")[[1L]], "\u20ac"))
+    expect_true(startsWith(attr(latin1, "notes")[[1L]], "\u0080"))
 })
 
 test_that("explicit encodings apply consistently to strL text", {

--- a/rust/dta-parser/src/file.rs
+++ b/rust/dta-parser/src/file.rs
@@ -12,7 +12,7 @@ use crate::legacy::{
 };
 use crate::metadata::{field_widths, resolve_type};
 use crate::selection::{resolve_columns, row_window};
-use crate::text::{field_bytes, is_utf8_boundary, TextDecoder, TextEncoding};
+use crate::text::{field_bytes, is_dataset_note, is_utf8_boundary, TextDecoder, TextEncoding};
 use crate::{
     classify_byte_missing, classify_double_missing_bits, classify_float_missing_bits,
     classify_int_missing, classify_long_missing, ByteOrder, Column, ColumnValues, DtaData,
@@ -1256,6 +1256,118 @@ fn validate_modern_sortlist<R: Read + Seek>(
     ensure_absolute("formats", after_close, header.section_offsets.formats)
 }
 
+fn read_modern_notes<R: Read + Seek>(
+    reader: &mut R,
+    header: &FileModernHeaderMap,
+    encoding: TextEncoding,
+    scratch: &mut Scratch,
+) -> Result<Vec<String>, DtaError> {
+    let width = if header.format_version == FormatVersion::V117 {
+        33_usize
+    } else {
+        129_usize
+    };
+    let names_length = width
+        .checked_mul(2)
+        .ok_or(DtaError::ArithmeticOverflow("characteristic names length"))?;
+    let mut cursor = expect_file_tag(
+        reader,
+        header.section_offsets.characteristics,
+        b"<characteristics>",
+        "<characteristics>",
+        scratch,
+    )?;
+    let mut notes = Vec::new();
+
+    loop {
+        let marker = read_exact_at(reader, cursor, 4, scratch, "reading characteristic tag")?;
+        if marker == b"</ch" {
+            cursor = expect_file_tag(
+                reader,
+                cursor,
+                b"</characteristics>",
+                "</characteristics>",
+                scratch,
+            )?;
+            ensure_absolute("data", cursor, header.section_offsets.data)?;
+            return Ok(notes);
+        }
+        if marker != b"<ch>" {
+            return Err(DtaError::UnexpectedTag {
+                expected: "<ch> or </characteristics>",
+                offset: error_offset(cursor),
+            });
+        }
+        cursor = checked_add_u64(cursor, 4, "characteristic opening tag")?;
+        let length_bytes =
+            read_exact_at(reader, cursor, 4, scratch, "reading characteristic length")?;
+        let payload_length = usize::try_from(read_u32(
+            &length_bytes,
+            0,
+            header.byte_order,
+            "characteristic length",
+        )?)
+        .map_err(|_| DtaError::ArithmeticOverflow("characteristic length"))?;
+        cursor = checked_add_u64(cursor, 4, "characteristic length")?;
+        if payload_length < names_length {
+            return Err(DtaError::Truncated {
+                context: "characteristic names",
+                offset: error_offset(cursor),
+                needed: names_length,
+                available: payload_length,
+            });
+        }
+        let close = checked_add_u64(
+            cursor,
+            u64::try_from(payload_length)
+                .map_err(|_| DtaError::ArithmeticOverflow("characteristic payload length"))?,
+            "characteristic payload",
+        )?;
+        let after_close = checked_add_u64(close, 5, "characteristic closing tag")?;
+        if after_close > header.section_offsets.data {
+            return Err(DtaError::Truncated {
+                context: "characteristic payload",
+                offset: error_offset(cursor),
+                needed: payload_length.saturating_add(5),
+                available: usize::try_from(header.section_offsets.data.saturating_sub(cursor))
+                    .unwrap_or(usize::MAX),
+            });
+        }
+        let names = read_exact_at(
+            reader,
+            cursor,
+            names_length,
+            scratch,
+            "reading characteristic names",
+        )?;
+        if is_dataset_note(&names[..width], &names[width..]) {
+            let value_offset = checked_add_u64(
+                cursor,
+                u64::try_from(names_length)
+                    .map_err(|_| DtaError::ArithmeticOverflow("characteristic value offset"))?,
+                "characteristic value offset",
+            )?;
+            let value_length = payload_length - names_length;
+            let mut never_cancel = || false;
+            let note = decode_range(
+                reader,
+                value_offset,
+                value_length,
+                encoding,
+                true,
+                scratch,
+                &mut never_cancel,
+                "reading characteristic value",
+            )?
+            .0;
+            if !note.is_empty() {
+                notes.push(note);
+            }
+        }
+        cursor = expect_file_tag(reader, close, b"</ch>", "</ch>", scratch)?;
+    }
+}
+
 fn read_modern_header_map<R: Read + Seek>(
     reader: &mut R,
     scratch: &mut Scratch,
@@ -1522,6 +1634,7 @@ fn read_modern_metadata<R: Read + Seek>(
         "variable_labels",
         scratch,
     )?;
+    let notes = read_modern_notes(reader, &header, encoding, scratch)?;
 
     let mut byte_offset = 0_u64;
     let mut variables = Vec::with_capacity(nvar);
@@ -1591,6 +1704,7 @@ fn read_modern_metadata<R: Read + Seek>(
         nvar: header.nvar,
         nobs: header.nobs,
         dataset_label: header.dataset_label,
+        notes,
         variables,
         section_offsets: header.section_offsets,
         obs_length: byte_offset,
@@ -1733,6 +1847,7 @@ fn read_legacy_metadata<R: Read + Seek>(
 
     let mut cursor = u64::try_from(fixed_end)
         .map_err(|_| DtaError::ArithmeticOverflow("legacy expansion offset"))?;
+    let mut notes = Vec::new();
     loop {
         let expansion =
             read_exact_at(reader, cursor, 5, scratch, "reading legacy expansion field")?;
@@ -1755,19 +1870,55 @@ fn read_legacy_metadata<R: Read + Seek>(
             });
         }
         cursor = checked_add_u64(cursor, 5, "legacy expansion header")?;
-        cursor = checked_add_u64(
+        let payload_length = usize::try_from(length)
+            .map_err(|_| DtaError::ArithmeticOverflow("legacy expansion length"))?;
+        let payload_end = checked_add_u64(
             cursor,
-            u64::try_from(length)
+            u64::try_from(payload_length)
                 .map_err(|_| DtaError::ArithmeticOverflow("legacy expansion length"))?,
             "legacy expansion payload",
         )?;
-        if cursor > file_length {
+        if payload_end > file_length {
             return Err(DtaError::Io {
                 context: "reading legacy expansion field",
-                offset: cursor,
+                offset: payload_end,
                 kind: ErrorKind::UnexpectedEof,
             });
         }
+        if data_type == 1 && payload_length >= 2 * VARNAME_WIDTH {
+            let names = read_exact_at(
+                reader,
+                cursor,
+                2 * VARNAME_WIDTH,
+                scratch,
+                "reading legacy characteristic names",
+            )?;
+            if is_dataset_note(&names[..VARNAME_WIDTH], &names[VARNAME_WIDTH..]) {
+                let value_offset = checked_add_u64(
+                    cursor,
+                    u64::try_from(2 * VARNAME_WIDTH).map_err(|_| {
+                        DtaError::ArithmeticOverflow("legacy characteristic value offset")
+                    })?,
+                    "legacy characteristic value offset",
+                )?;
+                let value_length = payload_length - 2 * VARNAME_WIDTH;
+                let note = decode_range(
+                    reader,
+                    value_offset,
+                    value_length,
+                    encoding,
+                    true,
+                    scratch,
+                    &mut never_cancel,
+                    "reading legacy characteristic value",
+                )?
+                .0;
+                if !note.is_empty() {
+                    notes.push(note);
+                }
+            }
+        }
+        cursor = payload_end;
     }
     let observation_bytes = nobs
         .checked_mul(byte_offset)
@@ -1789,6 +1940,7 @@ fn read_legacy_metadata<R: Read + Seek>(
         nvar,
         nobs,
         dataset_label,
+        notes,
         variables,
         section_offsets: SectionOffsets {
             stata_data: 0,
@@ -2617,6 +2769,7 @@ mod tests {
             nvar: 1,
             nobs: 1,
             dataset_label: String::new(),
+            notes: Vec::new(),
             variables: vec![VariableInfo {
                 name: "text".to_owned(),
                 dta_type: DtaType::StrL,

--- a/rust/dta-parser/src/file.rs
+++ b/rust/dta-parser/src/file.rs
@@ -1879,10 +1879,12 @@ fn read_legacy_metadata<R: Read + Seek>(
             "legacy expansion payload",
         )?;
         if payload_end > file_length {
-            return Err(DtaError::Io {
-                context: "reading legacy expansion field",
-                offset: payload_end,
-                kind: ErrorKind::UnexpectedEof,
+            return Err(DtaError::Truncated {
+                context: "legacy expansion-field payload",
+                offset: error_offset(cursor),
+                needed: payload_length,
+                available: usize::try_from(file_length.saturating_sub(cursor))
+                    .unwrap_or(usize::MAX),
             });
         }
         if data_type == 1 && payload_length >= 2 * VARNAME_WIDTH {

--- a/rust/dta-parser/src/legacy.rs
+++ b/rust/dta-parser/src/legacy.rs
@@ -1,5 +1,5 @@
 use crate::endian::{checked_add, checked_mul, read_i32, read_u16, slice_at};
-use crate::text::{field_bytes, TextEncoding};
+use crate::text::{field_bytes, is_dataset_note, TextEncoding};
 use crate::{
     ByteOrder, DtaError, DtaMetadata, DtaType, FormatVersion, SectionOffsets, VariableInfo,
 };
@@ -101,8 +101,10 @@ fn scan_expansion_fields_ordered(
     bytes: &[u8],
     start: usize,
     byte_order: ByteOrder,
-) -> Result<usize, DtaError> {
+    encoding: TextEncoding,
+) -> Result<(usize, Vec<String>), DtaError> {
     let mut cursor = start;
+    let mut notes = Vec::new();
     loop {
         let data_type = slice_at(bytes, cursor, 1, "legacy expansion-field type")?[0];
         let length_offset = checked_add(cursor, 1, "legacy expansion-field length")?;
@@ -113,7 +115,10 @@ fn scan_expansion_fields_ordered(
             "legacy expansion-field length",
         )?;
         if data_type == 0 && value == 0 {
-            return checked_add(cursor, 5, "legacy expansion-field terminator");
+            return Ok((
+                checked_add(cursor, 5, "legacy expansion-field terminator")?,
+                notes,
+            ));
         }
         if value < 0 {
             return Err(DtaError::NegativeExpansionLength {
@@ -130,7 +135,17 @@ fn scan_expansion_fields_ordered(
         let length = usize::try_from(value)
             .map_err(|_| DtaError::ArithmeticOverflow("legacy expansion-field length"))?;
         cursor = checked_add(cursor, 5, "legacy expansion-field header")?;
-        slice_at(bytes, cursor, length, "legacy expansion-field payload")?;
+        let payload = slice_at(bytes, cursor, length, "legacy expansion-field payload")?;
+        if data_type == 1 && payload.len() >= 2 * VARNAME_WIDTH {
+            let (variable, remainder) = payload.split_at(VARNAME_WIDTH);
+            let (characteristic, value) = remainder.split_at(VARNAME_WIDTH);
+            if is_dataset_note(variable, characteristic) {
+                let note = encoding.decode(field_bytes(value));
+                if !note.is_empty() {
+                    notes.push(note);
+                }
+            }
+        }
         cursor = checked_add(cursor, length, "legacy expansion-field payload")?;
     }
 }
@@ -166,7 +181,9 @@ pub(crate) fn parse_legacy_metadata(
     let fixed = legacy_fixed_offsets(nvar_usize, version)?;
     let expansion_start = fixed.end;
     slice_at(bytes, 0, expansion_start, "legacy fixed metadata sections")?;
-    let data_offset = scan_expansion_fields_ordered(bytes, expansion_start, byte_order)?;
+    let resolved_encoding = encoding.resolve(version);
+    let (data_offset, notes) =
+        scan_expansion_fields_ordered(bytes, expansion_start, byte_order, resolved_encoding)?;
     parse_legacy_metadata_layout(
         bytes,
         file_length,
@@ -175,7 +192,8 @@ pub(crate) fn parse_legacy_metadata(
         byte_order,
         nvar,
         nobs,
-        encoding.resolve(version),
+        resolved_encoding,
+        notes,
     )
 }
 
@@ -189,6 +207,7 @@ pub(crate) fn parse_legacy_metadata_layout(
     nvar: u32,
     nobs: u64,
     encoding: TextEncoding,
+    notes: Vec<String>,
 ) -> Result<DtaMetadata, DtaError> {
     let nvar_usize =
         usize::try_from(nvar).map_err(|_| DtaError::ArithmeticOverflow("legacy variable count"))?;
@@ -307,6 +326,7 @@ pub(crate) fn parse_legacy_metadata_layout(
         nvar,
         nobs,
         dataset_label,
+        notes,
         variables,
         section_offsets: SectionOffsets {
             stata_data: 0,

--- a/rust/dta-parser/src/metadata.rs
+++ b/rust/dta-parser/src/metadata.rs
@@ -3,7 +3,7 @@ use crate::endian::{
     read_u64, read_u8, slice_at,
 };
 use crate::legacy::parse_legacy_metadata;
-use crate::text::TextEncoding;
+use crate::text::{field_bytes, is_dataset_note, TextEncoding};
 use crate::{
     ByteOrder, DtaError, DtaMetadata, DtaType, FormatVersion, SectionOffsets, VariableInfo,
 };
@@ -35,6 +35,10 @@ const VALUE_LABEL_NAMES_OPEN: &[u8] = b"<value_label_names>";
 const VALUE_LABEL_NAMES_CLOSE: &[u8] = b"</value_label_names>";
 const VARIABLE_LABELS_OPEN: &[u8] = b"<variable_labels>";
 const VARIABLE_LABELS_CLOSE: &[u8] = b"</variable_labels>";
+const CHARACTERISTICS_OPEN: &[u8] = b"<characteristics>";
+const CHARACTERISTICS_CLOSE: &[u8] = b"</characteristics>";
+const CHARACTERISTIC_OPEN: &[u8] = b"<ch>";
+const CHARACTERISTIC_CLOSE: &[u8] = b"</ch>";
 
 const SECTION_MAP_ENTRIES: usize = 14;
 
@@ -302,6 +306,89 @@ fn validate_sortlist(
     ensure_map_offset("formats", cursor, offsets.formats)
 }
 
+fn parse_characteristics(
+    bytes: &[u8],
+    version: FormatVersion,
+    byte_order: ByteOrder,
+    offsets: &SectionOffsets,
+    encoding: TextEncoding,
+) -> Result<Vec<String>, DtaError> {
+    let start = offset_to_usize(offsets.characteristics, "characteristics")?;
+    if bytes.len() == start {
+        return Ok(Vec::new());
+    }
+    let data = offset_to_usize(offsets.data, "data")?;
+    let width = if version == FormatVersion::V117 {
+        33
+    } else {
+        129
+    };
+    let names_length = checked_mul(width, 2, "characteristic names length")?;
+    let mut cursor = expect_at(bytes, start, CHARACTERISTICS_OPEN, "<characteristics>")?;
+    let mut notes = Vec::new();
+
+    loop {
+        if bytes.get(cursor..cursor.saturating_add(CHARACTERISTICS_CLOSE.len()))
+            == Some(CHARACTERISTICS_CLOSE)
+        {
+            cursor = expect_at(bytes, cursor, CHARACTERISTICS_CLOSE, "</characteristics>")?;
+            ensure_map_offset("data", cursor, offsets.data)?;
+            return Ok(notes);
+        }
+
+        cursor = expect_at(bytes, cursor, CHARACTERISTIC_OPEN, "<ch>")?;
+        let payload_length = usize::try_from(read_u32(
+            bytes,
+            cursor,
+            byte_order,
+            "characteristic length",
+        )?)
+        .map_err(|_| DtaError::ArithmeticOverflow("characteristic length"))?;
+        cursor = checked_add(cursor, 4, "characteristic length")?;
+        if payload_length < names_length {
+            return Err(DtaError::Truncated {
+                context: "characteristic names",
+                offset: cursor,
+                needed: names_length,
+                available: payload_length,
+            });
+        }
+        let payload_end = checked_add(cursor, payload_length, "characteristic payload")?;
+        let record_end = checked_add(
+            payload_end,
+            CHARACTERISTIC_CLOSE.len(),
+            "characteristic closing tag",
+        )?;
+        if record_end > data {
+            return Err(DtaError::Truncated {
+                context: "characteristic payload",
+                offset: cursor,
+                needed: payload_length.saturating_add(CHARACTERISTIC_CLOSE.len()),
+                available: data.saturating_sub(cursor),
+            });
+        }
+        let payload = slice_at(bytes, cursor, payload_length, "characteristic payload")?;
+        let (variable, remainder) = payload.split_at(width);
+        let (characteristic, value) = remainder.split_at(width);
+        if is_dataset_note(variable, characteristic) {
+            let note = encoding.decode(field_bytes(value));
+            if !note.is_empty() {
+                notes.push(note);
+            }
+        }
+        cursor = payload_end;
+        cursor = expect_at(bytes, cursor, CHARACTERISTIC_CLOSE, "</ch>")?;
+        if cursor > data {
+            return Err(DtaError::MapOffsetMismatch {
+                section: "data",
+                expected: offsets.data,
+                actual: u64::try_from(cursor)
+                    .map_err(|_| DtaError::ArithmeticOverflow("characteristics end"))?,
+            });
+        }
+    }
+}
+
 pub(crate) fn resolve_type(code: u16, version: FormatVersion) -> Result<(DtaType, u32), DtaError> {
     let numeric = match code {
         65530 => Some((DtaType::Byte, 1)),
@@ -430,6 +517,13 @@ pub fn parse_metadata_with_encoding(
         },
         encoding,
     )?;
+    let notes = parse_characteristics(
+        bytes,
+        format_version,
+        byte_order,
+        &section_offsets,
+        encoding,
+    )?;
 
     let mut byte_offset = 0_u64;
     let mut variables = Vec::with_capacity(nvar_usize);
@@ -457,6 +551,7 @@ pub fn parse_metadata_with_encoding(
         nvar,
         nobs,
         dataset_label,
+        notes,
         variables,
         section_offsets,
         obs_length: byte_offset,

--- a/rust/dta-parser/src/selection.rs
+++ b/rust/dta-parser/src/selection.rs
@@ -45,6 +45,7 @@ mod tests {
             nvar,
             nobs,
             dataset_label: String::new(),
+            notes: Vec::new(),
             variables: Vec::new(),
             section_offsets: SectionOffsets::from_array([0; 14]),
             obs_length: 0,

--- a/rust/dta-parser/src/strl.rs
+++ b/rust/dta-parser/src/strl.rs
@@ -325,6 +325,7 @@ mod tests {
             nvar: 1,
             nobs,
             dataset_label: String::new(),
+            notes: Vec::new(),
             variables: vec![VariableInfo {
                 name: "long".into(),
                 dta_type: DtaType::StrL,

--- a/rust/dta-parser/src/text.rs
+++ b/rust/dta-parser/src/text.rs
@@ -115,6 +115,17 @@ pub(crate) fn field_bytes(bytes: &[u8]) -> &[u8] {
     &bytes[..end]
 }
 
+pub(crate) fn is_dataset_note(variable: &[u8], characteristic: &[u8]) -> bool {
+    if field_bytes(variable) != b"_dta" {
+        return false;
+    }
+    let name = field_bytes(characteristic);
+    let Some(index) = name.strip_prefix(b"note") else {
+        return false;
+    };
+    !index.is_empty() && index.iter().all(u8::is_ascii_digit)
+}
+
 pub(crate) fn is_utf8_continuation(byte: u8) -> bool {
     byte & 0xc0 == 0x80
 }

--- a/rust/dta-parser/src/types.rs
+++ b/rust/dta-parser/src/types.rs
@@ -316,6 +316,8 @@ pub struct DtaMetadata {
     #[serde(with = "decimal_u64")]
     pub nobs: u64,
     pub dataset_label: String,
+    #[serde(default)]
+    pub notes: Vec<String>,
     pub variables: Vec<VariableInfo>,
     pub section_offsets: SectionOffsets,
     #[serde(with = "decimal_u64")]
@@ -471,6 +473,7 @@ mod tests {
             nvar: 1,
             nobs: 9_007_199_254_740_993,
             dataset_label: "fixture".into(),
+            notes: vec!["first note".into()],
             variables: vec![VariableInfo {
                 name: "x".into(),
                 dta_type: DtaType::FixedString(12),
@@ -489,6 +492,7 @@ mod tests {
         assert_eq!(value["format_version"], 119);
         assert_eq!(value["byte_order"], "MSF");
         assert_eq!(value["nobs"], "9007199254740993");
+        assert_eq!(value["notes"][0], "first note");
         assert_eq!(value["variables"][0]["type"], "str12");
         assert_eq!(value["variables"][0]["byte_offset"], "0");
         assert_eq!(value["section_offsets"]["data"], "0");

--- a/rust/dta-parser/tests/file.rs
+++ b/rust/dta-parser/tests/file.rs
@@ -247,7 +247,28 @@ fn file_reads_match_slice_for_modern_strl_and_legacy_projections() {
         let mut file = DtaFile::from_reader(Cursor::new(bytes)).unwrap();
         let actual = file.read_with_options(&read_options).unwrap();
         assert_eq!(actual, expected, "{name}");
+        if name == "auto_v118.dta" {
+            assert_eq!(
+                actual.metadata.notes,
+                ["From Consumer Reports with permission", "1"]
+            );
+        }
     }
+}
+
+#[test]
+fn modern_characteristic_lengths_cannot_cross_the_data_section() {
+    let mut bytes = fixture("auto_v118.dta");
+    let metadata = dta_parser::parse_metadata(&bytes).unwrap();
+    let length = metadata.section_offsets.characteristics as usize + b"<characteristics><ch>".len();
+    bytes[length..length + 4].copy_from_slice(&u32::MAX.to_le_bytes());
+    assert!(matches!(
+        DtaFile::from_reader(Cursor::new(bytes)),
+        Err(DtaError::Truncated {
+            context: "characteristic payload",
+            ..
+        })
+    ));
 }
 
 #[test]
@@ -484,7 +505,7 @@ fn labels_are_lazy_and_cancellation_never_returns_partial_data() {
         .borrow()
         .reads
         .iter()
-        .any(|(offset, _)| *offset >= metadata.section_offsets.characteristics));
+        .any(|(offset, _)| *offset >= metadata.section_offsets.data));
     assert!(!trace
         .borrow()
         .reads

--- a/rust/dta-parser/tests/legacy.rs
+++ b/rust/dta-parser/tests/legacy.rs
@@ -242,18 +242,14 @@ fn rejects_malformed_legacy_counts_filetype_and_expansion_fields() {
         .characteristics as usize;
     let mut oversized = original;
     oversized[expansion + 1..expansion + 5].copy_from_slice(&i32::MAX.to_be_bytes());
+    let slice_error = parse_metadata(&oversized).unwrap_err();
     assert!(matches!(
-        parse_metadata(&oversized),
-        Err(DtaError::Truncated {
+        slice_error,
+        DtaError::Truncated {
             context: "legacy expansion-field payload",
             ..
-        })
+        }
     ));
-    assert!(matches!(
-        DtaFile::from_reader(Cursor::new(oversized)),
-        Err(DtaError::Io {
-            context: "reading legacy expansion field",
-            ..
-        })
-    ));
+    let file_error = DtaFile::from_reader(Cursor::new(oversized)).err().unwrap();
+    assert_eq!(file_error, slice_error);
 }

--- a/rust/dta-parser/tests/legacy.rs
+++ b/rust/dta-parser/tests/legacy.rs
@@ -41,10 +41,14 @@ fn synthetic_v113_msf() -> Vec<u8> {
     bytes[cursor..cursor + 5].copy_from_slice(b"na\xefve");
     bytes[cursor + 81..cursor + 87].copy_from_slice(b"quoted");
 
-    // One nonempty expansion field followed by the exact sentinel.
+    // One dataset note characteristic followed by the exact sentinel.
+    let mut note = vec![0_u8; 2 * 33];
+    note[..4].copy_from_slice(b"_dta");
+    note[33..38].copy_from_slice(b"note1");
+    note.extend_from_slice(b"Caf\xe9\0");
     bytes.push(1);
-    bytes.extend_from_slice(&3_i32.to_be_bytes());
-    bytes.extend_from_slice(b"abc");
+    bytes.extend_from_slice(&(note.len() as i32).to_be_bytes());
+    bytes.extend_from_slice(&note);
     bytes.extend_from_slice(&[0, 0, 0, 0, 0]);
     bytes.extend_from_slice(&321_i16.to_be_bytes());
     bytes.extend_from_slice(&[0x93, b'h', 0x94, 0]);
@@ -139,6 +143,7 @@ fn decodes_true_big_endian_v113_and_windows_1252() {
     assert_eq!(metadata.format_version, FormatVersion::V113);
     assert_eq!(metadata.byte_order, ByteOrder::Msf);
     assert_eq!(metadata.dataset_label, "Café");
+    assert_eq!(metadata.notes, ["Café"]);
     assert_eq!(metadata.variables[0].label, "naïve");
     let data = read_dta(&bytes).unwrap();
     match &data.columns[0].values {
@@ -164,6 +169,7 @@ fn explicit_encoding_overrides_every_legacy_text_surface() {
     let bytes = synthetic_v113_msf();
     let latin1 = read_dta_with_encoding(&bytes, TextEncoding::Iso8859_1).unwrap();
     assert_eq!(latin1.metadata.dataset_label, "Café");
+    assert_eq!(latin1.metadata.notes, ["Café"]);
     assert_eq!(latin1.metadata.variables[0].label, "naïve");
     let ColumnValues::FixedString { values } = &latin1.columns[1].values else {
         panic!("text must be a fixed string");
@@ -181,11 +187,28 @@ fn explicit_encoding_overrides_every_legacy_text_surface() {
 
     let utf8 = read_dta_with_encoding(&bytes, TextEncoding::Utf8).unwrap();
     assert_eq!(utf8.metadata.dataset_label, "Caf\u{fffd}");
+    assert_eq!(utf8.metadata.notes, ["Caf\u{fffd}"]);
     assert_eq!(utf8.metadata.variables[0].label, "na\u{fffd}ve");
 
     let mut file =
         DtaFile::from_reader_with_encoding(Cursor::new(bytes), TextEncoding::Iso8859_1).unwrap();
     assert_eq!(file.read().unwrap(), latin1);
+}
+
+#[test]
+fn omits_empty_legacy_dataset_notes() {
+    let mut bytes = synthetic_v113_msf();
+    let value = bytes
+        .windows(5)
+        .rposition(|window| window == b"Caf\xe9\0")
+        .unwrap();
+    bytes[value] = 0;
+    assert!(parse_metadata(&bytes).unwrap().notes.is_empty());
+    assert!(DtaFile::from_reader(Cursor::new(bytes))
+        .unwrap()
+        .metadata()
+        .notes
+        .is_empty());
 }
 
 #[test]
@@ -210,5 +233,27 @@ fn rejects_malformed_legacy_counts_filetype_and_expansion_fields() {
     assert!(matches!(
         parse_metadata(&invalid_terminator),
         Err(DtaError::InvalidExpansionTerminator { value: 1, .. })
+    ));
+
+    let original = synthetic_v113_msf();
+    let expansion = parse_metadata(&original)
+        .unwrap()
+        .section_offsets
+        .characteristics as usize;
+    let mut oversized = original;
+    oversized[expansion + 1..expansion + 5].copy_from_slice(&i32::MAX.to_be_bytes());
+    assert!(matches!(
+        parse_metadata(&oversized),
+        Err(DtaError::Truncated {
+            context: "legacy expansion-field payload",
+            ..
+        })
+    ));
+    assert!(matches!(
+        DtaFile::from_reader(Cursor::new(oversized)),
+        Err(DtaError::Io {
+            context: "reading legacy expansion field",
+            ..
+        })
     ));
 }

--- a/rust/dta-parser/tests/metadata.rs
+++ b/rust/dta-parser/tests/metadata.rs
@@ -81,6 +81,10 @@ fn matches_known_shared_fixture_metadata() {
     assert_eq!(metadata.nvar, 12);
     assert_eq!(metadata.nobs, 74);
     assert_eq!(metadata.dataset_label, "1978 automobile data");
+    assert_eq!(
+        metadata.notes,
+        ["From Consumer Reports with permission", "1"]
+    );
     assert_eq!(metadata.variables[0].name, "make");
     assert_eq!(metadata.variables[0].dta_type, DtaType::FixedString(18));
     assert_eq!(metadata.variables[0].label, "Make and model");
@@ -92,6 +96,7 @@ fn matches_known_shared_fixture_metadata() {
     assert_eq!(v117.format_version, FormatVersion::V117);
     assert_eq!(v117.variables[11].type_code, 65_530);
     assert_eq!(v117.variables[11].dta_type, DtaType::Byte);
+    assert_eq!(v117.notes, metadata.notes);
 }
 
 fn push_field(bytes: &mut Vec<u8>, value: &[u8], width: usize) {
@@ -194,7 +199,9 @@ fn accepts_a_valid_metadata_prefix_but_rejects_required_section_truncation() {
     let metadata = parse_metadata(&full).unwrap();
     let prefix_end = metadata.section_offsets.characteristics as usize;
     let prefix = &full[..prefix_end];
-    assert_eq!(parse_metadata(prefix).unwrap(), metadata);
+    let mut prefix_metadata = metadata;
+    prefix_metadata.notes.clear();
+    assert_eq!(parse_metadata(prefix).unwrap(), prefix_metadata);
 
     for length in [0, 1, 40, prefix_end / 2, prefix_end - 1] {
         assert!(
@@ -202,6 +209,40 @@ fn accepts_a_valid_metadata_prefix_but_rejects_required_section_truncation() {
             "length {length}"
         );
     }
+}
+
+#[test]
+fn rejects_truncated_or_malformed_modern_characteristics() {
+    let original = fixture("auto_v118.dta");
+    let metadata = parse_metadata(&original).unwrap();
+    let characteristics = metadata.section_offsets.characteristics as usize;
+    let data = metadata.section_offsets.data as usize;
+
+    assert!(matches!(
+        parse_metadata(&original[..data - 1]),
+        Err(DtaError::Truncated { .. }) | Err(DtaError::UnexpectedTag { .. })
+    ));
+
+    let mut short_names = original;
+    let length = characteristics + b"<characteristics><ch>".len();
+    short_names[length..length + 4].copy_from_slice(&1_u32.to_le_bytes());
+    assert!(matches!(
+        parse_metadata(&short_names),
+        Err(DtaError::Truncated {
+            context: "characteristic names",
+            ..
+        })
+    ));
+
+    let mut crosses_section = short_names;
+    crosses_section[length..length + 4].copy_from_slice(&u32::MAX.to_le_bytes());
+    assert!(matches!(
+        parse_metadata(&crosses_section),
+        Err(DtaError::Truncated {
+            context: "characteristic payload",
+            ..
+        })
+    ));
 }
 
 #[test]

--- a/rust/dta-parser/tests/observations.rs
+++ b/rust/dta-parser/tests/observations.rs
@@ -1,9 +1,11 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
+use std::io::Cursor;
 use std::path::{Path, PathBuf};
 
 use dta_parser::{
-    read_dta, read_dta_with_options, ColumnValues, DtaError, DtaType, MissingTag, ReadOptions,
+    read_dta, read_dta_with_options, ColumnValues, DtaError, DtaFile, DtaType, MissingTag,
+    ReadOptions,
 };
 use serde::Deserialize;
 use sha2::{Digest, Sha256};
@@ -109,7 +111,14 @@ fn synthetic_big_endian_v119() -> Vec<u8> {
     bytes.extend_from_slice(b"</variable_labels>");
 
     offsets[8] = bytes.len() as u64;
-    bytes.extend_from_slice(b"<characteristics></characteristics>");
+    bytes.extend_from_slice(b"<characteristics><ch>");
+    let note = b"big-endian metadata note\0";
+    let characteristic_length = 2 * 129 + note.len();
+    bytes.extend_from_slice(&(characteristic_length as u32).to_be_bytes());
+    push_field(&mut bytes, b"_dta", 129);
+    push_field(&mut bytes, b"note1", 129);
+    bytes.extend_from_slice(note);
+    bytes.extend_from_slice(b"</ch></characteristics>");
 
     offsets[9] = bytes.len() as u64;
     bytes.extend_from_slice(b"<data>");
@@ -592,12 +601,14 @@ fn every_checked_fixture_matches_the_typescript_haven_oracle() {
 
 #[test]
 fn decodes_big_endian_v119_observations_and_labels() {
-    let data = read_dta(&synthetic_big_endian_v119()).unwrap();
+    let bytes = synthetic_big_endian_v119();
+    let data = read_dta(&bytes).unwrap();
     assert_eq!(
         data.metadata.format_version,
         dta_parser::FormatVersion::V119
     );
     assert_eq!(data.metadata.byte_order, dta_parser::ByteOrder::Msf);
+    assert_eq!(data.metadata.notes, ["big-endian metadata note"]);
     assert_eq!(data.metadata.obs_length, 23);
     assert_eq!(data.row_count, 2);
 
@@ -659,6 +670,9 @@ fn decodes_big_endian_v119_observations_and_labels() {
     let table = data.value_label_table_for_variable(0).unwrap();
     assert_eq!(table.entry(-5).unwrap().label, "no");
     assert_eq!(table.entry(101).unwrap().label, "yes");
+
+    let mut file = DtaFile::from_reader(Cursor::new(bytes)).unwrap();
+    assert_eq!(file.read().unwrap(), data);
 }
 
 #[test]

--- a/rust/dta-parser/tests/value_labels.rs
+++ b/rust/dta-parser/tests/value_labels.rs
@@ -131,6 +131,7 @@ fn parses_a_strict_big_endian_v119_label_table() {
         nvar: 0,
         nobs: 0,
         dataset_label: String::new(),
+        notes: Vec::new(),
         variables: vec![],
         section_offsets: SectionOffsets {
             stata_data: 0,


### PR DESCRIPTION
## Summary

- parse ordered dataset notes from modern characteristics and legacy expansion fields
- attach haven-compatible `notes` attributes in both R materialization paths
- remove the package-specific `dta_format_version` attribute from returned tibbles while retaining format version in internal metadata
- add malformed-length, encoding, cardinality, projection/window, legacy, and big-endian v119 coverage

## Alignment decision

The default R result now follows haven's top-level metadata contract: `notes` is omitted when empty and otherwise preserves matching dataset-note records in file order, including `note0`. The parser's reusable Rust metadata still exposes the DTA format version, and R's internal `.dta_metadata()` keeps it available without adding a package-specific attribute to user-facing tibbles.

This intentionally does not add a general characteristics API or variable-scoped characteristics.

## Validation

- `cargo test --manifest-path rust/dta-parser/Cargo.toml` — 79 passed
- installed R testthat suite — 1,715 passed, 0 failed, 1 environment-only skip
- `./scripts/check-rust-sync.sh`
- Rust formatting checks
- `git diff --check`
- independent review cycle — clean

Closes #17

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Stata dataset notes are now extracted from both modern and legacy `.dta` files and included in the resulting metadata.
  * Dataset- and variable-level labels continue to be preserved alongside formats, value labels, long strings, and tagged missing values.
  * Notes are decoded using the selected text encoding (including explicit encoding overrides).

* **Bug Fixes**
  * The previously exposed `dta_format_version` dataset attribute is no longer set on parsed R data frames.
  * Improved handling and validation of truncated or malformed metadata/characteristics/legacy expansion data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->