### PR TITLE
Align safe row-window arguments with haven

### DIFF
--- a/r-package/dtaparser/R/read-dta.R
+++ b/r-package/dtaparser/R/read-dta.R
@@ -21,8 +21,12 @@
 #'   string storage as character and numeric storage as double. If a source
 #'   variable is selected more than once, its first selection and alias win.
 #'   Selection is resolved from metadata before observation data are read.
-#' @param skip Number of observations to skip.
-#' @param n_max Maximum observations to read. `Inf` reads all remaining rows.
+#' @param skip Number of observations to skip. Must be one non-negative whole
+#'   number no larger than `2^53`.
+#' @param n_max Maximum observations to read. `NA`, either infinity, and
+#'   negative finite values read all remaining rows, following haven's
+#'   unlimited-row convention. Non-negative values must be whole numbers no
+#'   larger than `2^53`.
 #' @param .name_repair Name repair passed to [tibble::as_tibble()].
 #' @return A tibble. `%td` columns and legacy or custom formats beginning `%d`
 #'   have class `Date`; `%tc` and `%tC` columns have classes `POSIXct` and
@@ -51,8 +55,7 @@ read_dta <- function(file, encoding = NULL, col_select = NULL, skip = 0,
 .read_dta_impl <- function(file, encoding, selection, skip, n_max,
                            .name_repair, materialization) {
     encoding <- .validate_dta_encoding(encoding)
-    .validate_count(skip, "skip", infinite = FALSE)
-    .validate_count(n_max, "n_max", infinite = TRUE)
+    row_window <- .normalize_row_window(skip, n_max)
 
     source <- .resolve_dta_source(file)
     on.exit(.cleanup_dta_source(source), add = TRUE)
@@ -79,8 +82,8 @@ read_dta <- function(file, encoding = NULL, col_select = NULL, skip = 0,
         C_dtaparser_read,
         source$path,
         column_indices,
-        as.double(skip),
-        as.double(n_max),
+        row_window$skip,
+        row_window$n_max,
         identical(materialization, "direct"),
         encoding
     )
@@ -192,13 +195,61 @@ read_dta <- function(file, encoding = NULL, col_select = NULL, skip = 0,
     canonical
 }
 
-.validate_count <- function(value, argument, infinite) {
-    valid_infinite <- infinite && is.numeric(value) && length(value) == 1L &&
-        is.infinite(value) && value > 0
-    valid_finite <- is.numeric(value) && length(value) == 1L && !is.na(value) &&
-        is.finite(value) && value >= 0 && value == floor(value) && value <= 2^53
-    if (!valid_infinite && !valid_finite) {
-        stop(sprintf("`%s` must be one non-negative whole number%s", argument,
-            if (infinite) " or Inf" else ""), call. = FALSE)
+.normalize_row_window <- function(skip, n_max) {
+    list(
+        skip = .normalize_skip(skip),
+        n_max = .normalize_n_max(n_max)
+    )
+}
+
+.normalize_skip <- function(value) {
+    .validate_count_shape(value, "skip")
+    if (is.na(value) || !is.finite(value) || value < 0 ||
+        value > 2^53 || (!is.integer(value) && value != floor(value))) {
+        stop(
+            "`skip` must be one non-negative whole number no larger than 2^53",
+            call. = FALSE
+        )
+    }
+    as.double(value)
+}
+
+.normalize_n_max <- function(value) {
+    if (length(value) != 1L) {
+        stop("`n_max` must have length 1", call. = FALSE)
+    }
+
+    # Bare NA is logical in R, but it is the conventional spelling of haven's
+    # unlimited-row sentinel. Other logical and non-numeric values remain
+    # invalid rather than entering native coercion.
+    if (identical(value, NA)) return(Inf)
+    .validate_count_type(value, "n_max")
+    if (is.na(value)) {
+        if (is.nan(value)) {
+            stop("`n_max` must not be NaN", call. = FALSE)
+        }
+        return(Inf)
+    }
+    if (is.infinite(value) || value < 0) return(Inf)
+    if (value > 2^53 || (!is.integer(value) && value != floor(value))) {
+        stop(paste(
+            "`n_max` must be a whole number no larger than 2^53,",
+            "or an unlimited-row sentinel"
+        ), call. = FALSE)
+    }
+    as.double(value)
+}
+
+.validate_count_shape <- function(value, argument) {
+    if (length(value) != 1L) {
+        stop(sprintf("`%s` must have length 1", argument), call. = FALSE)
+    }
+    .validate_count_type(value, argument)
+}
+
+.validate_count_type <- function(value, argument) {
+    if (is.object(value) || !(typeof(value) %in% c("integer", "double"))) {
+        stop(sprintf("`%s` must be one integer or double", argument),
+             call. = FALSE)
     }
 }

--- a/r-package/dtaparser/README.md
+++ b/r-package/dtaparser/README.md
@@ -99,8 +99,36 @@ No repeated 10 GB comparison was completed, so no 10 GB result is reported.
 - `.name_repair` is delegated to `tibble::as_tibble()` after selection aliases
   are applied.
 - Reads are synchronous. Long reads cooperatively check for R user interrupts.
-- R data frames are limited to `2^31 - 1` rows; `skip` and finite `n_max` must
-  be exactly representable non-negative whole numbers no larger than `2^53`.
+- R data frames are limited to `2^31 - 1` rows. `skip` must be an exactly
+  representable non-negative whole number no larger than `2^53`. For `n_max`,
+  `NA`, either infinity, and any negative finite value use haven's intentional
+  “all remaining rows” convention; non-negative values have the same whole
+  number and `2^53` limits.
+
+### Row-window compatibility
+
+`skip` and `n_max` are normalized once in R, before either materialization path
+enters native code. Safe scalar integers and integer-valued doubles therefore
+select the same rows as `haven::read_dta()`, including zero and values beyond
+the file's row count. The package also follows haven's documented internal
+`n_max` convention by mapping `NA`, `Inf`, `-Inf`, and negative finite values
+to one unlimited-row sentinel.
+
+Some haven 2.5.5 edge behavior comes from native integer coercion rather than
+its `n_max` normalization contract. This package deliberately rejects those
+cases before opening the file:
+
+| Input | dtaparser behavior | haven 2.5.5 behavior |
+| --- | --- | --- |
+| fractional non-negative `n_max` | error | truncates |
+| `NaN` `n_max` | error | reads all rows |
+| negative, missing, or infinite `skip` | error | native-coercion-dependent window |
+| fractional `skip` | error | error from the native boundary |
+| non-scalar or non-numeric values | error | error |
+| values greater than `2^53` | error | integer overflow/coercion behavior |
+
+Rejecting these inputs avoids silent truncation and platform-dependent
+overflow while retaining haven parity for meaningful row-window requests.
 
 The package includes a locked Cargo dependency graph and vendored crates so
 source builds do not contact a package registry. A Rust 1.74-or-newer toolchain

--- a/r-package/dtaparser/README.md
+++ b/r-package/dtaparser/README.md
@@ -110,13 +110,17 @@ No repeated 10 GB comparison was completed, so no 10 GB result is reported.
 `skip` and `n_max` are normalized once in R, before either materialization path
 enters native code. Safe scalar integers and integer-valued doubles therefore
 select the same rows as `haven::read_dta()`, including zero and values beyond
-the file's row count. The package also follows haven's documented internal
-`n_max` convention by mapping `NA`, `Inf`, `-Inf`, and negative finite values
-to one unlimited-row sentinel.
+the file's row count when they are representable by haven's native boundary.
+At the extreme `skip = 2^53` boundary, dtaparser deterministically returns an
+empty result while haven's native integer coercion is platform-dependent. The
+package also follows haven's intentional upstream `n_max` normalization by
+mapping `NA`, `Inf`, `-Inf`, and negative finite values to one unlimited-row
+sentinel.
 
 Some haven 2.5.5 edge behavior comes from native integer coercion rather than
-its `n_max` normalization contract. This package deliberately rejects those
-cases before opening the file:
+its `n_max` normalization contract. This package does not inherit those
+coercions: it validates or normalizes these inputs deterministically before
+opening the file:
 
 | Input | dtaparser behavior | haven 2.5.5 behavior |
 | --- | --- | --- |
@@ -125,9 +129,10 @@ cases before opening the file:
 | negative, missing, or infinite `skip` | error | native-coercion-dependent window |
 | fractional `skip` | error | error from the native boundary |
 | non-scalar or non-numeric values | error | error |
+| very large whole `skip` through `2^53` | deterministic row window | platform-dependent native coercion |
 | values greater than `2^53` | error | integer overflow/coercion behavior |
 
-Rejecting these inputs avoids silent truncation and platform-dependent
+These deterministic choices avoid silent truncation and platform-dependent
 overflow while retaining haven parity for meaningful row-window requests.
 
 The package includes a locked Cargo dependency graph and vendored crates so

--- a/r-package/dtaparser/man/read_dta.Rd
+++ b/r-package/dtaparser/man/read_dta.Rd
@@ -22,8 +22,12 @@ deterministically with U+FFFD. Haven 2.5.5 may instead omit an affected label.}
 \item{col_select}{One or more tidyselect expressions. Predicates treat Stata
 string storage as character and numeric storage as double. If a source
 variable is selected more than once, the first selection and alias win.}
-\item{skip}{Number of observations to skip.}
-\item{n_max}{Maximum observations to read, or \code{Inf}.}
+\item{skip}{Number of observations to skip. Must be one non-negative whole
+number no larger than \code{2^53}.}
+\item{n_max}{Maximum observations to read. \code{NA}, either infinity, and
+negative finite values read all remaining rows, following haven's unlimited-row
+convention. Non-negative values must be whole numbers no larger than
+\code{2^53}.}
 \item{.name_repair}{Name repair passed to \code{tibble::as_tibble()}.}
 }
 \value{A tibble containing native numeric and character vectors. \code{\%td}

--- a/r-package/dtaparser/src/rust/src/lib.rs
+++ b/r-package/dtaparser/src/rust/src/lib.rs
@@ -700,6 +700,9 @@ unsafe fn read_impl(
     direct_to_r: bool,
     encoding: TextEncoding,
 ) -> Result<Sexp, String> {
+    // Public semantics are normalized once by the R wrapper. These checks are
+    // only a defensive ABI guard for exact representability and +Inf as the
+    // single unlimited sentinel.
     if !skip.is_finite() || skip < 0.0 || skip.fract() != 0.0 || skip > (1_u64 << 53) as f64 {
         return Err("invalid skip value".to_owned());
     }

--- a/r-package/dtaparser/tests/testthat/test-read-dta.R
+++ b/r-package/dtaparser/tests/testthat/test-read-dta.R
@@ -150,7 +150,6 @@ test_that("safe row-window inputs align with haven in both collectors", {
         integer_valued_double = list(skip = 2, n_max = 3),
         zero = list(skip = 0, n_max = 0),
         skip_beyond_rows = list(skip = 1000, n_max = 3),
-        largest_exact_skip = list(skip = 2^53, n_max = 3),
         n_max_beyond_rows = list(skip = 72, n_max = 1000),
         bare_na_unlimited = list(skip = 2, n_max = NA),
         real_na_unlimited = list(skip = 2, n_max = NA_real_),
@@ -174,6 +173,19 @@ test_that("safe row-window inputs align with haven in both collectors", {
                          info = paste(name, "materialization"))
         expect_identical(actual, expected, info = name)
     }
+})
+
+test_that("the largest exact skip is deterministic in both collectors", {
+    path <- fixture("auto_v118.dta")
+    actual <- read_dta(
+        path, col_select = c("make", "price"), skip = 2^53, n_max = 3
+    )
+    rust_vectors <- dtaparser:::.read_dta_rust_vectors(
+        path, col_select = c("make", "price"), skip = 2^53, n_max = 3
+    )
+
+    expect_identical(actual, rust_vectors)
+    expect_identical(dim(actual), c(0L, 2L))
 })
 
 test_that("normalized windows cover empty data and zero-column projections", {
@@ -526,7 +538,7 @@ test_that("deliberate row-window divergences from haven are stable", {
     expect_error(read_dta(path, skip = -1, n_max = 2), "non-negative whole")
     expect_identical(nrow(haven::read_dta(path, skip = NA, n_max = 2)), 2L)
     expect_error(read_dta(path, skip = NA, n_max = 2), "integer or double")
-    expect_identical(nrow(haven::read_dta(path, skip = Inf, n_max = 2)), 0L)
+    expect_s3_class(haven::read_dta(path, skip = Inf, n_max = 2), "tbl_df")
     expect_error(read_dta(path, skip = Inf, n_max = 2), "non-negative whole")
     expect_error(haven::read_dta(path, skip = 2.9, n_max = 2),
                  "single integer")

--- a/r-package/dtaparser/tests/testthat/test-read-dta.R
+++ b/r-package/dtaparser/tests/testthat/test-read-dta.R
@@ -142,6 +142,79 @@ test_that("an empty projection retains the selected row count", {
     expect_identical(dim(result), c(3L, 0L))
 })
 
+test_that("safe row-window inputs align with haven in both collectors", {
+    skip_if_not_installed("haven")
+    path <- fixture("auto_v118.dta")
+    cases <- list(
+        integer = list(skip = 2L, n_max = 3L),
+        integer_valued_double = list(skip = 2, n_max = 3),
+        zero = list(skip = 0, n_max = 0),
+        skip_beyond_rows = list(skip = 1000, n_max = 3),
+        largest_exact_skip = list(skip = 2^53, n_max = 3),
+        n_max_beyond_rows = list(skip = 72, n_max = 1000),
+        bare_na_unlimited = list(skip = 2, n_max = NA),
+        real_na_unlimited = list(skip = 2, n_max = NA_real_),
+        positive_infinity_unlimited = list(skip = 2, n_max = Inf),
+        negative_infinity_unlimited = list(skip = 2, n_max = -Inf),
+        negative_integer_unlimited = list(skip = 2, n_max = -1L),
+        negative_double_unlimited = list(skip = 2, n_max = -1.5)
+    )
+
+    for (name in names(cases)) {
+        arguments <- c(
+            list(path, col_select = c("make", "price")), cases[[name]]
+        )
+        actual <- do.call(read_dta, arguments)
+        rust_vectors <- do.call(
+            dtaparser:::.read_dta_rust_vectors, arguments
+        )
+        expected <- do.call(haven::read_dta, arguments)
+
+        expect_identical(actual, rust_vectors,
+                         info = paste(name, "materialization"))
+        expect_identical(actual, expected, info = name)
+    }
+})
+
+test_that("normalized windows cover empty data and zero-column projections", {
+    skip_if_not_installed("haven")
+    empty <- tempfile(fileext = ".dta")
+    on.exit(unlink(empty), add = TRUE)
+    haven::write_dta(data.frame(number = double(), text = character()), empty)
+
+    for (n_max in list(0L, NA, Inf, -Inf, -1)) {
+        actual <- read_dta(empty, n_max = n_max)
+        rust_vectors <- dtaparser:::.read_dta_rust_vectors(
+            empty, n_max = n_max
+        )
+        expected <- haven::read_dta(empty, n_max = n_max)
+        expect_identical(actual, rust_vectors)
+        expect_identical(actual, expected)
+    }
+
+    path <- fixture("auto_v118.dta")
+    windows <- list(
+        zero = list(skip = 0, n_max = 0),
+        unlimited = list(skip = 2, n_max = NA),
+        out_of_range = list(skip = 1000, n_max = 10)
+    )
+    for (name in names(windows)) {
+        arguments <- c(
+            list(path, col_select = character()), windows[[name]]
+        )
+        actual <- do.call(read_dta, arguments)
+        rust_vectors <- do.call(
+            dtaparser:::.read_dta_rust_vectors, arguments
+        )
+        expected_rows <- do.call(
+            haven::read_dta, c(list(path), windows[[name]])
+        )
+        expect_identical(actual, rust_vectors, info = name)
+        expect_identical(nrow(actual), nrow(expected_rows), info = name)
+        expect_identical(ncol(actual), 0L, info = name)
+    }
+})
+
 test_that("typed predicates and duplicate selections are deterministic", {
     path <- fixture("auto_v118.dta")
 
@@ -398,10 +471,6 @@ test_that("argument and native parse failures are ordinary R errors", {
     expect_error(read_dta(path, encoding = c("UTF-8", "latin1")),
                  "one non-missing")
     expect_error(read_dta(path, encoding = 1), "one non-missing")
-    expect_error(read_dta(path, skip = -1), "non-negative")
-    expect_error(read_dta(path, skip = 1.5), "whole number")
-    expect_error(read_dta(path, n_max = NA_real_), "non-negative")
-    expect_error(read_dta(path, n_max = 2^53 + 2), "non-negative")
     expect_error(read_dta(path, col_select = absent), "absent")
 
     corrupt <- tempfile(fileext = ".dta")
@@ -410,4 +479,57 @@ test_that("argument and native parse failures are ordinary R errors", {
     expect_error(read_dta(corrupt), "header|format|small|read|I/O", ignore.case = TRUE)
     expect_error(dtaparser:::.read_dta_rust_vectors(corrupt),
                  "header|format|small|read|I/O", ignore.case = TRUE)
+})
+
+test_that("unsafe row-window coercions fail before parsing", {
+    missing_path <- tempfile(fileext = ".dta")
+    invalid <- list(
+        list(arguments = list(skip = -1), error = "non-negative whole"),
+        list(arguments = list(skip = NA_real_), error = "non-negative whole"),
+        list(arguments = list(skip = NaN), error = "non-negative whole"),
+        list(arguments = list(skip = Inf), error = "non-negative whole"),
+        list(arguments = list(skip = -Inf), error = "non-negative whole"),
+        list(arguments = list(skip = 1.5), error = "non-negative whole"),
+        list(arguments = list(skip = 2^53 + 2), error = "no larger than"),
+        list(arguments = list(skip = c(1, 2)), error = "length 1"),
+        list(arguments = list(skip = TRUE), error = "integer or double"),
+        list(arguments = list(skip = "1"), error = "integer or double"),
+        list(arguments = list(n_max = 1.5), error = "whole number"),
+        list(arguments = list(n_max = NaN), error = "must not be NaN"),
+        list(arguments = list(n_max = 2^53 + 2), error = "no larger than"),
+        list(arguments = list(n_max = c(1, 2)), error = "length 1"),
+        list(arguments = list(n_max = TRUE), error = "integer or double"),
+        list(arguments = list(n_max = NA_character_), error = "integer or double")
+    )
+    readers <- list(read_dta, dtaparser:::.read_dta_rust_vectors)
+
+    for (reader in readers) {
+        for (case in invalid) {
+            expect_error(
+                do.call(reader, c(list(missing_path), case$arguments)),
+                case$error
+            )
+        }
+    }
+})
+
+test_that("deliberate row-window divergences from haven are stable", {
+    skip_if_not_installed("haven")
+    path <- fixture("auto_v118.dta")
+
+    expect_identical(nrow(haven::read_dta(path, n_max = 2.9)), 2L)
+    expect_error(read_dta(path, n_max = 2.9), "whole number")
+    expect_identical(nrow(haven::read_dta(path, n_max = NaN)), 74L)
+    expect_error(read_dta(path, n_max = NaN), "must not be NaN")
+
+    expect_identical(nrow(haven::read_dta(path, skip = -1, n_max = 2)), 2L)
+    expect_error(read_dta(path, skip = -1, n_max = 2), "non-negative whole")
+    expect_identical(nrow(haven::read_dta(path, skip = NA, n_max = 2)), 2L)
+    expect_error(read_dta(path, skip = NA, n_max = 2), "integer or double")
+    expect_identical(nrow(haven::read_dta(path, skip = Inf, n_max = 2)), 0L)
+    expect_error(read_dta(path, skip = Inf, n_max = 2), "non-negative whole")
+    expect_error(haven::read_dta(path, skip = 2.9, n_max = 2),
+                 "single integer")
+    expect_error(read_dta(path, skip = 2.9, n_max = 2),
+                 "non-negative whole")
 })


### PR DESCRIPTION
## Summary

- normalize `skip` and `n_max` once in R before either materialization path
- align safe, conventional row-window inputs with haven 2.5.5
- make unsafe or platform-dependent native coercions explicit deterministic divergences
- document the compatibility boundary and test both collectors

## Compatibility decision

| Argument | Aligned with haven | Deliberate divergence |
| --- | --- | --- |
| `skip` | zero and ordinary positive whole scalar integers/integer-valued doubles; ordinary values beyond the row count naturally return no rows | reject missing, `NaN`, infinite, negative, fractional, values above `2^53`, non-scalar, and wrong-type inputs; exact very large values through `2^53` remain deterministic in dtaparser while haven's native result is platform-dependent |
| `n_max` | zero and positive whole scalar integers/integer-valued doubles; `NA`, `NA_real_`, `Inf`, `-Inf`, and every negative finite value mean unlimited | reject `NaN`, non-negative fractions, values above `2^53`, non-scalars, and wrong types |

The divergences are intentional. Haven's fractional and overflow behavior relies on lossy or platform-sensitive native coercion. Deterministic validation and normalization avoid silent truncation, accidental large reads, and unstable errors while preserving useful compatibility.

## Implementation

- one `.normalize_row_window()` result feeds both direct-R and Rust-vector materializers
- all unlimited `n_max` spellings become one `+Inf` ABI sentinel
- the existing valid-integer path remains unchanged
- Rust keeps defensive representability checks before bounds and allocation
- tests cover differential parity, deliberate divergences, projections, zero columns, empty data, and out-of-range windows
- cross-platform tests do not assume a particular haven overflow/coercion result

## Validation

- Rust formatting and tests
- source-package installation
- focused and full testthat suites
- fresh `R CMD build`
- fresh `R CMD check --no-manual` — Status: OK
- two independent review passes — clean
- `git diff --check`

Closes #19

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved `skip` and `n_max` row-window handling for more predictable row selection.
  * Enhanced alignment with `haven::read_dta()` including unlimited-row conventions and edge cases.
* **Bug Fixes**
  * Rejects invalid or unsafe row-window inputs earlier, with clearer error messages.
  * Improved consistency for empty files and zero-column reads across reading modes.
* **Documentation**
  * Expanded `read_dta` argument and README guidance for accepted values, limits, and special cases.
* **Tests**
  * Added/strengthened table-driven coverage for normalized row-window behavior and known haven divergences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->