### PR TITLE
Match haven legacy daily date formats

### DIFF
--- a/r-package/dtaparser/R/read-dta.R
+++ b/r-package/dtaparser/R/read-dta.R
@@ -24,9 +24,10 @@
 #' @param skip Number of observations to skip.
 #' @param n_max Maximum observations to read. `Inf` reads all remaining rows.
 #' @param .name_repair Name repair passed to [tibble::as_tibble()].
-#' @return A tibble. `%td` columns have class `Date`; `%tc` and `%tC` columns
-#'   have classes `POSIXct` and `POSIXt` in UTC. Other Stata temporal formats
-#'   remain numeric with their `format.stata` attribute.
+#' @return A tibble. `%td` columns and legacy or custom formats beginning `%d`
+#'   have class `Date`; `%tc` and `%tC` columns have classes `POSIXct` and
+#'   `POSIXt` in UTC. Other Stata temporal formats remain numeric with their
+#'   `format.stata` attribute.
 #' @export
 read_dta <- function(file, encoding = NULL, col_select = NULL, skip = 0,
                      n_max = Inf, .name_repair = "unique") {

--- a/r-package/dtaparser/README.md
+++ b/r-package/dtaparser/README.md
@@ -39,9 +39,10 @@ reusable Rust parser.
 
 The reader supports Stata releases 113--115 and 117--119. It retains dataset
 and variable labels, dataset notes, display formats, value-label tables,
-`strL` values, and system or `.a`--`.z` missing values. `%td` is converted to
-`Date`; `%tc` and `%tC` are converted to UTC `POSIXct`. Other Stata calendar
-formats remain numeric and retain their `format.stata` attribute.
+`strL` values, and system or `.a`--`.z` missing values. `%td` and legacy or
+custom daily-date formats beginning `%d` are converted to `Date`; `%tc` and
+`%tC` are converted to UTC `POSIXct`. Other Stata calendar formats remain
+numeric and retain their `format.stata` attribute.
 
 `encoding = NULL` follows the DTA release convention: Windows-1252 for
 releases 113--115 and UTF-8 for releases 117--119. To recover files whose

--- a/r-package/dtaparser/man/read_dta.Rd
+++ b/r-package/dtaparser/man/read_dta.Rd
@@ -26,7 +26,11 @@ variable is selected more than once, the first selection and alias win.}
 \item{n_max}{Maximum observations to read, or \code{Inf}.}
 \item{.name_repair}{Name repair passed to \code{tibble::as_tibble()}.}
 }
-\value{A tibble containing native numeric and character vectors.}
+\value{A tibble containing native numeric and character vectors. \code{\%td}
+columns and legacy or custom formats beginning \code{\%d} have class
+\code{Date}; \code{\%tc} and \code{\%tC} columns have classes \code{POSIXct}
+and \code{POSIXt} in UTC. Other Stata temporal formats remain numeric with
+their \code{format.stata} attribute.}
 \description{
 Reads Stata releases 113--115 and 117--119 through the native Rust parser,
 retaining dataset and variable labels, dataset notes, formats, value labels,

--- a/r-package/dtaparser/src/rust/src/lib.rs
+++ b/r-package/dtaparser/src/rust/src/lib.rs
@@ -101,10 +101,10 @@ enum TemporalKind {
 }
 
 fn temporal_kind(format: &str) -> TemporalKind {
-    if format.starts_with("%td") {
-        TemporalKind::Date
-    } else if format.starts_with("%tc") || format.starts_with("%tC") {
+    if format.starts_with("%tC") || format.starts_with("%tc") {
         TemporalKind::Datetime
+    } else if format.starts_with("%td") || format.starts_with("%d") {
+        TemporalKind::Date
     } else {
         TemporalKind::None
     }
@@ -896,7 +896,34 @@ pub unsafe extern "C" fn dtaparser_free_error(error: *mut c_char) {
 
 #[cfg(test)]
 mod tests {
-    use super::{selected_row_count, validate_r_row_count, R_DATA_FRAME_MAX_ROWS};
+    use super::{
+        selected_row_count, temporal_kind, validate_r_row_count, TemporalKind,
+        R_DATA_FRAME_MAX_ROWS,
+    };
+
+    #[test]
+    fn temporal_formats_match_haven_prefix_rules() {
+        for format in ["%td", "%tdDD/NN/CCYY", "%d", "%dCY-N-D", "%dollars"] {
+            assert!(
+                matches!(temporal_kind(format), TemporalKind::Date),
+                "{format} should be a daily date"
+            );
+        }
+        for format in ["%tc", "%tcDDmonCCYY_HH:MM:SS", "%tC", "%tCCustom"] {
+            assert!(
+                matches!(temporal_kind(format), TemporalKind::Datetime),
+                "{format} should be a datetime"
+            );
+        }
+        for format in [
+            "%D", "%9d", "%tw", "%tm", "%tq", "%th", "%ty", "%t", "d", "",
+        ] {
+            assert!(
+                matches!(temporal_kind(format), TemporalKind::None),
+                "{format} should remain numeric"
+            );
+        }
+    }
 
     #[test]
     fn selected_row_windows_are_clamped_before_decode() {

--- a/r-package/dtaparser/tests/testthat/test-read-dta.R
+++ b/r-package/dtaparser/tests/testthat/test-read-dta.R
@@ -211,6 +211,88 @@ test_that("date and datetime storage become native R temporal vectors", {
     expect_identical(attr(actual$instant, "tzone"), "UTC")
 })
 
+test_that("legacy and custom daily-date formats match haven", {
+    skip_if_not_installed("haven")
+    path <- tempfile(fileext = ".dta")
+    on.exit(unlink(path), add = TRUE)
+
+    formats <- c(
+        daily_td = "%td",
+        daily_d = "%d",
+        daily_custom = "%dCY-N-D",
+        daily_unusual = "%dollars",
+        daily_other = "%dfoo",
+        datetime_tc = "%tc",
+        datetime_tC = "%tC",
+        near_uppercase_d = "%D",
+        near_width_d = "%9d",
+        weekly = "%tw",
+        monthly = "%tm",
+        quarterly = "%tq",
+        halfyear = "%th",
+        yearly = "%ty",
+        incomplete_temporal = "%t",
+        bare_d = "d"
+    )
+    values <- c(0, 3653, haven::tagged_na("a"), NA_real_)
+    input <- as.data.frame(lapply(formats, function(format) {
+        column <- values
+        attr(column, "format.stata") <- format
+        column
+    }), check.names = FALSE)
+    haven::write_dta(input, path, version = 15)
+
+    actual <- read_dta(path)
+    rust_vectors <- dtaparser:::.read_dta_rust_vectors(path)
+    expected <- haven::read_dta(path)
+
+    expect_identical(actual, rust_vectors)
+    for (name in names(formats)) {
+        expect_identical(actual[[name]], expected[[name]], info = name)
+        expect_identical(attr(actual[[name]], "format.stata"), formats[[name]],
+                         info = name)
+        expect_identical(haven::na_tag(actual[[name]]),
+                         haven::na_tag(expected[[name]]), info = name)
+    }
+
+    date_names <- names(formats)[startsWith(formats, "%d") |
+                                 startsWith(formats, "%td")]
+    datetime_names <- names(formats)[startsWith(formats, "%tc") |
+                                     startsWith(formats, "%tC")]
+    numeric_names <- setdiff(names(formats), c(date_names, datetime_names))
+    expect_true(all(vapply(actual[date_names], inherits, logical(1), "Date")))
+    expect_true(all(vapply(actual[datetime_names], inherits, logical(1),
+                           "POSIXct")))
+    expect_true(all(vapply(actual[datetime_names], function(column) {
+        identical(attr(column, "tzone"), "UTC")
+    }, logical(1))))
+    expect_true(all(vapply(actual[numeric_names], function(column) {
+        identical(class(column), "numeric")
+    }, logical(1))))
+
+    selected_names <- c("daily_custom", "datetime_tC", "near_uppercase_d")
+    selected <- read_dta(
+        path,
+        col_select = all_of(selected_names),
+        skip = 1,
+        n_max = 2
+    )
+    selected_rust_vectors <- dtaparser:::.read_dta_rust_vectors(
+        path,
+        col_select = all_of(selected_names),
+        skip = 1,
+        n_max = 2
+    )
+    selected_expected <- haven::read_dta(
+        path,
+        col_select = all_of(selected_names),
+        skip = 1,
+        n_max = 2
+    )
+    expect_identical(selected, selected_rust_vectors)
+    expect_identical(selected, selected_expected)
+})
+
 test_that("explicit encodings match haven across ordinary textual surfaces", {
     skip_if_not_installed("haven")
     for (version in c(115L, 118L)) local({


### PR DESCRIPTION
## Summary

- recognize Stata formats beginning `%d` as daily dates, matching haven 2.5.5
- preserve the existing ordered, case-sensitive `%tc`/`%tC` datetime classification and numeric handling for near misses
- add differential coverage for both direct-R and Rust-vector materialization, missing tags, projection, and row windows
- document legacy and custom daily-date behavior in the R package

## Why

The R bridge recognized `%td` but left older and custom daily-date formats such as `%d` and `%dCY-N-D` numeric. Haven classifies any case-sensitive `%d...` prefix as `Date`; matching that rule closes the remaining temporal recognition gap without changing parser-core behavior or the default numeric path.

## Validation

- `cargo fmt --check`
- bridge `cargo test` (3 passed)
- full R testthat suite (one pre-existing loopback-server skip)
- `R CMD build`
- `R CMD check --no-manual` (`Status: OK`)
- independent review: CLEAN

Closes #18

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved handling of legacy and custom Stata daily date formats, converting them to R `Date` values.
  * Preserved UTC conversion for Stata datetime formats and numeric handling for other temporal formats.

* **Documentation**
  * Clarified date/time conversion behavior in the function documentation and README.

* **Tests**
  * Added coverage confirming compatibility with Haven across date, datetime, and other temporal formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->