### PR TITLE
Benchmark R performance and validate fertility survey corpora

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -28,6 +28,13 @@ installed; the C ABI
 does not expose stable internal timers, so a finer native R split would require
 instrumenting production code and is deliberately not claimed here.
 
+The [`large-scale/`](large-scale/) harness separately compares the public
+Direct-R reader, the retained internal Rust-vector collector, and haven on
+deterministic 100 MB and 1 GB files. It runs full and projected-eight-column
+workloads for 101 iterations by default and writes all generated artifacts below
+ignored `target/large-scale/`. See its README for the checkout-local package
+library guard, correctness checks, orchestration command, and output matrix.
+
 Record the exact command, toolchain, host, fixture sizes, iteration count, and
 correctness status in `baseline.md`. Results are evidence for investigation,
 not a release gate.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -38,3 +38,7 @@ library guard, correctness checks, orchestration command, and output matrix.
 Record the exact command, toolchain, host, fixture sizes, iteration count, and
 correctness status in `baseline.md`. Results are evidence for investigation,
 not a release gate.
+
+The manual [`fertility-surveys/`](fertility-surveys/) framework separately
+checks the private fertility-survey corpus with explicit opt-in and CI refusal
+safeguards.

--- a/benchmarks/fertility-surveys/README.md
+++ b/benchmarks/fertility-surveys/README.md
@@ -79,8 +79,11 @@ batch 1, one-row windows at contiguous offsets beginning at the structural row
 count, with zero rows returned and valid three-reader projection attestations.
 Zero-column supported files use a single explicit empty projection batch and the
 same traversal and terminal requirements. Inputs are fully hashed before accepting
-checkpoints and again after
-all tiles; cheap size/mtime fingerprints detect changes around each child.
+checkpoints and again after all tiles. For every supported file, the parent keeps a
+verified source descriptor open; each isolated tile receives that descriptor and
+creates its private target-local copy-on-write snapshot directly from the descriptor
+before any reader opens a pathname. Source identity and cheap size/mtime fingerprints
+are revalidated around each child, and snapshots are removed when the child exits.
 
 ## Wave 3 generated-output corpus
 
@@ -97,20 +100,29 @@ benchmarks/fertility-surveys/benchmark.sh \
 It recursively inventories regular files whose extension is `.dta` or `.DTA`,
 including top-level aggregate files and nested survey files, and ignores every
 other entry. Stable `F0001`-style IDs are assigned by bytewise-sorted canonical
-relative path. Relative paths, byte sizes, modification times, SHA-512 values,
-and source-root filesystem identity are frozen only in the ignored private
+relative path. The root and every ancestor directory are pinned through retained
+no-follow directory descriptors; each DTA is opened relative to its pinned parent,
+and device, inode, mode, size, modification time, and change time are revalidated
+around descriptor-bound hashing and release reads. Relative paths and private file
+metadata are frozen only in the ignored private
 `target/fertility-surveys/raw/output-inventory/wave3/inventory.rds` artifact.
 Public manifests expose only the stable ID, `program=output`, the privacy-safe
 `survey`/`aggregate` level, and DTA release.
 
 The run refuses any other output root and asserts the observed baseline exactly:
 1,226 files, 70,748,321,626 bytes, and a largest file of 10,332,252,930 bytes.
-It supports releases 113-115 and 117-118 and preserves release 111 as an
-expected unsupported classification. Source files and the upstream repository
-are read-only; all mutable state remains under the checkout-local ignored
-target. Aggregate files are identified separately because the upstream build
-uses forced Stata append coercion; that provenance explains stored analytical
-types but never excuses a disagreement among Direct-R, Rust-vector, and Haven.
+The observed output family supports releases 113, 114, 115, and 118 and preserves
+release 111 as an expected unsupported classification. Source files and the
+upstream repository are read-only; all mutable state remains under the
+checkout-local ignored target. Aggregate files are identified separately because
+the upstream build uses forced Stata append coercion; that provenance explains
+stored analytical types but never excuses a disagreement among Direct-R,
+Rust-vector, and Haven.
+
+Fresh generated-output execution and publication use corpus schema 12, which
+binds each isolated worker to the descriptor identity captured during input
+attestation. Corpus schema 10 is retained only as the explicitly documented
+historical Wave 2 replay format; it is not the identity of current Wave 3 evidence.
 
 All normal filters, encoding overrides, resource bounds, resume, and shard
 options apply. An unfiltered output run is recorded as a full family. Merge

--- a/benchmarks/fertility-surveys/README.md
+++ b/benchmarks/fertility-surveys/README.md
@@ -174,14 +174,20 @@ benchmarks/fertility-surveys/benchmark.sh \
 ```
 
 The assessment consumes and strictly revalidates each family's merged `CURRENT`
-bundle, including its results, summary, family manifest, aggregate input
-attestation, evidence-family identity, and merge identity. Its own identity binds
-both source merge identities. Immediately before publication it reloads both
-merged bundles, rebuilds the live inventory, and repeats accepted-artifact and
-current-byte validation. It preserves both source identities and classifications,
-requires the original full family to retain `inventory-hash-error` for exactly
-`F0633`-`F0637` with the sole privacy-safe reason `signature-mismatch`, and exposes
-two orthogonal statuses:
+bundle. The accepted family must use the complete current five-file merged schema,
+including its aggregate input attestation and acceptance authority. Only the
+original/base role has a compatibility path for the immutable four-file
+schema-10/report-schema-2 fresh full-family bundle: it requires exactly 8 shards,
+1,004 canonical files, the exact legacy provenance and file schemas, the live
+inventory and current report-schema-2 framework snapshot, and recomputes the
+schema-2 evidence-family identity. It does not synthesize the absent attestation
+table or permit this format for accepted evidence. A privacy-safe identity over
+the exact legacy provenance and public content IDs is bound into the assessment
+identity and revalidated at both publication boundaries. Merge and republication
+remain current-schema-only. The assessment preserves both source identities and
+classifications, requires the original full family to retain
+`inventory-hash-error` for exactly `F0633`-`F0637` with the sole privacy-safe
+reason `signature-mismatch`, and exposes two orthogonal statuses:
 `manifest_gate=blocked-signature-mismatch` and
 `explicit_local_evidence_gate=validated`. It does not replace the manifest gate,
 rewrite either family, or authorize Wave 3.

--- a/benchmarks/fertility-surveys/README.md
+++ b/benchmarks/fertility-surveys/README.md
@@ -89,6 +89,8 @@ From the checkout root:
 export DTAPARSER_FERTILITY_CORPUS=I_UNDERSTAND_THIS_READS_PROPRIETARY_DATA
 benchmarks/fertility-surveys/benchmark.sh --inventory-only
 benchmarks/fertility-surveys/benchmark.sh --id=F0001 --timeout-seconds=120
+benchmarks/fertility-surveys/benchmark.sh \
+  --id=F0574 --encoding-override=F0574:ISO-8859-1 --timeout-seconds=120
 ```
 
 Inventory IDs are stable row numbers, not release selectors. To exercise the
@@ -150,6 +152,9 @@ tile. Available options are:
 - `--program=dhs,mics` (comma-separated)
 - `--release=113,118` (comma-separated)
 - `--id=F0001,F0002` (privacy-safe inventory IDs)
+- `--encoding-override=F0001:ENCODING` (repeatable or comma-separated;
+  canonical encodings are `UTF-8`, `Windows-1252`, and `ISO-8859-1`;
+  aliases include `UTF8`, `CP1252`, and `latin1`)
 - `--shard-index=N --shard-count=N` (both required; one-based)
 - `--max-files=N`
 - `--timeout-seconds=N`
@@ -161,6 +166,18 @@ tile. Available options are:
 - `--max-tiles-per-batch=N` (hard traversal ceiling; default 100,000)
 - `--beyond-end-windows=N` (terminal verification windows; default 1, maximum 8)
 - `--retry` (rerun failed tiles only; completed matches and mismatches resume)
+
+Encoding overrides are explicit run configuration, never tracked corpus-specific
+policy. Every override ID must belong to the complete selected family, and every
+shard in that family must receive the same sorted canonical map. The selected
+encoding is passed symmetrically to public direct-R materialization, internal
+Rust-vector materialization, Haven, structural name discovery, value and terminal
+windows, and `strL` sizing samples. The canonical privacy-safe map is recorded in
+run provenance and bound into the configuration and family identities. Changing
+it therefore selects a different checkpoint namespace; omitting it preserves the
+legacy configuration identity and reader defaults. Historical schema-10 replay
+rejects encoding overrides because replay must retain its exact recorded
+configuration.
 
 The orchestrator builds the current checkout package into an immutable,
 provenance-addressed generation beneath `target/fertility-surveys/raw/builds/`.
@@ -249,6 +266,28 @@ directories are safely reclaimed. The shell uses a restrictive umask and the R
 writers enforce private artifact permissions. Do not copy RDS checkpoints
 outside the private target
 directory because they contain input signatures.
+
+## Privacy-safe mismatch adjudication
+
+Raw differential evidence remains immutable and is never normalized, hidden, or
+rewritten to match one reader. Adjudication should be a separate derived process:
+
+1. Group raw results by the existing public mismatch signature and fixed reader-pair
+   identity, retaining the raw file and comparison counts for every cluster.
+2. Select one or more privacy-safe inventory IDs per cluster for an explicitly
+   authorized, target-local attribute-only diagnostic.
+3. Record only fixed categories such as variable label, value-label mapping, class,
+   format, or character-decoding policy; direct-versus-Rust agreement; a fixed owner
+   category; the explicit encoding modes tested; and the source raw signature.
+4. Require a second review before marking a cluster intentional. The derived record
+   may explain or reclassify a confirmed divergence, but it must continue to link to
+   the unchanged raw signature and counts.
+5. Keep diagnostic paths, names, labels, values, error text, and source hashes out of
+   both the derived artifact and public reports. Store any private working material
+   only under the ignored target-local raw directory and remove it after review.
+
+This process can adjudicate the observed public signature clusters incrementally
+without rereading the complete corpus or changing the public result schema.
 
 ## Deterministic tests
 

--- a/benchmarks/fertility-surveys/README.md
+++ b/benchmarks/fertility-surveys/README.md
@@ -121,10 +121,13 @@ the upstream build uses forced Stata append coercion; that provenance explains
 stored analytical types but never excuses a disagreement among Direct-R,
 Rust-vector, and Haven.
 
-Fresh generated-output execution and publication use corpus schema 12, which
+Fresh generated-output execution and publication use corpus schema 13, which
 binds each isolated worker to the descriptor identity captured during input
-attestation. Corpus schema 10 is retained only as the explicitly documented
-historical Wave 2 replay format; it is not the identity of current Wave 3 evidence.
+attestation. A transient pathname identity change is published with the canonical
+`input-changed` reason and its tile checkpoint is replaceable under `--retry`, so
+restoring the attested input cannot permanently poison resume. Corpus schema 10 is
+retained only as the explicitly documented historical Wave 2 replay format; it is
+not the identity of current Wave 3 evidence.
 
 All normal filters, encoding overrides, resource bounds, resume, and shard
 options apply. An unfiltered output run is recorded as a full family. Merge

--- a/benchmarks/fertility-surveys/README.md
+++ b/benchmarks/fertility-surveys/README.md
@@ -26,15 +26,54 @@ A valid inventory has exactly 1,004 unique files and these release counts:
 
 Every file is SHA-512 hashed; a non-empty recorded signature must match, while
 rows whose historical signature is empty are bound to the hash computed by the
-checkpoint. For each supported file, one isolated R subprocess reads the complete
-file through `dtaparser::read_dta()`, requires exact
-identity with `dtaparser:::.read_dta_rust_vectors()`, then compares the complete
-result with `haven::read_dta()`. Haven comparison checks dimensions, names,
-data-frame and column attributes, storage types, missing positions and kinds,
-tagged missing values, exact non-floating and nonfinite values, and an exhaustive
-elementwise absolute tolerance of `1e-7` for finite floating values. Inputs are
-hashed by the parent before launch, independently in the child, again after the
-child exits, and once more before report publication.
+checkpoint. Supported files are never decoded into whole-file data frames. An
+isolated metadata subprocess compares zero-row direct-R, internal Rust-vector,
+and haven frames, including dataset label/notes and every column's class, label,
+`format.stata`, value labels, and `tzone`. A bounded source-header parser
+independently obtains the declared observation count, column count, fixed-string
+widths (including `str2045`), and `strL` identity without decoding values.
+Direct-R and Rust-vector zero-column shape reads are checked against that count;
+the installed haven rejects an empty projection. Normal traversal is bound to the
+source count. The first column batch then receives only a configured small number
+of deterministic beyond-end windows (default one, hard maximum eight). Any reader
+that still returns rows is classified `row-termination-mismatch`; it never extends
+traversal. A hard per-batch tile ceiling likewise produces `unresolved` rather
+than an open-ended loop. Haven participates in zero-row metadata comparison,
+beyond-end verification, and every value tile.
+
+Columns remain in source order. `--column-batch` bounds their count, while `strL`
+columns are always isolated. Row sizing uses numeric bytes, exact fixed-string
+widths, a conservative per-object overhead, three-reader cell and byte budgets,
+and returns a one-row window for every `strL` batch. Each child also starts with
+`R_MAX_VSIZE` set to `--memory-mib` (minimum 128 MiB), making the memory budget an
+enforced vector-heap limit rather than only a scheduling estimate. Memory-limit
+failures are reduced to a privacy-safe fixed classification. Every metadata/value
+tile runs in its own timeout-isolated subprocess and reads exactly
+that projection/window through `dtaparser::read_dta()`,
+`dtaparser:::.read_dta_rust_vectors()`, and `haven::read_dta()`.
+
+Comparison evaluates every available direct-R/Rust, direct-R/haven, and
+Rust/haven pair and accumulates every mismatch rather than returning at the first
+one. It checks dimensions, the overlapping common row prefix even when dimensions
+differ, names, dataset/column attributes, storage types, missing
+positions and NA/NaN kinds, tagged missing values, Date/POSIXct/tzone semantics,
+exact strings and integers, exact Date/POSIXct unclassed values and nonfinite
+values, and every ordinary finite floating value with absolute tolerance `1e-7`.
+Mismatches do not stop later tiles. Public
+reports contain only fixed categories, counts, and hashed signatures; values,
+labels, names, paths, and reader messages remain private. Each reader also emits
+an ordered, framework-salted projection hash and count for every value and
+terminal tile. The worker compares returned names/order to the requested batch in
+memory, and completeness requires matching attestations from all three readers;
+raw variable names are never stored in these attestations or published. A
+supported file can be classified `pass` only after exact gap-free coverage of
+every expected row and column batch plus exactly the configured terminal probes:
+batch 1, one-row windows at contiguous offsets beginning at the structural row
+count, with zero rows returned and valid three-reader projection attestations.
+Zero-column supported files use a single explicit empty projection batch and the
+same traversal and terminal requirements. Inputs are fully hashed before accepting
+checkpoints and again after
+all tiles; cheap size/mtime fingerprints detect changes around each child.
 
 ## Run manually
 
@@ -66,8 +105,8 @@ The exhaustive run is:
 benchmarks/fertility-surveys/benchmark.sh
 ```
 
-Do not run it casually. The default timeout is 600 seconds per file. Available
-options are:
+Do not run it casually. The default timeout is 600 seconds per metadata/value
+tile. Available options are:
 
 - `--inventory-only`
 - `--program=dhs,mics` (comma-separated)
@@ -76,7 +115,14 @@ options are:
 - `--shard-index=N --shard-count=N` (both required; one-based)
 - `--max-files=N`
 - `--timeout-seconds=N`
-- `--retry` (rerun only prior failures; matches and unsupported releases resume)
+- `--chunk-rows=N` (hard row-window cap; default 10,000)
+- `--column-batch=N` (maximum columns per batch; default 16; `strL` is isolated)
+- `--memory-mib=N` (sizing budget and enforced child vector limit; default 256,
+  minimum 128)
+- `--cell-budget=N` (cells across all three readers; default 1,000,000)
+- `--max-tiles-per-batch=N` (hard traversal ceiling; default 100,000)
+- `--beyond-end-windows=N` (terminal verification windows; default 1, maximum 8)
+- `--retry` (rerun failed tiles only; completed matches and mismatches resume)
 
 The orchestrator builds the current checkout package and installs it beneath
 `target/fertility-surveys/raw/library/`. Build provenance binds the commit,
@@ -99,16 +145,25 @@ mid-run while permitting safe recovery after an owner dies or initialization is
 abandoned. Workers source an immutable provenance-addressed
 script snapshot, and all provenance is recomputed before report publication.
 
-Each file has an atomic RDS checkpoint bound to the checkpoint schema, framework
-and package provenance, `datasigs.csv`, inventory ID, release, expected signature,
-and a parent-captured input identity containing the actual SHA-512 or a stable
-hash-error fingerprint. Checkpoint compatibility also includes the requested
-per-file timeout, so changing `--timeout-seconds` cannot silently reuse a result
-created under a different limit. Current identities are rechecked after each
-child, before resume, and before publication. This makes timeout,
-subprocess-error, and input-hash-error checkpoints publishable and resumable.
-`--retry` reruns those failures; without it they resume like other completed
-checkpoints. Filters and shards do not alter checkpoint identity.
+Each file has private atomic metadata, tile, and aggregate RDS checkpoints bound
+to the checkpoint schema, framework/package provenance, `datasigs.csv`, inventory
+ID/release/signature, full input identity, exact tile projection/window, and a
+stable configuration ID. The configuration includes timeout, row cap, column
+batch, memory budget, cell budget, reader count, object overhead, probe count, and
+tile ceiling, so changing any sizing/resource limit cannot silently reuse foreign
+tiles. Timeout, memory-limit, crash, and reader-error tiles are resumable and are
+rerun only with `--retry`;
+completed semantic mismatches remain valid evidence. Filters and shards do not
+alter tile identity.
+
+File-level classifications include `pass`, `expected-unsupported-111`,
+`inventory-hash-error`, `direct-vs-rust-mismatch`, `dtaparser-only-error`,
+`haven-only-error`, `shared-reader-error`, `metadata-mismatch`, `value-mismatch`,
+`tag-mismatch`, `date-mismatch`, `encoding-mismatch`,
+`row-termination-mismatch`, `known-intentional-divergence`, `timeout`,
+`memory-limit`, `crash`, and `unresolved`. Detailed
+secondary fixed categories and hashed mismatch signatures are retained without
+publishing source metadata or values.
 
 Each filter/shard selection publishes a complete immutable report bundle beneath
 `raw/reports/<selection-id>/` and atomically updates only that selection's
@@ -138,10 +193,13 @@ Rscript --vanilla benchmarks/fertility-surveys/test-framework.R
 ```
 
 They cover exact non-recursive inventory mapping, release parsing, privacy-safe
-inventory projection, argument validation, filtering, sharding, retry/checkpoint
-invalidation, atomic publication, timeout publication/resume/retry, parent input
-identity and timeout compatibility, live-owner lock/temp preservation followed
-by dead-owner recovery, dependency relocation/modification invalidation, nested
-parent-R/callr temporary-directory confinement including live callr control and
-serialization artifacts, semantic mismatch classifications and numeric outliers,
+inventory projection, argument validation, filtering/sharding, deterministic
+width-aware batches and adaptive row sizing, fixed-width and `strL` structural
+metadata, nonterminating-reader and tile-ceiling bounds, enforced memory-limit
+attribution, metadata/zero-column contracts, multi-tile gap-free coverage,
+continued traversal after early mismatches,
+tile-level timeout resume/retry, schema/input/config invalidation, exhaustive
+metadata/value/tag/date/encoding categories and numeric outliers, absence of
+unbounded supported-file reads, atomic publication, parent input identity, live
+owner recovery, dependency provenance, nested parent-R/callr temp confinement,
 release-111 handling, signature refusal, and CI/manual opt-in refusal.

--- a/benchmarks/fertility-surveys/README.md
+++ b/benchmarks/fertility-surveys/README.md
@@ -3,8 +3,9 @@
 This is a local, report-only compatibility framework for the private fertility
 survey cache. It is never a CI or release gate. It refuses to run when common CI
 or GitHub Actions variables are present and requires an explicit manual opt-in.
-It does not add Stata release 111 support: release-111 files are inventoried and
-classified as `expected-unsupported-111` without being passed to a reader.
+It does not add Stata/SE 7 format-111 support: those files are inventoried,
+classified as `expected-unsupported-111`, and identified as outside dtaparser's
+current supported format range without being passed to a reader.
 
 Every Wave 2 invocation requires caller-supplied `--cache-root` and `--manifest`
 arguments naming existing absolute canonical, non-symlink paths. The inventory
@@ -19,7 +20,7 @@ A valid inventory has exactly 1,004 unique files and these release counts:
 
 | Release | Files | Differential status |
 |---:|---:|---|
-| 111 | 130 | inventoried, unsupported |
+| 111 | 130 | inventoried; outside dtaparser's current format range |
 | 113 | 475 | compared |
 | 114 | 23 | compared |
 | 117 | 150 | compared |
@@ -27,7 +28,9 @@ A valid inventory has exactly 1,004 unique files and these release counts:
 
 Every file is SHA-512 hashed; a non-empty recorded signature must match, while
 rows whose historical signature is empty are bound to the hash computed by the
-checkpoint. Supported files are never decoded into whole-file data frames. An
+checkpoint. The supplied manifest and its recorded hashes are external provenance
+assertions: this repository binds inputs to them fail-closed but does not maintain,
+warrant, or repair those external values. Supported files are never decoded into whole-file data frames. An
 isolated metadata subprocess compares zero-row direct-R, internal Rust-vector,
 and haven frames, including dataset label/notes and every column's class, label,
 `format.stata`, value labels, and `tzone`. A bounded source-header parser
@@ -81,11 +84,13 @@ Zero-column supported files use a single explicit empty projection batch and the
 same traversal and terminal requirements. Inputs are fully hashed before accepting
 checkpoints and again after all tiles. For every supported file, the parent keeps a
 verified source descriptor open; each isolated tile receives that descriptor and
-creates its private target-local copy-on-write snapshot directly from the descriptor
-before any reader opens a pathname. Source identity and cheap size/mtime fingerprints
-are revalidated around each child, and snapshots are removed when the child exits.
-If the host filesystem cannot create that descriptor-derived copy-on-write snapshot,
-the run aborts before publishing a case result rather than recording a reader crash.
+first attempts a private target-local copy-on-write clone directly from it. If the
+platform or filesystem cannot clone, the worker falls back to a private bounded-chunk
+byte-for-byte copy from the already-open descriptor before any reader opens a pathname.
+Source identity and cheap size/mtime fingerprints are revalidated around each child,
+and snapshots are removed when the child exits. If neither descriptor-derived
+materialization method succeeds, the run aborts before publishing a case result rather
+than recording a reader crash.
 
 ## Wave 3 generated-output corpus
 
@@ -193,8 +198,10 @@ benchmarks/fertility-surveys/benchmark.sh \
 
 ## Explicit accepted-current-hash evidence for F0633-F0637
 
-The historical SHA-512 values in `datasigs.csv` remain the manifest authority and
-are never rewritten. If a separately authorized local review accepts the current
+The historical SHA-512 values in `datasigs.csv` are caller-supplied external
+provenance and are never rewritten. Reconciling or maintaining them is outside
+this repository's parser-compatibility responsibility. If a separately authorized
+local review accepts the current
 bytes for exactly `F0633` through `F0637`, capture those bytes into a private,
 immutable content-addressed commitment beneath the ignored artifact root:
 
@@ -270,10 +277,12 @@ identity and revalidated at both publication boundaries. Merge and republication
 remain current-schema-only. The assessment preserves both source identities and
 classifications, requires the original full family to retain
 `inventory-hash-error` for exactly `F0633`-`F0637` with the sole privacy-safe
-reason `signature-mismatch`, and exposes two orthogonal statuses:
-`manifest_gate=blocked-signature-mismatch` and
-`explicit_local_evidence_gate=validated`. It does not replace the manifest gate,
-rewrite either family, or authorize Wave 3.
+reason `signature-mismatch`, and exposes two historically named orthogonal status
+fields: `manifest_gate=blocked-signature-mismatch` and
+`explicit_local_evidence_gate=validated`. The first records only the unresolved
+caller-supplied external provenance assertion; it is not a dtaparser parser gate
+or repository responsibility. The assessment does not rewrite either family or
+authorize Wave 3.
 
 ## Historical schema-10 validation and republication
 
@@ -314,7 +323,16 @@ tile. Available options are:
 - `--cache-root=/absolute/canonical/path` and
   `--manifest=/absolute/canonical/file.csv` (both required in raw mode and
   rejected in generated-output mode)
+- `--output-root=/absolute/canonical/path` (required in generated-output mode
+  and rejected with raw root arguments)
 - `--inventory-only`
+- `--capture-accepted-current-hashes` (publish the separately authorized private
+  five-file commitment described above)
+- `--family-id=ID` (merge a completed shard family)
+- `--assessment-family-id=ID --accepted-family-id=ID` (publish the Wave 2
+  raw-plus-supplemental assessment; both are required together)
+- `--republish-framework=ID` (historical validation/republication mode)
+- `--validate-only` (validate historical evidence without publishing it)
 - `--program=dhs,mics` (comma-separated)
 - `--release=113,118` (comma-separated)
 - `--id=F0001,F0002` (privacy-safe inventory IDs)

--- a/benchmarks/fertility-surveys/README.md
+++ b/benchmarks/fertility-surveys/README.md
@@ -43,12 +43,18 @@ beyond-end verification, and every value tile.
 
 Columns remain in source order. `--column-batch` bounds their count, while `strL`
 columns are always isolated. Row sizing uses numeric bytes, exact fixed-string
-widths, a conservative per-object overhead, three-reader cell and byte budgets,
-and returns a one-row window for every `strL` batch. Each child also starts with
-`R_MAX_VSIZE` set to `--memory-mib` (minimum 128 MiB), making the memory budget an
-enforced vector-heap limit rather than only a scheduling estimate. Memory-limit
-failures are reduced to a privacy-safe fixed classification. Every metadata/value
-tile runs in its own timeout-isolated subprocess and reads exactly
+widths, a conservative per-object overhead, and three-reader cell and byte budgets.
+For each `strL` batch, one isolated sizing child reads a fixed deterministic sample
+of one-row windows, retains only the maximum aggregate payload-byte count, and
+chooses a safety-factored row window bounded by the ordinary row/cell/memory caps.
+If a rare larger payload makes a value child hit its enforced memory limit, that
+range is split deterministically until it succeeds or reaches a one-row leaf;
+failed parents and sizing children also count against the hard subprocess-tile
+ceiling. Each child starts with `R_MAX_VSIZE` set to `--memory-mib` (minimum 128
+MiB), making the memory budget an enforced vector-heap limit rather than only a
+scheduling estimate. Memory-limit failures are reduced to a privacy-safe fixed
+classification. Every metadata/value tile runs in its own timeout-isolated
+subprocess and reads exactly
 that projection/window through `dtaparser::read_dta()`,
 `dtaparser:::.read_dta_rust_vectors()`, and `haven::read_dta()`.
 
@@ -124,30 +130,31 @@ tile. Available options are:
 - `--beyond-end-windows=N` (terminal verification windows; default 1, maximum 8)
 - `--retry` (rerun failed tiles only; completed matches and mismatches resume)
 
-The orchestrator builds the current checkout package and installs it beneath
-`target/fertility-surveys/raw/library/`. Before any corpus item is processed it
-must pass a synthetic metadata regression through the exact production callr
-callback, target-local temporary directory, and immutable framework snapshot; the
-regression also proves comparator helpers remain confined to the callback lexical
-environment. Build provenance binds the commit,
-scoped dirty state, package and framework source digests, source tarball, and the
-installed package. Every runtime dependency is bound by version, canonical
-installed path, canonical loaded-namespace path, and deterministic installed-tree
-digest. A valid existing installation is reused so checkpoints can resume;
-source, dependency, or installation changes force a rebuild and a new framework
-identity. The private run lock and per-run temporary directory publish the
-orchestrating shell's PID, host, and OS-verified process-start generation as their
-authoritative owner. A separate long-lived helper refreshes only a supplemental
-heartbeat while monitoring that exact shell generation. Matching live PID/start
-identity remains authoritative if heartbeat updates are delayed or the helper
-itself dies; confirmed owner death or a live PID with a different start generation
-permits recovery regardless of helper state. Permission-denied or unavailable
+The orchestrator builds the current checkout package into an immutable,
+provenance-addressed generation beneath `target/fertility-surveys/raw/builds/`.
+A short owner-aware build lock covers installation, SHA-256 package/dependency
+provenance, and framework snapshot preparation, then is released before corpus
+execution. Concurrent starters wait for that setup and reuse the same verified
+generation rather than replacing a live shard's library. Before any corpus item is
+processed, exact production callr regressions exercise both metadata and `strL`
+sizing through the target-local temporary directory and immutable snapshot; they
+also prove comparator helpers remain confined to the callback lexical environment.
+
+Each active shard then acquires its own selection lock plus sorted per-case locks.
+Disjoint deterministic shards run concurrently and share atomic per-case
+checkpoints, while any overlapping active selection is rejected. The lock and
+per-run temporary directory publish the orchestrating shell's PID, host, and
+OS-verified process-start generation as their authoritative owner. A separate
+long-lived helper refreshes a supplemental heartbeat while monitoring that exact
+shell generation. Matching local PID/start identity or a fresh matching remote
+heartbeat preserves ownership; confirmed owner death or a live PID with a
+different start generation permits recovery. Permission-denied or unavailable
 process probes are indeterminate rather than dead and use conservative
-heartbeat/stale-age handling, never immediate reclamation. This prevents another
-invocation from replacing the installation
-mid-run while permitting safe recovery after an owner dies or initialization is
-abandoned. Workers source an immutable provenance-addressed
-script snapshot, and all provenance is recomputed before report publication.
+heartbeat/stale-age handling. Build staging lives inside the owner-tracked private
+run directory, so abandoned setup is reclaimed without touching another live
+shard. Workers source the immutable provenance-addressed script snapshot, and all
+source, dependency, installed-package, inventory, and framework provenance is
+recomputed before report publication.
 
 Each file has private atomic metadata, tile, and aggregate RDS checkpoints bound
 to the checkpoint schema, framework/package provenance, `datasigs.csv`, inventory
@@ -172,11 +179,32 @@ publishing source metadata or values.
 Each filter/shard selection publishes a complete immutable report bundle beneath
 `raw/reports/<selection-id>/` and atomically updates only that selection's
 `CURRENT` pointer, so smoke runs and separate shards do not overwrite one another.
-Results carry framework and build provenance IDs.
+Results carry framework, configuration, inventory, family, and build provenance
+IDs. After every shard in a family completes, merge its privacy-safe reports with:
+
+```sh
+benchmarks/fertility-surveys/benchmark.sh --family-id=<family-id>
+```
+
+Prepare publishes a privacy-safe canonical inventory manifest inside the immutable
+framework snapshot. Every shard report carries the complete canonical family
+manifest, including deterministic shard ownership, and binds it by SHA-256-derived
+identity to its family provenance. The merge reconstructs the family from the
+snapshot plus the strictly parsed filter specification and requires exact manifest,
+per-shard, and union membership and ordering. It also requires exactly one report
+for every shard index and identical framework/configuration/build/inventory/report
+schema provenance. An unfiltered family must contain exactly `F0001` through
+`F1004`, preserve release counts 111=130, 113=475, 114=23, 117=150, and 118=226,
+classify all release-111 files as expected unsupported, and account for exactly five
+supported inventory hash errors plus 869 supported executable outcomes. Validation
+finishes before any merged output is staged or published; publication is atomic
+beneath `raw/merged/<family-id>/`.
 
 All generated files, package builds, checkpoints, and reports stay below the
-ignored `target/fertility-surveys/raw/` directory. Public TSVs contain only
-privacy-safe IDs, program/level/release, shapes, timings, and classifications.
+ignored `target/fertility-surveys/raw/` directory. Public result TSVs use one exact,
+versioned schema and reject missing, reordered, or unexpected columns before
+publication. They contain only privacy-safe IDs, program/level/release, shapes,
+timings, fixed categories, and hashed mismatch signatures.
 They never contain source paths, survey names, labels, values, or reader error
 text. Subprocess failures are reduced to fixed classifications for the same
 reason. `inventory-hash-error` reports only a fixed privacy-safe reason
@@ -200,13 +228,16 @@ Rscript --vanilla benchmarks/fertility-surveys/test-framework.R
 ```
 
 They cover exact non-recursive inventory mapping, release parsing, privacy-safe
-inventory projection, argument validation, filtering/sharding, deterministic
-width-aware batches and adaptive row sizing, fixed-width and `strL` structural
-metadata, nonterminating-reader and tile-ceiling bounds, enforced memory-limit
-attribution, metadata/zero-column contracts, multi-tile gap-free coverage,
-continued traversal after early mismatches,
-tile-level timeout resume/retry, schema/input/config invalidation, exhaustive
-metadata/value/tag/date/encoding categories and numeric outliers, absence of
-unbounded supported-file reads, atomic publication, parent input identity, live
-owner recovery, dependency provenance, nested parent-R/callr temp confinement,
-release-111 handling, signature refusal, and CI/manual opt-in refusal.
+inventory projection, argument validation, deterministic disjoint filtering and
+sharding, concurrent selection/case ownership, empty shards, strict merge
+accounting, width-aware batches, fixed-width and `strL` structural metadata,
+bounded deterministic `strL` payload sampling, practical small-payload tile
+counts, rare-large-payload recursive splitting, hard execution ceilings, gap-free
+coverage, and sizing/value checkpoint resume. They also cover nonterminating-reader
+bounds, enforced memory-limit attribution, metadata/zero-column contracts,
+continued traversal after early mismatches, timeout retry, schema/input/config
+invalidation, exhaustive metadata/value/tag/date/encoding categories and numeric
+outliers, absence of unbounded supported-file reads, atomic publication, immutable
+SHA-256 build/dependency provenance, live and remote owner recovery, nested
+parent-R/callr temp confinement, release-111 handling, signature refusal, and
+CI/manual opt-in refusal.

--- a/benchmarks/fertility-surveys/README.md
+++ b/benchmarks/fertility-surveys/README.md
@@ -84,6 +84,8 @@ verified source descriptor open; each isolated tile receives that descriptor and
 creates its private target-local copy-on-write snapshot directly from the descriptor
 before any reader opens a pathname. Source identity and cheap size/mtime fingerprints
 are revalidated around each child, and snapshots are removed when the child exits.
+If the host filesystem cannot create that descriptor-derived copy-on-write snapshot,
+the run aborts before publishing a case result rather than recording a reader crash.
 
 ## Wave 3 generated-output corpus
 

--- a/benchmarks/fertility-surveys/README.md
+++ b/benchmarks/fertility-surveys/README.md
@@ -116,9 +116,13 @@ All normal filters, encoding overrides, resource bounds, resume, and shard
 options apply. An unfiltered output run is recorded as a full family. Merge
 validation requires exactly all 1,226 frozen IDs, the frozen release and
 survey/aggregate distributions, release 111 only as expected unsupported,
-and complete terminal outcomes for every supported file; timeout, memory,
-crash, unresolved, inventory-hash, or incomplete outcomes cannot pass that
-full-family gate. Merging an output family repeats the explicit root:
+and terminal outcomes with exact completed-versus-expected tile accounting for
+every supported file. A `pass` must also have `complete=TRUE`; an explicit
+reader-error or divergence terminal may have `complete=FALSE` because that field
+records all-reader projection success rather than whether every planned tile ran.
+Timeout, memory, crash, unresolved, inventory-hash, or partial tile accounting
+cannot pass the full-family gate. Merging an output family repeats the explicit
+root:
 
 ```sh
 benchmarks/fertility-surveys/benchmark.sh \

--- a/benchmarks/fertility-surveys/README.md
+++ b/benchmarks/fertility-surveys/README.md
@@ -6,14 +6,14 @@ or GitHub Actions variables are present and requires an explicit manual opt-in.
 It does not add Stata release 111 support: release-111 files are inventoried and
 classified as `expected-unsupported-111` without being passed to a reader.
 
-The default Wave 2 inventory intentionally reproduces
-`~/repos/fertility_surveys/check_raw_data.r` path construction rather than
-recursively searching the cache. It reads exactly
-`~/repos/fertility_surveys/datasigs.csv`, maps underscores in non-WFS survey
-folder names to commas, maps women/birth records to `wm.dta`/`bh.dta`, maps WFS
-to `<survey>.dta`, tries the program's primary directory, and only for DHS tries
-`DHS/Original_Data_Provenance_Unknown`. The cache root is exactly
-`/opt/aww_cache`; neither path can be overridden by command-line options.
+Every Wave 2 invocation requires caller-supplied `--cache-root` and `--manifest`
+arguments naming existing absolute canonical, non-symlink paths. The inventory
+intentionally reproduces the authorized upstream inventory mapping rather than
+recursively searching the cache. It reads exactly the supplied manifest, maps
+underscores in non-WFS survey folder names to commas, maps women/birth records
+to `wm.dta`/`bh.dta`, maps WFS to `<survey>.dta`, tries each program's primary
+directory, and only for DHS tries `DHS/Original_Data_Provenance_Unknown`.
+Neither source argument is inferred, globbed, or discovered from a checkout.
 
 A valid inventory has exactly 1,004 unique files and these release counts:
 
@@ -92,11 +92,12 @@ the run aborts before publishing a case result rather than recording a reader cr
 The same comparator, isolated workers, bounded tiles, checkpoints, sharding,
 provenance, privacy filtering, and publication machinery also supports the
 explicit generated-output root. This mode is enabled only by supplying the
-exact canonical absolute path:
+exact authorized canonical absolute path. Set `OUTPUT_ROOT` to that private path;
+the public documentation does not publish it:
 
 ```sh
 benchmarks/fertility-surveys/benchmark.sh \
-  --output-root=/Users/jmb/repos/fertility_surveys/output --inventory-only
+  --output-root="$OUTPUT_ROOT" --inventory-only
 ```
 
 It recursively inventories regular files whose extension is `.dta` or `.DTA`,
@@ -105,9 +106,8 @@ other entry. Stable `F0001`-style IDs are assigned by bytewise-sorted canonical
 relative path. The root and every ancestor directory are pinned through retained
 no-follow directory descriptors; each DTA is opened relative to its pinned parent,
 and device, inode, mode, size, modification time, and change time are revalidated
-around descriptor-bound hashing and release reads. Relative paths and private file
-metadata are frozen only in the ignored private
-`target/fertility-surveys/raw/output-inventory/wave3/inventory.rds` artifact.
+around descriptor-bound hashing and release reads. Relative paths and private file metadata are frozen only in a content-bound
+artifact beneath the ignored private artifact root.
 Public inventory manifests expose only the stable ID, `program=output`, the
 privacy-safe `survey`/`aggregate` level, and DTA release. Public family manifests
 add the deterministic `shard_index`.
@@ -145,7 +145,7 @@ root:
 ```sh
 benchmarks/fertility-surveys/benchmark.sh \
   --family-id=<family-id> \
-  --output-root=/Users/jmb/repos/fertility_surveys/output
+  --output-root="$OUTPUT_ROOT"
 ```
 
 ## Run manually
@@ -154,9 +154,15 @@ From the checkout root:
 
 ```sh
 export DTAPARSER_FERTILITY_CORPUS=I_UNDERSTAND_THIS_READS_PROPRIETARY_DATA
-benchmarks/fertility-surveys/benchmark.sh --inventory-only
-benchmarks/fertility-surveys/benchmark.sh --id=F0001 --timeout-seconds=120
+export CACHE_ROOT=/absolute/canonical/private-cache-root
+export MANIFEST=/absolute/canonical/private-manifest.csv
 benchmarks/fertility-surveys/benchmark.sh \
+  --cache-root="$CACHE_ROOT" --manifest="$MANIFEST" --inventory-only
+benchmarks/fertility-surveys/benchmark.sh \
+  --cache-root="$CACHE_ROOT" --manifest="$MANIFEST" \
+  --id=F0001 --timeout-seconds=120
+benchmarks/fertility-surveys/benchmark.sh \
+  --cache-root="$CACHE_ROOT" --manifest="$MANIFEST" \
   --id=F0574 --encoding-override=F0574:ISO-8859-1 --timeout-seconds=120
 ```
 
@@ -164,20 +170,25 @@ Inventory IDs are stable row numbers, not release selectors. To exercise the
 unsupported classification without asking a reader to open a file, use:
 
 ```sh
-benchmarks/fertility-surveys/benchmark.sh --release=111 --max-files=1 --timeout-seconds=120
+benchmarks/fertility-surveys/benchmark.sh \
+  --cache-root="$CACHE_ROOT" --manifest="$MANIFEST" \
+  --release=111 --max-files=1 --timeout-seconds=120
 ```
 
 A bounded supported-file smoke run can use another release and the same count
 filter:
 
 ```sh
-benchmarks/fertility-surveys/benchmark.sh --release=118 --max-files=1 --timeout-seconds=120
+benchmarks/fertility-surveys/benchmark.sh \
+  --cache-root="$CACHE_ROOT" --manifest="$MANIFEST" \
+  --release=118 --max-files=1 --timeout-seconds=120
 ```
 
 The exhaustive run is:
 
 ```sh
-benchmarks/fertility-surveys/benchmark.sh
+benchmarks/fertility-surveys/benchmark.sh \
+  --cache-root="$CACHE_ROOT" --manifest="$MANIFEST"
 ```
 
 ## Explicit accepted-current-hash evidence for F0633-F0637
@@ -185,21 +196,22 @@ benchmarks/fertility-surveys/benchmark.sh
 The historical SHA-512 values in `datasigs.csv` remain the manifest authority and
 are never rewritten. If a separately authorized local review accepts the current
 bytes for exactly `F0633` through `F0637`, capture those bytes into a private,
-immutable commitment below `target/fertility-surveys/raw/`:
+immutable content-addressed commitment beneath the ignored artifact root:
 
 ```sh
 commitment_id=$(
-  benchmarks/fertility-surveys/benchmark.sh --capture-accepted-current-hashes
+  benchmarks/fertility-surveys/benchmark.sh \
+    --cache-root="$CACHE_ROOT" --manifest="$MANIFEST" \
+    --capture-accepted-current-hashes
 )
 ```
 
 Capture requires the normal proprietary-data opt-in, is refused in CI and GitHub
 Actions, rejects symlinked output ancestors, confines publication to the
-checkout-local canonical `target/fertility-surveys/raw` path, validates exactly
-five canonical 128-hex SHA-512 values, and emits only the privacy-safe commitment
-ID. The private artifact is not tracked and contains no source paths. It does not
-modify `datasigs.csv`, `/opt/aww_cache`, or any
-existing checkpoint or report.
+canonical ignored artifact root, validates exactly five canonical 128-hex
+SHA-512 values, and emits only the privacy-safe commitment ID. The private
+artifact is not tracked and contains no source paths. It does not modify the
+supplied manifest, cache root, or any existing checkpoint or report.
 
 Run the separate accepted family only through the explicit CLI option. There is
 no environment-variable fallback, and accepted execution rejects every selection
@@ -207,6 +219,7 @@ other than the exact unsharded five-ID family:
 
 ```sh
 benchmarks/fertility-surveys/benchmark.sh \
+  --cache-root="$CACHE_ROOT" --manifest="$MANIFEST" \
   --accepted-current-hashes="$commitment_id" \
   --id=F0633,F0634,F0635,F0636,F0637
 ```
@@ -224,7 +237,9 @@ manifest as verified.
 Merge the resulting separate five-ID family normally:
 
 ```sh
-benchmarks/fertility-surveys/benchmark.sh --family-id=<accepted-family-id>
+benchmarks/fertility-surveys/benchmark.sh \
+  --cache-root="$CACHE_ROOT" --manifest="$MANIFEST" \
+  --family-id=<accepted-family-id>
 ```
 
 Merge validation requires exactly one shard, exactly `F0633`-`F0637`, consistent
@@ -236,12 +251,13 @@ After both families have been merged, publish a separate derived assessment:
 
 ```sh
 benchmarks/fertility-surveys/benchmark.sh \
+  --cache-root="$CACHE_ROOT" --manifest="$MANIFEST" \
   --assessment-family-id=<original-full-family-id> \
   --accepted-family-id=<accepted-five-family-id>
 ```
 
-The assessment consumes and strictly revalidates each family's merged `CURRENT`
-bundle. The accepted family must use the complete current five-file merged schema,
+The assessment consumes and strictly revalidates each family's explicitly
+selected private merged bundle. The accepted family must use the complete current five-file merged schema,
 including its aggregate input attestation and acceptance authority. Only the
 original/base role has a compatibility path for the immutable four-file
 schema-10/report-schema-2 fresh full-family bundle: it requires exactly 8 shards,
@@ -270,6 +286,7 @@ privacy, and public-schema check, but does not stage or publish reports:
 
 ```sh
 benchmarks/fertility-surveys/benchmark.sh \
+  --cache-root="$CACHE_ROOT" --manifest="$MANIFEST" \
   --republish-framework=6f0e40d786d054ec2cb924c74dabb67b66bb0d079f01147294c48187565a6488 \
   --validate-only --shard-count=8 --chunk-rows=50000 --column-batch=32 \
   --memory-mib=1024 --cell-budget=10000000 --max-tiles-per-batch=100000 \
@@ -285,8 +302,8 @@ empty-reader `paste0()` bug is discarded, and only in this historical replay pat
 Current execution and normal checkpoint resume reject that artifact.
 
 All shard bundles are validated and staged before publication. Bundle renames and
-`CURRENT` pointer updates form one rollback-checked transaction: a staging, rename,
-or pointer failure restores every prior pointer and removes every new bundle, while
+private pointer updates form one rollback-checked transaction: a staging, rename,
+or pointer failure restores every prior selection and removes every new bundle, while
 a failed rollback is reported rather than treated as success. Historical replay
 validates and republishes historical evidence; it is not a substitute for the
 mandatory final exhaustive fresh run with the corrected worker.
@@ -294,6 +311,9 @@ mandatory final exhaustive fresh run with the corrected worker.
 Do not run it casually. The default timeout is 600 seconds per metadata/value
 tile. Available options are:
 
+- `--cache-root=/absolute/canonical/path` and
+  `--manifest=/absolute/canonical/file.csv` (both required in raw mode and
+  rejected in generated-output mode)
 - `--inventory-only`
 - `--program=dhs,mics` (comma-separated)
 - `--release=113,118` (comma-separated)
@@ -328,7 +348,7 @@ rejects encoding overrides because replay must retain its exact recorded
 configuration.
 
 The orchestrator builds the current checkout package into an immutable,
-provenance-addressed generation beneath `target/fertility-surveys/raw/builds/`.
+provenance-addressed generation beneath the ignored private artifact root.
 A short owner-aware build lock covers installation, SHA-256 package/dependency
 provenance, and framework snapshot preparation, then is released before corpus
 execution. Concurrent starters wait for that setup and reuse the same verified
@@ -374,14 +394,16 @@ File-level classifications include `pass`, `expected-unsupported-111`,
 secondary fixed categories and hashed mismatch signatures are retained without
 publishing source metadata or values.
 
-Each filter/shard selection publishes a complete immutable report bundle beneath
-`raw/reports/<selection-id>/` and atomically updates only that selection's
-`CURRENT` pointer, so smoke runs and separate shards do not overwrite one another.
+Each filter/shard selection publishes a complete immutable, content-bound private
+report bundle and atomically updates only that selection's private pointer, so
+smoke runs and separate shards do not overwrite one another.
 Results carry framework, configuration, inventory, family, and build provenance
 IDs. After every shard in a family completes, merge its privacy-safe reports with:
 
 ```sh
-benchmarks/fertility-surveys/benchmark.sh --family-id=<family-id>
+benchmarks/fertility-surveys/benchmark.sh \
+  --cache-root="$CACHE_ROOT" --manifest="$MANIFEST" \
+  --family-id=<family-id>
 ```
 
 Prepare publishes a privacy-safe canonical inventory manifest inside the immutable
@@ -395,11 +417,10 @@ schema provenance. An unfiltered family must contain exactly `F0001` through
 `F1004`, preserve release counts 111=130, 113=475, 114=23, 117=150, and 118=226,
 classify all release-111 files as expected unsupported, and account for exactly five
 supported inventory hash errors plus 869 supported executable outcomes. Validation
-finishes before any merged output is staged or published; publication is atomic
-beneath `raw/merged/<family-id>/`.
+finishes before any merged output is staged or published; publication is atomic within the ignored private artifact root.
 
-All generated files, package builds, checkpoints, and reports stay below the
-ignored `target/fertility-surveys/raw/` directory. Public result TSVs use one exact,
+All generated files, package builds, checkpoints, and reports stay below an
+ignored checkout-local private artifact root. Public result TSVs use one exact,
 versioned schema and reject missing, reordered, or unexpected columns before
 publication. They contain only privacy-safe IDs, program/level/release, shapes,
 timings, fixed categories, and hashed mismatch signatures.
@@ -409,9 +430,9 @@ reason. `inventory-hash-error` reports only a fixed privacy-safe reason
 (`hash-read-error`, `signature-mismatch`, or `input-changed`); a nonempty recorded
 signature mismatch is never silently treated like an intentionally empty
 historical signature. Before any parent R or callr process starts, the shell creates a private
-per-run `TMPDIR` beneath `raw/tmp/`; parent and child R processes verify their
-canonical `tempdir()` remains beneath the raw root, and abandoned run temp
-directories are safely reclaimed. The shell uses a restrictive umask and the R
+per-run temporary directory beneath the ignored artifact root; parent and child
+R processes verify their canonical `tempdir()` remains confined there, and
+abandoned temporary directories are safely reclaimed. The shell uses a restrictive umask and the R
 writers enforce private artifact permissions. Do not copy RDS checkpoints
 outside the private target
 directory because they contain input signatures.

--- a/benchmarks/fertility-surveys/README.md
+++ b/benchmarks/fertility-surveys/README.md
@@ -1,0 +1,147 @@
+# Manual fertility-survey differential corpus
+
+This is a local, report-only compatibility framework for the private fertility
+survey cache. It is never a CI or release gate. It refuses to run when common CI
+or GitHub Actions variables are present and requires an explicit manual opt-in.
+It does not add Stata release 111 support: release-111 files are inventoried and
+classified as `unsupported-release` without being passed to a reader.
+
+The inventory intentionally reproduces `~/repos/fertility_surveys/check_raw_data.r`
+path construction rather than recursively searching the cache. It reads exactly
+`~/repos/fertility_surveys/datasigs.csv`, maps underscores in non-WFS survey
+folder names to commas, maps women/birth records to `wm.dta`/`bh.dta`, maps WFS
+to `<survey>.dta`, tries the program's primary directory, and only for DHS tries
+`DHS/Original_Data_Provenance_Unknown`. The cache root is exactly
+`/opt/aww_cache`; neither path can be overridden by command-line options.
+
+A valid inventory has exactly 1,004 unique files and these release counts:
+
+| Release | Files | Differential status |
+|---:|---:|---|
+| 111 | 130 | inventoried, unsupported |
+| 113 | 475 | compared |
+| 114 | 23 | compared |
+| 117 | 150 | compared |
+| 118 | 226 | compared |
+
+Every file is SHA-512 hashed; a non-empty recorded signature must match, while
+rows whose historical signature is empty are bound to the hash computed by the
+checkpoint. For each supported file, one isolated R subprocess reads the complete
+file through `dtaparser::read_dta()`, requires exact
+identity with `dtaparser:::.read_dta_rust_vectors()`, then compares the complete
+result with `haven::read_dta()`. Haven comparison checks dimensions, names,
+data-frame and column attributes, storage types, missing positions and kinds,
+tagged missing values, exact non-floating and nonfinite values, and an exhaustive
+elementwise absolute tolerance of `1e-7` for finite floating values. Inputs are
+hashed by the parent before launch, independently in the child, again after the
+child exits, and once more before report publication.
+
+## Run manually
+
+From the checkout root:
+
+```sh
+export DTAPARSER_FERTILITY_CORPUS=I_UNDERSTAND_THIS_READS_PROPRIETARY_DATA
+benchmarks/fertility-surveys/benchmark.sh --inventory-only
+benchmarks/fertility-surveys/benchmark.sh --id=F0001 --timeout-seconds=120
+```
+
+Inventory IDs are stable row numbers, not release selectors. To exercise the
+unsupported classification without asking a reader to open a file, use:
+
+```sh
+benchmarks/fertility-surveys/benchmark.sh --release=111 --max-files=1 --timeout-seconds=120
+```
+
+A bounded supported-file smoke run can use another release and the same count
+filter:
+
+```sh
+benchmarks/fertility-surveys/benchmark.sh --release=118 --max-files=1 --timeout-seconds=120
+```
+
+The exhaustive run is:
+
+```sh
+benchmarks/fertility-surveys/benchmark.sh
+```
+
+Do not run it casually. The default timeout is 600 seconds per file. Available
+options are:
+
+- `--inventory-only`
+- `--program=dhs,mics` (comma-separated)
+- `--release=113,118` (comma-separated)
+- `--id=F0001,F0002` (privacy-safe inventory IDs)
+- `--shard-index=N --shard-count=N` (both required; one-based)
+- `--max-files=N`
+- `--timeout-seconds=N`
+- `--retry` (rerun only prior failures; matches and unsupported releases resume)
+
+The orchestrator builds the current checkout package and installs it beneath
+`target/fertility-surveys/raw/library/`. Build provenance binds the commit,
+scoped dirty state, package and framework source digests, source tarball, and the
+installed package. Every runtime dependency is bound by version, canonical
+installed path, canonical loaded-namespace path, and deterministic installed-tree
+digest. A valid existing installation is reused so checkpoints can resume;
+source, dependency, or installation changes force a rebuild and a new framework
+identity. The private run lock and per-run temporary directory publish the
+orchestrating shell's PID, host, and OS-verified process-start generation as their
+authoritative owner. A separate long-lived helper refreshes only a supplemental
+heartbeat while monitoring that exact shell generation. Matching live PID/start
+identity remains authoritative if heartbeat updates are delayed or the helper
+itself dies; confirmed owner death or a live PID with a different start generation
+permits recovery regardless of helper state. Permission-denied or unavailable
+process probes are indeterminate rather than dead and use conservative
+heartbeat/stale-age handling, never immediate reclamation. This prevents another
+invocation from replacing the installation
+mid-run while permitting safe recovery after an owner dies or initialization is
+abandoned. Workers source an immutable provenance-addressed
+script snapshot, and all provenance is recomputed before report publication.
+
+Each file has an atomic RDS checkpoint bound to the checkpoint schema, framework
+and package provenance, `datasigs.csv`, inventory ID, release, expected signature,
+and a parent-captured input identity containing the actual SHA-512 or a stable
+hash-error fingerprint. Checkpoint compatibility also includes the requested
+per-file timeout, so changing `--timeout-seconds` cannot silently reuse a result
+created under a different limit. Current identities are rechecked after each
+child, before resume, and before publication. This makes timeout,
+subprocess-error, and input-hash-error checkpoints publishable and resumable.
+`--retry` reruns those failures; without it they resume like other completed
+checkpoints. Filters and shards do not alter checkpoint identity.
+
+Each filter/shard selection publishes a complete immutable report bundle beneath
+`raw/reports/<selection-id>/` and atomically updates only that selection's
+`CURRENT` pointer, so smoke runs and separate shards do not overwrite one another.
+Results carry framework and build provenance IDs.
+
+All generated files, package builds, checkpoints, and reports stay below the
+ignored `target/fertility-surveys/raw/` directory. Public TSVs contain only
+privacy-safe IDs, program/level/release, shapes, timings, and classifications.
+They never contain source paths, survey names, labels, values, or reader error
+text. Subprocess failures are reduced to fixed classifications for the same
+reason. Before any parent R or callr process starts, the shell creates a private
+per-run `TMPDIR` beneath `raw/tmp/`; parent and child R processes verify their
+canonical `tempdir()` remains beneath the raw root, and abandoned run temp
+directories are safely reclaimed. The shell uses a restrictive umask and the R
+writers enforce private artifact permissions. Do not copy RDS checkpoints
+outside the private target
+directory because they contain input signatures.
+
+## Deterministic tests
+
+The synthetic framework tests create only temporary fake headers and synthetic
+R values; they do not read the private corpus:
+
+```sh
+Rscript --vanilla benchmarks/fertility-surveys/test-framework.R
+```
+
+They cover exact non-recursive inventory mapping, release parsing, privacy-safe
+inventory projection, argument validation, filtering, sharding, retry/checkpoint
+invalidation, atomic publication, timeout publication/resume/retry, parent input
+identity and timeout compatibility, live-owner lock/temp preservation followed
+by dead-owner recovery, dependency relocation/modification invalidation, nested
+parent-R/callr temporary-directory confinement including live callr control and
+serialization artifacts, semantic mismatch classifications and numeric outliers,
+release-111 handling, signature refusal, and CI/manual opt-in refusal.

--- a/benchmarks/fertility-surveys/README.md
+++ b/benchmarks/fertility-surveys/README.md
@@ -113,7 +113,12 @@ uses forced Stata append coercion; that provenance explains stored analytical
 types but never excuses a disagreement among Direct-R, Rust-vector, and Haven.
 
 All normal filters, encoding overrides, resource bounds, resume, and shard
-options apply. Merging an output family repeats the explicit root:
+options apply. An unfiltered output run is recorded as a full family. Merge
+validation requires exactly all 1,226 frozen IDs, the frozen release and
+survey/aggregate distributions, release 111 only as expected unsupported,
+and complete terminal outcomes for every supported file; timeout, memory,
+crash, unresolved, inventory-hash, or incomplete outcomes cannot pass that
+full-family gate. Merging an output family repeats the explicit root:
 
 ```sh
 benchmarks/fertility-surveys/benchmark.sh \

--- a/benchmarks/fertility-surveys/README.md
+++ b/benchmarks/fertility-surveys/README.md
@@ -6,8 +6,9 @@ or GitHub Actions variables are present and requires an explicit manual opt-in.
 It does not add Stata release 111 support: release-111 files are inventoried and
 classified as `unsupported-release` without being passed to a reader.
 
-The inventory intentionally reproduces `~/repos/fertility_surveys/check_raw_data.r`
-path construction rather than recursively searching the cache. It reads exactly
+The default Wave 2 inventory intentionally reproduces
+`~/repos/fertility_surveys/check_raw_data.r` path construction rather than
+recursively searching the cache. It reads exactly
 `~/repos/fertility_surveys/datasigs.csv`, maps underscores in non-WFS survey
 folder names to commas, maps women/birth records to `wm.dta`/`bh.dta`, maps WFS
 to `<survey>.dta`, tries the program's primary directory, and only for DHS tries
@@ -80,6 +81,45 @@ Zero-column supported files use a single explicit empty projection batch and the
 same traversal and terminal requirements. Inputs are fully hashed before accepting
 checkpoints and again after
 all tiles; cheap size/mtime fingerprints detect changes around each child.
+
+## Wave 3 generated-output corpus
+
+The same comparator, isolated workers, bounded tiles, checkpoints, sharding,
+provenance, privacy filtering, and publication machinery also supports the
+explicit generated-output root. This mode is enabled only by supplying the
+exact canonical absolute path:
+
+```sh
+benchmarks/fertility-surveys/benchmark.sh \
+  --output-root=/Users/jmb/repos/fertility_surveys/output --inventory-only
+```
+
+It recursively inventories regular files whose extension is `.dta` or `.DTA`,
+including top-level aggregate files and nested survey files, and ignores every
+other entry. Stable `F0001`-style IDs are assigned by bytewise-sorted canonical
+relative path. Relative paths, byte sizes, modification times, SHA-512 values,
+and source-root filesystem identity are frozen only in the ignored private
+`target/fertility-surveys/raw/output-inventory/wave3/inventory.rds` artifact.
+Public manifests expose only the stable ID, `program=output`, the privacy-safe
+`survey`/`aggregate` level, and DTA release.
+
+The run refuses any other output root and asserts the observed baseline exactly:
+1,226 files, 70,748,321,626 bytes, and a largest file of 10,332,252,930 bytes.
+It supports releases 113-115 and 117-118 and preserves release 111 as an
+expected unsupported classification. Source files and the upstream repository
+are read-only; all mutable state remains under the checkout-local ignored
+target. Aggregate files are identified separately because the upstream build
+uses forced Stata append coercion; that provenance explains stored analytical
+types but never excuses a disagreement among Direct-R, Rust-vector, and Haven.
+
+All normal filters, encoding overrides, resource bounds, resume, and shard
+options apply. Merging an output family repeats the explicit root:
+
+```sh
+benchmarks/fertility-surveys/benchmark.sh \
+  --family-id=<family-id> \
+  --output-root=/Users/jmb/repos/fertility_surveys/output
+```
 
 ## Run manually
 

--- a/benchmarks/fertility-surveys/README.md
+++ b/benchmarks/fertility-surveys/README.md
@@ -125,7 +125,11 @@ tile. Available options are:
 - `--retry` (rerun failed tiles only; completed matches and mismatches resume)
 
 The orchestrator builds the current checkout package and installs it beneath
-`target/fertility-surveys/raw/library/`. Build provenance binds the commit,
+`target/fertility-surveys/raw/library/`. Before any corpus item is processed it
+must pass a synthetic metadata regression through the exact production callr
+callback, target-local temporary directory, and immutable framework snapshot; the
+regression also proves comparator helpers remain confined to the callback lexical
+environment. Build provenance binds the commit,
 scoped dirty state, package and framework source digests, source tarball, and the
 installed package. Every runtime dependency is bound by version, canonical
 installed path, canonical loaded-namespace path, and deterministic installed-tree
@@ -175,7 +179,10 @@ ignored `target/fertility-surveys/raw/` directory. Public TSVs contain only
 privacy-safe IDs, program/level/release, shapes, timings, and classifications.
 They never contain source paths, survey names, labels, values, or reader error
 text. Subprocess failures are reduced to fixed classifications for the same
-reason. Before any parent R or callr process starts, the shell creates a private
+reason. `inventory-hash-error` reports only a fixed privacy-safe reason
+(`hash-read-error`, `signature-mismatch`, or `input-changed`); a nonempty recorded
+signature mismatch is never silently treated like an intentionally empty
+historical signature. Before any parent R or callr process starts, the shell creates a private
 per-run `TMPDIR` beneath `raw/tmp/`; parent and child R processes verify their
 canonical `tempdir()` remains beneath the raw root, and abandoned run temp
 directories are safely reclaimed. The shell uses a restrictive umask and the R

--- a/benchmarks/fertility-surveys/README.md
+++ b/benchmarks/fertility-surveys/README.md
@@ -111,6 +111,38 @@ The exhaustive run is:
 benchmarks/fertility-surveys/benchmark.sh
 ```
 
+## Historical schema-10 validation and republication
+
+The complete eight-shard run from framework
+`6f0e40d786d054ec2cb924c74dabb67b66bb0d079f01147294c48187565a6488`
+can be revalidated from its private schema-10 result and tile checkpoints without
+opening any DTA input or launching a reader. Validation-only performs every build,
+framework, configuration, inventory, input-attestation, checkpoint, aggregation,
+privacy, and public-schema check, but does not stage or publish reports:
+
+```sh
+benchmarks/fertility-surveys/benchmark.sh \
+  --republish-framework=6f0e40d786d054ec2cb924c74dabb67b66bb0d079f01147294c48187565a6488 \
+  --validate-only --shard-count=8 --chunk-rows=50000 --column-batch=32 \
+  --memory-mib=1024 --cell-budget=10000000 --max-tiles-per-batch=100000 \
+  --beyond-end-windows=1 --timeout-seconds=600
+```
+
+Remove `--validate-only` to atomically publish all eight replay-derived shard
+bundles. Republication requires exactly eight shards and the exact recorded
+configuration. It records `historical-schema-10-replay` evidence provenance and a
+privacy-safe aggregate input-attestation ID; individual expected or actual hashes
+remain private. Only the exact schema-10 `-reader-error` artifact caused by the
+empty-reader `paste0()` bug is discarded, and only in this historical replay path.
+Current execution and normal checkpoint resume reject that artifact.
+
+All shard bundles are validated and staged before publication. Bundle renames and
+`CURRENT` pointer updates form one rollback-checked transaction: a staging, rename,
+or pointer failure restores every prior pointer and removes every new bundle, while
+a failed rollback is reported rather than treated as success. Historical replay
+validates and republishes historical evidence; it is not a substitute for the
+mandatory final exhaustive fresh run with the corrected worker.
+
 Do not run it casually. The default timeout is 600 seconds per metadata/value
 tile. Available options are:
 

--- a/benchmarks/fertility-surveys/README.md
+++ b/benchmarks/fertility-surveys/README.md
@@ -4,7 +4,7 @@ This is a local, report-only compatibility framework for the private fertility
 survey cache. It is never a CI or release gate. It refuses to run when common CI
 or GitHub Actions variables are present and requires an explicit manual opt-in.
 It does not add Stata release 111 support: release-111 files are inventoried and
-classified as `unsupported-release` without being passed to a reader.
+classified as `expected-unsupported-111` without being passed to a reader.
 
 The default Wave 2 inventory intentionally reproduces
 `~/repos/fertility_surveys/check_raw_data.r` path construction rather than
@@ -108,8 +108,9 @@ and device, inode, mode, size, modification time, and change time are revalidate
 around descriptor-bound hashing and release reads. Relative paths and private file
 metadata are frozen only in the ignored private
 `target/fertility-surveys/raw/output-inventory/wave3/inventory.rds` artifact.
-Public manifests expose only the stable ID, `program=output`, the privacy-safe
-`survey`/`aggregate` level, and DTA release.
+Public inventory manifests expose only the stable ID, `program=output`, the
+privacy-safe `survey`/`aggregate` level, and DTA release. Public family manifests
+add the deterministic `shard_index`.
 
 The run refuses any other output root and asserts the observed baseline exactly:
 1,226 files, 70,748,321,626 bytes, and a largest file of 10,332,252,930 bytes.

--- a/benchmarks/fertility-surveys/README.md
+++ b/benchmarks/fertility-surveys/README.md
@@ -113,6 +113,79 @@ The exhaustive run is:
 benchmarks/fertility-surveys/benchmark.sh
 ```
 
+## Explicit accepted-current-hash evidence for F0633-F0637
+
+The historical SHA-512 values in `datasigs.csv` remain the manifest authority and
+are never rewritten. If a separately authorized local review accepts the current
+bytes for exactly `F0633` through `F0637`, capture those bytes into a private,
+immutable commitment below `target/fertility-surveys/raw/`:
+
+```sh
+commitment_id=$(
+  benchmarks/fertility-surveys/benchmark.sh --capture-accepted-current-hashes
+)
+```
+
+Capture requires the normal proprietary-data opt-in, is refused in CI and GitHub
+Actions, rejects symlinked output ancestors, confines publication to the
+checkout-local canonical `target/fertility-surveys/raw` path, validates exactly
+five canonical 128-hex SHA-512 values, and emits only the privacy-safe commitment
+ID. The private artifact is not tracked and contains no source paths. It does not
+modify `datasigs.csv`, `/opt/aww_cache`, or any
+existing checkpoint or report.
+
+Run the separate accepted family only through the explicit CLI option. There is
+no environment-variable fallback, and accepted execution rejects every selection
+other than the exact unsharded five-ID family:
+
+```sh
+benchmarks/fertility-surveys/benchmark.sh \
+  --accepted-current-hashes="$commitment_id" \
+  --id=F0633,F0634,F0635,F0636,F0637
+```
+
+The loader revalidates the immutable artifact, its authority and commitment
+identity, the unchanged manifest signatures, and the current file bytes. The
+same validation runs again before publication. The commitment authority, ID, and
+artifact identity are bound into the accepted framework, configuration, input,
+checkpoint, family, selection, evidence, and report-bundle identities. The
+original `expected_sha512` remains unchanged and its status remains
+`signature-mismatch`; accepted execution records a separate
+`accepted-current-sha512-match` local-evidence status and never describes the
+manifest as verified.
+
+Merge the resulting separate five-ID family normally:
+
+```sh
+benchmarks/fertility-surveys/benchmark.sh --family-id=<accepted-family-id>
+```
+
+Merge validation requires exactly one shard, exactly `F0633`-`F0637`, consistent
+acceptance provenance, and executable outcomes for all five. Immediately before
+publication it rebuilds the live canonical inventory, reloads the exact immutable
+artifact, verifies its recorded SHA-256 identity, and revalidates all five current
+files. It cannot merge the accepted evidence into the original 1,004-file family.
+After both families have been merged, publish a separate derived assessment:
+
+```sh
+benchmarks/fertility-surveys/benchmark.sh \
+  --assessment-family-id=<original-full-family-id> \
+  --accepted-family-id=<accepted-five-family-id>
+```
+
+The assessment consumes and strictly revalidates each family's merged `CURRENT`
+bundle, including its results, summary, family manifest, aggregate input
+attestation, evidence-family identity, and merge identity. Its own identity binds
+both source merge identities. Immediately before publication it reloads both
+merged bundles, rebuilds the live inventory, and repeats accepted-artifact and
+current-byte validation. It preserves both source identities and classifications,
+requires the original full family to retain `inventory-hash-error` for exactly
+`F0633`-`F0637` with the sole privacy-safe reason `signature-mismatch`, and exposes
+two orthogonal statuses:
+`manifest_gate=blocked-signature-mismatch` and
+`explicit_local_evidence_gate=validated`. It does not replace the manifest gate,
+rewrite either family, or authorize Wave 3.
+
 ## Historical schema-10 validation and republication
 
 The complete eight-shard run from framework
@@ -165,6 +238,8 @@ tile. Available options are:
 - `--cell-budget=N` (cells across all three readers; default 1,000,000)
 - `--max-tiles-per-batch=N` (hard traversal ceiling; default 100,000)
 - `--beyond-end-windows=N` (terminal verification windows; default 1, maximum 8)
+- `--accepted-current-hashes=ID` (explicit private commitment; valid only with
+  the exact unsharded `F0633`-`F0637` selection)
 - `--retry` (rerun failed tiles only; completed matches and mismatches resume)
 
 Encoding overrides are explicit run configuration, never tracked corpus-specific
@@ -211,8 +286,9 @@ ID/release/signature, full input identity, exact tile projection/window, and a
 stable configuration ID. The configuration includes timeout, row cap, column
 batch, memory budget, cell budget, reader count, object overhead, probe count, and
 tile ceiling, so changing any sizing/resource limit cannot silently reuse foreign
-tiles. Timeout, memory-limit, crash, and reader-error tiles are resumable and are
-rerun only with `--retry`;
+tiles. Timeout, memory-limit, crash, reader-error, and independent
+`structural-metadata-unavailable` tiles are resumable and are rerun only with
+`--retry`;
 completed semantic mismatches remain valid evidence. Filters and shards do not
 alter tile identity.
 
@@ -310,5 +386,7 @@ continued traversal after early mismatches, timeout retry, schema/input/config
 invalidation, exhaustive metadata/value/tag/date/encoding categories and numeric
 outliers, absence of unbounded supported-file reads, atomic publication, immutable
 SHA-256 build/dependency provenance, live and remote owner recovery, nested
-parent-R/callr temp confinement, release-111 handling, signature refusal, and
-CI/manual opt-in refusal.
+parent-R/callr temp confinement, release-111 handling, signature refusal,
+structural-metadata retry, accepted-hash parsing and exact selection, private
+artifact/input invalidation, identity isolation, strict accepted-family merge,
+derived dual-gate assessment, and CI/manual opt-in refusal.

--- a/benchmarks/fertility-surveys/accepted.R
+++ b/benchmarks/fertility-surveys/accepted.R
@@ -128,14 +128,15 @@ fertility_revalidate_accepted_publication <- function(
         ), drop = FALSE], use.names = FALSE)))) {
         stop("accepted publication framework provenance is invalid")
     }
-    if (is.null(inventory)) inventory <- fertility_build_inventory()
+    if (is.null(inventory) || is.null(datasigs_path)) {
+        stop("accepted publication revalidation requires explicit inventory and manifest")
+    }
     fertility_validate_canonical_inventory(
         fertility_inventory_manifest(inventory), exact = TRUE
     )
     acceptance <- fertility_revalidate_recorded_acceptance(
         raw_root, provenance, inventory
     )
-    if (is.null(datasigs_path)) datasigs_path <- fertility_required_paths()$datasigs
     if (!identical(
         fertility_framework_id(
             provenance$build_provenance_id[[1L]], datasigs_path, acceptance
@@ -433,14 +434,27 @@ if (sys.nframe() == 0L) {
     source(file.path(script_dir, "runner.R"))
     fertility_assert_manual_run()
     arguments <- commandArgs(trailingOnly = TRUE)
-    if (!identical(arguments, "--capture-accepted-current-hashes")) {
-        stop("usage: accepted.R --capture-accepted-current-hashes")
+    capture_arguments <- arguments[arguments == "--capture-accepted-current-hashes"]
+    source_arguments <- arguments[vapply(arguments, function(argument) any(startsWith(
+        argument, c("--cache-root=", "--manifest=")
+    )), logical(1))]
+    if (length(capture_arguments) != 1L || length(source_arguments) != 2L ||
+        length(arguments) != 3L) {
+        stop(paste(
+            "usage: accepted.R --capture-accepted-current-hashes",
+            "--cache-root=/absolute/path --manifest=/absolute/path"
+        ))
     }
+    source_options <- fertility_validate_source_arguments(
+        fertility_parse_arguments(source_arguments)
+    )
     checkout_root <- fertility_checkout_root(script_path)
     raw_root <- fertility_assert_acceptance_raw_root(
         file.path(checkout_root, "target", "fertility-surveys", "raw"),
         checkout_root
     )
-    inventory <- fertility_build_inventory()
+    inventory <- fertility_build_inventory(
+        fertility_required_paths(source_options)
+    )
     cat(fertility_capture_acceptance(inventory, raw_root))
 }

--- a/benchmarks/fertility-surveys/accepted.R
+++ b/benchmarks/fertility-surveys/accepted.R
@@ -95,14 +95,30 @@ fertility_revalidate_recorded_acceptance <- function(raw_root, provenance,
 fertility_revalidate_accepted_publication <- function(
     raw_root, provenance, inventory = NULL, datasigs_path = NULL
 ) {
+    schema_fields <- c(
+        "schema_version", "report_schema_version",
+        "source_corpus_schema_version"
+    )
     required <- c(
-        "evidence_origin", "source_corpus_schema_version", "framework_id",
-        "build_provenance_id", "inventory_id", "report_schema_id"
+        schema_fields, "evidence_origin", "framework_id", "build_provenance_id",
+        "inventory_id", "report_schema_id"
     )
     if (!is.data.frame(provenance) || !all(required %in% names(provenance)) ||
-        any(vapply(required, function(field) {
+        any(vapply(schema_fields, function(field) {
+            !is.atomic(provenance[[field]]) || !is.null(dim(provenance[[field]]))
+        }, logical(1)))) {
+        stop("accepted publication framework provenance is invalid")
+    }
+    provenance[schema_fields] <- lapply(
+        provenance[schema_fields], as.character
+    )
+    if (any(vapply(required, function(field) {
             length(unique(provenance[[field]])) != 1L
         }, logical(1))) ||
+        !identical(provenance$schema_version[[1L]],
+                   as.character(fertility_schema_version)) ||
+        !identical(provenance$report_schema_version[[1L]],
+                   as.character(fertility_report_schema_version)) ||
         !identical(provenance$evidence_origin[[1L]], "fresh-execution") ||
         !identical(provenance$source_corpus_schema_version[[1L]],
                    as.character(fertility_schema_version)) ||

--- a/benchmarks/fertility-surveys/accepted.R
+++ b/benchmarks/fertility-surveys/accepted.R
@@ -1,0 +1,430 @@
+fertility_accepted_ids <- function() sprintf("F%04d", 633:637)
+
+fertility_acceptance_authority <- function() "explicit-local-current-sha512-v1"
+
+fertility_acceptance_commitment_id <- function(authority, entries) {
+    if (!is.data.frame(entries) || !identical(
+        names(entries), c("id", "expected_sha512", "accepted_sha512")
+    )) stop("accepted-current-hash artifact schema is invalid")
+    fertility_stable_id(list(
+        authority = authority,
+        ids = paste(entries$id, collapse = ","),
+        manifest_commitments = paste(entries$expected_sha512, collapse = ","),
+        accepted_commitments = paste(entries$accepted_sha512, collapse = ",")
+    ))
+}
+
+fertility_validate_acceptance_entries <- function(entries) {
+    if (!is.data.frame(entries) || !identical(
+        names(entries), c("id", "expected_sha512", "accepted_sha512")
+    ) || !identical(as.character(entries$id), fertility_accepted_ids()) ||
+        any(!grepl("^[0-9a-f]{128}$", entries$expected_sha512)) ||
+        any(!grepl("^[0-9a-f]{128}$", entries$accepted_sha512)) ||
+        any(entries$expected_sha512 == entries$accepted_sha512)) {
+        stop("accepted-current-hash artifact is invalid")
+    }
+    entries$id <- as.character(entries$id)
+    entries$expected_sha512 <- as.character(entries$expected_sha512)
+    entries$accepted_sha512 <- as.character(entries$accepted_sha512)
+    rownames(entries) <- NULL
+    entries
+}
+
+fertility_acceptance_artifact_root <- function(raw_root) {
+    file.path(raw_root, "accepted-current-hashes")
+}
+
+fertility_assert_acceptance_raw_root <- function(raw_root, checkout_root) {
+    expected <- fertility_assert_checkout_raw_root(
+        raw_root, checkout_root, create = TRUE
+    )
+    Sys.chmod(expected, mode = "0700")
+    expected
+}
+
+fertility_validate_acceptance_directory <- function(directory, parent) {
+    directory <- fertility_assert_existing_directory(
+        directory, parent, "accepted-current-hash commitment"
+    )
+    contents <- list.files(
+        directory, all.files = TRUE, no.. = TRUE,
+        recursive = FALSE, include.dirs = TRUE
+    )
+    if (!identical(contents, "commitment.rds")) {
+        stop("accepted-current-hash commitment must contain exactly commitment.rds")
+    }
+    path <- file.path(directory, "commitment.rds")
+    if (fertility_path_is_symlink(path) || !file_test("-f", path)) {
+        stop("accepted-current-hash artifact must be a regular nonsymlink file")
+    }
+    fertility_assert_existing_file(
+        path, directory, "accepted-current-hash artifact"
+    )
+}
+
+fertility_revalidate_recorded_acceptance <- function(raw_root, provenance,
+                                                      inventory) {
+    required <- c(
+        "acceptance_authority", "acceptance_commitment_id",
+        "acceptance_artifact_sha256", "inventory_id"
+    )
+    if (!is.data.frame(provenance) || nrow(provenance) < 1L ||
+        !all(required %in% names(provenance)) ||
+        any(provenance$acceptance_authority != fertility_acceptance_authority()) ||
+        length(unique(provenance$acceptance_commitment_id)) != 1L ||
+        length(unique(provenance$acceptance_artifact_sha256)) != 1L ||
+        length(unique(provenance$inventory_id)) != 1L ||
+        !grepl("^[0-9a-f]{64}$", provenance$acceptance_commitment_id[[1L]]) ||
+        !grepl("^[0-9a-f]{64}$", provenance$acceptance_artifact_sha256[[1L]]) ||
+        !identical(provenance$inventory_id[[1L]], fertility_inventory_id(inventory))) {
+        stop("recorded accepted-current-hash provenance is invalid")
+    }
+    acceptance <- fertility_load_acceptance(
+        raw_root, provenance$acceptance_commitment_id[[1L]], inventory
+    )
+    if (!identical(acceptance$authority,
+                   provenance$acceptance_authority[[1L]]) ||
+        !identical(acceptance$artifact_sha256,
+                   provenance$acceptance_artifact_sha256[[1L]])) {
+        stop("recorded accepted-current-hash artifact identity changed")
+    }
+    fertility_validate_acceptance_current(acceptance, inventory)
+    acceptance
+}
+
+fertility_revalidate_accepted_publication <- function(
+    raw_root, provenance, inventory = NULL, datasigs_path = NULL
+) {
+    required <- c(
+        "evidence_origin", "source_corpus_schema_version", "framework_id",
+        "build_provenance_id", "inventory_id", "report_schema_id"
+    )
+    if (!is.data.frame(provenance) || !all(required %in% names(provenance)) ||
+        any(vapply(required, function(field) {
+            length(unique(provenance[[field]])) != 1L
+        }, logical(1))) ||
+        !identical(provenance$evidence_origin[[1L]], "fresh-execution") ||
+        !identical(provenance$source_corpus_schema_version[[1L]],
+                   as.character(fertility_schema_version)) ||
+        !identical(provenance$report_schema_id[[1L]], fertility_report_schema_id()) ||
+        any(!grepl("^[0-9a-f]{64}$", unlist(provenance[1L, c(
+            "framework_id", "build_provenance_id", "inventory_id"
+        ), drop = FALSE], use.names = FALSE)))) {
+        stop("accepted publication framework provenance is invalid")
+    }
+    if (is.null(inventory)) inventory <- fertility_build_inventory()
+    fertility_validate_canonical_inventory(
+        fertility_inventory_manifest(inventory), exact = TRUE
+    )
+    acceptance <- fertility_revalidate_recorded_acceptance(
+        raw_root, provenance, inventory
+    )
+    if (is.null(datasigs_path)) datasigs_path <- fertility_required_paths()$datasigs
+    if (!identical(
+        fertility_framework_id(
+            provenance$build_provenance_id[[1L]], datasigs_path, acceptance
+        ),
+        provenance$framework_id[[1L]]
+    )) stop("accepted publication framework provenance changed")
+    framework_inventory <- fertility_framework_inventory(
+        file.path(raw_root, "framework", provenance$framework_id[[1L]]),
+        inventory = inventory, framework_id = provenance$framework_id[[1L]],
+        report_schema_version = fertility_report_schema_version
+    )
+    if (!identical(provenance$inventory_id[[1L]],
+                   framework_inventory$provenance$inventory_id[[1L]])) {
+        stop("accepted publication inventory provenance changed")
+    }
+    recorded_acceptance <- framework_inventory$acceptance_provenance
+    if (is.null(recorded_acceptance) || !identical(
+        recorded_acceptance,
+        data.frame(
+            authority = provenance$acceptance_authority[[1L]],
+            commitment_id = provenance$acceptance_commitment_id[[1L]],
+            artifact_sha256 = provenance$acceptance_artifact_sha256[[1L]],
+            stringsAsFactors = FALSE, check.names = FALSE
+        )
+    )) stop("accepted publication framework acceptance provenance changed")
+    invisible(list(
+        acceptance = acceptance, inventory = inventory,
+        framework_inventory = framework_inventory
+    ))
+}
+
+fertility_capture_acceptance <- function(inventory, raw_root) {
+    ids <- fertility_accepted_ids()
+    selected <- inventory[match(ids, inventory$id), , drop = FALSE]
+    if (nrow(selected) != length(ids) || anyNA(selected$id) ||
+        !identical(as.character(selected$id), ids) ||
+        any(!grepl("^[0-9a-f]{128}$", selected$expected_sha512))) {
+        stop("accepted-current-hash inventory selection is invalid")
+    }
+    captures <- lapply(seq_len(nrow(selected)), function(index) {
+        fertility_capture_input(as.list(selected[index, , drop = FALSE]))
+    })
+    if (any(vapply(captures, function(value) {
+        !identical(value$hash_status, "ok") ||
+            !grepl("^[0-9a-f]{128}$", value$actual_sha512)
+    }, logical(1)))) stop("accepted-current-hash capture failed")
+    entries <- data.frame(
+        id = ids,
+        expected_sha512 = tolower(selected$expected_sha512),
+        accepted_sha512 = vapply(captures, `[[`, character(1), "actual_sha512"),
+        stringsAsFactors = FALSE, check.names = FALSE
+    )
+    entries <- fertility_validate_acceptance_entries(entries)
+    authority <- fertility_acceptance_authority()
+    commitment_id <- fertility_acceptance_commitment_id(authority, entries)
+    artifact <- list(
+        schema_version = fertility_schema_version,
+        authority = authority,
+        commitment_id = commitment_id,
+        entries = entries,
+        created_at_utc = format(Sys.time(), "%Y-%m-%dT%H:%M:%SZ", tz = "UTC")
+    )
+    revalidate_capture_inputs <- function() {
+        current <- vapply(seq_len(nrow(selected)), function(index) {
+            captured <- fertility_capture_input(
+                as.list(selected[index, , drop = FALSE])
+            )
+            if (!identical(captured$hash_status, "ok")) {
+                stop("accepted-current-hash input changed during capture")
+            }
+            captured$actual_sha512
+        }, character(1))
+        if (!identical(current, entries$accepted_sha512)) {
+            stop("accepted-current-hash input changed during capture")
+        }
+        invisible(TRUE)
+    }
+    parent <- fertility_acceptance_artifact_root(raw_root)
+    invisible(fertility_assert_direct_child(
+        parent, raw_root, "accepted-current-hashes output directory",
+        must_work = FALSE
+    ))
+    if (!dir.exists(parent) &&
+        !dir.create(parent, showWarnings = FALSE, mode = "0700")) {
+        stop("could not create accepted-current-hash artifact root")
+    }
+    invisible(fertility_assert_direct_child(
+        parent, raw_root, "accepted-current-hashes output directory"
+    ))
+    destination <- file.path(parent, commitment_id)
+    artifact_path <- file.path(destination, "commitment.rds")
+    invisible(fertility_assert_direct_child(
+        destination, parent, "accepted-current-hash commitment", must_work = FALSE
+    ))
+    Sys.chmod(parent, mode = "0700")
+    finish_commitment <- function(boundary = NULL) {
+        loaded <- fertility_load_acceptance(raw_root, commitment_id, inventory)
+        if (!identical(loaded$entries, entries)) {
+            stop("immutable accepted-current-hash artifact conflicts with capture")
+        }
+        if (!is.null(boundary)) fertility_publication_test_hook(
+            boundary,
+            list(parent = parent, destination = destination,
+                 artifact = artifact_path)
+        )
+        fertility_validate_acceptance_directory(destination, parent)
+        revalidate_capture_inputs()
+        commitment_id
+    }
+    if (file.exists(destination) || dir.exists(destination) ||
+        fertility_path_is_symlink(destination)) {
+        return(finish_commitment(
+            "acceptance-before-existing-reuse-revalidation"
+        ))
+    }
+    stage <- tempfile(".acceptance.", tmpdir = parent)
+    if (!dir.create(stage, showWarnings = FALSE, mode = "0700")) {
+        stop("could not create accepted-current-hash staging directory")
+    }
+    on.exit(unlink(stage, recursive = TRUE), add = TRUE)
+    stage_artifact <- file.path(stage, "commitment.rds")
+    fertility_atomic_save_rds(artifact, stage_artifact)
+    Sys.chmod(stage_artifact, mode = "0600")
+    invisible(fertility_assert_direct_child(
+        parent, raw_root, "accepted-current-hashes output directory"
+    ))
+    stage <- fertility_assert_existing_directory(
+        stage, parent, "accepted-current-hash staging directory"
+    )
+    fertility_validate_acceptance_directory(stage, parent)
+    fertility_publication_test_hook(
+        "acceptance-before-destination-publication",
+        list(parent = parent, destination = destination, stage = stage)
+    )
+    revalidate_capture_inputs()
+    fertility_validate_acceptance_directory(stage, parent)
+    moved_identity <- NULL
+    validate_stage_for_publication <- function(from, to, label) {
+        revalidate_capture_inputs()
+        fertility_validate_acceptance_directory(from, parent)
+        moved_identity <<- fertility_filesystem_identity(
+            from, "accepted-current-hash staging directory"
+        )
+        invisible(TRUE)
+    }
+    publication_error <- tryCatch({
+        fertility_atomic_rename_noreplace(
+            stage, destination, "accepted-current-hash commitment",
+            validate_source = validate_stage_for_publication
+        )
+        NULL
+    }, error = identity)
+    if (!is.null(publication_error)) {
+        if (file.exists(destination) || dir.exists(destination) ||
+            fertility_path_is_symlink(destination)) {
+            return(finish_commitment(
+                "acceptance-before-concurrent-winner-revalidation"
+            ))
+        }
+        stop(publication_error)
+    }
+    Sys.chmod(destination, mode = "0700")
+    result <- tryCatch(finish_commitment(
+        "acceptance-before-new-publication-revalidation"
+    ), error = identity)
+    if (inherits(result, "error")) {
+        publication_content_valid <- isTRUE(tryCatch({
+            loaded <- fertility_load_acceptance(
+                raw_root, commitment_id, inventory
+            )
+            fertility_validate_acceptance_directory(destination, parent)
+            identical(loaded$entries, entries)
+        }, error = function(error) FALSE))
+        if (!publication_content_valid) {
+            destination_identity <- tryCatch(
+                fertility_filesystem_identity(
+                    destination, "published accepted-current-hash commitment"
+                ),
+                error = function(error) NULL
+            )
+            if (!is.null(moved_identity) &&
+                identical(destination_identity, moved_identity)) {
+                removed <- tryCatch(fertility_remove_confirmed_new_path(
+                    destination, parent,
+                    "invalid newly published accepted-current-hash commitment"
+                ), error = function(error) FALSE)
+                if (!isTRUE(removed)) {
+                    stop("could not roll back invalid accepted-current-hash publication")
+                }
+            }
+        }
+        stop(result)
+    }
+    result
+}
+
+fertility_load_acceptance <- function(raw_root, commitment_id, inventory = NULL) {
+    if (!is.character(commitment_id) || length(commitment_id) != 1L ||
+        !grepl("^[0-9a-f]{64}$", commitment_id)) {
+        stop("accepted-current-hash commitment ID is invalid")
+    }
+    artifact_root <- fertility_acceptance_artifact_root(raw_root)
+    if (fertility_path_is_symlink(raw_root) || fertility_path_is_symlink(artifact_root)) {
+        stop("accepted-current-hash artifact root must not be a symlink")
+    }
+    resolved_raw_root <- normalizePath(raw_root, winslash = "/", mustWork = TRUE)
+    root <- normalizePath(artifact_root, winslash = "/", mustWork = TRUE)
+    if (!identical(dirname(root), resolved_raw_root)) {
+        stop("accepted-current-hash artifact root escaped its private root")
+    }
+    directory <- fertility_assert_existing_directory(
+        file.path(root, commitment_id), root,
+        "accepted-current-hash commitment"
+    )
+    path <- fertility_validate_acceptance_directory(directory, root)
+    resolved_directory <- normalizePath(directory, winslash = "/", mustWork = TRUE)
+    resolved_path <- normalizePath(path, winslash = "/", mustWork = TRUE)
+    if (!identical(dirname(resolved_directory), root) ||
+        !identical(dirname(resolved_path), resolved_directory)) {
+        stop("accepted-current-hash artifact escaped its private root")
+    }
+    artifact <- tryCatch(readRDS(resolved_path), error = function(error) NULL)
+    required <- c(
+        "schema_version", "authority", "commitment_id", "entries", "created_at_utc"
+    )
+    if (!is.list(artifact) || !identical(names(artifact), required) ||
+        !identical(artifact$schema_version, fertility_schema_version) ||
+        !identical(artifact$authority, fertility_acceptance_authority()) ||
+        !identical(artifact$commitment_id, commitment_id) ||
+        !is.character(artifact$created_at_utc) || length(artifact$created_at_utc) != 1L ||
+        !grepl("^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$",
+               artifact$created_at_utc)) {
+        stop("accepted-current-hash artifact is invalid")
+    }
+    entries <- fertility_validate_acceptance_entries(artifact$entries)
+    if (!identical(
+        fertility_acceptance_commitment_id(artifact$authority, entries), commitment_id
+    )) stop("accepted-current-hash commitment identity is invalid")
+    if (!is.null(inventory)) {
+        selected <- inventory[match(entries$id, inventory$id), , drop = FALSE]
+        if (nrow(selected) != nrow(entries) || anyNA(selected$id) ||
+            !identical(as.character(selected$id), entries$id) ||
+            !identical(tolower(as.character(selected$expected_sha512)),
+                       entries$expected_sha512)) {
+            stop("accepted-current-hash artifact does not match the manifest inventory")
+        }
+    }
+    list(
+        authority = artifact$authority,
+        commitment_id = artifact$commitment_id,
+        entries = entries,
+        artifact_sha256 = unname(tools::sha256sum(resolved_path))
+    )
+}
+
+fertility_validate_acceptance_current <- function(acceptance, inventory) {
+    if (is.null(acceptance)) return(invisible(TRUE))
+    selected <- inventory[match(acceptance$entries$id, inventory$id), , drop = FALSE]
+    if (!identical(as.character(selected$id), acceptance$entries$id) ||
+        !identical(tolower(as.character(selected$expected_sha512)),
+                   acceptance$entries$expected_sha512)) {
+        stop("accepted-current-hash inventory changed")
+    }
+    actual <- vapply(seq_len(nrow(selected)), function(index) {
+        value <- tryCatch(
+            fertility_file_sha512(selected$path[[index]]), error = function(error) NA_character_
+        )
+        if (is.na(value)) stop("accepted-current-hash input validation failed")
+        value
+    }, character(1))
+    if (!identical(actual, acceptance$entries$accepted_sha512)) {
+        stop("accepted-current-hash input validation failed")
+    }
+    invisible(TRUE)
+}
+
+fertility_validate_accepted_selection <- function(options, family) {
+    if (!nzchar(options$accepted_current_hashes)) return(invisible(TRUE))
+    exact_ids <- fertility_accepted_ids()
+    if (!identical(sort(options$ids), exact_ids) || length(options$programs) ||
+        length(options$releases) || is.finite(options$max_files) ||
+        options$shard_index != 1L || options$shard_count != 1L ||
+        !identical(as.character(family$id), exact_ids)) {
+        stop("accepted-current-hash execution requires exactly F0633 through F0637")
+    }
+    invisible(TRUE)
+}
+
+if (sys.nframe() == 0L) {
+    script_path <- normalizePath(sub("^--file=", "", grep(
+        "^--file=", commandArgs(trailingOnly = FALSE), value = TRUE
+    )[[1L]]), winslash = "/")
+    script_dir <- dirname(script_path)
+    source(file.path(script_dir, "common.R"))
+    source(file.path(script_dir, "runner.R"))
+    fertility_assert_manual_run()
+    arguments <- commandArgs(trailingOnly = TRUE)
+    if (!identical(arguments, "--capture-accepted-current-hashes")) {
+        stop("usage: accepted.R --capture-accepted-current-hashes")
+    }
+    checkout_root <- fertility_checkout_root(script_path)
+    raw_root <- fertility_assert_acceptance_raw_root(
+        file.path(checkout_root, "target", "fertility-surveys", "raw"),
+        checkout_root
+    )
+    inventory <- fertility_build_inventory()
+    cat(fertility_capture_acceptance(inventory, raw_root))
+}

--- a/benchmarks/fertility-surveys/assessment.R
+++ b/benchmarks/fertility-surveys/assessment.R
@@ -30,7 +30,8 @@ raw_root <- fertility_assert_checkout_raw_root(
 )
 invisible(fertility_assert_tempdir(raw_root))
 
-load_family <- function(family_id, inventory) {
+load_family <- function(family_id, inventory, role = c("original", "accepted")) {
+    role <- match.arg(role)
     merged_root <- fertility_assert_direct_child(
         file.path(raw_root, "merged"), raw_root, "merged output directory"
     )
@@ -38,21 +39,41 @@ load_family <- function(family_id, inventory) {
         file.path(merged_root, family_id), merged_root,
         "assessment merged-family parent"
     )
+    common_files <- fertility_assessment_bundle_files("legacy-original")
     current <- fertility_current_bundle_paths(
-        parent,
-        c(
-            provenance = "merge-provenance.tsv", results = "results.tsv",
-            summary = "summary.tsv", family_manifest = "family-manifest.tsv",
-            input_attestation = "input-attestation.tsv"
-        ),
-        "assessment merged-family"
+        parent, common_files, "assessment merged-family"
     )
-    paths <- current$paths
+    entries <- list.files(
+        current$bundle, all.files = TRUE, no.. = TRUE, full.names = TRUE,
+        recursive = FALSE, include.dirs = TRUE
+    )
+    format <- fertility_assessment_bundle_format(basename(entries), role)
+    files <- if (identical(format, "current-merged-report-v2")) {
+        fertility_assessment_bundle_files("current")
+    } else common_files
+    paths <- setNames(file.path(current$bundle, unname(files)), names(files))
+    for (index in seq_along(paths)) {
+        paths[[index]] <- fertility_assert_existing_file(
+            paths[[index]], current$bundle,
+            paste("assessment merged-family", names(paths)[[index]])
+        )
+        if (!file_test("-f", paths[[index]]) || fertility_path_is_symlink(paths[[index]])) {
+            stop("assessment merged-family must contain only regular nonsymlink files")
+        }
+    }
     bundle <- lapply(paths, function(path) read.delim(
         path, colClasses = "character", check.names = FALSE
     ))
-    validated <- fertility_validate_merged_bundle(bundle, family_id, inventory)
-    snapshot_schema <- if (identical(
+    validated <- if (identical(format, "current-merged-report-v2")) {
+        fertility_validate_merged_bundle(bundle, family_id, inventory)
+    } else {
+        fertility_validate_assessment_legacy_original_bundle(
+            bundle, family_id, inventory
+        )
+    }
+    snapshot_schema <- if (identical(format, "legacy-original-merged-report-v2")) {
+        fertility_report_schema_version
+    } else if (identical(
         validated$provenance$evidence_origin[[1L]],
         "historical-schema-10-replay"
     )) fertility_legacy_report_schema_version else fertility_report_schema_version
@@ -63,16 +84,19 @@ load_family <- function(family_id, inventory) {
         report_schema_version = snapshot_schema
     )
     if (!identical(validated$provenance$inventory_id[[1L]],
-                   framework_inventory$provenance$inventory_id[[1L]])) {
+                   framework_inventory$provenance$inventory_id[[1L]]) ||
+        (identical(role, "original") &&
+         !is.null(framework_inventory$acceptance_provenance))) {
         stop("assessment merged-family inventory provenance changed")
     }
+    validated$run_name <- current$run_name
     validated
 }
 
 load_sources <- function() {
     inventory <- fertility_build_inventory()
-    full <- load_family(full_family_id, inventory)
-    accepted <- load_family(accepted_family_id, inventory)
+    full <- load_family(full_family_id, inventory, "original")
+    accepted <- load_family(accepted_family_id, inventory, "accepted")
     gates <- fertility_validate_assessment_families(full, accepted)
     publication <- fertility_revalidate_accepted_publication(
         raw_root, accepted$provenance, inventory
@@ -84,13 +108,22 @@ load_sources <- function() {
 sources <- load_sources()
 full <- sources$full
 accepted <- sources$accepted
+assessment_source_snapshot <- function(source) list(
+    run_name = source$run_name, source_format = source$source_format,
+    source_id = source$source_id, results = source$results,
+    summary = source$summary, family_manifest = source$family_manifest,
+    input_attestation = source$input_attestation, provenance = source$provenance,
+    full_default = source$full_default,
+    evidence_family_id = source$evidence_family_id,
+    family_input_attestation_id = source$family_input_attestation_id,
+    merge_id = source$merge_id
+)
+full_snapshot <- assessment_source_snapshot(full)
+accepted_snapshot <- assessment_source_snapshot(accepted)
 revalidate_assessment_sources <- function() {
     current <- load_sources()
-    if (!identical(current$full$merge_id, full$merge_id) ||
-        !identical(current$full$evidence_family_id, full$evidence_family_id) ||
-        !identical(current$accepted$merge_id, accepted$merge_id) ||
-        !identical(current$accepted$evidence_family_id,
-                   accepted$evidence_family_id) ||
+    if (!identical(assessment_source_snapshot(current$full), full_snapshot) ||
+        !identical(assessment_source_snapshot(current$accepted), accepted_snapshot) ||
         !identical(current$acceptance$artifact_sha256,
                    sources$acceptance$artifact_sha256) ||
         !identical(current$gates, sources$gates)) {
@@ -102,10 +135,16 @@ gates <- sources$gates
 authority <- gates$acceptance_authority
 commitment_id <- gates$acceptance_commitment_id
 assessment_id <- fertility_stable_id(list(
+    assessment_contract = "derived-dual-gate-source-identity-v2",
     original_family_id = full_family_id,
+    original_source_format = full$source_format,
+    original_source_id = full$source_id,
     original_evidence_family_id = full$evidence_family_id,
+    original_family_input_attestation_id = full$family_input_attestation_id,
     original_merge_id = full$merge_id,
     accepted_family_id = accepted_family_id,
+    accepted_source_format = accepted$source_format,
+    accepted_source_id = accepted$source_id,
     accepted_evidence_family_id = accepted$evidence_family_id,
     accepted_merge_id = accepted$merge_id,
     acceptance_authority = authority,
@@ -115,10 +154,16 @@ assessment_id <- fertility_stable_id(list(
 ))
 assessment <- data.frame(
     assessment_id = assessment_id,
+    assessment_contract = "derived-dual-gate-source-identity-v2",
     original_family_id = full_family_id,
+    original_source_format = full$source_format,
+    original_source_id = full$source_id,
     original_evidence_family_id = full$evidence_family_id,
+    original_family_input_attestation_id = full$family_input_attestation_id,
     original_merge_id = full$merge_id,
     accepted_family_id = accepted_family_id,
+    accepted_source_format = accepted$source_format,
+    accepted_source_id = accepted$source_id,
     accepted_evidence_family_id = accepted$evidence_family_id,
     accepted_merge_id = accepted$merge_id,
     acceptance_authority = authority,

--- a/benchmarks/fertility-surveys/assessment.R
+++ b/benchmarks/fertility-surveys/assessment.R
@@ -1,0 +1,212 @@
+script_path <- normalizePath(sub("^--file=", "", grep(
+    "^--file=", commandArgs(trailingOnly = FALSE), value = TRUE
+)[[1L]]), winslash = "/")
+script_dir <- dirname(script_path)
+source(file.path(script_dir, "common.R"))
+source(file.path(script_dir, "accepted.R"))
+source(file.path(script_dir, "runner.R"))
+source(file.path(script_dir, "runtime.R"))
+
+fertility_assert_manual_run()
+arguments <- commandArgs(trailingOnly = TRUE)
+if (length(arguments) != 2L ||
+    sum(startsWith(arguments, "--assessment-family-id=")) != 1L ||
+    sum(startsWith(arguments, "--accepted-family-id=")) != 1L) {
+    stop(paste(
+        "usage: assessment.R --assessment-family-id=FULL_ID",
+        "--accepted-family-id=ACCEPTED_ID"
+    ))
+}
+value <- function(prefix) sub("^[^=]+=", "", arguments[startsWith(arguments, prefix)])
+full_family_id <- value("--assessment-family-id=")
+accepted_family_id <- value("--accepted-family-id=")
+if (any(!grepl("^[0-9a-f]{64}$", c(full_family_id, accepted_family_id))) ||
+    identical(full_family_id, accepted_family_id)) {
+    stop("assessment family IDs are invalid")
+}
+checkout_root <- fertility_checkout_root(script_path)
+raw_root <- fertility_assert_checkout_raw_root(
+    file.path(checkout_root, "target", "fertility-surveys", "raw"), checkout_root
+)
+invisible(fertility_assert_tempdir(raw_root))
+
+load_family <- function(family_id, inventory) {
+    merged_root <- fertility_assert_direct_child(
+        file.path(raw_root, "merged"), raw_root, "merged output directory"
+    )
+    parent <- fertility_assert_direct_child(
+        file.path(merged_root, family_id), merged_root,
+        "assessment merged-family parent"
+    )
+    current <- fertility_current_bundle_paths(
+        parent,
+        c(
+            provenance = "merge-provenance.tsv", results = "results.tsv",
+            summary = "summary.tsv", family_manifest = "family-manifest.tsv",
+            input_attestation = "input-attestation.tsv"
+        ),
+        "assessment merged-family"
+    )
+    paths <- current$paths
+    bundle <- lapply(paths, function(path) read.delim(
+        path, colClasses = "character", check.names = FALSE
+    ))
+    validated <- fertility_validate_merged_bundle(bundle, family_id, inventory)
+    snapshot_schema <- if (identical(
+        validated$provenance$evidence_origin[[1L]],
+        "historical-schema-10-replay"
+    )) fertility_legacy_report_schema_version else fertility_report_schema_version
+    framework_inventory <- fertility_framework_inventory(
+        file.path(raw_root, "framework", validated$provenance$framework_id[[1L]]),
+        inventory = inventory,
+        framework_id = validated$provenance$framework_id[[1L]],
+        report_schema_version = snapshot_schema
+    )
+    if (!identical(validated$provenance$inventory_id[[1L]],
+                   framework_inventory$provenance$inventory_id[[1L]])) {
+        stop("assessment merged-family inventory provenance changed")
+    }
+    validated
+}
+
+load_sources <- function() {
+    inventory <- fertility_build_inventory()
+    full <- load_family(full_family_id, inventory)
+    accepted <- load_family(accepted_family_id, inventory)
+    gates <- fertility_validate_assessment_families(full, accepted)
+    publication <- fertility_revalidate_accepted_publication(
+        raw_root, accepted$provenance, inventory
+    )
+    list(inventory = inventory, full = full, accepted = accepted,
+         gates = gates, acceptance = publication$acceptance)
+}
+
+sources <- load_sources()
+full <- sources$full
+accepted <- sources$accepted
+revalidate_assessment_sources <- function() {
+    current <- load_sources()
+    if (!identical(current$full$merge_id, full$merge_id) ||
+        !identical(current$full$evidence_family_id, full$evidence_family_id) ||
+        !identical(current$accepted$merge_id, accepted$merge_id) ||
+        !identical(current$accepted$evidence_family_id,
+                   accepted$evidence_family_id) ||
+        !identical(current$acceptance$artifact_sha256,
+                   sources$acceptance$artifact_sha256) ||
+        !identical(current$gates, sources$gates)) {
+        stop("assessment source evidence changed before publication")
+    }
+    invisible(current)
+}
+gates <- sources$gates
+authority <- gates$acceptance_authority
+commitment_id <- gates$acceptance_commitment_id
+assessment_id <- fertility_stable_id(list(
+    original_family_id = full_family_id,
+    original_evidence_family_id = full$evidence_family_id,
+    original_merge_id = full$merge_id,
+    accepted_family_id = accepted_family_id,
+    accepted_evidence_family_id = accepted$evidence_family_id,
+    accepted_merge_id = accepted$merge_id,
+    acceptance_authority = authority,
+    acceptance_commitment_id = commitment_id,
+    manifest_gate = gates$manifest_gate,
+    explicit_local_evidence_gate = gates$explicit_local_evidence_gate
+))
+assessment <- data.frame(
+    assessment_id = assessment_id,
+    original_family_id = full_family_id,
+    original_evidence_family_id = full$evidence_family_id,
+    original_merge_id = full$merge_id,
+    accepted_family_id = accepted_family_id,
+    accepted_evidence_family_id = accepted$evidence_family_id,
+    accepted_merge_id = accepted$merge_id,
+    acceptance_authority = authority,
+    acceptance_commitment_id = commitment_id,
+    original_family_preserved = TRUE,
+    accepted_family_preserved = TRUE,
+    manifest_gate = gates$manifest_gate,
+    explicit_local_evidence_gate = gates$explicit_local_evidence_gate,
+    original_files = nrow(full$results),
+    accepted_files = nrow(accepted$results),
+    created_at_utc = format(Sys.time(), "%Y-%m-%dT%H:%M:%SZ", tz = "UTC"),
+    stringsAsFactors = FALSE, check.names = FALSE
+)
+invisible(fertility_assert_checkout_raw_root(raw_root, checkout_root))
+parent <- fertility_assert_output_parent(
+    raw_root, "assessments", assessment_id, create = TRUE
+)
+Sys.chmod(c(file.path(raw_root, "assessments"), parent), mode = "0700")
+stage <- tempfile(".assessment.", tmpdir = parent)
+dir.create(stage, mode = "0700")
+invisible(fertility_assert_direct_child(
+    stage, parent, "assessment staging directory"
+))
+on.exit(unlink(stage, recursive = TRUE), add = TRUE)
+fertility_atomic_write_table(assessment, file.path(stage, "assessment.tsv"))
+validate_assessment_bundle <- function(path) {
+    fertility_validate_exact_table_bundle(
+        path, c(assessment = "assessment.tsv"),
+        list(assessment = assessment), "assessment publication bundle"
+    )
+    invisible(TRUE)
+}
+run_name <- paste0(format(Sys.time(), "%Y%m%dT%H%M%SZ", tz = "UTC"), "-", Sys.getpid())
+destination <- file.path(parent, run_name)
+fertility_publication_test_hook(
+    "assessment-before-bundle-revalidation",
+    list(parent = parent, stage = stage, destination = destination)
+)
+invisible(revalidate_assessment_sources())
+invisible(validate_assessment_bundle(stage))
+invisible(fertility_assert_checkout_raw_root(raw_root, checkout_root))
+parent <- fertility_assert_output_parent(raw_root, "assessments", assessment_id)
+invisible(fertility_assert_existing_directory(
+    stage, parent, "assessment staging directory"
+))
+destination <- fertility_assert_new_destination(
+    destination, parent, "assessment publication bundle"
+)
+fertility_atomic_rename_noreplace(
+    stage, destination, "assessment publication bundle"
+)
+pointer <- tempfile("CURRENT.", tmpdir = parent)
+writeLines(run_name, pointer, useBytes = TRUE)
+Sys.chmod(pointer, mode = "0600")
+pointer_ready <- tryCatch({
+    fertility_publication_test_hook(
+        "assessment-before-current-revalidation",
+        list(parent = parent, bundle = destination,
+             pointer = file.path(parent, "CURRENT"))
+    )
+    revalidate_assessment_sources()
+    validate_assessment_bundle(destination)
+    fertility_assert_checkout_raw_root(raw_root, checkout_root)
+    parent <- fertility_assert_output_parent(
+        raw_root, "assessments", assessment_id
+    )
+    fertility_assert_existing_directory(
+        destination, parent, "assessment publication bundle"
+    )
+    fertility_assert_existing_file(
+        pointer, parent, "temporary assessment pointer"
+    )
+    fertility_assert_direct_child(
+        file.path(parent, "CURRENT"), parent,
+        "assessment CURRENT pointer", must_work = FALSE
+    )
+    TRUE
+}, error = function(error) {
+    fertility_remove_confirmed_new_path(
+        destination, parent, "new assessment publication bundle"
+    )
+    stop(error)
+})
+if (!isTRUE(pointer_ready) ||
+    !file.rename(pointer, file.path(parent, "CURRENT"))) {
+    fertility_remove_confirmed_new_path(
+        destination, parent, "new assessment publication bundle"
+    )
+    stop("could not publish derived assessment pointer")
+}
+message("validated merged manifest-gated family and explicit local five-ID evidence")

--- a/benchmarks/fertility-surveys/assessment.R
+++ b/benchmarks/fertility-surveys/assessment.R
@@ -9,15 +9,26 @@ source(file.path(script_dir, "runtime.R"))
 
 fertility_assert_manual_run()
 arguments <- commandArgs(trailingOnly = TRUE)
-if (length(arguments) != 2L ||
-    sum(startsWith(arguments, "--assessment-family-id=")) != 1L ||
-    sum(startsWith(arguments, "--accepted-family-id=")) != 1L) {
+family_arguments <- arguments[vapply(arguments, function(argument) any(startsWith(
+    argument, c("--assessment-family-id=", "--accepted-family-id=")
+)), logical(1))]
+source_arguments <- arguments[vapply(arguments, function(argument) any(startsWith(
+    argument, c("--cache-root=", "--manifest=")
+)), logical(1))]
+if (length(arguments) != 4L || length(family_arguments) != 2L ||
+    length(source_arguments) != 2L ||
+    sum(startsWith(family_arguments, "--assessment-family-id=")) != 1L ||
+    sum(startsWith(family_arguments, "--accepted-family-id=")) != 1L) {
     stop(paste(
         "usage: assessment.R --assessment-family-id=FULL_ID",
-        "--accepted-family-id=ACCEPTED_ID"
+        "--accepted-family-id=ACCEPTED_ID --cache-root=/absolute/path",
+        "--manifest=/absolute/path"
     ))
 }
-value <- function(prefix) sub("^[^=]+=", "", arguments[startsWith(arguments, prefix)])
+source_options <- fertility_validate_source_arguments(
+    fertility_parse_arguments(source_arguments)
+)
+value <- function(prefix) sub("^[^=]+=", "", family_arguments[startsWith(family_arguments, prefix)])
 full_family_id <- value("--assessment-family-id=")
 accepted_family_id <- value("--accepted-family-id=")
 if (any(!grepl("^[0-9a-f]{64}$", c(full_family_id, accepted_family_id))) ||
@@ -94,12 +105,15 @@ load_family <- function(family_id, inventory, role = c("original", "accepted")) 
 }
 
 load_sources <- function() {
-    inventory <- fertility_build_inventory()
+    inventory <- fertility_build_inventory(
+        fertility_required_paths(source_options)
+    )
     full <- load_family(full_family_id, inventory, "original")
     accepted <- load_family(accepted_family_id, inventory, "accepted")
     gates <- fertility_validate_assessment_families(full, accepted)
     publication <- fertility_revalidate_accepted_publication(
-        raw_root, accepted$provenance, inventory
+        raw_root, accepted$provenance, inventory,
+        fertility_required_paths(source_options)$datasigs
     )
     list(inventory = inventory, full = full, accepted = accepted,
          gates = gates, acceptance = publication$acceptance)

--- a/benchmarks/fertility-surveys/benchmark.sh
+++ b/benchmarks/fertility-surveys/benchmark.sh
@@ -1,0 +1,153 @@
+#!/bin/sh
+set -eu
+umask 077
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+checkout_root=$(CDPATH= cd -- "$script_dir/../.." && pwd)
+raw_root="$checkout_root/target/fertility-surveys/raw"
+library="$raw_root/library"
+provenance="$raw_root/build-provenance.tsv"
+export R_ENVIRON_USER=/dev/null
+export R_PROFILE_USER=/dev/null
+
+if [ "${CI:-}" ] || [ "${GITHUB_ACTIONS:-}" ] || [ "${GITHUB_RUN_ID:-}" ] || [ "${GITHUB_WORKFLOW:-}" ]; then
+    printf '%s\n' 'fertility corpus runs are refused in CI and GitHub Actions' >&2
+    exit 2
+fi
+if [ "${DTAPARSER_FERTILITY_CORPUS:-}" != 'I_UNDERSTAND_THIS_READS_PROPRIETARY_DATA' ]; then
+    printf '%s\n' 'manual opt-in required: set DTAPARSER_FERTILITY_CORPUS=I_UNDERSTAND_THIS_READS_PROPRIETARY_DATA' >&2
+    exit 2
+fi
+
+mkdir -p "$raw_root/tmp"
+chmod 700 "$raw_root" "$raw_root/tmp"
+run_tmp=$(mktemp -d "$raw_root/tmp/run.XXXXXX")
+chmod 700 "$run_tmp"
+export TMPDIR="$run_tmp"
+owner_state="$run_tmp/.orchestrator"
+owner_helper_pid=
+lock_dir="$raw_root/.run-lock"
+lock_token=
+build_dir=
+staged_library=
+staged_provenance=
+cleanup() {
+    [ -z "$build_dir" ] || rm -rf "$build_dir"
+    [ -z "$staged_library" ] || rm -rf "$staged_library"
+    [ -z "$staged_provenance" ] || rm -f "$staged_provenance"
+    if [ -n "$lock_token" ]; then
+        Rscript --vanilla "$script_dir/runtime.R" release-lock "$lock_dir" "$lock_token" >/dev/null 2>&1 || true
+    fi
+    if [ -n "$owner_helper_pid" ]; then
+        kill "$owner_helper_pid" >/dev/null 2>&1 || true
+        wait "$owner_helper_pid" >/dev/null 2>&1 || true
+    fi
+    rm -rf "$run_tmp"
+}
+trap cleanup EXIT HUP INT TERM
+Rscript --vanilla -e 'if (!requireNamespace("ps", quietly=TRUE)) quit(status=1)' || {
+    printf '%s\n' 'ps is required' >&2
+    exit 1
+}
+Rscript --vanilla "$script_dir/runtime.R" hold-owner "$owner_state" "$$" &
+owner_helper_pid=$!
+owner_ready=false
+for attempt in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20; do
+    if [ -f "$owner_state/owner.tsv" ]; then
+        owner_ready=true
+        break
+    fi
+    kill -0 "$owner_helper_pid" >/dev/null 2>&1 || break
+    sleep 0.05
+done
+if [ "$owner_ready" != true ]; then
+    printf '%s\n' 'could not initialize fertility corpus owner process' >&2
+    exit 1
+fi
+Rscript --vanilla "$script_dir/runtime.R" write-temp-owner "$run_tmp" "$owner_state"
+Rscript --vanilla "$script_dir/runtime.R" clean-temp "$raw_root/tmp" "$run_tmp"
+
+case " $* " in
+    *' --inventory-only '*)
+        Rscript --vanilla "$script_dir/run.R" "$@"
+        exit $?
+        ;;
+esac
+
+if ! lock_token=$(Rscript --vanilla "$script_dir/runtime.R" acquire-lock "$lock_dir" "$owner_state"); then
+    printf '%s\n' 'another fertility corpus build or run is active' >&2
+    exit 1
+fi
+
+for package in haven openssl callr ps readr rlang tibble tidyselect; do
+    Rscript --vanilla -e 'if (!requireNamespace(commandArgs(TRUE)[[1L]], quietly=TRUE)) quit(status=1)' "$package" || {
+        printf '%s\n' "$package is required" >&2
+        exit 1
+    }
+done
+
+valid_install=false
+if [ -f "$provenance" ] && [ -d "$library/dtaparser" ]; then
+    if Rscript --vanilla -e '
+        source(commandArgs(TRUE)[[1L]]); source(commandArgs(TRUE)[[2L]]);
+        fertility_verify_provenance(commandArgs(TRUE)[[3L]], commandArgs(TRUE)[[4L]], commandArgs(TRUE)[[5L]])
+    ' "$script_dir/common.R" "$script_dir/provenance.R" "$checkout_root" "$library" "$provenance" >/dev/null 2>&1; then
+        valid_install=true
+    fi
+fi
+
+if [ "$valid_install" != true ]; then
+    build_dir="$raw_root/.build.$$"
+    staged_library="$raw_root/.library.$$"
+    staged_provenance="$raw_root/.build-provenance.tsv.$$"
+    package_source_before=$(Rscript --vanilla -e '
+        source(commandArgs(TRUE)[[1L]]); source(commandArgs(TRUE)[[2L]]);
+        cat(fertility_tree_digest(commandArgs(TRUE)[[3L]], "r-package/dtaparser"))
+    ' "$script_dir/common.R" "$script_dir/provenance.R" "$checkout_root")
+    mkdir -p "$build_dir" "$staged_library"
+    (
+        cd "$build_dir"
+        R CMD build "$checkout_root/r-package/dtaparser"
+    )
+    tarball=
+    tarball_count=0
+    for candidate in "$build_dir"/dtaparser_*.tar.gz; do
+        if [ -f "$candidate" ]; then
+            tarball=$candidate
+            tarball_count=$((tarball_count + 1))
+        fi
+    done
+    if [ "$tarball_count" -ne 1 ]; then
+        printf '%s\n' 'expected exactly one dtaparser source tarball' >&2
+        exit 1
+    fi
+    tarball_sha256=$(Rscript --vanilla -e 'cat(tolower(unname(tools::sha256sum(commandArgs(TRUE)[[1L]]))))' "$tarball")
+    R CMD INSTALL --library="$staged_library" "$tarball"
+    package_source_after=$(Rscript --vanilla -e '
+        source(commandArgs(TRUE)[[1L]]); source(commandArgs(TRUE)[[2L]]);
+        cat(fertility_tree_digest(commandArgs(TRUE)[[3L]], "r-package/dtaparser"))
+    ' "$script_dir/common.R" "$script_dir/provenance.R" "$checkout_root")
+    if [ "$package_source_before" != "$package_source_after" ]; then
+        printf '%s\n' 'package source changed during build or installation' >&2
+        exit 1
+    fi
+    Rscript --vanilla -e '
+        source(commandArgs(TRUE)[[1L]]); source(commandArgs(TRUE)[[2L]]);
+        fertility_write_provenance(commandArgs(TRUE)[[3L]], commandArgs(TRUE)[[4L]], commandArgs(TRUE)[[5L]], commandArgs(TRUE)[[6L]])
+    ' "$script_dir/common.R" "$script_dir/provenance.R" "$checkout_root" "$staged_library" "$staged_provenance" "$tarball_sha256"
+    rm -rf "$library"
+    mv "$staged_library" "$library"
+    # The recorded installed path changes from the staging name to library; regenerate
+    # only after the atomic directory move.
+    Rscript --vanilla -e '
+        source(commandArgs(TRUE)[[1L]]); source(commandArgs(TRUE)[[2L]]);
+        fertility_write_provenance(commandArgs(TRUE)[[3L]], commandArgs(TRUE)[[4L]], commandArgs(TRUE)[[5L]], commandArgs(TRUE)[[6L]])
+    ' "$script_dir/common.R" "$script_dir/provenance.R" "$checkout_root" "$library" "$staged_provenance" "$tarball_sha256"
+    mv -f "$staged_provenance" "$provenance"
+    rm -rf "$build_dir"
+    build_dir=
+    staged_library=
+    staged_provenance=
+fi
+
+Rscript --vanilla "$script_dir/run.R" "$@"

--- a/benchmarks/fertility-surveys/benchmark.sh
+++ b/benchmarks/fertility-surveys/benchmark.sh
@@ -5,8 +5,7 @@ umask 077
 script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 checkout_root=$(CDPATH= cd -- "$script_dir/../.." && pwd)
 raw_root="$checkout_root/target/fertility-surveys/raw"
-library="$raw_root/library"
-provenance="$raw_root/build-provenance.tsv"
+builds_root="$raw_root/builds"
 export R_ENVIRON_USER=/dev/null
 export R_PROFILE_USER=/dev/null
 
@@ -26,17 +25,15 @@ chmod 700 "$run_tmp"
 export TMPDIR="$run_tmp"
 owner_state="$run_tmp/.orchestrator"
 owner_helper_pid=
-lock_dir="$raw_root/.run-lock"
-lock_token=
+build_lock="$raw_root/.build-lock"
+build_lock_token=
 build_dir=
-staged_library=
-staged_provenance=
+staged_bundle=
 cleanup() {
     [ -z "$build_dir" ] || rm -rf "$build_dir"
-    [ -z "$staged_library" ] || rm -rf "$staged_library"
-    [ -z "$staged_provenance" ] || rm -f "$staged_provenance"
-    if [ -n "$lock_token" ]; then
-        Rscript --vanilla "$script_dir/runtime.R" release-lock "$lock_dir" "$lock_token" >/dev/null 2>&1 || true
+    [ -z "$staged_bundle" ] || rm -rf "$staged_bundle"
+    if [ -n "$build_lock_token" ]; then
+        Rscript --vanilla "$script_dir/runtime.R" release-lock "$build_lock" "$build_lock_token" >/dev/null 2>&1 || true
     fi
     if [ -n "$owner_helper_pid" ]; then
         kill "$owner_helper_pid" >/dev/null 2>&1 || true
@@ -44,7 +41,10 @@ cleanup() {
     fi
     rm -rf "$run_tmp"
 }
-trap cleanup EXIT HUP INT TERM
+trap cleanup EXIT
+trap 'exit 129' HUP
+trap 'exit 130' INT
+trap 'exit 143' TERM
 Rscript --vanilla -e 'if (!requireNamespace("ps", quietly=TRUE)) quit(status=1)' || {
     printf '%s\n' 'ps is required' >&2
     exit 1
@@ -72,10 +72,14 @@ case " $* " in
         Rscript --vanilla "$script_dir/run.R" "$@"
         exit $?
         ;;
+    *' --family-id='*)
+        Rscript --vanilla "$script_dir/merge.R" "$@"
+        exit $?
+        ;;
 esac
 
-if ! lock_token=$(Rscript --vanilla "$script_dir/runtime.R" acquire-lock "$lock_dir" "$owner_state"); then
-    printf '%s\n' 'another fertility corpus build or run is active' >&2
+if ! build_lock_token=$(Rscript --vanilla "$script_dir/runtime.R" acquire-lock-wait "$build_lock" "$owner_state"); then
+    printf '%s\n' 'could not acquire fertility corpus build lock' >&2
     exit 1
 fi
 
@@ -86,20 +90,35 @@ for package in haven openssl callr ps readr rlang tibble tidyselect; do
     }
 done
 
+mkdir -p "$builds_root"
+chmod 700 "$builds_root"
+current_id=
+if [ -f "$builds_root/CURRENT" ]; then
+    current_id=$(tr -d '\r\n' < "$builds_root/CURRENT")
+    case "$current_id" in
+        ''|*[!0-9a-f]*) current_id= ;;
+    esac
+    [ "${#current_id}" -eq 64 ] || current_id=
+fi
 valid_install=false
-if [ -f "$provenance" ] && [ -d "$library/dtaparser" ]; then
-    if Rscript --vanilla -e '
-        source(commandArgs(TRUE)[[1L]]); source(commandArgs(TRUE)[[2L]]);
-        fertility_verify_provenance(commandArgs(TRUE)[[3L]], commandArgs(TRUE)[[4L]], commandArgs(TRUE)[[5L]])
-    ' "$script_dir/common.R" "$script_dir/provenance.R" "$checkout_root" "$library" "$provenance" >/dev/null 2>&1; then
-        valid_install=true
+if [ -n "$current_id" ]; then
+    library="$builds_root/$current_id/library"
+    provenance="$builds_root/$current_id/build-provenance.tsv"
+    if [ -f "$provenance" ] && [ -d "$library/dtaparser" ]; then
+        if Rscript --vanilla -e '
+            source(commandArgs(TRUE)[[1L]]); source(commandArgs(TRUE)[[2L]]);
+            fertility_verify_provenance(commandArgs(TRUE)[[3L]], commandArgs(TRUE)[[4L]], commandArgs(TRUE)[[5L]])
+        ' "$script_dir/common.R" "$script_dir/provenance.R" "$checkout_root" "$library" "$provenance" >/dev/null 2>&1; then
+            valid_install=true
+        fi
     fi
 fi
 
 if [ "$valid_install" != true ]; then
-    build_dir="$raw_root/.build.$$"
-    staged_library="$raw_root/.library.$$"
-    staged_provenance="$raw_root/.build-provenance.tsv.$$"
+    build_dir="$run_tmp/build"
+    staged_bundle="$run_tmp/generation"
+    staged_library="$staged_bundle/library"
+    staged_provenance="$staged_bundle/build-provenance.tsv"
     package_source_before=$(Rscript --vanilla -e '
         source(commandArgs(TRUE)[[1L]]); source(commandArgs(TRUE)[[2L]]);
         cat(fertility_tree_digest(commandArgs(TRUE)[[3L]], "r-package/dtaparser"))
@@ -135,19 +154,33 @@ if [ "$valid_install" != true ]; then
         source(commandArgs(TRUE)[[1L]]); source(commandArgs(TRUE)[[2L]]);
         fertility_write_provenance(commandArgs(TRUE)[[3L]], commandArgs(TRUE)[[4L]], commandArgs(TRUE)[[5L]], commandArgs(TRUE)[[6L]])
     ' "$script_dir/common.R" "$script_dir/provenance.R" "$checkout_root" "$staged_library" "$staged_provenance" "$tarball_sha256"
-    rm -rf "$library"
-    mv "$staged_library" "$library"
-    # The recorded installed path changes from the staging name to library; regenerate
-    # only after the atomic directory move.
-    Rscript --vanilla -e '
-        source(commandArgs(TRUE)[[1L]]); source(commandArgs(TRUE)[[2L]]);
-        fertility_write_provenance(commandArgs(TRUE)[[3L]], commandArgs(TRUE)[[4L]], commandArgs(TRUE)[[5L]], commandArgs(TRUE)[[6L]])
-    ' "$script_dir/common.R" "$script_dir/provenance.R" "$checkout_root" "$library" "$staged_provenance" "$tarball_sha256"
-    mv -f "$staged_provenance" "$provenance"
+    current_id=$(Rscript --vanilla -e 'x <- read.delim(commandArgs(TRUE)[[1L]], colClasses="character", check.names=FALSE); cat(x$provenance_id[[1L]])' "$staged_provenance")
+    generation="$builds_root/$current_id"
+    if [ -e "$generation" ]; then
+        printf '%s\n' 'immutable corpus build generation already exists but was not reusable' >&2
+        exit 1
+    fi
+    mv "$staged_bundle" "$generation"
+    staged_bundle=
+    library="$generation/library"
+    provenance="$generation/build-provenance.tsv"
     rm -rf "$build_dir"
     build_dir=
-    staged_library=
-    staged_provenance=
+    current_tmp="$run_tmp/CURRENT"
+    printf '%s\n' "$current_id" > "$current_tmp"
+    chmod 600 "$current_tmp"
+    mv -f "$current_tmp" "$builds_root/CURRENT"
 fi
 
+export DTAPARSER_FERTILITY_LIBRARY="$library"
+export DTAPARSER_FERTILITY_PROVENANCE="$provenance"
+framework_id=$(Rscript --vanilla "$script_dir/prepare.R")
+export DTAPARSER_FERTILITY_FRAMEWORK_ID="$framework_id"
+if ! Rscript --vanilla "$script_dir/runtime.R" release-lock "$build_lock" "$build_lock_token"; then
+    printf '%s\n' 'could not release fertility corpus build lock' >&2
+    exit 1
+fi
+build_lock_token=
+
+export DTAPARSER_FERTILITY_OWNER_STATE="$owner_state"
 Rscript --vanilla "$script_dir/run.R" "$@"

--- a/benchmarks/fertility-surveys/benchmark.sh
+++ b/benchmarks/fertility-surveys/benchmark.sh
@@ -18,6 +18,50 @@ if [ "${DTAPARSER_FERTILITY_CORPUS:-}" != 'I_UNDERSTAND_THIS_READS_PROPRIETARY_D
     exit 2
 fi
 
+cache_root_count=0
+manifest_count=0
+output_root_count=0
+for source_argument in "$@"; do
+    case "$source_argument" in
+        --cache-root=*)
+            cache_root_count=$((cache_root_count + 1))
+            source_path=${source_argument#*=}
+            ;;
+        --manifest=*)
+            manifest_count=$((manifest_count + 1))
+            source_path=${source_argument#*=}
+            ;;
+        --output-root=*)
+            output_root_count=$((output_root_count + 1))
+            source_path=${source_argument#*=}
+            ;;
+        *) continue ;;
+    esac
+    case "$source_path" in
+        /*) ;;
+        *)
+            printf '%s\n' 'fertility source roots must be explicit absolute paths' >&2
+            exit 2
+            ;;
+    esac
+    case "$source_path" in
+        *//*|*/./*|*/../*|*/.|*/..)
+            printf '%s\n' 'fertility source roots must be canonical paths' >&2
+            exit 2
+            ;;
+    esac
+done
+if [ "$output_root_count" -gt 0 ]; then
+    if [ "$output_root_count" -ne 1 ] || [ "$cache_root_count" -ne 0 ] ||
+       [ "$manifest_count" -ne 0 ]; then
+        printf '%s\n' '--output-root must be supplied once without raw root arguments' >&2
+        exit 2
+    fi
+elif [ "$cache_root_count" -ne 1 ] || [ "$manifest_count" -ne 1 ]; then
+    printf '%s\n' 'raw fertility mode requires explicit --cache-root and --manifest' >&2
+    exit 2
+fi
+
 ensure_direct_directory() {
     ensure_direct_directory_parent=$1
     ensure_direct_directory_child=$2
@@ -213,8 +257,8 @@ case " $* " in
         exit $?
         ;;
     *' --capture-accepted-current-hashes '*)
-        [ "$#" -eq 1 ] || {
-            printf '%s\n' 'accepted-current-hash capture takes no other options' >&2
+        [ "$#" -eq 3 ] || {
+            printf '%s\n' 'accepted-current-hash capture requires only explicit raw roots' >&2
             exit 2
         }
         Rscript --vanilla "$script_dir/accepted.R" "$@"

--- a/benchmarks/fertility-surveys/benchmark.sh
+++ b/benchmarks/fertility-surveys/benchmark.sh
@@ -2,8 +2,8 @@
 set -eu
 umask 077
 
-script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
-checkout_root=$(CDPATH= cd -- "$script_dir/../.." && pwd)
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd -P)
+checkout_root=$(CDPATH= cd -- "$script_dir/../.." && pwd -P)
 raw_root="$checkout_root/target/fertility-surveys/raw"
 builds_root="$raw_root/builds"
 export R_ENVIRON_USER=/dev/null
@@ -18,7 +18,120 @@ if [ "${DTAPARSER_FERTILITY_CORPUS:-}" != 'I_UNDERSTAND_THIS_READS_PROPRIETARY_D
     exit 2
 fi
 
-mkdir -p "$raw_root/tmp"
+ensure_direct_directory() {
+    parent=$1
+    child=$2
+    if [ -L "$parent" ] || [ -L "$child" ] || [ ! -d "$parent" ]; then
+        printf '%s\n' 'fertility output paths must not contain symlinks' >&2
+        exit 2
+    fi
+    if [ ! -d "$child" ]; then
+        mkdir "$child"
+    fi
+    parent_canonical=$(CDPATH= cd -- "$parent" && pwd -P)
+    child_canonical=$(CDPATH= cd -- "$child" && pwd -P)
+    if [ "$child_canonical" != "$parent_canonical/$(basename -- "$child")" ]; then
+        printf '%s\n' 'fertility outputs must remain in the checkout-local raw root' >&2
+        exit 2
+    fi
+}
+
+assert_direct_directory() {
+    parent=$1
+    child=$2
+    label=$3
+    if [ -L "$parent" ] || [ -L "$child" ] || [ ! -d "$parent" ] || [ ! -d "$child" ]; then
+        printf '%s\n' "$label must be a direct non-symlink directory" >&2
+        exit 2
+    fi
+    parent_canonical=$(CDPATH= cd -- "$parent" && pwd -P)
+    child_canonical=$(CDPATH= cd -- "$child" && pwd -P)
+    if [ "$parent_canonical" != "$parent" ] ||
+       [ "$child_canonical" != "$parent_canonical/$(basename -- "$child")" ] ||
+       [ "$(dirname -- "$child")" != "$parent" ]; then
+        printf '%s\n' "$label escaped its canonical parent" >&2
+        exit 2
+    fi
+}
+
+assert_direct_file() {
+    parent=$1
+    child=$2
+    label=$3
+    assert_direct_directory "$(dirname -- "$parent")" "$parent" "$label parent"
+    if [ -L "$child" ] || [ ! -f "$child" ] || [ -d "$child" ] ||
+       [ "$(dirname -- "$child")" != "$parent" ]; then
+        printf '%s\n' "$label must be a direct non-symlink file" >&2
+        exit 2
+    fi
+}
+
+atomic_move_noreplace() {
+    source_path=$1
+    destination_path=$2
+    label=$3
+    command -v python3 >/dev/null 2>&1 || {
+        printf '%s\n' 'python3 is required for atomic no-replace publication' >&2
+        exit 1
+    }
+    if python3 - "$source_path" "$destination_path" <<'PY'
+import ctypes
+import errno
+import os
+import sys
+src = os.fsencode(sys.argv[1])
+dst = os.fsencode(sys.argv[2])
+libc = ctypes.CDLL(None, use_errno=True)
+if sys.platform == "darwin":
+    fn = libc.renamex_np
+    fn.argtypes = [ctypes.c_char_p, ctypes.c_char_p, ctypes.c_uint]
+    rc = fn(src, dst, 4)
+else:
+    fn = getattr(libc, "renameat2", None)
+    if fn is None:
+        sys.exit(18)
+    fn.argtypes = [ctypes.c_int, ctypes.c_char_p, ctypes.c_int,
+                   ctypes.c_char_p, ctypes.c_uint]
+    rc = fn(-100, src, -100, dst, 1)
+if rc != 0:
+    value = ctypes.get_errno()
+    sys.exit(17 if value in (errno.EEXIST, errno.ENOTEMPTY) else 19)
+PY
+    then
+        return 0
+    else
+        move_status=$?
+        if [ "$move_status" -eq 17 ]; then
+            printf '%s\n' "$label destination already exists" >&2
+            exit 2
+        fi
+        printf '%s\n' "atomic no-replace publication failed for $label" >&2
+        exit 1
+    fi
+}
+
+for output_component in \
+    "$checkout_root" \
+    "$checkout_root/target" \
+    "$checkout_root/target/fertility-surveys" \
+    "$raw_root" \
+    "$raw_root/tmp"
+do
+    if [ -L "$output_component" ]; then
+        printf '%s\n' 'fertility output paths must not contain symlinks' >&2
+        exit 2
+    fi
+done
+ensure_direct_directory "$checkout_root" "$checkout_root/target"
+ensure_direct_directory "$checkout_root/target" "$checkout_root/target/fertility-surveys"
+ensure_direct_directory "$checkout_root/target/fertility-surveys" "$raw_root"
+ensure_direct_directory "$raw_root" "$raw_root/tmp"
+raw_canonical=$(CDPATH= cd -- "$raw_root" && pwd -P)
+tmp_canonical=$(CDPATH= cd -- "$raw_root/tmp" && pwd -P)
+if [ "$raw_canonical" != "$raw_root" ] || [ "$tmp_canonical" != "$raw_root/tmp" ]; then
+    printf '%s\n' 'fertility outputs must remain in the checkout-local raw root' >&2
+    exit 2
+fi
 chmod 700 "$raw_root" "$raw_root/tmp"
 run_tmp=$(mktemp -d "$raw_root/tmp/run.XXXXXX")
 chmod 700 "$run_tmp"
@@ -73,6 +186,18 @@ case " $* " in
         Rscript --vanilla "$script_dir/run.R" "$@"
         exit $?
         ;;
+    *' --capture-accepted-current-hashes '*)
+        [ "$#" -eq 1 ] || {
+            printf '%s\n' 'accepted-current-hash capture takes no other options' >&2
+            exit 2
+        }
+        Rscript --vanilla "$script_dir/accepted.R" "$@"
+        exit $?
+        ;;
+    *' --assessment-family-id='*)
+        Rscript --vanilla "$script_dir/assessment.R" "$@"
+        exit $?
+        ;;
     *' --family-id='*)
         Rscript --vanilla "$script_dir/merge.R" "$@"
         exit $?
@@ -95,11 +220,18 @@ for package in haven openssl callr ps readr rlang tibble tidyselect; do
     }
 done
 
-mkdir -p "$builds_root"
+ensure_direct_directory "$raw_root" "$builds_root"
+assert_direct_directory "$raw_root" "$builds_root" 'builds root'
 chmod 700 "$builds_root"
 current_id=
-if [ -f "$builds_root/CURRENT" ]; then
-    current_id=$(tr -d '\r\n' < "$builds_root/CURRENT")
+current_pointer="$builds_root/CURRENT"
+if [ -L "$current_pointer" ] || [ -d "$current_pointer" ]; then
+    printf '%s\n' 'build CURRENT must be a direct non-symlink file' >&2
+    exit 2
+fi
+if [ -f "$current_pointer" ]; then
+    assert_direct_file "$builds_root" "$current_pointer" 'build CURRENT'
+    current_id=$(tr -d '\r\n' < "$current_pointer")
     case "$current_id" in
         ''|*[!0-9a-f]*) current_id= ;;
     esac
@@ -107,16 +239,20 @@ if [ -f "$builds_root/CURRENT" ]; then
 fi
 valid_install=false
 if [ -n "$current_id" ]; then
-    library="$builds_root/$current_id/library"
-    provenance="$builds_root/$current_id/build-provenance.tsv"
-    if [ -f "$provenance" ] && [ -d "$library/dtaparser" ]; then
-        if Rscript --vanilla -e '
+    generation="$builds_root/$current_id"
+    library="$generation/library"
+    provenance="$generation/build-provenance.tsv"
+    package_dir="$library/dtaparser"
+    assert_direct_directory "$builds_root" "$generation" 'selected build generation'
+    assert_direct_directory "$generation" "$library" 'selected build library'
+    assert_direct_file "$generation" "$provenance" 'selected build provenance'
+    assert_direct_directory "$library" "$package_dir" 'selected dtaparser package'
+    if Rscript --vanilla -e '
             source(commandArgs(TRUE)[[1L]]); source(commandArgs(TRUE)[[2L]]);
             fertility_verify_provenance(commandArgs(TRUE)[[3L]], commandArgs(TRUE)[[4L]], commandArgs(TRUE)[[5L]])
         ' "$script_dir/common.R" "$script_dir/provenance.R" "$checkout_root" "$library" "$provenance" >/dev/null 2>&1; then
             valid_install=true
         fi
-    fi
 fi
 
 if [ "$valid_install" != true ]; then
@@ -161,11 +297,17 @@ if [ "$valid_install" != true ]; then
     ' "$script_dir/common.R" "$script_dir/provenance.R" "$checkout_root" "$staged_library" "$staged_provenance" "$tarball_sha256"
     current_id=$(Rscript --vanilla -e 'x <- read.delim(commandArgs(TRUE)[[1L]], colClasses="character", check.names=FALSE); cat(x$provenance_id[[1L]])' "$staged_provenance")
     generation="$builds_root/$current_id"
-    if [ -e "$generation" ]; then
+    assert_direct_directory "$raw_root" "$builds_root" 'builds root'
+    if [ -e "$generation" ] || [ -L "$generation" ]; then
         printf '%s\n' 'immutable corpus build generation already exists but was not reusable' >&2
         exit 1
     fi
-    mv "$staged_bundle" "$generation"
+    if [ "$(dirname -- "$generation")" != "$builds_root" ]; then
+        printf '%s\n' 'build generation escaped its canonical parent' >&2
+        exit 2
+    fi
+    atomic_move_noreplace "$staged_bundle" "$generation" \
+        'immutable corpus build generation'
     staged_bundle=
     library="$generation/library"
     provenance="$generation/build-provenance.tsv"
@@ -174,12 +316,34 @@ if [ "$valid_install" != true ]; then
     current_tmp="$run_tmp/CURRENT"
     printf '%s\n' "$current_id" > "$current_tmp"
     chmod 600 "$current_tmp"
-    mv -f "$current_tmp" "$builds_root/CURRENT"
+    assert_direct_directory "$raw_root" "$builds_root" 'builds root'
+    assert_direct_directory "$builds_root" "$generation" 'published build generation'
+    assert_direct_directory "$generation" "$library" 'published build library'
+    assert_direct_file "$generation" "$provenance" 'published build provenance'
+    assert_direct_directory "$library" "$library/dtaparser" 'published dtaparser package'
+    if [ -L "$current_pointer" ] || [ -d "$current_pointer" ]; then
+        printf '%s\n' 'build CURRENT must be a direct non-symlink file' >&2
+        exit 2
+    fi
+    [ ! -f "$current_pointer" ] || assert_direct_file "$builds_root" "$current_pointer" 'build CURRENT'
+    mv -f "$current_tmp" "$current_pointer"
+fi
+
+assert_direct_directory "$raw_root" "$builds_root" 'builds root'
+assert_direct_directory "$builds_root" "$generation" 'selected build generation'
+assert_direct_directory "$generation" "$library" 'selected build library'
+assert_direct_file "$generation" "$provenance" 'selected build provenance'
+assert_direct_directory "$library" "$library/dtaparser" 'selected dtaparser package'
+assert_direct_file "$builds_root" "$current_pointer" 'build CURRENT'
+selected_current_id=$(tr -d '\r\n' < "$current_pointer")
+if [ "$selected_current_id" != "$current_id" ]; then
+    printf '%s\n' 'selected build CURRENT changed before framework preparation' >&2
+    exit 2
 fi
 
 export DTAPARSER_FERTILITY_LIBRARY="$library"
 export DTAPARSER_FERTILITY_PROVENANCE="$provenance"
-framework_id=$(Rscript --vanilla "$script_dir/prepare.R")
+framework_id=$(Rscript --vanilla "$script_dir/prepare.R" "$@")
 export DTAPARSER_FERTILITY_FRAMEWORK_ID="$framework_id"
 if ! Rscript --vanilla "$script_dir/runtime.R" release-lock "$build_lock" "$build_lock_token"; then
     printf '%s\n' 'could not release fertility corpus build lock' >&2

--- a/benchmarks/fertility-surveys/benchmark.sh
+++ b/benchmarks/fertility-surveys/benchmark.sh
@@ -66,6 +66,7 @@ if [ "$owner_ready" != true ]; then
 fi
 Rscript --vanilla "$script_dir/runtime.R" write-temp-owner "$run_tmp" "$owner_state"
 Rscript --vanilla "$script_dir/runtime.R" clean-temp "$raw_root/tmp" "$run_tmp"
+export DTAPARSER_FERTILITY_OWNER_STATE="$owner_state"
 
 case " $* " in
     *' --inventory-only '*)
@@ -74,6 +75,10 @@ case " $* " in
         ;;
     *' --family-id='*)
         Rscript --vanilla "$script_dir/merge.R" "$@"
+        exit $?
+        ;;
+    *' --republish-framework='*)
+        Rscript --vanilla "$script_dir/republish.R" "$@"
         exit $?
         ;;
 esac
@@ -182,5 +187,4 @@ if ! Rscript --vanilla "$script_dir/runtime.R" release-lock "$build_lock" "$buil
 fi
 build_lock_token=
 
-export DTAPARSER_FERTILITY_OWNER_STATE="$owner_state"
 Rscript --vanilla "$script_dir/run.R" "$@"

--- a/benchmarks/fertility-surveys/benchmark.sh
+++ b/benchmarks/fertility-surveys/benchmark.sh
@@ -19,62 +19,87 @@ if [ "${DTAPARSER_FERTILITY_CORPUS:-}" != 'I_UNDERSTAND_THIS_READS_PROPRIETARY_D
 fi
 
 ensure_direct_directory() {
-    parent=$1
-    child=$2
-    if [ -L "$parent" ] || [ -L "$child" ] || [ ! -d "$parent" ]; then
+    ensure_direct_directory_parent=$1
+    ensure_direct_directory_child=$2
+    if [ -L "$ensure_direct_directory_parent" ] ||
+       [ -L "$ensure_direct_directory_child" ] ||
+       [ ! -d "$ensure_direct_directory_parent" ]; then
         printf '%s\n' 'fertility output paths must not contain symlinks' >&2
         exit 2
     fi
-    if [ ! -d "$child" ]; then
-        mkdir "$child"
+    if [ ! -d "$ensure_direct_directory_child" ]; then
+        mkdir "$ensure_direct_directory_child"
     fi
-    parent_canonical=$(CDPATH= cd -- "$parent" && pwd -P)
-    child_canonical=$(CDPATH= cd -- "$child" && pwd -P)
-    if [ "$child_canonical" != "$parent_canonical/$(basename -- "$child")" ]; then
+    ensure_direct_directory_parent_canonical=$(
+        CDPATH= cd -- "$ensure_direct_directory_parent" && pwd -P
+    )
+    ensure_direct_directory_child_canonical=$(
+        CDPATH= cd -- "$ensure_direct_directory_child" && pwd -P
+    )
+    if [ "$ensure_direct_directory_child_canonical" != \
+         "$ensure_direct_directory_parent_canonical/$(basename -- "$ensure_direct_directory_child")" ]; then
         printf '%s\n' 'fertility outputs must remain in the checkout-local raw root' >&2
         exit 2
     fi
 }
 
 assert_direct_directory() {
-    parent=$1
-    child=$2
-    label=$3
-    if [ -L "$parent" ] || [ -L "$child" ] || [ ! -d "$parent" ] || [ ! -d "$child" ]; then
-        printf '%s\n' "$label must be a direct non-symlink directory" >&2
+    assert_direct_directory_parent=$1
+    assert_direct_directory_child=$2
+    assert_direct_directory_label=$3
+    if [ -L "$assert_direct_directory_parent" ] ||
+       [ -L "$assert_direct_directory_child" ] ||
+       [ ! -d "$assert_direct_directory_parent" ] ||
+       [ ! -d "$assert_direct_directory_child" ]; then
+        printf '%s\n' "$assert_direct_directory_label must be a direct non-symlink directory" >&2
         exit 2
     fi
-    parent_canonical=$(CDPATH= cd -- "$parent" && pwd -P)
-    child_canonical=$(CDPATH= cd -- "$child" && pwd -P)
-    if [ "$parent_canonical" != "$parent" ] ||
-       [ "$child_canonical" != "$parent_canonical/$(basename -- "$child")" ] ||
-       [ "$(dirname -- "$child")" != "$parent" ]; then
-        printf '%s\n' "$label escaped its canonical parent" >&2
+    assert_direct_directory_parent_canonical=$(
+        CDPATH= cd -- "$assert_direct_directory_parent" && pwd -P
+    )
+    assert_direct_directory_child_canonical=$(
+        CDPATH= cd -- "$assert_direct_directory_child" && pwd -P
+    )
+    if [ "$assert_direct_directory_parent_canonical" != \
+         "$assert_direct_directory_parent" ] ||
+       [ "$assert_direct_directory_child_canonical" != \
+         "$assert_direct_directory_parent_canonical/$(basename -- "$assert_direct_directory_child")" ] ||
+       [ "$(dirname -- "$assert_direct_directory_child")" != \
+         "$assert_direct_directory_parent" ]; then
+        printf '%s\n' "$assert_direct_directory_label escaped its canonical parent" >&2
         exit 2
     fi
 }
 
 assert_direct_file() {
-    parent=$1
-    child=$2
-    label=$3
-    assert_direct_directory "$(dirname -- "$parent")" "$parent" "$label parent"
-    if [ -L "$child" ] || [ ! -f "$child" ] || [ -d "$child" ] ||
-       [ "$(dirname -- "$child")" != "$parent" ]; then
-        printf '%s\n' "$label must be a direct non-symlink file" >&2
+    assert_direct_file_parent=$1
+    assert_direct_file_child=$2
+    assert_direct_file_label=$3
+    assert_direct_directory \
+        "$(dirname -- "$assert_direct_file_parent")" \
+        "$assert_direct_file_parent" \
+        "$assert_direct_file_label parent"
+    if [ -L "$assert_direct_file_child" ] ||
+       [ ! -f "$assert_direct_file_child" ] ||
+       [ -d "$assert_direct_file_child" ] ||
+       [ "$(dirname -- "$assert_direct_file_child")" != \
+         "$assert_direct_file_parent" ]; then
+        printf '%s\n' "$assert_direct_file_label must be a direct non-symlink file" >&2
         exit 2
     fi
 }
 
 atomic_move_noreplace() {
-    source_path=$1
-    destination_path=$2
-    label=$3
+    atomic_move_noreplace_source_path=$1
+    atomic_move_noreplace_destination_path=$2
+    atomic_move_noreplace_label=$3
     command -v python3 >/dev/null 2>&1 || {
         printf '%s\n' 'python3 is required for atomic no-replace publication' >&2
         exit 1
     }
-    if python3 - "$source_path" "$destination_path" <<'PY'
+    if python3 - \
+        "$atomic_move_noreplace_source_path" \
+        "$atomic_move_noreplace_destination_path" <<'PY'
 import ctypes
 import errno
 import os
@@ -100,12 +125,13 @@ PY
     then
         return 0
     else
-        move_status=$?
-        if [ "$move_status" -eq 17 ]; then
-            printf '%s\n' "$label destination already exists" >&2
+        atomic_move_noreplace_status=$?
+        if [ "$atomic_move_noreplace_status" -eq 17 ]; then
+            printf '%s\n' "$atomic_move_noreplace_label destination already exists" >&2
             exit 2
         fi
-        printf '%s\n' "atomic no-replace publication failed for $label" >&2
+        printf '%s\n' \
+            "atomic no-replace publication failed for $atomic_move_noreplace_label" >&2
         exit 1
     fi
 }

--- a/benchmarks/fertility-surveys/common.R
+++ b/benchmarks/fertility-surveys/common.R
@@ -2,10 +2,14 @@ fertility_schema_version <- 10L
 fertility_expected_rows <- 1004L
 fertility_expected_releases <- c(`111` = 130L, `113` = 475L, `114` = 23L,
                                   `117` = 150L, `118` = 226L)
-fertility_supported_releases <- c(113L, 114L, 117L, 118L)
-fertility_programs <- c("dhs", "mics", "wfs", "nsfg", "enadid")
-fertility_levels <- c("women", "births")
+fertility_supported_releases <- c(113L, 114L, 115L, 117L, 118L)
+fertility_programs <- c("dhs", "mics", "wfs", "nsfg", "enadid", "output")
+fertility_levels <- c("women", "births", "survey", "aggregate")
 fertility_opt_in_value <- "I_UNDERSTAND_THIS_READS_PROPRIETARY_DATA"
+fertility_output_root <- "/Users/jmb/repos/fertility_surveys/output"
+fertility_output_expected_files <- 1226L
+fertility_output_expected_bytes <- 70748321626
+fertility_output_expected_largest <- 10332252930
 
 fertility_script_path <- function() {
     argument <- grep("^--file=", commandArgs(trailingOnly = FALSE), value = TRUE)
@@ -611,12 +615,156 @@ fertility_assert_manual_run <- function() {
     }
 }
 
-fertility_required_paths <- function() {
+fertility_output_requested <- function(options) {
+    !is.null(options$output_root) && nzchar(options$output_root)
+}
+
+fertility_assert_output_root <- function(path) {
+    if (!identical(path, fertility_output_root)) {
+        stop("--output-root must be exactly ", fertility_output_root)
+    }
+    root <- fertility_assert_canonical_components(path, "fertility output root")
+    if (!dir.exists(root) || fertility_path_is_symlink(root)) {
+        stop("fertility output root must be a canonical non-symlink directory")
+    }
+    root
+}
+
+fertility_output_entries <- function(root) {
+    root <- fertility_assert_output_root(root)
+    paths <- character()
+    walk <- function(parent) {
+        entries <- sort(list.files(
+            parent, all.files = TRUE, no.. = TRUE, full.names = TRUE,
+            recursive = FALSE, include.dirs = TRUE
+        ), method = "radix")
+        for (entry in entries) {
+            if (!identical(dirname(entry), parent) || fertility_path_is_symlink(entry)) {
+                next
+            }
+            info <- file.info(entry)
+            if (nrow(info) != 1L || is.na(info$isdir[[1L]])) next
+            if (isTRUE(info$isdir[[1L]])) {
+                walk(normalizePath(entry, winslash = "/", mustWork = TRUE))
+            } else if (isTRUE(file_test("-f", entry)) &&
+                       grepl("[.]dta$", basename(entry), ignore.case = TRUE)) {
+                resolved <- normalizePath(entry, winslash = "/", mustWork = TRUE)
+                if (!startsWith(resolved, paste0(root, "/"))) {
+                    stop("fertility output DTA escaped its root")
+                }
+                paths <<- c(paths, resolved)
+            }
+        }
+    }
+    walk(root)
+    sort(paths, method = "radix")
+}
+
+fertility_output_stat_manifest <- function(root) {
+    paths <- fertility_output_entries(root)
+    info <- file.info(paths)
+    relative <- substring(paths, nchar(root) + 2L)
+    if (!length(paths) || anyNA(info$size) || anyDuplicated(relative) ||
+        any(!nzchar(relative))) stop("fertility output inventory is invalid")
+    result <- data.frame(
+        relative_path = relative,
+        size = as.character(info$size),
+        modified = format(info$mtime, "%Y-%m-%dT%H:%M:%OS6Z", tz = "UTC"),
+        stringsAsFactors = FALSE, check.names = FALSE
+    )
+    rownames(result) <- NULL
+    result
+}
+
+fertility_validate_output_baseline <- function(manifest) {
+    sizes <- suppressWarnings(as.double(manifest$size))
+    if (nrow(manifest) != fertility_output_expected_files || anyNA(sizes) ||
+        sum(sizes) != fertility_output_expected_bytes ||
+        max(sizes) != fertility_output_expected_largest) {
+        stop(sprintf(
+            paste0("fertility output baseline drift: expected %d files, %.0f bytes, ",
+                   "largest %.0f bytes; observed %d files, %.0f bytes, largest %.0f bytes"),
+            fertility_output_expected_files, fertility_output_expected_bytes,
+            fertility_output_expected_largest, nrow(manifest), sum(sizes), max(sizes)
+        ))
+    }
+    invisible(TRUE)
+}
+
+fertility_output_inventory_path <- function(raw_root) {
+    directory <- fertility_assert_output_parent(
+        raw_root, "output-inventory", "wave3", create = TRUE
+    )
+    file.path(directory, "inventory.rds")
+}
+
+fertility_build_output_inventory <- function(root, raw_root) {
+    root <- fertility_assert_output_root(root)
+    manifest <- fertility_output_stat_manifest(root)
+    fertility_validate_output_baseline(manifest)
+    path <- fertility_output_inventory_path(raw_root)
+    frozen <- if (file.exists(path)) readRDS(fertility_assert_existing_file(
+        path, dirname(path), "frozen output inventory"
+    )) else NULL
+    if (is.null(frozen)) {
+        paths <- file.path(root, manifest$relative_path)
+        hashes <- vapply(paths, fertility_file_sha512, character(1))
+        after <- fertility_output_stat_manifest(root)
+        fertility_validate_output_baseline(after)
+        if (!identical(manifest, after)) stop("fertility output changed during inventory")
+        releases <- vapply(paths, fertility_release, integer(1))
+        frozen <- list(
+            schema_version = 1L,
+            root_identity = fertility_filesystem_identity(root, "fertility output root"),
+            manifest = transform(manifest, release = releases, sha512 = hashes),
+            created_at_utc = format(Sys.time(), "%Y-%m-%dT%H:%M:%SZ", tz = "UTC")
+        )
+        fertility_atomic_save_rds(frozen, path)
+    }
+    if (is.list(frozen) && is.data.frame(frozen$manifest)) {
+        rownames(frozen$manifest) <- NULL
+    }
+    expected_names <- c("relative_path", "size", "modified", "release", "sha512")
+    if (!is.list(frozen) || !identical(frozen$schema_version, 1L) ||
+        !identical(names(frozen$manifest), expected_names) ||
+        !identical(frozen$root_identity,
+                   fertility_filesystem_identity(root, "fertility output root")) ||
+        !identical(frozen$manifest[c("relative_path", "size", "modified")], manifest) ||
+        any(!grepl("^[0-9a-f]{128}$", frozen$manifest$sha512)) ||
+        any(!(frozen$manifest$release %in% c(111L, fertility_supported_releases)))) {
+        stop("frozen fertility output inventory changed or is invalid")
+    }
+    paths <- file.path(root, frozen$manifest$relative_path)
+    level <- ifelse(!grepl("/", frozen$manifest$relative_path, fixed = TRUE),
+                    "aggregate", "survey")
+    inventory <- data.frame(
+        id = sprintf("F%04d", seq_len(nrow(frozen$manifest))),
+        program = "output", level = level,
+        release = as.integer(frozen$manifest$release), path = paths,
+        expected_sha512 = frozen$manifest$sha512,
+        stringsAsFactors = FALSE, check.names = FALSE
+    )
+    attr(inventory, "authority_path") <- path
+    inventory
+}
+
+fertility_required_paths <- function(options = NULL, raw_root = NULL) {
+    if (!is.null(options) && fertility_output_requested(options)) {
+        if (is.null(raw_root)) stop("raw root is required for output inventory authority")
+        return(list(output = fertility_assert_output_root(options$output_root),
+                    datasigs = fertility_output_inventory_path(raw_root)))
+    }
     home <- normalizePath("~", winslash = "/", mustWork = TRUE)
     list(
         cache = "/opt/aww_cache",
         datasigs = file.path(home, "repos", "fertility_surveys", "datasigs.csv")
     )
+}
+
+fertility_build_selected_inventory <- function(options, raw_root) {
+    if (fertility_output_requested(options)) {
+        fertility_build_output_inventory(options$output_root, raw_root)
+    } else fertility_build_inventory()
 }
 
 fertility_atomic_save_rds <- function(value, path) {
@@ -704,7 +852,7 @@ fertility_structural_metadata <- function(path) {
     on.exit(close(connection), add = TRUE)
     bytes <- readBin(connection, "raw", n = 4L * 1024L * 1024L)
     release <- fertility_release(path)
-    if (release %in% c(113L, 114L)) {
+    if (release %in% c(113L, 114L, 115L)) {
         if (length(bytes) < 109L) stop("legacy DTA header is truncated")
         byteorder <- if (as.integer(bytes[[2L]]) == 1L) "MSF" else "LSF"
         columns <- fertility_raw_uint(bytes, 5L, 2L, byteorder)

--- a/benchmarks/fertility-surveys/common.R
+++ b/benchmarks/fertility-surveys/common.R
@@ -1,4 +1,4 @@
-fertility_schema_version <- 10L
+fertility_schema_version <- 11L
 fertility_expected_rows <- 1004L
 fertility_expected_releases <- c(`111` = 130L, `113` = 475L, `114` = 23L,
                                   `117` = 150L, `118` = 226L)
@@ -681,7 +681,7 @@ fertility_output_descriptor_manifest <- function(root, include_content = FALSE) 
         "    if not head: fail()",
         "    if head.startswith(b'<stata_dta>'):",
         "        marker=b'<release>'; start=head.find(marker)",
-        "        if start < 0: fail()",
+        "        if start < 0 or head.find(marker,start+1) >= 0: fail()",
         "        value=head[start+len(marker):start+len(marker)+3]",
         "        if len(value) != 3 or not value.isdigit(): fail()",
         "        return value.decode('ascii')",
@@ -818,7 +818,7 @@ fertility_nofollow_file_capture <- function(path, include_release = FALSE) {
         "        if not head: raise RuntimeError('empty DTA input')",
         "        if head.startswith(b'<stata_dta>'):",
         "            marker=b'<release>'; start=head.find(marker)",
-        "            if start < 0: raise RuntimeError('release missing')",
+        "            if start < 0 or head.find(marker,start+1) >= 0: raise RuntimeError('release missing or ambiguous')",
         "            value=head[start+len(marker):start+len(marker)+3]",
         "            if len(value) != 3 or not value.isdigit(): raise RuntimeError('release invalid')",
         "            fields.append(value.decode('ascii'))",
@@ -955,6 +955,12 @@ fertility_output_metadata_equal <- function(left, right) {
         nrow(left) != nrow(right) ||
         !identical(left$relative_path, right$relative_path) ||
         !identical(left$size, right$size)) return(FALSE)
+    timestamp <- paste0(
+        "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:",
+        "[0-9]{2}[.][0-9]{6}Z$"
+    )
+    if (any(!grepl(timestamp, left$modified)) ||
+        any(!grepl(timestamp, right$modified))) return(FALSE)
     left_time <- suppressWarnings(as.numeric(as.POSIXct(
         sub("Z$", "", left$modified), format = "%Y-%m-%dT%H:%M:%OS", tz = "UTC"
     )))

--- a/benchmarks/fertility-surveys/common.R
+++ b/benchmarks/fertility-surveys/common.R
@@ -4,7 +4,9 @@ fertility_expected_releases <- c(`111` = 130L, `113` = 475L, `114` = 23L,
                                   `117` = 150L, `118` = 226L)
 fertility_supported_releases <- c(113L, 114L, 115L, 117L, 118L)
 fertility_programs <- c("dhs", "mics", "wfs", "nsfg", "enadid", "output")
-fertility_levels <- c("women", "births", "survey", "aggregate")
+fertility_cache_levels <- c("women", "births")
+fertility_output_levels <- c("survey", "aggregate")
+fertility_levels <- c(fertility_cache_levels, fertility_output_levels)
 fertility_opt_in_value <- "I_UNDERSTAND_THIS_READS_PROPRIETARY_DATA"
 fertility_output_root <- "/Users/jmb/repos/fertility_surveys/output"
 fertility_output_expected_files <- 1226L
@@ -1401,7 +1403,9 @@ fertility_build_inventory <- function(paths = fertility_required_paths(),
         if (!(program %in% fertility_programs) || !(program %in% names(path1))) {
             stop("datasigs.csv contains an unknown program")
         }
-        if (!(level %in% fertility_levels)) stop("datasigs.csv contains an unknown level")
+        if (!(level %in% fertility_cache_levels)) {
+            stop("datasigs.csv contains an unknown cache level")
+        }
         folder <- if (identical(program, "wfs")) "" else
             gsub("_", ",", rows$survey[[i]], fixed = TRUE)
         filename <- if (identical(program, "wfs")) {

--- a/benchmarks/fertility-surveys/common.R
+++ b/benchmarks/fertility-surveys/common.R
@@ -238,13 +238,6 @@ fertility_filesystem_identity <- function(path, label) {
     output[[1L]]
 }
 
-fertility_identity_is_regular_file <- function(identity) {
-    fields <- strsplit(identity, ":", fixed = TRUE)[[1L]]
-    length(fields) == 3L && !is.na(mode <- suppressWarnings(
-        as.integer(fields[[3L]])
-    )) && bitwAnd(mode, 61440L) == 32768L
-}
-
 fertility_atomic_rename_noreplace <- function(
     from, to, label, validate_source = NULL
 ) {
@@ -643,6 +636,65 @@ fertility_output_inventory_test_hook <- function(boundary, context) {
     invisible(NULL)
 }
 
+fertility_output_regular_entries <- function(root) {
+    python <- Sys.which("python3")
+    if (!nzchar(python)) stop("python3 is required for output inventory")
+    code <- paste(
+        "import os, stat, sys",
+        "def fail():",
+        "    raise RuntimeError('unsafe output inventory entry')",
+        "def walk(parent):",
+        "    try:",
+        "        with os.scandir(parent) as iterator:",
+        "            entries = sorted(list(iterator), key=lambda value: os.fsencode(value.name))",
+        "    except OSError:",
+        "        fail()",
+        "    for entry in entries:",
+        "        is_dta = entry.name.lower().endswith('.dta')",
+        "        try:",
+        "            mode = entry.stat(follow_symlinks=False).st_mode",
+        "        except OSError:",
+        "            fail()",
+        "        if stat.S_ISLNK(mode):",
+        "            try:",
+        "                linked_directory = entry.is_dir(follow_symlinks=True)",
+        "            except OSError:",
+        "                linked_directory = False",
+        "            if linked_directory or is_dta:",
+        "                fail()",
+        "            continue",
+        "        if stat.S_ISDIR(mode):",
+        "            walk(entry.path)",
+        "        elif is_dta:",
+        "            if not stat.S_ISREG(mode):",
+        "                fail()",
+        "            print(os.fsencode(entry.path).hex())",
+        "walk(sys.argv[1])",
+        sep = "\n"
+    )
+    output <- suppressWarnings(system2(
+        python, c("-c", shQuote(code), shQuote(root)),
+        stdout = TRUE, stderr = FALSE
+    ))
+    status <- attr(output, "status", exact = TRUE)
+    if (!is.null(status) && status != 0L) {
+        stop("fertility output inventory could not attest regular files")
+    }
+    decode <- function(value) {
+        if (!nzchar(value) || nchar(value) %% 2L != 0L ||
+            !grepl("^[0-9a-f]+$", value)) {
+            stop("fertility output regular-file attestation is malformed")
+        }
+        starts <- seq.int(1L, nchar(value), by = 2L)
+        bytes <- suppressWarnings(strtoi(substring(value, starts, starts + 1L), 16L))
+        if (anyNA(bytes)) stop("fertility output regular-file attestation is malformed")
+        result <- rawToChar(as.raw(bytes))
+        Encoding(result) <- "UTF-8"
+        result
+    }
+    unname(sort(vapply(output, decode, character(1)), method = "radix"))
+}
+
 fertility_output_entries <- function(root) {
     root <- fertility_assert_output_root(root)
     paths <- character()
@@ -701,12 +753,6 @@ fertility_output_entries <- function(root) {
             if (isTRUE(confirmed$isdir[[1L]])) {
                 walk(entry)
             } else if (is_dta) {
-                identity <- fertility_filesystem_identity(
-                    entry, "fertility output DTA"
-                )
-                if (!fertility_identity_is_regular_file(identity)) {
-                    stop("fertility output DTA must be a regular file")
-                }
                 if (!startsWith(entry, paste0(root, "/"))) {
                     stop("fertility output DTA escaped its root")
                 }
@@ -715,7 +761,12 @@ fertility_output_entries <- function(root) {
         }
     }
     walk(root)
-    sort(paths, method = "radix")
+    paths <- sort(paths, method = "radix")
+    attested <- fertility_output_regular_entries(root)
+    if (!identical(paths, attested)) {
+        stop("fertility output inventory changed during regular-file attestation")
+    }
+    paths
 }
 
 fertility_output_stat_manifest <- function(root) {

--- a/benchmarks/fertility-surveys/common.R
+++ b/benchmarks/fertility-surveys/common.R
@@ -1,4 +1,4 @@
-fertility_schema_version <- 11L
+fertility_schema_version <- 12L
 fertility_expected_rows <- 1004L
 fertility_expected_releases <- c(`111` = 130L, `113` = 475L, `114` = 23L,
                                   `117` = 150L, `118` = 226L)
@@ -733,14 +733,32 @@ fertility_output_descriptor_manifest <- function(root, include_content = FALSE) 
         "            if not stat.S_ISREG(before.st_mode): fail()",
         "            attest(parent_fd,name,path,before)",
         "    if identity(os.fstat(parent_fd)) != identity(parent_before): fail()",
-        "root_expected=os.lstat(root)",
-        "try: root_fd=os.open(root,dir_flags)",
+        "parts=[part for part in root.split(b'/') if part]",
+        "root_chain=[]; descriptors=[]",
+        "filesystem_root_expected=os.lstat(b'/')",
+        "try: filesystem_root_fd=os.open(b'/',dir_flags)",
         "except OSError: fail()",
+        "descriptors.append(filesystem_root_fd)",
+        "if identity(os.fstat(filesystem_root_fd)) != identity(filesystem_root_expected): fail()",
+        "parent_fd=filesystem_root_fd",
         "try:",
-        "    if identity(os.fstat(root_fd)) != identity(root_expected): fail()",
+        "    for part in parts:",
+        "        expected=os.stat(part,dir_fd=parent_fd,follow_symlinks=False)",
+        "        if not stat.S_ISDIR(expected.st_mode): fail()",
+        "        child_fd=os.open(part,dir_flags,dir_fd=parent_fd); descriptors.append(child_fd)",
+        "        if identity(os.fstat(child_fd)) != identity(expected): fail()",
+        "        root_chain.append((parent_fd,part,child_fd,expected)); parent_fd=child_fd",
+        "    root_fd=parent_fd; root_expected=os.fstat(root_fd)",
         "    walk(root_fd,root)",
-        "    if identity(os.fstat(root_fd)) != identity(root_expected) or identity(os.lstat(root)) != identity(root_expected): fail()",
-        "finally: os.close(root_fd)",
+        "    if identity(os.fstat(root_fd)) != identity(root_expected): fail()",
+        "    for ancestor_fd,part,child_fd,ancestor_expected in reversed(root_chain):",
+        "        current=os.stat(part,dir_fd=ancestor_fd,follow_symlinks=False)",
+        "        if identity(os.fstat(child_fd)) != identity(ancestor_expected) or identity(current) != identity(ancestor_expected): fail()",
+        "    if identity(os.fstat(filesystem_root_fd)) != identity(filesystem_root_expected) or identity(os.lstat(b'/')) != identity(filesystem_root_expected): fail()",
+        "finally:",
+        "    for descriptor in reversed(descriptors):",
+        "        try: os.close(descriptor)",
+        "        except OSError: pass",
         sep = "\n"
     )
     output <- suppressWarnings(system2(
@@ -883,6 +901,110 @@ fertility_nofollow_file_capture <- function(path, include_release = FALSE) {
         release = if (include_release) suppressWarnings(as.integer(fields[[9L]])) else
             NULL
     )
+}
+
+fertility_open_bound_input_connection <- function(path, input) {
+    if (!requireNamespace("processx", quietly = TRUE)) stop("processx is required")
+    required <- c("device", "inode", "mode", "size", "modified_ns", "changed_ns")
+    if (!is.list(input) || any(!required %in% names(input)) ||
+        any(vapply(input[required], function(value) {
+            !is.character(value) || length(value) != 1L || is.na(value) ||
+                !grepl("^[0-9]+$", value)
+        }, logical(1)))) stop("bound input identity is invalid")
+    path <- fertility_assert_existing_file(path, dirname(path), "bound worker input")
+    connection <- processx::conn_create_file(path, read = TRUE, write = FALSE)
+    close_connection <- TRUE
+    on.exit(if (close_connection) {
+        try(processx::processx_conn_close(connection), silent = TRUE)
+    }, add = TRUE)
+    python <- Sys.which("python3")
+    if (!nzchar(python)) stop("python3 is required for bound worker input")
+    code <- paste(
+        "import os,sys",
+        "value=os.fstat(3)",
+        "print('\\t'.join(str(part) for part in (value.st_dev,value.st_ino,value.st_mode,value.st_size,value.st_mtime_ns,value.st_ctime_ns)))",
+        sep = "\n"
+    )
+    observed <- tryCatch(processx::run(
+        python, c("-c", code), stdout = "|", stderr = "|",
+        connections = list(connection), poll_connection = FALSE,
+        error_on_status = FALSE
+    ), error = function(error) NULL)
+    fields <- if (is.list(observed) && identical(observed$status, 0L)) {
+        strsplit(trimws(observed$stdout), "\t", fixed = TRUE)[[1L]]
+    } else character()
+    if (length(fields) != length(required) ||
+        !identical(unname(fields), unname(unlist(input[required], use.names = FALSE)))) {
+        stop("bound worker input does not match captured identity")
+    }
+    close_connection <- FALSE
+    connection
+}
+
+fertility_close_bound_input_connection <- function(connection) {
+    if (!is.null(connection)) {
+        try(processx::processx_conn_close(connection), silent = TRUE)
+    }
+    invisible(NULL)
+}
+
+fertility_bound_input_path <- function() "/dev/fd/3"
+
+fertility_materialize_bound_input <- function(path, input, raw_root) {
+    if (!identical(path, fertility_bound_input_path())) {
+        stop("bound worker input path is invalid")
+    }
+    invisible(fertility_assert_tempdir(raw_root))
+    required <- c("device", "inode", "mode", "size", "modified_ns", "changed_ns")
+    if (!is.list(input) || any(!required %in% names(input)) ||
+        any(vapply(input[required], function(value) {
+            !is.character(value) || length(value) != 1L || is.na(value) ||
+                !grepl("^[0-9]+$", value)
+        }, logical(1)))) stop("bound worker input identity is invalid")
+    destination <- tempfile(
+        "bound-worker-input-", tmpdir = Sys.getenv("TMPDIR"), fileext = ".dta"
+    )
+    on.exit(if (file.exists(destination) || fertility_path_is_symlink(destination)) {
+        unlink(destination)
+    }, add = TRUE)
+    python <- Sys.which("python3")
+    if (!nzchar(python)) stop("python3 is required for bound worker input")
+    code <- paste(
+        "import ctypes,os,stat,sys",
+        "destination=os.fsencode(sys.argv[1]); expected=tuple(int(value) for value in sys.argv[2:])",
+        "def identity(value): return (value.st_dev,value.st_ino,value.st_mode,value.st_size,value.st_mtime_ns,value.st_ctime_ns)",
+        "before=os.fstat(3)",
+        "if identity(before) != expected or not stat.S_ISREG(before.st_mode): sys.exit(17)",
+        "libc=ctypes.CDLL(None,use_errno=True); clone=getattr(libc,'fclonefileat',None)",
+        "if clone is None: sys.exit(18)",
+        "clone.argtypes=[ctypes.c_int,ctypes.c_int,ctypes.c_char_p,ctypes.c_uint]",
+        "if clone(3,-2,destination,0) != 0: sys.exit(19)",
+        "after=os.fstat(3); copied=os.lstat(destination)",
+        "if identity(after) != identity(before) or not stat.S_ISREG(copied.st_mode) or copied.st_size != before.st_size: sys.exit(20)",
+        sep = "\n"
+    )
+    status <- suppressWarnings(system2(
+        python, c("-c", shQuote(code), shQuote(destination),
+                  unname(unlist(input[required], use.names = FALSE))),
+        stdout = FALSE, stderr = FALSE
+    ))
+    if (!identical(status, 0L) || !file.exists(destination) ||
+        dir.exists(destination) || fertility_path_is_symlink(destination) ||
+        !isTRUE(file_test("-f", destination))) {
+        stop("could not materialize descriptor-bound worker input")
+    }
+    destination <- normalizePath(destination, winslash = "/", mustWork = TRUE)
+    on.exit(NULL, add = FALSE)
+    destination
+}
+
+fertility_reset_bound_input <- function(path) {
+    if (!is.character(path) || length(path) != 1L || is.na(path) ||
+        !grepl("^/dev/fd/[0-9]+$", path)) return(invisible(FALSE))
+    connection <- file(path, open = "rb")
+    on.exit(close(connection), add = TRUE)
+    seek(connection, where = 0, origin = "start")
+    invisible(TRUE)
 }
 
 fertility_output_entries <- function(root) {
@@ -1135,6 +1257,7 @@ fertility_atomic_write_table <- function(value, path) {
 
 fertility_file_sha512 <- function(path) {
     if (!requireNamespace("openssl", quietly = TRUE)) stop("openssl is required")
+    fertility_reset_bound_input(path)
     unname(unclass(tolower(as.character(openssl::sha512(file(path))))))
 }
 
@@ -1150,6 +1273,7 @@ fertility_stable_id <- function(fields) {
 }
 
 fertility_release <- function(path) {
+    fertility_reset_bound_input(path)
     connection <- file(path, open = "rb")
     on.exit(close(connection), add = TRUE)
     bytes <- readBin(connection, "raw", n = 256L)
@@ -1191,6 +1315,7 @@ fertility_raw_uint <- function(bytes, start, size, byteorder) {
 }
 
 fertility_structural_metadata <- function(path) {
+    fertility_reset_bound_input(path)
     connection <- file(path, open = "rb")
     on.exit(close(connection), add = TRUE)
     bytes <- readBin(connection, "raw", n = 4L * 1024L * 1024L)

--- a/benchmarks/fertility-surveys/common.R
+++ b/benchmarks/fertility-surveys/common.R
@@ -499,12 +499,72 @@ fertility_revalidate_current_bundle <- function(
     current
 }
 
+fertility_probe_current_bundle_family <- function(parent, label) {
+    parent <- fertility_assert_canonical_components(parent, paste(label, "parent"))
+    if (!dir.exists(parent)) stop(label, " parent must be an existing directory")
+    pointer <- fertility_assert_existing_file(
+        file.path(parent, "CURRENT"), parent, paste(label, "CURRENT pointer")
+    )
+    if (!file_test("-f", pointer)) {
+        stop(label, " CURRENT pointer must be a regular file")
+    }
+    run_name <- tryCatch(
+        readLines(pointer, warn = FALSE, n = 1L),
+        error = function(error) character()
+    )
+    if (length(run_name) != 1L || !grepl("^[A-Za-z0-9._-]+$", run_name)) {
+        stop(label, " CURRENT pointer is invalid")
+    }
+    bundle <- fertility_assert_direct_child(
+        file.path(parent, run_name), parent, paste(label, "bundle"),
+        must_work = FALSE
+    )
+    if (fertility_path_is_symlink(bundle)) {
+        stop(label, " bundle must not be a symlink")
+    }
+    if (!dir.exists(bundle)) {
+        if (file.exists(bundle)) stop(label, " bundle must be a directory")
+        return(NULL)
+    }
+    bundle <- fertility_assert_existing_directory(
+        bundle, parent, paste(label, "bundle")
+    )
+    provenance_path <- fertility_assert_direct_child(
+        file.path(bundle, "run-provenance.tsv"), bundle,
+        paste(label, "provenance"), must_work = FALSE
+    )
+    if (fertility_path_is_symlink(provenance_path)) {
+        stop(label, " provenance must not be a symlink")
+    }
+    if (!file.exists(provenance_path)) {
+        if (dir.exists(provenance_path)) {
+            stop(label, " provenance must be a regular file")
+        }
+        return(NULL)
+    }
+    provenance_path <- fertility_assert_existing_file(
+        provenance_path, bundle, paste(label, "provenance")
+    )
+    if (!file_test("-f", provenance_path)) {
+        stop(label, " provenance must be a regular file")
+    }
+    provenance <- tryCatch(read.delim(
+        provenance_path, colClasses = "character", check.names = FALSE
+    ), error = function(error) NULL)
+    if (is.null(provenance) || nrow(provenance) != 1L ||
+        !"family_id" %in% names(provenance)) return(NULL)
+    list(run_name = run_name, family_id = provenance$family_id[[1L]])
+}
+
 fertility_current_bundle_paths <- function(parent, files, label) {
     parent <- fertility_assert_canonical_components(parent, paste(label, "parent"))
     if (!dir.exists(parent)) stop(label, " parent must be an existing directory")
     pointer <- fertility_assert_existing_file(
         file.path(parent, "CURRENT"), parent, paste(label, "CURRENT pointer")
     )
+    if (!file_test("-f", pointer)) {
+        stop(label, " CURRENT pointer must be a regular file")
+    }
     run_name <- tryCatch(
         readLines(pointer, warn = FALSE, n = 1L),
         error = function(error) character()
@@ -520,8 +580,21 @@ fertility_current_bundle_paths <- function(parent, files, label) {
         paths[[index]] <- fertility_assert_existing_file(
             paths[[index]], bundle, paste(label, names(paths)[[index]])
         )
+        if (!file_test("-f", paths[[index]])) {
+            stop(label, " ", names(paths)[[index]], " must be a regular file")
+        }
     }
     list(bundle = bundle, paths = paths, run_name = run_name)
+}
+
+fertility_current_bundle_for_family <- function(
+    parent, family_id, files, label
+) {
+    probe <- fertility_probe_current_bundle_family(parent, label)
+    if (is.null(probe) || !identical(probe$family_id, family_id)) return(NULL)
+    fertility_revalidate_current_bundle(
+        parent, probe$run_name, files, label
+    )
 }
 
 fertility_assert_manual_run <- function() {

--- a/benchmarks/fertility-surveys/common.R
+++ b/benchmarks/fertility-surveys/common.R
@@ -12,6 +12,7 @@ fertility_output_root <- "/Users/jmb/repos/fertility_surveys/output"
 fertility_output_expected_files <- 1226L
 fertility_output_expected_bytes <- 70748321626
 fertility_output_expected_largest <- 10332252930
+fertility_output_inventory_schema_version <- 2L
 
 fertility_script_path <- function() {
     argument <- grep("^--file=", commandArgs(trailingOnly = FALSE), value = TRUE)
@@ -952,7 +953,8 @@ fertility_close_bound_input_connection <- function(connection) {
 
 fertility_bound_input_path <- function() "/dev/fd/3"
 
-fertility_materialize_bound_input <- function(path, input, raw_root) {
+fertility_materialize_bound_input <- function(path, input, raw_root,
+                                              destination = NULL) {
     if (!identical(path, fertility_bound_input_path())) {
         stop("bound worker input path is invalid")
     }
@@ -963,9 +965,20 @@ fertility_materialize_bound_input <- function(path, input, raw_root) {
             !is.character(value) || length(value) != 1L || is.na(value) ||
                 !grepl("^[0-9]+$", value)
         }, logical(1)))) stop("bound worker input identity is invalid")
-    destination <- tempfile(
-        "bound-worker-input-", tmpdir = Sys.getenv("TMPDIR"), fileext = ".dta"
-    )
+    temporary <- normalizePath(Sys.getenv("TMPDIR"), winslash = "/", mustWork = TRUE)
+    if (is.null(destination)) {
+        destination <- tempfile(
+            "bound-worker-input-", tmpdir = temporary, fileext = ".dta"
+        )
+    } else {
+        destination <- path.expand(destination)
+        if (!is.character(destination) || length(destination) != 1L ||
+            is.na(destination) || !identical(dirname(destination), temporary) ||
+            file.exists(destination) || dir.exists(destination) ||
+            fertility_path_is_symlink(destination)) {
+            stop("bound worker snapshot destination is invalid")
+        }
+    }
     on.exit(if (file.exists(destination) || fertility_path_is_symlink(destination)) {
         unlink(destination)
     }, add = TRUE)
@@ -1157,6 +1170,17 @@ fertility_build_output_inventory <- function(root, raw_root) {
     frozen <- if (file.exists(path)) readRDS(fertility_assert_existing_file(
         path, dirname(path), "frozen output inventory"
     )) else NULL
+    if (is.list(frozen) && identical(frozen$schema_version, 1L)) {
+        superseded <- file.path(dirname(path), "inventory-schema1.rds")
+        if (file.exists(superseded) || dir.exists(superseded) ||
+            fertility_path_is_symlink(superseded)) {
+            stop("superseded output inventory destination already exists")
+        }
+        fertility_atomic_rename_noreplace(
+            path, superseded, "superseded output inventory"
+        )
+        frozen <- NULL
+    }
     if (is.null(frozen)) {
         content <- fertility_output_descriptor_manifest(root, TRUE)
         content_manifest <- data.frame(
@@ -1172,12 +1196,12 @@ fertility_build_output_inventory <- function(root, raw_root) {
         )
         after <- fertility_output_descriptor_manifest(root, FALSE)
         fertility_validate_output_baseline(content_manifest)
-        if (!identical(manifest, content_manifest) ||
+        if (!fertility_output_metadata_equal(manifest, content_manifest) ||
             !identical(content[identity_fields], after[identity_fields])) {
             stop("fertility output changed during descriptor-bound inventory")
         }
         frozen <- list(
-            schema_version = 1L,
+            schema_version = fertility_output_inventory_schema_version,
             root_identity = fertility_filesystem_identity(root, "fertility output root"),
             manifest = transform(
                 content_manifest, release = content$release, sha512 = content$sha512
@@ -1190,7 +1214,9 @@ fertility_build_output_inventory <- function(root, raw_root) {
         rownames(frozen$manifest) <- NULL
     }
     expected_names <- c("relative_path", "size", "modified", "release", "sha512")
-    if (!is.list(frozen) || !identical(frozen$schema_version, 1L) ||
+    if (!is.list(frozen) || !identical(
+            frozen$schema_version, fertility_output_inventory_schema_version
+        ) ||
         !identical(names(frozen$manifest), expected_names) ||
         !identical(frozen$root_identity,
                    fertility_filesystem_identity(root, "fertility output root")) ||

--- a/benchmarks/fertility-surveys/common.R
+++ b/benchmarks/fertility-surveys/common.R
@@ -1,8 +1,10 @@
-fertility_schema_version <- 6L
+fertility_schema_version <- 10L
 fertility_expected_rows <- 1004L
 fertility_expected_releases <- c(`111` = 130L, `113` = 475L, `114` = 23L,
                                   `117` = 150L, `118` = 226L)
 fertility_supported_releases <- c(113L, 114L, 117L, 118L)
+fertility_programs <- c("dhs", "mics", "wfs", "nsfg", "enadid")
+fertility_levels <- c("women", "births")
 fertility_opt_in_value <- "I_UNDERSTAND_THIS_READS_PROPRIETARY_DATA"
 
 fertility_script_path <- function() {
@@ -200,8 +202,10 @@ fertility_build_inventory <- function(paths = fertility_required_paths(),
     for (i in seq_len(nrow(rows))) {
         program <- tolower(rows$program[[i]])
         level <- tolower(rows$level[[i]])
-        if (!(program %in% names(path1))) stop("datasigs.csv contains an unknown program")
-        if (!(level %in% c("women", "births"))) stop("datasigs.csv contains an unknown level")
+        if (!(program %in% fertility_programs) || !(program %in% names(path1))) {
+            stop("datasigs.csv contains an unknown program")
+        }
+        if (!(level %in% fertility_levels)) stop("datasigs.csv contains an unknown level")
         folder <- if (identical(program, "wfs")) "" else
             gsub("_", ",", rows$survey[[i]], fixed = TRUE)
         filename <- if (identical(program, "wfs")) {

--- a/benchmarks/fertility-surveys/common.R
+++ b/benchmarks/fertility-surveys/common.R
@@ -672,11 +672,11 @@ fertility_output_descriptor_manifest <- function(root, include_content = FALSE) 
     code <- paste(
         "import hashlib, os, stat, sys",
         "root=os.fsencode(sys.argv[1]); include_content=sys.argv[2] == '1'",
-        "flags=os.O_RDONLY | getattr(os, 'O_CLOEXEC', 0) | getattr(os, 'O_NOFOLLOW', 0)",
-        "def fail():",
-        "    raise RuntimeError('unsafe output inventory entry')",
+        "base_flags=os.O_RDONLY | getattr(os,'O_CLOEXEC',0) | getattr(os,'O_NOFOLLOW',0)",
+        "file_flags=base_flags; dir_flags=base_flags | getattr(os,'O_DIRECTORY',0)",
+        "def fail(): raise RuntimeError('unsafe output inventory entry')",
         "def identity(value):",
-        "    return (value.st_dev,value.st_ino,value.st_mode,value.st_size,value.st_mtime_ns)",
+        "    return (value.st_dev,value.st_ino,value.st_mode,value.st_size,value.st_mtime_ns,value.st_ctime_ns)",
         "def release(head):",
         "    if not head: fail()",
         "    if head.startswith(b'<stata_dta>'):",
@@ -686,16 +686,13 @@ fertility_output_descriptor_manifest <- function(root, include_content = FALSE) 
         "        if len(value) != 3 or not value.isdigit(): fail()",
         "        return value.decode('ascii')",
         "    return str(head[0])",
-        "def attest(path):",
-        "    try:",
-        "        fd=os.open(path,flags)",
-        "    except OSError:",
-        "        fail()",
+        "def attest(parent_fd,name,path,expected):",
+        "    try: fd=os.open(name,file_flags,dir_fd=parent_fd)",
+        "    except OSError: fail()",
         "    try:",
         "        before=os.fstat(fd)",
-        "        if not stat.S_ISREG(before.st_mode): fail()",
-        "        linked=os.lstat(path)",
-        "        if identity(linked) != identity(before): fail()",
+        "        if not stat.S_ISREG(before.st_mode) or identity(before) != identity(expected): fail()",
+        "        if identity(os.stat(name,dir_fd=parent_fd,follow_symlinks=False)) != identity(before): fail()",
         "        digest=hashlib.sha512() if include_content else None; head=b''",
         "        if include_content:",
         "            while True:",
@@ -703,35 +700,47 @@ fertility_output_descriptor_manifest <- function(root, include_content = FALSE) 
         "                if not chunk: break",
         "                if len(head) < 256: head += chunk[:256-len(head)]",
         "                digest.update(chunk)",
-        "        after=os.fstat(fd); current=os.lstat(path)",
+        "        after=os.fstat(fd); current=os.stat(name,dir_fd=parent_fd,follow_symlinks=False)",
         "        if identity(after) != identity(before) or identity(current) != identity(before): fail()",
-        "        fields=[path.hex(),str(before.st_dev),str(before.st_ino),str(before.st_mode),str(before.st_size),str(before.st_mtime_ns),repr(before.st_mtime)]",
+        "        fields=[path.hex(),str(before.st_dev),str(before.st_ino),str(before.st_mode),str(before.st_size),str(before.st_mtime_ns),str(before.st_ctime_ns),repr(before.st_mtime)]",
         "        if include_content: fields += [release(head),digest.hexdigest()]",
         "        print('\\t'.join(fields))",
-        "    finally:",
-        "        os.close(fd)",
-        "def walk(parent):",
-        "    try:",
-        "        with os.scandir(parent) as iterator:",
-        "            entries=sorted(list(iterator),key=lambda value:value.name)",
-        "    except OSError:",
-        "        fail()",
-        "    for entry in entries:",
-        "        is_dta=entry.name.lower().endswith(b'.dta')",
-        "        try:",
-        "            mode=entry.stat(follow_symlinks=False).st_mode",
-        "        except OSError:",
-        "            fail()",
-        "        if stat.S_ISLNK(mode):",
-        "            try: linked_directory=entry.is_dir(follow_symlinks=True)",
+        "    finally: os.close(fd)",
+        "def walk(parent_fd,parent_path):",
+        "    parent_before=os.fstat(parent_fd)",
+        "    try: names=sorted(os.listdir(parent_fd),key=os.fsencode)",
+        "    except OSError: fail()",
+        "    for text in names:",
+        "        name=os.fsencode(text); is_dta=name.lower().endswith(b'.dta')",
+        "        try: before=os.stat(name,dir_fd=parent_fd,follow_symlinks=False)",
+        "        except OSError: fail()",
+        "        if stat.S_ISLNK(before.st_mode):",
+        "            try: linked_directory=stat.S_ISDIR(os.stat(name,dir_fd=parent_fd,follow_symlinks=True).st_mode)",
         "            except OSError: linked_directory=False",
         "            if linked_directory or is_dta: fail()",
         "            continue",
-        "        if stat.S_ISDIR(mode): walk(entry.path)",
+        "        path=os.path.join(parent_path,name)",
+        "        if stat.S_ISDIR(before.st_mode):",
+        "            try: child_fd=os.open(name,dir_flags,dir_fd=parent_fd)",
+        "            except OSError: fail()",
+        "            try:",
+        "                if identity(os.fstat(child_fd)) != identity(before): fail()",
+        "                walk(child_fd,path)",
+        "                current=os.stat(name,dir_fd=parent_fd,follow_symlinks=False)",
+        "                if identity(os.fstat(child_fd)) != identity(before) or identity(current) != identity(before): fail()",
+        "            finally: os.close(child_fd)",
         "        elif is_dta:",
-        "            if not stat.S_ISREG(mode): fail()",
-        "            attest(entry.path)",
-        "walk(root)",
+        "            if not stat.S_ISREG(before.st_mode): fail()",
+        "            attest(parent_fd,name,path,before)",
+        "    if identity(os.fstat(parent_fd)) != identity(parent_before): fail()",
+        "root_expected=os.lstat(root)",
+        "try: root_fd=os.open(root,dir_flags)",
+        "except OSError: fail()",
+        "try:",
+        "    if identity(os.fstat(root_fd)) != identity(root_expected): fail()",
+        "    walk(root_fd,root)",
+        "    if identity(os.fstat(root_fd)) != identity(root_expected) or identity(os.lstat(root)) != identity(root_expected): fail()",
+        "finally: os.close(root_fd)",
         sep = "\n"
     )
     output <- suppressWarnings(system2(
@@ -744,7 +753,7 @@ fertility_output_descriptor_manifest <- function(root, include_content = FALSE) 
         stop("fertility output inventory could not attest descriptor-bound regular files")
     }
     fields <- strsplit(output, "\t", fixed = TRUE)
-    expected_fields <- if (include_content) 9L else 7L
+    expected_fields <- if (include_content) 10L else 8L
     if (any(lengths(fields) != expected_fields)) {
         stop("fertility output descriptor attestation is malformed")
     }
@@ -756,14 +765,15 @@ fertility_output_descriptor_manifest <- function(root, include_content = FALSE) 
         mode = vapply(fields, `[[`, character(1), 4L),
         size = vapply(fields, `[[`, character(1), 5L),
         modified_ns = vapply(fields, `[[`, character(1), 6L),
-        modified_seconds = vapply(fields, `[[`, character(1), 7L),
+        changed_ns = vapply(fields, `[[`, character(1), 7L),
+        modified_seconds = vapply(fields, `[[`, character(1), 8L),
         stringsAsFactors = FALSE, check.names = FALSE
     )
     if (include_content) {
         result$release <- suppressWarnings(as.integer(vapply(
-            fields, `[[`, character(1), 8L
+            fields, `[[`, character(1), 9L
         )))
-        result$sha512 <- vapply(fields, `[[`, character(1), 9L)
+        result$sha512 <- vapply(fields, `[[`, character(1), 10L)
         if (anyNA(result$release) || any(!grepl("^[0-9a-f]{128}$", result$sha512))) {
             stop("fertility output descriptor content attestation is malformed")
         }
@@ -776,6 +786,7 @@ fertility_output_descriptor_manifest <- function(root, include_content = FALSE) 
         any(!grepl("^[0-9]+$", result$mode)) ||
         any(!grepl("^(0|[1-9][0-9]*)$", result$size)) ||
         any(!grepl("^[0-9]+$", result$modified_ns)) ||
+        any(!grepl("^[0-9]+$", result$changed_ns)) ||
         any(!grepl("^[0-9]+([.][0-9]+)?$", result$modified_seconds))) {
         stop("fertility output descriptor attestation is invalid")
     }
@@ -798,22 +809,40 @@ fertility_nofollow_file_capture <- function(path, include_release = FALSE) {
     code <- paste(
         "import hashlib, os, stat, sys",
         "path=os.fsencode(sys.argv[1]); include_release=sys.argv[2] == '1'",
-        "flags=os.O_RDONLY | getattr(os,'O_CLOEXEC',0) | getattr(os,'O_NOFOLLOW',0)",
-        "def identity(value): return (value.st_dev,value.st_ino,value.st_mode,value.st_size,value.st_mtime_ns)",
-        "fd=os.open(path,flags)",
+        "base_flags=os.O_RDONLY | getattr(os,'O_CLOEXEC',0) | getattr(os,'O_NOFOLLOW',0)",
+        "file_flags=base_flags; dir_flags=base_flags | getattr(os,'O_DIRECTORY',0)",
+        "def identity(value):",
+        "    return (value.st_dev,value.st_ino,value.st_mode,value.st_size,value.st_mtime_ns,value.st_ctime_ns)",
+        "parts=[part for part in path.split(b'/') if part]",
+        "if not parts: raise RuntimeError('invalid input path')",
+        "directory_parts=parts[:-1]; name=parts[-1]; chain=[]; descriptors=[]",
+        "root_expected=os.lstat(b'/'); root_fd=os.open(b'/',dir_flags); descriptors.append(root_fd)",
+        "if identity(os.fstat(root_fd)) != identity(root_expected): raise RuntimeError('root changed')",
+        "parent_fd=root_fd",
         "try:",
+        "    for part in directory_parts:",
+        "        expected=os.stat(part,dir_fd=parent_fd,follow_symlinks=False)",
+        "        if not stat.S_ISDIR(expected.st_mode): raise RuntimeError('parent is not directory')",
+        "        child_fd=os.open(part,dir_flags,dir_fd=parent_fd); descriptors.append(child_fd)",
+        "        if identity(os.fstat(child_fd)) != identity(expected): raise RuntimeError('parent changed')",
+        "        chain.append((parent_fd,part,child_fd,expected)); parent_fd=child_fd",
+        "    expected=os.stat(name,dir_fd=parent_fd,follow_symlinks=False)",
+        "    fd=os.open(name,file_flags,dir_fd=parent_fd); descriptors.append(fd)",
         "    before=os.fstat(fd)",
-        "    if not stat.S_ISREG(before.st_mode): raise RuntimeError('not regular')",
-        "    if identity(os.lstat(path)) != identity(before): raise RuntimeError('identity changed')",
+        "    if not stat.S_ISREG(before.st_mode) or identity(before) != identity(expected): raise RuntimeError('not regular')",
         "    digest=hashlib.sha512(); head=b''",
         "    while True:",
         "        chunk=os.read(fd,1024*1024)",
         "        if not chunk: break",
         "        if len(head) < 256: head += chunk[:256-len(head)]",
         "        digest.update(chunk)",
-        "    after=os.fstat(fd)",
-        "    if identity(after) != identity(before) or identity(os.lstat(path)) != identity(before): raise RuntimeError('identity changed')",
-        "    fields=[str(before.st_dev),str(before.st_ino),str(before.st_mode),str(before.st_size),str(before.st_mtime_ns),repr(before.st_mtime),digest.hexdigest()]",
+        "    after=os.fstat(fd); current=os.stat(name,dir_fd=parent_fd,follow_symlinks=False)",
+        "    if identity(after) != identity(before) or identity(current) != identity(before): raise RuntimeError('identity changed')",
+        "    for ancestor_fd,part,child_fd,ancestor_expected in reversed(chain):",
+        "        current=os.stat(part,dir_fd=ancestor_fd,follow_symlinks=False)",
+        "        if identity(os.fstat(child_fd)) != identity(ancestor_expected) or identity(current) != identity(ancestor_expected): raise RuntimeError('parent changed')",
+        "    if identity(os.fstat(root_fd)) != identity(root_expected) or identity(os.lstat(b'/')) != identity(root_expected): raise RuntimeError('root changed')",
+        "    fields=[str(before.st_dev),str(before.st_ino),str(before.st_mode),str(before.st_size),str(before.st_mtime_ns),str(before.st_ctime_ns),repr(before.st_mtime),digest.hexdigest()]",
         "    if include_release:",
         "        if not head: raise RuntimeError('empty DTA input')",
         "        if head.startswith(b'<stata_dta>'):",
@@ -825,7 +854,9 @@ fertility_nofollow_file_capture <- function(path, include_release = FALSE) {
         "        else: fields.append(str(head[0]))",
         "    print('\\t'.join(fields))",
         "finally:",
-        "    os.close(fd)",
+        "    for descriptor in reversed(descriptors):",
+        "        try: os.close(descriptor)",
+        "        except OSError: pass",
         sep = "\n"
     )
     output <- suppressWarnings(system2(
@@ -836,19 +867,20 @@ fertility_nofollow_file_capture <- function(path, include_release = FALSE) {
     status <- attr(output, "status", exact = TRUE)
     fields <- if (length(output) == 1L) strsplit(output, "\t", fixed = TRUE)[[1L]] else
         character()
-    expected_fields <- if (include_release) 8L else 7L
+    expected_fields <- if (include_release) 9L else 8L
     if ((!is.null(status) && status != 0L) ||
         length(fields) != expected_fields ||
-        any(!grepl("^[0-9]+$", fields[seq_len(5L)])) ||
-        !grepl("^[0-9]+([.][0-9]+)?$", fields[[6L]]) ||
-        !grepl("^[0-9a-f]{128}$", fields[[7L]])) {
+        any(!grepl("^[0-9]+$", fields[seq_len(6L)])) ||
+        !grepl("^[0-9]+([.][0-9]+)?$", fields[[7L]]) ||
+        !grepl("^[0-9a-f]{128}$", fields[[8L]])) {
         stop("descriptor-bound file capture failed")
     }
     list(
         device = fields[[1L]], inode = fields[[2L]], mode = fields[[3L]],
         size = fields[[4L]], modified_ns = fields[[5L]],
-        modified_seconds = fields[[6L]], sha512 = fields[[7L]],
-        release = if (include_release) suppressWarnings(as.integer(fields[[8L]])) else
+        changed_ns = fields[[6L]], modified_seconds = fields[[7L]],
+        sha512 = fields[[8L]],
+        release = if (include_release) suppressWarnings(as.integer(fields[[9L]])) else
             NULL
     )
 }
@@ -1011,7 +1043,8 @@ fertility_build_output_inventory <- function(root, raw_root) {
             stringsAsFactors = FALSE, check.names = FALSE
         )
         identity_fields <- c(
-            "path", "device", "inode", "mode", "size", "modified_ns"
+            "path", "device", "inode", "mode", "size", "modified_ns",
+            "changed_ns"
         )
         after <- fertility_output_descriptor_manifest(root, FALSE)
         fertility_validate_output_baseline(content_manifest)

--- a/benchmarks/fertility-surveys/common.R
+++ b/benchmarks/fertility-surveys/common.R
@@ -8,7 +8,6 @@ fertility_cache_levels <- c("women", "births")
 fertility_output_levels <- c("survey", "aggregate")
 fertility_levels <- c(fertility_cache_levels, fertility_output_levels)
 fertility_opt_in_value <- "I_UNDERSTAND_THIS_READS_PROPRIETARY_DATA"
-fertility_output_root <- "/Users/jmb/repos/fertility_surveys/output"
 fertility_output_expected_files <- 1226L
 fertility_output_expected_bytes <- 70748321626
 fertility_output_expected_largest <- 10332252930
@@ -623,9 +622,6 @@ fertility_output_requested <- function(options) {
 }
 
 fertility_assert_output_root <- function(path) {
-    if (!identical(path, fertility_output_root)) {
-        stop("--output-root must be exactly ", fertility_output_root)
-    }
     root <- fertility_assert_canonical_components(path, "fertility output root")
     if (!dir.exists(root) || fertility_path_is_symlink(root)) {
         stop("fertility output root must be a canonical non-symlink directory")
@@ -1241,23 +1237,21 @@ fertility_build_output_inventory <- function(root, raw_root) {
     inventory
 }
 
-fertility_required_paths <- function(options = NULL, raw_root = NULL) {
-    if (!is.null(options) && fertility_output_requested(options)) {
+fertility_required_paths <- function(options, raw_root = NULL) {
+    options <- fertility_validate_source_arguments(options)
+    if (fertility_output_requested(options)) {
         if (is.null(raw_root)) stop("raw root is required for output inventory authority")
         return(list(output = fertility_assert_output_root(options$output_root),
                     datasigs = fertility_output_inventory_path(raw_root)))
     }
-    home <- normalizePath("~", winslash = "/", mustWork = TRUE)
-    list(
-        cache = "/opt/aww_cache",
-        datasigs = file.path(home, "repos", "fertility_surveys", "datasigs.csv")
-    )
+    list(cache = options$cache_root, datasigs = options$manifest)
 }
 
 fertility_build_selected_inventory <- function(options, raw_root) {
+    paths <- fertility_required_paths(options, raw_root)
     if (fertility_output_requested(options)) {
-        fertility_build_output_inventory(options$output_root, raw_root)
-    } else fertility_build_inventory()
+        fertility_build_output_inventory(paths$output, raw_root)
+    } else fertility_build_inventory(paths)
 }
 
 fertility_atomic_save_rds <- function(value, path) {
@@ -1395,23 +1389,25 @@ fertility_structural_metadata <- function(path) {
          column_bytes = as.double(column_bytes), strl = strl)
 }
 
-fertility_build_inventory <- function(paths = fertility_required_paths(),
-                                      assert_counts = TRUE,
-                                      enforce_required_paths = TRUE) {
-    expected_cache <- "/opt/aww_cache"
-    expected_datasigs <- file.path(normalizePath("~", winslash = "/", mustWork = TRUE),
-                                   "repos", "fertility_surveys", "datasigs.csv")
-    if (enforce_required_paths &&
-        (!identical(paths$cache, expected_cache) ||
-         !identical(paths$datasigs, expected_datasigs))) {
-        stop("corpus paths are fixed to /opt/aww_cache and ~/repos/fertility_surveys/datasigs.csv")
+fertility_build_inventory <- function(paths, assert_counts = TRUE) {
+    if (!is.list(paths) || !identical(names(paths), c("cache", "datasigs"))) {
+        stop("explicit cache and manifest paths are required")
     }
-    if (!dir.exists(paths$cache)) stop("required /opt/aww_cache directory is missing")
-    cache_root <- normalizePath(paths$cache, winslash = "/", mustWork = TRUE)
-    if (!file.exists(paths$datasigs)) {
-        stop("required ~/repos/fertility_surveys/datasigs.csv file is missing")
+    cache_root <- fertility_assert_canonical_components(
+        paths$cache, "fertility cache root"
+    )
+    if (!dir.exists(cache_root) || fertility_path_is_symlink(cache_root)) {
+        stop("fertility cache root must be a canonical non-symlink directory")
     }
-    rows <- read.csv(paths$datasigs, colClasses = "character", check.names = FALSE,
+    datasigs_path <- fertility_assert_canonical_components(
+        paths$datasigs, "fertility manifest"
+    )
+    if (!file.exists(datasigs_path) || dir.exists(datasigs_path) ||
+        fertility_path_is_symlink(datasigs_path) ||
+        !isTRUE(file_test("-f", datasigs_path))) {
+        stop("fertility manifest must be a canonical non-symlink regular file")
+    }
+    rows <- read.csv(datasigs_path, colClasses = "character", check.names = FALSE,
                      stringsAsFactors = FALSE)
     required <- c("program", "survey", "level", "sha512")
     if (!all(required %in% names(rows))) stop("datasigs.csv is missing required columns")

--- a/benchmarks/fertility-surveys/common.R
+++ b/benchmarks/fertility-surveys/common.R
@@ -1,4 +1,4 @@
-fertility_schema_version <- 5L
+fertility_schema_version <- 6L
 fertility_expected_rows <- 1004L
 fertility_expected_releases <- c(`111` = 130L, `113` = 475L, `114` = 23L,
                                   `117` = 150L, `118` = 226L)

--- a/benchmarks/fertility-surveys/common.R
+++ b/benchmarks/fertility-surveys/common.R
@@ -238,6 +238,13 @@ fertility_filesystem_identity <- function(path, label) {
     output[[1L]]
 }
 
+fertility_identity_is_regular_file <- function(identity) {
+    fields <- strsplit(identity, ":", fixed = TRUE)[[1L]]
+    length(fields) == 3L && !is.na(mode <- suppressWarnings(
+        as.integer(fields[[3L]])
+    )) && bitwAnd(mode, 61440L) == 32768L
+}
+
 fertility_atomic_rename_noreplace <- function(
     from, to, label, validate_source = NULL
 ) {
@@ -630,29 +637,80 @@ fertility_assert_output_root <- function(path) {
     root
 }
 
+fertility_output_inventory_test_hook <- function(boundary, context) {
+    hook <- getOption("dtaparser.fertility.output_inventory_test_hook")
+    if (is.function(hook)) hook(boundary, context)
+    invisible(NULL)
+}
+
 fertility_output_entries <- function(root) {
     root <- fertility_assert_output_root(root)
     paths <- character()
     walk <- function(parent) {
-        entries <- sort(list.files(
+        parent <- fertility_assert_canonical_components(
+            parent, "fertility output inventory directory"
+        )
+        if (file.access(parent, 4L) != 0L || file.access(parent, 1L) != 0L) {
+            stop("fertility output inventory directory is not traversable")
+        }
+        entries <- tryCatch(sort(list.files(
             parent, all.files = TRUE, no.. = TRUE, full.names = TRUE,
             recursive = FALSE, include.dirs = TRUE
-        ), method = "radix")
+        ), method = "radix"), warning = function(condition) {
+            stop("could not enumerate fertility output inventory directory")
+        }, error = function(condition) {
+            stop("could not enumerate fertility output inventory directory")
+        })
         for (entry in entries) {
-            if (!identical(dirname(entry), parent) || fertility_path_is_symlink(entry)) {
+            is_dta <- grepl("[.]dta$", basename(entry), ignore.case = TRUE)
+            if (!identical(dirname(entry), parent)) {
+                stop("fertility output entry is not a direct descendant")
+            }
+            fertility_output_inventory_test_hook(
+                "before-entry-info", list(parent = parent, entry = entry)
+            )
+            linked <- fertility_path_is_symlink(entry)
+            info <- file.info(entry)
+            if (nrow(info) != 1L || is.na(info$isdir[[1L]])) {
+                stop("fertility output entry metadata is unavailable")
+            }
+            if (linked) {
+                if (isTRUE(info$isdir[[1L]])) {
+                    stop("fertility output inventory refuses symlinked directories")
+                }
+                if (is_dta) {
+                    stop("fertility output inventory refuses DTA symlinks")
+                }
                 next
             }
-            info <- file.info(entry)
-            if (nrow(info) != 1L || is.na(info$isdir[[1L]])) next
-            if (isTRUE(info$isdir[[1L]])) {
-                walk(normalizePath(entry, winslash = "/", mustWork = TRUE))
-            } else if (isTRUE(file_test("-f", entry)) &&
-                       grepl("[.]dta$", basename(entry), ignore.case = TRUE)) {
-                resolved <- normalizePath(entry, winslash = "/", mustWork = TRUE)
-                if (!startsWith(resolved, paste0(root, "/"))) {
+            fertility_output_inventory_test_hook(
+                "after-entry-info", list(parent = parent, entry = entry)
+            )
+            entry <- fertility_assert_direct_child(
+                entry, parent, "fertility output entry"
+            )
+            if (fertility_path_is_symlink(entry)) {
+                stop("fertility output entry changed to a symlink during inventory")
+            }
+            confirmed <- file.info(entry)
+            if (nrow(confirmed) != 1L || is.na(confirmed$isdir[[1L]]) ||
+                !identical(isTRUE(confirmed$isdir[[1L]]),
+                           isTRUE(info$isdir[[1L]]))) {
+                stop("fertility output entry changed during inventory")
+            }
+            if (isTRUE(confirmed$isdir[[1L]])) {
+                walk(entry)
+            } else if (is_dta) {
+                identity <- fertility_filesystem_identity(
+                    entry, "fertility output DTA"
+                )
+                if (!fertility_identity_is_regular_file(identity)) {
+                    stop("fertility output DTA must be a regular file")
+                }
+                if (!startsWith(entry, paste0(root, "/"))) {
                     stop("fertility output DTA escaped its root")
                 }
-                paths <<- c(paths, resolved)
+                paths <<- c(paths, entry)
             }
         }
     }

--- a/benchmarks/fertility-surveys/common.R
+++ b/benchmarks/fertility-surveys/common.R
@@ -636,63 +636,221 @@ fertility_output_inventory_test_hook <- function(boundary, context) {
     invisible(NULL)
 }
 
-fertility_output_regular_entries <- function(root) {
+fertility_decode_hex_path <- function(value) {
+    if (!nzchar(value) || nchar(value) %% 2L != 0L ||
+        !grepl("^[0-9a-f]+$", value)) {
+        stop("fertility output regular-file attestation is malformed")
+    }
+    starts <- seq.int(1L, nchar(value), by = 2L)
+    bytes <- suppressWarnings(strtoi(substring(value, starts, starts + 1L), 16L))
+    if (anyNA(bytes)) stop("fertility output regular-file attestation is malformed")
+    result <- rawToChar(as.raw(bytes))
+    Encoding(result) <- "UTF-8"
+    result
+}
+
+fertility_descriptor_timestamp <- function(seconds_text) {
+    value <- suppressWarnings(as.double(seconds_text))
+    if (length(value) != 1L || is.na(value) || !is.finite(value)) {
+        stop("fertility output descriptor timestamp is invalid")
+    }
+    format(as.POSIXct(value, origin = "1970-01-01", tz = "UTC"),
+           "%Y-%m-%dT%H:%M:%OS6Z", tz = "UTC")
+}
+
+fertility_output_descriptor_manifest <- function(root, include_content = FALSE) {
+    root <- fertility_assert_output_root(root)
+    if (!is.logical(include_content) || length(include_content) != 1L ||
+        is.na(include_content)) stop("invalid output descriptor attestation mode")
+    fertility_output_inventory_test_hook(
+        if (include_content) "before-descriptor-content-read" else
+            "before-descriptor-stat-read",
+        list(root = root)
+    )
     python <- Sys.which("python3")
     if (!nzchar(python)) stop("python3 is required for output inventory")
     code <- paste(
-        "import os, stat, sys",
+        "import hashlib, os, stat, sys",
+        "root=os.fsencode(sys.argv[1]); include_content=sys.argv[2] == '1'",
+        "flags=os.O_RDONLY | getattr(os, 'O_CLOEXEC', 0) | getattr(os, 'O_NOFOLLOW', 0)",
         "def fail():",
         "    raise RuntimeError('unsafe output inventory entry')",
+        "def identity(value):",
+        "    return (value.st_dev,value.st_ino,value.st_mode,value.st_size,value.st_mtime_ns)",
+        "def release(head):",
+        "    if not head: fail()",
+        "    if head.startswith(b'<stata_dta>'):",
+        "        marker=b'<release>'; start=head.find(marker)",
+        "        if start < 0: fail()",
+        "        value=head[start+len(marker):start+len(marker)+3]",
+        "        if len(value) != 3 or not value.isdigit(): fail()",
+        "        return value.decode('ascii')",
+        "    return str(head[0])",
+        "def attest(path):",
+        "    try:",
+        "        fd=os.open(path,flags)",
+        "    except OSError:",
+        "        fail()",
+        "    try:",
+        "        before=os.fstat(fd)",
+        "        if not stat.S_ISREG(before.st_mode): fail()",
+        "        linked=os.lstat(path)",
+        "        if identity(linked) != identity(before): fail()",
+        "        digest=hashlib.sha512() if include_content else None; head=b''",
+        "        if include_content:",
+        "            while True:",
+        "                chunk=os.read(fd,1024*1024)",
+        "                if not chunk: break",
+        "                if len(head) < 256: head += chunk[:256-len(head)]",
+        "                digest.update(chunk)",
+        "        after=os.fstat(fd); current=os.lstat(path)",
+        "        if identity(after) != identity(before) or identity(current) != identity(before): fail()",
+        "        fields=[path.hex(),str(before.st_dev),str(before.st_ino),str(before.st_mode),str(before.st_size),str(before.st_mtime_ns),repr(before.st_mtime)]",
+        "        if include_content: fields += [release(head),digest.hexdigest()]",
+        "        print('\\t'.join(fields))",
+        "    finally:",
+        "        os.close(fd)",
         "def walk(parent):",
         "    try:",
         "        with os.scandir(parent) as iterator:",
-        "            entries = sorted(list(iterator), key=lambda value: os.fsencode(value.name))",
+        "            entries=sorted(list(iterator),key=lambda value:value.name)",
         "    except OSError:",
         "        fail()",
         "    for entry in entries:",
-        "        is_dta = entry.name.lower().endswith('.dta')",
+        "        is_dta=entry.name.lower().endswith(b'.dta')",
         "        try:",
-        "            mode = entry.stat(follow_symlinks=False).st_mode",
+        "            mode=entry.stat(follow_symlinks=False).st_mode",
         "        except OSError:",
         "            fail()",
         "        if stat.S_ISLNK(mode):",
-        "            try:",
-        "                linked_directory = entry.is_dir(follow_symlinks=True)",
-        "            except OSError:",
-        "                linked_directory = False",
-        "            if linked_directory or is_dta:",
-        "                fail()",
+        "            try: linked_directory=entry.is_dir(follow_symlinks=True)",
+        "            except OSError: linked_directory=False",
+        "            if linked_directory or is_dta: fail()",
         "            continue",
-        "        if stat.S_ISDIR(mode):",
-        "            walk(entry.path)",
+        "        if stat.S_ISDIR(mode): walk(entry.path)",
         "        elif is_dta:",
-        "            if not stat.S_ISREG(mode):",
-        "                fail()",
-        "            print(os.fsencode(entry.path).hex())",
-        "walk(sys.argv[1])",
+        "            if not stat.S_ISREG(mode): fail()",
+        "            attest(entry.path)",
+        "walk(root)",
         sep = "\n"
     )
     output <- suppressWarnings(system2(
-        python, c("-c", shQuote(code), shQuote(root)),
+        python, c("-c", shQuote(code), shQuote(root),
+                  if (include_content) "1" else "0"),
         stdout = TRUE, stderr = FALSE
     ))
     status <- attr(output, "status", exact = TRUE)
-    if (!is.null(status) && status != 0L) {
-        stop("fertility output inventory could not attest regular files")
+    if ((!is.null(status) && status != 0L) || !length(output)) {
+        stop("fertility output inventory could not attest descriptor-bound regular files")
     }
-    decode <- function(value) {
-        if (!nzchar(value) || nchar(value) %% 2L != 0L ||
-            !grepl("^[0-9a-f]+$", value)) {
-            stop("fertility output regular-file attestation is malformed")
+    fields <- strsplit(output, "\t", fixed = TRUE)
+    expected_fields <- if (include_content) 9L else 7L
+    if (any(lengths(fields) != expected_fields)) {
+        stop("fertility output descriptor attestation is malformed")
+    }
+    result <- data.frame(
+        path = vapply(fields, function(value) fertility_decode_hex_path(value[[1L]]),
+                      character(1)),
+        device = vapply(fields, `[[`, character(1), 2L),
+        inode = vapply(fields, `[[`, character(1), 3L),
+        mode = vapply(fields, `[[`, character(1), 4L),
+        size = vapply(fields, `[[`, character(1), 5L),
+        modified_ns = vapply(fields, `[[`, character(1), 6L),
+        modified_seconds = vapply(fields, `[[`, character(1), 7L),
+        stringsAsFactors = FALSE, check.names = FALSE
+    )
+    if (include_content) {
+        result$release <- suppressWarnings(as.integer(vapply(
+            fields, `[[`, character(1), 8L
+        )))
+        result$sha512 <- vapply(fields, `[[`, character(1), 9L)
+        if (anyNA(result$release) || any(!grepl("^[0-9a-f]{128}$", result$sha512))) {
+            stop("fertility output descriptor content attestation is malformed")
         }
-        starts <- seq.int(1L, nchar(value), by = 2L)
-        bytes <- suppressWarnings(strtoi(substring(value, starts, starts + 1L), 16L))
-        if (anyNA(bytes)) stop("fertility output regular-file attestation is malformed")
-        result <- rawToChar(as.raw(bytes))
-        Encoding(result) <- "UTF-8"
-        result
     }
-    unname(sort(vapply(output, decode, character(1)), method = "radix"))
+    result <- result[order(result$path, method = "radix"), , drop = FALSE]
+    rownames(result) <- NULL
+    if (anyDuplicated(result$path) || any(!startsWith(result$path, paste0(root, "/"))) ||
+        any(!grepl("^[0-9]+$", result$device)) ||
+        any(!grepl("^[0-9]+$", result$inode)) ||
+        any(!grepl("^[0-9]+$", result$mode)) ||
+        any(!grepl("^(0|[1-9][0-9]*)$", result$size)) ||
+        any(!grepl("^[0-9]+$", result$modified_ns)) ||
+        any(!grepl("^[0-9]+([.][0-9]+)?$", result$modified_seconds))) {
+        stop("fertility output descriptor attestation is invalid")
+    }
+    result
+}
+
+fertility_output_regular_entries <- function(root) {
+    unname(fertility_output_descriptor_manifest(root, FALSE)$path)
+}
+
+fertility_nofollow_file_capture <- function(path, include_release = FALSE) {
+    if (!is.logical(include_release) || length(include_release) != 1L ||
+        is.na(include_release)) stop("invalid descriptor file capture mode")
+    path <- fertility_assert_existing_file(path, dirname(path), "descriptor input")
+    fertility_output_inventory_test_hook(
+        "before-descriptor-file-read", list(path = path)
+    )
+    python <- Sys.which("python3")
+    if (!nzchar(python)) stop("python3 is required for descriptor file capture")
+    code <- paste(
+        "import hashlib, os, stat, sys",
+        "path=os.fsencode(sys.argv[1]); include_release=sys.argv[2] == '1'",
+        "flags=os.O_RDONLY | getattr(os,'O_CLOEXEC',0) | getattr(os,'O_NOFOLLOW',0)",
+        "def identity(value): return (value.st_dev,value.st_ino,value.st_mode,value.st_size,value.st_mtime_ns)",
+        "fd=os.open(path,flags)",
+        "try:",
+        "    before=os.fstat(fd)",
+        "    if not stat.S_ISREG(before.st_mode): raise RuntimeError('not regular')",
+        "    if identity(os.lstat(path)) != identity(before): raise RuntimeError('identity changed')",
+        "    digest=hashlib.sha512(); head=b''",
+        "    while True:",
+        "        chunk=os.read(fd,1024*1024)",
+        "        if not chunk: break",
+        "        if len(head) < 256: head += chunk[:256-len(head)]",
+        "        digest.update(chunk)",
+        "    after=os.fstat(fd)",
+        "    if identity(after) != identity(before) or identity(os.lstat(path)) != identity(before): raise RuntimeError('identity changed')",
+        "    fields=[str(before.st_dev),str(before.st_ino),str(before.st_mode),str(before.st_size),str(before.st_mtime_ns),repr(before.st_mtime),digest.hexdigest()]",
+        "    if include_release:",
+        "        if not head: raise RuntimeError('empty DTA input')",
+        "        if head.startswith(b'<stata_dta>'):",
+        "            marker=b'<release>'; start=head.find(marker)",
+        "            if start < 0: raise RuntimeError('release missing')",
+        "            value=head[start+len(marker):start+len(marker)+3]",
+        "            if len(value) != 3 or not value.isdigit(): raise RuntimeError('release invalid')",
+        "            fields.append(value.decode('ascii'))",
+        "        else: fields.append(str(head[0]))",
+        "    print('\\t'.join(fields))",
+        "finally:",
+        "    os.close(fd)",
+        sep = "\n"
+    )
+    output <- suppressWarnings(system2(
+        python, c("-c", shQuote(code), shQuote(path),
+                  if (include_release) "1" else "0"),
+        stdout = TRUE, stderr = FALSE
+    ))
+    status <- attr(output, "status", exact = TRUE)
+    fields <- if (length(output) == 1L) strsplit(output, "\t", fixed = TRUE)[[1L]] else
+        character()
+    expected_fields <- if (include_release) 8L else 7L
+    if ((!is.null(status) && status != 0L) ||
+        length(fields) != expected_fields ||
+        any(!grepl("^[0-9]+$", fields[seq_len(5L)])) ||
+        !grepl("^[0-9]+([.][0-9]+)?$", fields[[6L]]) ||
+        !grepl("^[0-9a-f]{128}$", fields[[7L]])) {
+        stop("descriptor-bound file capture failed")
+    }
+    list(
+        device = fields[[1L]], inode = fields[[2L]], mode = fields[[3L]],
+        size = fields[[4L]], modified_ns = fields[[5L]],
+        modified_seconds = fields[[6L]], sha512 = fields[[7L]],
+        release = if (include_release) suppressWarnings(as.integer(fields[[8L]])) else
+            NULL
+    )
 }
 
 fertility_output_entries <- function(root) {
@@ -771,18 +929,40 @@ fertility_output_entries <- function(root) {
 
 fertility_output_stat_manifest <- function(root) {
     paths <- fertility_output_entries(root)
-    info <- file.info(paths)
+    attested <- fertility_output_descriptor_manifest(root, FALSE)
+    if (!identical(paths, attested$path)) {
+        stop("fertility output inventory changed during descriptor stat capture")
+    }
     relative <- substring(paths, nchar(root) + 2L)
-    if (!length(paths) || anyNA(info$size) || anyDuplicated(relative) ||
-        any(!nzchar(relative))) stop("fertility output inventory is invalid")
+    if (!length(paths) || anyDuplicated(relative) || any(!nzchar(relative))) {
+        stop("fertility output inventory is invalid")
+    }
     result <- data.frame(
         relative_path = relative,
-        size = as.character(info$size),
-        modified = format(info$mtime, "%Y-%m-%dT%H:%M:%OS6Z", tz = "UTC"),
+        size = attested$size,
+        modified = vapply(attested$modified_seconds, fertility_descriptor_timestamp,
+                          character(1)),
         stringsAsFactors = FALSE, check.names = FALSE
     )
     rownames(result) <- NULL
     result
+}
+
+fertility_output_metadata_equal <- function(left, right) {
+    fields <- c("relative_path", "size", "modified")
+    if (!is.data.frame(left) || !is.data.frame(right) ||
+        !all(fields %in% names(left)) || !all(fields %in% names(right)) ||
+        nrow(left) != nrow(right) ||
+        !identical(left$relative_path, right$relative_path) ||
+        !identical(left$size, right$size)) return(FALSE)
+    left_time <- suppressWarnings(as.numeric(as.POSIXct(
+        sub("Z$", "", left$modified), format = "%Y-%m-%dT%H:%M:%OS", tz = "UTC"
+    )))
+    right_time <- suppressWarnings(as.numeric(as.POSIXct(
+        sub("Z$", "", right$modified), format = "%Y-%m-%dT%H:%M:%OS", tz = "UTC"
+    )))
+    !anyNA(left_time) && !anyNA(right_time) &&
+        all(abs(left_time - right_time) <= 2e-6)
 }
 
 fertility_validate_output_baseline <- function(manifest) {
@@ -816,16 +996,29 @@ fertility_build_output_inventory <- function(root, raw_root) {
         path, dirname(path), "frozen output inventory"
     )) else NULL
     if (is.null(frozen)) {
-        paths <- file.path(root, manifest$relative_path)
-        hashes <- vapply(paths, fertility_file_sha512, character(1))
-        after <- fertility_output_stat_manifest(root)
-        fertility_validate_output_baseline(after)
-        if (!identical(manifest, after)) stop("fertility output changed during inventory")
-        releases <- vapply(paths, fertility_release, integer(1))
+        content <- fertility_output_descriptor_manifest(root, TRUE)
+        content_manifest <- data.frame(
+            relative_path = substring(content$path, nchar(root) + 2L),
+            size = content$size,
+            modified = vapply(content$modified_seconds, fertility_descriptor_timestamp,
+                              character(1)),
+            stringsAsFactors = FALSE, check.names = FALSE
+        )
+        identity_fields <- c(
+            "path", "device", "inode", "mode", "size", "modified_ns"
+        )
+        after <- fertility_output_descriptor_manifest(root, FALSE)
+        fertility_validate_output_baseline(content_manifest)
+        if (!identical(manifest, content_manifest) ||
+            !identical(content[identity_fields], after[identity_fields])) {
+            stop("fertility output changed during descriptor-bound inventory")
+        }
         frozen <- list(
             schema_version = 1L,
             root_identity = fertility_filesystem_identity(root, "fertility output root"),
-            manifest = transform(manifest, release = releases, sha512 = hashes),
+            manifest = transform(
+                content_manifest, release = content$release, sha512 = content$sha512
+            ),
             created_at_utc = format(Sys.time(), "%Y-%m-%dT%H:%M:%SZ", tz = "UTC")
         )
         fertility_atomic_save_rds(frozen, path)
@@ -838,7 +1031,9 @@ fertility_build_output_inventory <- function(root, raw_root) {
         !identical(names(frozen$manifest), expected_names) ||
         !identical(frozen$root_identity,
                    fertility_filesystem_identity(root, "fertility output root")) ||
-        !identical(frozen$manifest[c("relative_path", "size", "modified")], manifest) ||
+        !fertility_output_metadata_equal(
+            frozen$manifest[c("relative_path", "size", "modified")], manifest
+        ) ||
         any(!grepl("^[0-9a-f]{128}$", frozen$manifest$sha512)) ||
         any(!(frozen$manifest$release %in% c(111L, fertility_supported_releases)))) {
         stop("frozen fertility output inventory changed or is invalid")

--- a/benchmarks/fertility-surveys/common.R
+++ b/benchmarks/fertility-surveys/common.R
@@ -17,6 +17,513 @@ fertility_checkout_root <- function(script_path = fertility_script_path()) {
     normalizePath(file.path(dirname(script_path), "..", ".."), winslash = "/")
 }
 
+fertility_path_is_symlink <- function(path) {
+    link <- Sys.readlink(path)
+    !is.na(link) & nzchar(link)
+}
+
+fertility_assert_canonical_components <- function(path, label,
+                                                   must_exist = TRUE) {
+    lexical <- path.expand(path)
+    if (length(lexical) != 1L || is.na(lexical) || !startsWith(lexical, "/")) {
+        stop(label, " must be an absolute canonical path")
+    }
+    pieces <- strsplit(sub("^/", "", lexical), "/", fixed = TRUE)[[1L]]
+    current <- "/"
+    for (piece in pieces[nzchar(pieces)]) {
+        if (piece %in% c(".", "..")) stop(label, " must be canonical")
+        current <- file.path(current, piece)
+        exists <- file.exists(current) || dir.exists(current) ||
+            fertility_path_is_symlink(current)
+        if (exists && fertility_path_is_symlink(current)) {
+            stop(label, " must not traverse symlinks")
+        }
+        if (!exists) break
+    }
+    if (must_exist) {
+        if (!file.exists(lexical) && !dir.exists(lexical)) {
+            stop(label, " must exist")
+        }
+        resolved <- normalizePath(lexical, winslash = "/", mustWork = TRUE)
+        if (!identical(resolved, lexical)) stop(label, " must be canonical")
+    }
+    lexical
+}
+
+fertility_assert_existing_directory <- function(path, parent, label) {
+    path <- fertility_assert_direct_child(path, parent, label)
+    if (!dir.exists(path)) stop(label, " must be an existing directory")
+    fertility_assert_canonical_components(path, label)
+}
+
+fertility_assert_existing_file <- function(path, parent, label) {
+    path <- fertility_assert_direct_child(path, parent, label)
+    if (!file.exists(path) || dir.exists(path)) {
+        stop(label, " must be an existing regular file")
+    }
+    fertility_assert_canonical_components(path, label)
+}
+
+fertility_assert_checkpoint_file <- function(path, label,
+                                             must_exist = FALSE) {
+    parent <- fertility_assert_canonical_components(
+        dirname(path), paste(label, "parent")
+    )
+    if (!dir.exists(parent)) stop(label, " parent must exist")
+    if (fertility_path_is_symlink(path) || dir.exists(path)) {
+        stop(label, " must not be a symlink or directory")
+    }
+    if (must_exist || file.exists(path)) {
+        return(fertility_assert_existing_file(path, parent, label))
+    }
+    fertility_assert_direct_child(path, parent, label, must_work = FALSE)
+}
+
+fertility_assert_new_destination <- function(path, parent, label) {
+    path <- fertility_assert_direct_child(
+        path, parent, label, must_work = FALSE
+    )
+    if (file.exists(path) || dir.exists(path) || fertility_path_is_symlink(path)) {
+        stop(label, " already exists")
+    }
+    path
+}
+
+fertility_remove_confirmed_new_path <- function(path, parent, label) {
+    path <- fertility_assert_direct_child(path, parent, label)
+    if (fertility_path_is_symlink(path)) {
+        stop("refusing to remove symlinked ", label)
+    }
+    unlink(path, recursive = TRUE)
+    !file.exists(path) && !dir.exists(path) && !fertility_path_is_symlink(path)
+}
+
+fertility_character_frame <- function(value) {
+    if (!is.data.frame(value)) stop("expected table must be a data frame")
+    result <- as.data.frame(
+        lapply(value, as.character), stringsAsFactors = FALSE,
+        check.names = FALSE
+    )
+    rownames(result) <- NULL
+    result
+}
+
+fertility_validate_exact_table_bundle <- function(
+    bundle, files, expected, label
+) {
+    bundle <- fertility_assert_existing_directory(
+        bundle, dirname(bundle), paste(label, "directory")
+    )
+    expected_files <- unname(files)
+    if (!identical(names(files), names(expected)) ||
+        anyDuplicated(expected_files) || !length(files) ||
+        any(!nzchar(expected_files)) ||
+        !identical(basename(expected_files), expected_files)) {
+        stop(label, " specification is invalid")
+    }
+    entries <- sort(list.files(
+        bundle, all.files = TRUE, no.. = TRUE, full.names = TRUE,
+        recursive = FALSE, include.dirs = TRUE
+    ))
+    if (!identical(sort(basename(entries)), sort(expected_files))) {
+        stop(label, " exact file set changed")
+    }
+    loaded <- lapply(seq_along(files), function(index) {
+        path <- fertility_assert_existing_file(
+            file.path(bundle, files[[index]]), bundle,
+            paste(label, names(files)[[index]])
+        )
+        if (!file_test("-f", path) || fertility_path_is_symlink(path)) {
+            stop(label, " must contain only regular nonsymlink files")
+        }
+        read.delim(path, colClasses = "character", check.names = FALSE)
+    })
+    names(loaded) <- names(files)
+    expected <- lapply(expected, fertility_character_frame)
+    if (!identical(loaded, expected)) stop(label, " exact contents changed")
+    loaded
+}
+
+fertility_attest_existing_files <- function(paths, label) {
+    paths <- vapply(paths, function(path) fertility_assert_existing_file(
+        path, dirname(path), label
+    ), character(1))
+    list(paths = paths, sha256 = unname(tools::sha256sum(paths)))
+}
+
+fertility_revalidate_existing_files <- function(attestation, label) {
+    if (!is.list(attestation) || !identical(
+        names(attestation), c("paths", "sha256")
+    )) stop(label, " attestation is invalid")
+    current <- fertility_attest_existing_files(attestation$paths, label)
+    if (!identical(current, attestation)) stop(label, " identity changed")
+    invisible(TRUE)
+}
+
+fertility_attest_regular_tree <- function(directory, label) {
+    directory <- fertility_assert_existing_directory(
+        directory, dirname(directory), paste(label, "root")
+    )
+    files <- character()
+    walk <- function(parent) {
+        entries <- sort(list.files(
+            parent, all.files = TRUE, no.. = TRUE, full.names = TRUE,
+            recursive = FALSE, include.dirs = TRUE
+        ))
+        for (entry in entries) {
+            if (!identical(dirname(entry), parent) || fertility_path_is_symlink(entry)) {
+                stop(label, " must not contain symlinks or escaped entries")
+            }
+            info <- file.info(entry)
+            if (nrow(info) != 1L || is.na(info$isdir[[1L]])) {
+                stop(label, " contains an unavailable entry")
+            }
+            resolved <- normalizePath(entry, winslash = "/", mustWork = TRUE)
+            if (!identical(dirname(resolved), parent) ||
+                !identical(resolved, file.path(parent, basename(entry)))) {
+                stop(label, " entry escaped its canonical direct parent")
+            }
+            if (isTRUE(info$isdir[[1L]])) {
+                walk(resolved)
+            } else if (isTRUE(file_test("-f", resolved))) {
+                files <<- c(files, resolved)
+            } else {
+                stop(label, " contains a non-regular file")
+            }
+        }
+    }
+    walk(directory)
+    files <- sort(files)
+    if (!length(files)) stop(label, " is empty")
+    relative <- substring(files, nchar(directory) + 2L)
+    list(
+        directory = directory, paths = relative,
+        sha256 = unname(tools::sha256sum(files))
+    )
+}
+
+fertility_revalidate_regular_tree <- function(attestation, label) {
+    if (!is.list(attestation) || !identical(
+        names(attestation), c("directory", "paths", "sha256")
+    )) stop(label, " attestation is invalid")
+    current <- fertility_attest_regular_tree(attestation$directory, label)
+    if (!identical(current, attestation)) stop(label, " identity changed")
+    invisible(TRUE)
+}
+
+fertility_filesystem_identity <- function(path, label) {
+    path <- fertility_assert_canonical_components(path, label)
+    if (fertility_path_is_symlink(path)) stop(label, " must not be a symlink")
+    python <- Sys.which("python3")
+    if (!nzchar(python)) stop("python3 is required for filesystem identity")
+    code <- paste(
+        "import os, sys",
+        "value=os.lstat(sys.argv[1])",
+        "print(f'{value.st_dev}:{value.st_ino}:{value.st_mode}')",
+        sep = "\n"
+    )
+    output <- suppressWarnings(system2(
+        python, c("-c", shQuote(code), shQuote(path)),
+        stdout = TRUE, stderr = FALSE
+    ))
+    status <- attr(output, "status", exact = TRUE)
+    if ((!is.null(status) && status != 0L) || length(output) != 1L ||
+        !grepl("^[0-9]+:[0-9]+:[0-9]+$", output[[1L]])) {
+        stop("could not attest filesystem identity for ", label)
+    }
+    output[[1L]]
+}
+
+fertility_atomic_rename_noreplace <- function(
+    from, to, label, validate_source = NULL
+) {
+    from <- path.expand(from)
+    to <- path.expand(to)
+    if (!file.exists(from) && !dir.exists(from)) stop(label, " source is absent")
+    if (fertility_path_is_symlink(from) || fertility_path_is_symlink(to)) {
+        stop(label, " must not use symlinks")
+    }
+    fertility_assert_canonical_components(dirname(from), paste(label, "source parent"))
+    fertility_assert_canonical_components(dirname(to), paste(label, "destination parent"))
+    fertility_publication_test_hook(
+        "atomic-noreplace-before-operation",
+        list(from = from, to = to, label = label)
+    )
+    if (!is.null(validate_source)) {
+        if (!is.function(validate_source)) {
+            stop(label, " source validator must be a function")
+        }
+        validate_source(from, to, label)
+    }
+    python <- Sys.which("python3")
+    if (!nzchar(python)) stop("python3 is required for atomic no-replace publication")
+    code <- paste(
+        "import ctypes, errno, os, sys",
+        "src=os.fsencode(sys.argv[1]); dst=os.fsencode(sys.argv[2])",
+        "libc=ctypes.CDLL(None, use_errno=True)",
+        "if sys.platform == 'darwin':",
+        "    fn=libc.renamex_np; fn.argtypes=[ctypes.c_char_p,ctypes.c_char_p,ctypes.c_uint]",
+        "    rc=fn(src,dst,4)",
+        "else:",
+        "    fn=getattr(libc,'renameat2',None)",
+        "    if fn is None: sys.exit(18)",
+        "    fn.argtypes=[ctypes.c_int,ctypes.c_char_p,ctypes.c_int,ctypes.c_char_p,ctypes.c_uint]",
+        "    rc=fn(-100,src,-100,dst,1)",
+        "if rc != 0:",
+        "    value=ctypes.get_errno()",
+        "    sys.exit(17 if value in (errno.EEXIST, errno.ENOTEMPTY) else 19)",
+        sep = "\n"
+    )
+    status <- suppressWarnings(system2(
+        python, c("-c", shQuote(code), shQuote(from), shQuote(to)),
+        stdout = FALSE, stderr = FALSE
+    ))
+    if (identical(status, 17L)) stop(label, " destination already exists")
+    if (!identical(status, 0L)) stop("atomic no-replace publication failed for ", label)
+    invisible(TRUE)
+}
+
+fertility_publication_test_hook <- function(boundary, context = list()) {
+    hook <- getOption("dtaparser.fertility.publication_test_hook")
+    if (is.function(hook)) hook(boundary, context)
+    invisible(TRUE)
+}
+
+fertility_assert_checkout_raw_root <- function(raw_root, checkout_root, create = FALSE) {
+    checkout_lexical <- path.expand(checkout_root)
+    checkout <- normalizePath(checkout_lexical, winslash = "/", mustWork = TRUE)
+    if (!identical(checkout_lexical, checkout) || fertility_path_is_symlink(checkout_lexical)) {
+        stop("fertility checkout root must be canonical and non-symlinked")
+    }
+    expected <- file.path(checkout, "target", "fertility-surveys", "raw")
+    if (!identical(path.expand(raw_root), expected)) {
+        stop("fertility outputs must use the checkout-local raw root")
+    }
+    components <- c(
+        checkout, file.path(checkout, "target"),
+        file.path(checkout, "target", "fertility-surveys"), expected
+    )
+    existing <- components[file.exists(components) | dir.exists(components)]
+    if (length(existing) && any(fertility_path_is_symlink(existing))) {
+        stop("fertility output ancestors must not be symlinks")
+    }
+    if (create) {
+        parent <- checkout
+        for (name in c("target", "fertility-surveys", "raw")) {
+            child <- file.path(parent, name)
+            if (fertility_path_is_symlink(child)) {
+                stop("fertility output ancestors must not be symlinks")
+            }
+            if (!dir.exists(child) &&
+                !dir.create(child, showWarnings = FALSE, mode = "0700")) {
+                stop("could not create checkout-local fertility output directory")
+            }
+            if (fertility_path_is_symlink(parent) || fertility_path_is_symlink(child) ||
+                !identical(
+                    dirname(normalizePath(child, winslash = "/", mustWork = TRUE)),
+                    normalizePath(parent, winslash = "/", mustWork = TRUE)
+                )) stop("fertility raw root escaped the checkout")
+            parent <- child
+        }
+    }
+    if (!dir.exists(expected) || any(fertility_path_is_symlink(components)) ||
+        !identical(normalizePath(expected, winslash = "/", mustWork = TRUE),
+                   expected)) {
+        stop("fertility raw root escaped the checkout")
+    }
+    expected
+}
+
+fertility_assert_direct_child <- function(path, parent, label,
+                                          must_work = TRUE) {
+    parent_lexical <- path.expand(parent)
+    path_lexical <- path.expand(path)
+    if (!identical(dirname(path_lexical), parent_lexical)) {
+        stop(label, " must be directly beneath its expected parent")
+    }
+    if (!dir.exists(parent_lexical) || fertility_path_is_symlink(parent_lexical)) {
+        stop(label, " parent must be an existing non-symlink directory")
+    }
+    fertility_assert_canonical_components(
+        parent_lexical, paste(label, "parent")
+    )
+    if ((file.exists(path_lexical) || dir.exists(path_lexical)) &&
+        fertility_path_is_symlink(path_lexical)) {
+        stop(label, " must not be a symlink")
+    }
+    if (must_work) {
+        resolved_parent <- normalizePath(
+            parent_lexical, winslash = "/", mustWork = TRUE
+        )
+        resolved <- normalizePath(path_lexical, winslash = "/", mustWork = TRUE)
+        if (!identical(dirname(resolved), resolved_parent)) {
+            stop(label, " escaped its expected parent")
+        }
+    }
+    path_lexical
+}
+
+fertility_assert_output_parent <- function(raw_root, collection, identity,
+                                           create = FALSE) {
+    collection_path <- file.path(raw_root, collection)
+    fertility_assert_direct_child(
+        collection_path, raw_root, paste(collection, "output directory"),
+        must_work = FALSE
+    )
+    if (create && !dir.exists(collection_path) &&
+        !dir.create(collection_path, showWarnings = FALSE, mode = "0700")) {
+        stop("could not create ", collection, " output directory")
+    }
+    fertility_assert_direct_child(
+        collection_path, raw_root, paste(collection, "output directory")
+    )
+    parent <- file.path(collection_path, identity)
+    fertility_assert_direct_child(
+        parent, collection_path, paste(collection, "publication parent"),
+        must_work = FALSE
+    )
+    if (create && !dir.exists(parent) &&
+        !dir.create(parent, showWarnings = FALSE, mode = "0700")) {
+        stop("could not create ", collection, " publication parent")
+    }
+    fertility_assert_direct_child(
+        parent, collection_path, paste(collection, "publication parent")
+    )
+}
+
+fertility_resolve_checkpoint_case <- function(
+    raw_root, framework_id, config_id, case_id, require_result = TRUE
+) {
+    if (!grepl("^[0-9a-f]{64}$", framework_id) ||
+        !grepl("^[0-9a-f]{64}$", config_id) ||
+        !grepl("^F[0-9]{4}$", case_id)) stop("checkpoint identity is invalid")
+    checkpoints <- fertility_assert_existing_directory(
+        file.path(raw_root, "checkpoints"), raw_root,
+        "checkpoints output directory"
+    )
+    framework <- fertility_assert_existing_directory(
+        file.path(checkpoints, framework_id), checkpoints,
+        "framework checkpoint directory"
+    )
+    configuration <- fertility_assert_existing_directory(
+        file.path(framework, config_id), framework,
+        "configuration checkpoint directory"
+    )
+    case <- fertility_assert_existing_directory(
+        file.path(configuration, case_id), configuration,
+        "checkpoint case directory"
+    )
+    result <- file.path(case, "result.rds")
+    if (require_result) result <- fertility_assert_existing_file(
+        result, case, "checkpoint case result"
+    )
+    tiles <- file.path(case, "tiles")
+    if (file.exists(tiles) || dir.exists(tiles) || fertility_path_is_symlink(tiles)) {
+        tiles <- fertility_assert_existing_directory(
+            tiles, case, "checkpoint tile directory"
+        )
+    } else tiles <- NULL
+    list(
+        checkpoints = checkpoints, framework = framework,
+        configuration = configuration, case = case,
+        result = result, tiles = tiles
+    )
+}
+
+fertility_checkpoint_tile_files <- function(case_paths) {
+    if (!is.list(case_paths) || is.null(case_paths$case)) {
+        stop("checkpoint case paths are invalid")
+    }
+    if (is.null(case_paths$tiles)) return(character())
+    tile_root <- fertility_assert_existing_directory(
+        case_paths$tiles, case_paths$case, "checkpoint tile directory"
+    )
+    entries <- list.files(tile_root, all.files = TRUE, no.. = TRUE)
+    if (any(!grepl("^[A-Za-z0-9._-]+[.]rds$", entries))) {
+        stop("checkpoint tile directory contains an invalid entry")
+    }
+    vapply(entries, function(name) fertility_assert_existing_file(
+        file.path(tile_root, name), tile_root, "checkpoint tile file"
+    ), character(1))
+}
+
+fertility_resolve_build_bundle <- function(raw_root, build_id = NULL,
+                                           require_current = FALSE) {
+    builds_root <- fertility_assert_existing_directory(
+        file.path(raw_root, "builds"), raw_root, "builds output directory"
+    )
+    current_id <- NULL
+    if (require_current) {
+        current_path <- fertility_assert_existing_file(
+            file.path(builds_root, "CURRENT"), builds_root, "build CURRENT pointer"
+        )
+        value <- readLines(current_path, warn = FALSE, n = 1L)
+        if (length(value) != 1L || !grepl("^[0-9a-f]{64}$", value)) {
+            stop("build CURRENT pointer is invalid")
+        }
+        current_id <- value[[1L]]
+        if (!is.null(build_id) && !identical(build_id, current_id)) {
+            stop("selected build CURRENT changed")
+        }
+        build_id <- current_id
+    }
+    if (is.null(build_id) || length(build_id) != 1L ||
+        !grepl("^[0-9a-f]{64}$", build_id)) stop("build identity is invalid")
+    generation <- fertility_assert_existing_directory(
+        file.path(builds_root, build_id), builds_root, "build generation"
+    )
+    library <- fertility_assert_existing_directory(
+        file.path(generation, "library"), generation, "build library"
+    )
+    provenance <- fertility_assert_existing_file(
+        file.path(generation, "build-provenance.tsv"), generation,
+        "build provenance"
+    )
+    package <- fertility_assert_existing_directory(
+        file.path(library, "dtaparser"), library, "installed dtaparser package"
+    )
+    list(
+        builds_root = builds_root, current_id = current_id,
+        generation = generation, library = library,
+        provenance = provenance, package = package
+    )
+}
+
+fertility_revalidate_current_bundle <- function(
+    parent, expected_run_name, files, label
+) {
+    current <- fertility_current_bundle_paths(parent, files, label)
+    if (!identical(current$run_name, expected_run_name)) {
+        stop(label, " CURRENT changed before publication")
+    }
+    current
+}
+
+fertility_current_bundle_paths <- function(parent, files, label) {
+    parent <- fertility_assert_canonical_components(parent, paste(label, "parent"))
+    if (!dir.exists(parent)) stop(label, " parent must be an existing directory")
+    pointer <- fertility_assert_existing_file(
+        file.path(parent, "CURRENT"), parent, paste(label, "CURRENT pointer")
+    )
+    run_name <- tryCatch(
+        readLines(pointer, warn = FALSE, n = 1L),
+        error = function(error) character()
+    )
+    if (length(run_name) != 1L || !grepl("^[A-Za-z0-9._-]+$", run_name)) {
+        stop(label, " CURRENT pointer is invalid")
+    }
+    bundle <- fertility_assert_existing_directory(
+        file.path(parent, run_name), parent, paste(label, "bundle")
+    )
+    paths <- setNames(file.path(bundle, unname(files)), names(files))
+    for (index in seq_along(paths)) {
+        paths[[index]] <- fertility_assert_existing_file(
+            paths[[index]], bundle, paste(label, names(paths)[[index]])
+        )
+    }
+    list(bundle = bundle, paths = paths, run_name = run_name)
+}
+
 fertility_assert_manual_run <- function() {
     ci_variables <- c("CI", "GITHUB_ACTIONS", "GITHUB_RUN_ID", "GITHUB_WORKFLOW")
     active <- ci_variables[nzchar(Sys.getenv(ci_variables, unset = ""))]

--- a/benchmarks/fertility-surveys/common.R
+++ b/benchmarks/fertility-surveys/common.R
@@ -1,4 +1,4 @@
-fertility_schema_version <- 12L
+fertility_schema_version <- 13L
 fertility_expected_rows <- 1004L
 fertility_expected_releases <- c(`111` = 130L, `113` = 475L, `114` = 23L,
                                   `117` = 150L, `118` = 226L)

--- a/benchmarks/fertility-surveys/common.R
+++ b/benchmarks/fertility-surveys/common.R
@@ -950,7 +950,8 @@ fertility_close_bound_input_connection <- function(connection) {
 fertility_bound_input_path <- function() "/dev/fd/3"
 
 fertility_materialize_bound_input <- function(path, input, raw_root,
-                                              destination = NULL) {
+                                              destination = NULL,
+                                              prefer_clone = TRUE) {
     if (!identical(path, fertility_bound_input_path())) {
         stop("bound worker input path is invalid")
     }
@@ -975,6 +976,8 @@ fertility_materialize_bound_input <- function(path, input, raw_root,
             stop("bound worker snapshot destination is invalid")
         }
     }
+    if (!is.logical(prefer_clone) || length(prefer_clone) != 1L ||
+        is.na(prefer_clone)) stop("bound worker clone preference is invalid")
     on.exit(if (file.exists(destination) || fertility_path_is_symlink(destination)) {
         unlink(destination)
     }, add = TRUE)
@@ -982,21 +985,41 @@ fertility_materialize_bound_input <- function(path, input, raw_root,
     if (!nzchar(python)) stop("python3 is required for bound worker input")
     code <- paste(
         "import ctypes,os,stat,sys",
-        "destination=os.fsencode(sys.argv[1]); expected=tuple(int(value) for value in sys.argv[2:])",
+        "destination=os.fsencode(sys.argv[1]); expected=tuple(int(value) for value in sys.argv[2:8]); prefer_clone=sys.argv[8]=='1'",
         "def identity(value): return (value.st_dev,value.st_ino,value.st_mode,value.st_size,value.st_mtime_ns,value.st_ctime_ns)",
         "before=os.fstat(3)",
         "if identity(before) != expected or not stat.S_ISREG(before.st_mode): sys.exit(17)",
-        "libc=ctypes.CDLL(None,use_errno=True); clone=getattr(libc,'fclonefileat',None)",
-        "if clone is None: sys.exit(18)",
-        "clone.argtypes=[ctypes.c_int,ctypes.c_int,ctypes.c_char_p,ctypes.c_uint]",
-        "if clone(3,-2,destination,0) != 0: sys.exit(19)",
+        "cloned=False",
+        "if prefer_clone:",
+        "    libc=ctypes.CDLL(None,use_errno=True); clone=getattr(libc,'fclonefileat',None)",
+        "    if clone is not None:",
+        "        clone.argtypes=[ctypes.c_int,ctypes.c_int,ctypes.c_char_p,ctypes.c_uint]",
+        "        cloned=clone(3,-2,destination,0)==0",
+        "if not cloned:",
+        "    flags=os.O_WRONLY|os.O_CREAT|os.O_EXCL|getattr(os,'O_NOFOLLOW',0)|getattr(os,'O_CLOEXEC',0)",
+        "    output=os.open(destination,flags,0o600)",
+        "    try:",
+        "        offset=0",
+        "        while offset < before.st_size:",
+        "            data=os.pread(3,min(1048576,before.st_size-offset),offset)",
+        "            if not data: sys.exit(18)",
+        "            view=memoryview(data)",
+        "            while view:",
+        "                written=os.write(output,view)",
+        "                if written <= 0: sys.exit(19)",
+        "                view=view[written:]",
+        "            offset+=len(data)",
+        "        os.fsync(output)",
+        "    finally:",
+        "        os.close(output)",
         "after=os.fstat(3); copied=os.lstat(destination)",
         "if identity(after) != identity(before) or not stat.S_ISREG(copied.st_mode) or copied.st_size != before.st_size: sys.exit(20)",
         sep = "\n"
     )
     status <- suppressWarnings(system2(
         python, c("-c", shQuote(code), shQuote(destination),
-                  unname(unlist(input[required], use.names = FALSE))),
+                  unname(unlist(input[required], use.names = FALSE)),
+                  if (prefer_clone) "1" else "0"),
         stdout = FALSE, stderr = FALSE
     ))
     if (!identical(status, 0L) || !file.exists(destination) ||

--- a/benchmarks/fertility-surveys/common.R
+++ b/benchmarks/fertility-surveys/common.R
@@ -1,4 +1,4 @@
-fertility_schema_version <- 1L
+fertility_schema_version <- 5L
 fertility_expected_rows <- 1004L
 fertility_expected_releases <- c(`111` = 130L, `113` = 475L, `114` = 23L,
                                   `117` = 150L, `118` = 226L)
@@ -97,6 +97,76 @@ fertility_release <- function(path) {
         return(as.integer(release))
     }
     as.integer(bytes[[1L]])
+}
+
+fertility_raw_find <- function(bytes, needle) {
+    needle <- charToRaw(needle)
+    if (length(bytes) < length(needle)) return(integer())
+    starts <- which(bytes == needle[[1L]])
+    starts <- starts[starts + length(needle) - 1L <= length(bytes)]
+    starts[vapply(starts, function(start) {
+        identical(bytes[start:(start + length(needle) - 1L)], needle)
+    }, logical(1))]
+}
+
+fertility_raw_uint <- function(bytes, start, size, byteorder) {
+    selected <- as.double(bytes[start:(start + size - 1L)])
+    if (identical(byteorder, "MSF")) selected <- rev(selected)
+    value <- sum(selected * 256^(seq_along(selected) - 1L))
+    if (!is.finite(value) || value > 2^53) stop("DTA count exceeds exact R range")
+    value
+}
+
+fertility_structural_metadata <- function(path) {
+    connection <- file(path, open = "rb")
+    on.exit(close(connection), add = TRUE)
+    bytes <- readBin(connection, "raw", n = 4L * 1024L * 1024L)
+    release <- fertility_release(path)
+    if (release %in% c(113L, 114L)) {
+        if (length(bytes) < 109L) stop("legacy DTA header is truncated")
+        byteorder <- if (as.integer(bytes[[2L]]) == 1L) "MSF" else "LSF"
+        columns <- fertility_raw_uint(bytes, 5L, 2L, byteorder)
+        rows <- fertility_raw_uint(bytes, 7L, 4L, byteorder)
+        start <- 110L
+        if (start + columns - 1L > length(bytes)) stop("legacy DTA types are truncated")
+        codes <- as.integer(bytes[start:(start + columns - 1L)])
+        column_bytes <- ifelse(codes <= 244L, pmax(codes, 1L), 8L)
+        return(list(rows = rows, columns = as.integer(columns),
+                    column_bytes = as.double(column_bytes), strl = rep(FALSE, columns)))
+    }
+    if (!(release %in% c(117L, 118L))) stop("unsupported structural DTA release")
+    first_after <- function(needle, after = 0L) {
+        found <- fertility_raw_find(bytes, needle)
+        found <- found[found > after]
+        if (!length(found)) stop("modern DTA structural tag is missing")
+        found[[1L]]
+    }
+    byte_start <- first_after("<byteorder>")
+    byte_end <- first_after("</byteorder>", byte_start)
+    order_start <- byte_start + length(charToRaw("<byteorder>"))
+    byteorder <- rawToChar(bytes[order_start:(byte_end - 1L)])
+    read_tag_uint <- function(tag, size) {
+        opening <- first_after(paste0("<", tag, ">"))
+        closing <- first_after(paste0("</", tag, ">"), opening)
+        start <- opening + length(charToRaw(paste0("<", tag, ">")))
+        if (closing - start != size) stop("modern DTA structural field has wrong size")
+        fertility_raw_uint(bytes, start, size, byteorder)
+    }
+    columns <- read_tag_uint("K", 2L)
+    rows <- read_tag_uint("N", if (release == 118L) 8L else 4L)
+    map_end <- first_after("</map>")
+    opening <- first_after("<variable_types>", map_end)
+    closing <- first_after("</variable_types>", opening)
+    start <- opening + length(charToRaw("<variable_types>"))
+    if (closing - start != columns * 2L) stop("modern DTA types have wrong size")
+    codes <- vapply(seq_len(columns), function(i) {
+        fertility_raw_uint(bytes, start + (i - 1L) * 2L, 2L, byteorder)
+    }, numeric(1))
+    strl <- codes == 32768L
+    column_bytes <- ifelse(strl, Inf, ifelse(codes >= 1L & codes <= 2045L,
+                                             codes, 8L))
+    list(rows = rows, columns = as.integer(columns),
+         column_bytes = as.double(column_bytes), strl = strl)
 }
 
 fertility_build_inventory <- function(paths = fertility_required_paths(),

--- a/benchmarks/fertility-surveys/common.R
+++ b/benchmarks/fertility-surveys/common.R
@@ -1,0 +1,184 @@
+fertility_schema_version <- 1L
+fertility_expected_rows <- 1004L
+fertility_expected_releases <- c(`111` = 130L, `113` = 475L, `114` = 23L,
+                                  `117` = 150L, `118` = 226L)
+fertility_supported_releases <- c(113L, 114L, 117L, 118L)
+fertility_opt_in_value <- "I_UNDERSTAND_THIS_READS_PROPRIETARY_DATA"
+
+fertility_script_path <- function() {
+    argument <- grep("^--file=", commandArgs(trailingOnly = FALSE), value = TRUE)
+    if (!length(argument)) stop("could not determine script path", call. = FALSE)
+    normalizePath(sub("^--file=", "", argument[[1L]]), winslash = "/")
+}
+
+fertility_checkout_root <- function(script_path = fertility_script_path()) {
+    normalizePath(file.path(dirname(script_path), "..", ".."), winslash = "/")
+}
+
+fertility_assert_manual_run <- function() {
+    ci_variables <- c("CI", "GITHUB_ACTIONS", "GITHUB_RUN_ID", "GITHUB_WORKFLOW")
+    active <- ci_variables[nzchar(Sys.getenv(ci_variables, unset = ""))]
+    if (length(active)) {
+        stop("fertility corpus runs are refused in CI and GitHub Actions", call. = FALSE)
+    }
+    if (!identical(Sys.getenv("DTAPARSER_FERTILITY_CORPUS"), fertility_opt_in_value)) {
+        stop(paste0(
+            "manual opt-in required: set DTAPARSER_FERTILITY_CORPUS=",
+            fertility_opt_in_value
+        ), call. = FALSE)
+    }
+}
+
+fertility_required_paths <- function() {
+    home <- normalizePath("~", winslash = "/", mustWork = TRUE)
+    list(
+        cache = "/opt/aww_cache",
+        datasigs = file.path(home, "repos", "fertility_surveys", "datasigs.csv")
+    )
+}
+
+fertility_atomic_save_rds <- function(value, path) {
+    dir.create(dirname(path), recursive = TRUE, showWarnings = FALSE, mode = "0700")
+    Sys.chmod(dirname(path), mode = "0700")
+    temporary <- tempfile(paste0(basename(path), "."), tmpdir = dirname(path))
+    on.exit(unlink(temporary), add = TRUE)
+    saveRDS(value, temporary, version = 3L)
+    Sys.chmod(temporary, mode = "0600")
+    if (!file.rename(temporary, path)) stop("could not atomically replace checkpoint")
+    invisible(path)
+}
+
+fertility_atomic_write_table <- function(value, path) {
+    dir.create(dirname(path), recursive = TRUE, showWarnings = FALSE, mode = "0700")
+    Sys.chmod(dirname(path), mode = "0700")
+    temporary <- tempfile(paste0(basename(path), "."), tmpdir = dirname(path))
+    on.exit(unlink(temporary), add = TRUE)
+    write.table(value, temporary, sep = "\t", row.names = FALSE, quote = FALSE,
+                na = "")
+    Sys.chmod(temporary, mode = "0600")
+    if (!file.rename(temporary, path)) stop("could not atomically replace report")
+    invisible(path)
+}
+
+fertility_file_sha512 <- function(path) {
+    if (!requireNamespace("openssl", quietly = TRUE)) stop("openssl is required")
+    unname(unclass(tolower(as.character(openssl::sha512(file(path))))))
+}
+
+fertility_stable_id <- function(fields) {
+    values <- vapply(names(fields), function(name) {
+        value <- fields[[name]]
+        if (length(value) != 1L) stop("stable ID fields must be scalar")
+        paste0(name, "=", as.character(value[[1L]]))
+    }, character(1))
+    unname(unclass(tolower(as.character(openssl::sha256(
+        charToRaw(paste(values, collapse = "\n"))
+    )))))
+}
+
+fertility_release <- function(path) {
+    connection <- file(path, open = "rb")
+    on.exit(close(connection), add = TRUE)
+    bytes <- readBin(connection, "raw", n = 256L)
+    if (!length(bytes)) stop("empty DTA input")
+    modern_prefix <- charToRaw("<stata_dta>")
+    is_modern <- length(bytes) >= length(modern_prefix) &&
+        identical(bytes[seq_along(modern_prefix)], modern_prefix)
+    if (is_modern) {
+        needle <- charToRaw("<release>")
+        starts <- seq_len(length(bytes) - length(needle) + 1L)
+        found <- starts[vapply(starts, function(start) {
+            identical(bytes[start:(start + length(needle) - 1L)], needle)
+        }, logical(1))]
+        if (length(found) != 1L) stop("modern DTA release marker is missing")
+        release_start <- found[[1L]] + length(needle)
+        release <- rawToChar(bytes[release_start:(release_start + 2L)])
+        if (!grepl("^[0-9]{3}$", release)) stop("modern DTA release is invalid")
+        return(as.integer(release))
+    }
+    as.integer(bytes[[1L]])
+}
+
+fertility_build_inventory <- function(paths = fertility_required_paths(),
+                                      assert_counts = TRUE,
+                                      enforce_required_paths = TRUE) {
+    expected_cache <- "/opt/aww_cache"
+    expected_datasigs <- file.path(normalizePath("~", winslash = "/", mustWork = TRUE),
+                                   "repos", "fertility_surveys", "datasigs.csv")
+    if (enforce_required_paths &&
+        (!identical(paths$cache, expected_cache) ||
+         !identical(paths$datasigs, expected_datasigs))) {
+        stop("corpus paths are fixed to /opt/aww_cache and ~/repos/fertility_surveys/datasigs.csv")
+    }
+    if (!dir.exists(paths$cache)) stop("required /opt/aww_cache directory is missing")
+    cache_root <- normalizePath(paths$cache, winslash = "/", mustWork = TRUE)
+    if (!file.exists(paths$datasigs)) {
+        stop("required ~/repos/fertility_surveys/datasigs.csv file is missing")
+    }
+    rows <- read.csv(paths$datasigs, colClasses = "character", check.names = FALSE,
+                     stringsAsFactors = FALSE)
+    required <- c("program", "survey", "level", "sha512")
+    if (!all(required %in% names(rows))) stop("datasigs.csv is missing required columns")
+
+    path1 <- c(
+        dhs = "DHS/Original_Data", mics = "MICS/Data/Original Data",
+        wfs = "WFS/Data", nsfg = "NSFG/Data/Original Data",
+        enadid = "ENADID/Data/Original Data"
+    )
+    path2 <- c(dhs = "DHS/Original_Data_Provenance_Unknown")
+    inventory <- vector("list", nrow(rows))
+    for (i in seq_len(nrow(rows))) {
+        program <- tolower(rows$program[[i]])
+        level <- tolower(rows$level[[i]])
+        if (!(program %in% names(path1))) stop("datasigs.csv contains an unknown program")
+        if (!(level %in% c("women", "births"))) stop("datasigs.csv contains an unknown level")
+        folder <- if (identical(program, "wfs")) "" else
+            gsub("_", ",", rows$survey[[i]], fixed = TRUE)
+        filename <- if (identical(program, "wfs")) {
+            paste0(rows$survey[[i]], ".dta")
+        } else if (identical(level, "women")) "wm.dta" else "bh.dta"
+        candidates <- file.path(paths$cache, unname(path1[[program]]), folder, filename)
+        if (program %in% names(path2)) {
+            candidates <- c(candidates, file.path(
+                paths$cache, unname(path2[[program]]), folder, filename
+            ))
+        }
+        present <- candidates[file.exists(candidates)]
+        if (!length(present)) stop(sprintf("inventory row F%04d is missing", i))
+        # Match check_raw_data.r exactly: the primary path wins and the DHS
+        # provenance-unknown path is consulted only when the primary is absent.
+        resolved <- normalizePath(present[[1L]], winslash = "/", mustWork = TRUE)
+        if (!startsWith(resolved, paste0(cache_root, "/"))) {
+            stop(sprintf("inventory row F%04d resolves outside the cache root", i))
+        }
+        inventory[[i]] <- data.frame(
+            id = sprintf("F%04d", i), program = program, level = level,
+            release = fertility_release(resolved), path = resolved,
+            expected_sha512 = tolower(rows$sha512[[i]]),
+            stringsAsFactors = FALSE
+        )
+    }
+    inventory <- do.call(rbind, inventory)
+    if (anyDuplicated(inventory$id) || anyDuplicated(inventory$path)) {
+        stop("inventory IDs and resolved input paths must be unique")
+    }
+    if (assert_counts) {
+        if (nrow(inventory) != fertility_expected_rows) {
+            stop("expected exactly 1,004 datasigs.csv rows")
+        }
+        actual <- table(factor(inventory$release,
+                               levels = as.integer(names(fertility_expected_releases))))
+        names(actual) <- names(fertility_expected_releases)
+        if (!identical(as.integer(actual), as.integer(fertility_expected_releases))) {
+            stop("DTA release counts do not match the expected corpus inventory")
+        }
+        if (any(!(inventory$release %in% as.integer(names(fertility_expected_releases))))) {
+            stop("corpus contains an unexpected DTA release")
+        }
+    }
+    inventory
+}
+
+fertility_public_inventory <- function(inventory) {
+    inventory[c("id", "program", "level", "release")]
+}

--- a/benchmarks/fertility-surveys/compare.R
+++ b/benchmarks/fertility-surveys/compare.R
@@ -1,0 +1,79 @@
+fertility_mismatch <- function(classification, component = NA_integer_) {
+    list(ok = FALSE, classification = classification, component = component)
+}
+
+fertility_match <- function() {
+    list(ok = TRUE, classification = "match", component = NA_integer_)
+}
+
+fertility_compare_internal <- function(direct, rust_vectors) {
+    if (identical(direct, rust_vectors)) return(fertility_match())
+    fertility_mismatch("internal-collector-mismatch")
+}
+
+fertility_compare_attributes <- function(actual, expected, component) {
+    if (identical(attributes(actual), attributes(expected))) return(NULL)
+    fertility_mismatch("attribute-mismatch", component)
+}
+
+fertility_compare_values <- function(actual, expected, component,
+                                     tolerance = 1e-7) {
+    if (!identical(is.na(actual), is.na(expected))) {
+        return(fertility_mismatch("missing-position-mismatch", component))
+    }
+    if (is.numeric(actual) && is.numeric(expected) &&
+        !identical(is.nan(actual), is.nan(expected))) {
+        return(fertility_mismatch("missing-kind-mismatch", component))
+    }
+    if (is.numeric(actual) && is.numeric(expected)) {
+        if (!identical(haven::na_tag(actual), haven::na_tag(expected))) {
+            return(fertility_mismatch("tagged-missing-mismatch", component))
+        }
+        present <- !is.na(actual)
+        actual_values <- unclass(actual[present])
+        expected_values <- unclass(expected[present])
+        if (is.double(actual) || is.double(expected)) {
+            actual_finite <- is.finite(actual_values)
+            expected_finite <- is.finite(expected_values)
+            if (!identical(actual_finite, expected_finite) ||
+                !identical(actual_values[!actual_finite],
+                           expected_values[!expected_finite])) {
+                equal <- FALSE
+            } else {
+                differences <- abs(actual_values[actual_finite] -
+                                   expected_values[expected_finite])
+                equal <- all(differences <= tolerance)
+            }
+        } else {
+            equal <- identical(actual_values, expected_values)
+        }
+    } else {
+        equal <- identical(unclass(actual), unclass(expected))
+    }
+    if (!equal) fertility_mismatch("value-mismatch", component) else NULL
+}
+
+fertility_compare_haven <- function(actual, expected, tolerance = 1e-7) {
+    if (!identical(dim(actual), dim(expected))) {
+        return(fertility_mismatch("dimension-mismatch"))
+    }
+    if (!identical(names(actual), names(expected))) {
+        return(fertility_mismatch("name-mismatch"))
+    }
+    frame_attributes <- function(value) {
+        attributes(value)[setdiff(names(attributes(value)), c("names", "row.names"))]
+    }
+    if (!identical(frame_attributes(actual), frame_attributes(expected))) {
+        return(fertility_mismatch("data-frame-attribute-mismatch"))
+    }
+    for (i in seq_along(actual)) {
+        if (!identical(typeof(actual[[i]]), typeof(expected[[i]]))) {
+            return(fertility_mismatch("storage-type-mismatch", i))
+        }
+        mismatch <- fertility_compare_attributes(actual[[i]], expected[[i]], i)
+        if (!is.null(mismatch)) return(mismatch)
+        mismatch <- fertility_compare_values(actual[[i]], expected[[i]], i, tolerance)
+        if (!is.null(mismatch)) return(mismatch)
+    }
+    fertility_match()
+}

--- a/benchmarks/fertility-surveys/compare.R
+++ b/benchmarks/fertility-surveys/compare.R
@@ -1,79 +1,185 @@
+fertility_mismatch_record <- function(category, detail, component = NA_integer_) {
+    data.frame(
+        category = category, detail = detail, component = as.integer(component),
+        pair = NA_character_, stringsAsFactors = FALSE
+    )
+}
+
+fertility_bind_mismatches <- function(parts) {
+    parts <- parts[vapply(parts, nrow, integer(1)) > 0L]
+    if (!length(parts)) {
+        return(data.frame(
+            category = character(), detail = character(), component = integer(),
+            pair = character(), stringsAsFactors = FALSE
+        ))
+    }
+    result <- do.call(rbind, parts)
+    rownames(result) <- NULL
+    unique(result)
+}
+
 fertility_mismatch <- function(classification, component = NA_integer_) {
-    list(ok = FALSE, classification = classification, component = component)
+    list(ok = FALSE, classification = classification, component = component,
+         mismatches = fertility_mismatch_record(
+             fertility_public_mismatch_category(classification), classification, component
+         ))
 }
 
 fertility_match <- function() {
-    list(ok = TRUE, classification = "match", component = NA_integer_)
+    list(ok = TRUE, classification = "match", component = NA_integer_,
+         mismatches = fertility_bind_mismatches(list()))
 }
 
-fertility_compare_internal <- function(direct, rust_vectors) {
-    if (identical(direct, rust_vectors)) return(fertility_match())
-    fertility_mismatch("internal-collector-mismatch")
+fertility_public_mismatch_category <- function(detail) {
+    if (grepl("tagged|missing-tag", detail)) return("tag-mismatch")
+    if (grepl("date|posix|tzone", detail)) return("date-mismatch")
+    if (grepl("character|string|encoding", detail)) return("encoding-mismatch")
+    if (grepl("attribute|label|format|storage|class|name|dimension|row-count|column-count",
+              detail)) return("metadata-mismatch")
+    if (grepl("value|missing|nonfinite", detail)) return("value-mismatch")
+    "unresolved"
 }
 
-fertility_compare_attributes <- function(actual, expected, component) {
-    if (identical(attributes(actual), attributes(expected))) return(NULL)
-    fertility_mismatch("attribute-mismatch", component)
+fertility_compare_attribute_set <- function(actual, expected, component,
+                                              frame = FALSE) {
+    ignored <- if (frame) c("names", "row.names", "class") else character()
+    actual_attributes <- attributes(actual)
+    expected_attributes <- attributes(expected)
+    names_union <- sort(unique(c(names(actual_attributes), names(expected_attributes))))
+    names_union <- setdiff(names_union, ignored)
+    parts <- lapply(names_union, function(name) {
+        if (identical(actual_attributes[[name]], expected_attributes[[name]])) {
+            return(fertility_bind_mismatches(list()))
+        }
+        detail <- if (identical(name, "tzone")) "tzone-mismatch" else
+            if (identical(name, "class") &&
+                any(c(actual_attributes[[name]], expected_attributes[[name]]) %in%
+                    c("Date", "POSIXct", "POSIXt"))) "date-class-mismatch" else
+            paste0("attribute-", name, "-mismatch")
+        fertility_mismatch_record(fertility_public_mismatch_category(detail),
+                                  detail, component)
+    })
+    fertility_bind_mismatches(parts)
 }
 
-fertility_compare_values <- function(actual, expected, component,
-                                     tolerance = 1e-7) {
-    if (!identical(is.na(actual), is.na(expected))) {
-        return(fertility_mismatch("missing-position-mismatch", component))
-    }
-    if (is.numeric(actual) && is.numeric(expected) &&
-        !identical(is.nan(actual), is.nan(expected))) {
-        return(fertility_mismatch("missing-kind-mismatch", component))
+fertility_compare_column_values <- function(actual, expected, component,
+                                             tolerance = 1e-7) {
+    parts <- list()
+    actual_missing <- is.na(actual)
+    expected_missing <- is.na(expected)
+    if (!identical(actual_missing, expected_missing)) {
+        parts[[length(parts) + 1L]] <- fertility_mismatch_record(
+            "value-mismatch", "missing-position-mismatch", component
+        )
     }
     if (is.numeric(actual) && is.numeric(expected)) {
-        if (!identical(haven::na_tag(actual), haven::na_tag(expected))) {
-            return(fertility_mismatch("tagged-missing-mismatch", component))
+        if (!identical(is.nan(actual), is.nan(expected))) {
+            parts[[length(parts) + 1L]] <- fertility_mismatch_record(
+                "value-mismatch", "missing-kind-mismatch", component
+            )
         }
-        present <- !is.na(actual)
-        actual_values <- unclass(actual[present])
-        expected_values <- unclass(expected[present])
-        if (is.double(actual) || is.double(expected)) {
-            actual_finite <- is.finite(actual_values)
-            expected_finite <- is.finite(expected_values)
-            if (!identical(actual_finite, expected_finite) ||
-                !identical(actual_values[!actual_finite],
-                           expected_values[!expected_finite])) {
-                equal <- FALSE
-            } else {
-                differences <- abs(actual_values[actual_finite] -
-                                   expected_values[expected_finite])
-                equal <- all(differences <= tolerance)
-            }
-        } else {
-            equal <- identical(actual_values, expected_values)
+        if (!identical(haven::na_tag(actual), haven::na_tag(expected))) {
+            parts[[length(parts) + 1L]] <- fertility_mismatch_record(
+                "tag-mismatch", "tagged-missing-mismatch", component
+            )
+        }
+    }
+    comparable <- !actual_missing & !expected_missing
+    if (!any(comparable)) return(fertility_bind_mismatches(parts))
+    actual_values <- unclass(actual[comparable])
+    expected_values <- unclass(expected[comparable])
+    date_like <- inherits(actual, c("Date", "POSIXct", "POSIXt")) ||
+        inherits(expected, c("Date", "POSIXct", "POSIXt"))
+    detail <- if (date_like) "date-value-mismatch" else
+        if (is.character(actual) || is.character(expected)) "encoding-value-mismatch" else
+        "value-mismatch"
+    equal <- TRUE
+    if (is.numeric(actual_values) && is.numeric(expected_values)) {
+        actual_finite <- is.finite(actual_values)
+        expected_finite <- is.finite(expected_values)
+        if (!identical(actual_finite, expected_finite) ||
+            !identical(actual_values[!actual_finite],
+                       expected_values[!expected_finite])) {
+            parts[[length(parts) + 1L]] <- fertility_mismatch_record(
+                if (date_like) "date-mismatch" else "value-mismatch",
+                if (date_like) "date-nonfinite-mismatch" else "nonfinite-mismatch",
+                component
+            )
+        }
+        finite_both <- actual_finite & expected_finite
+        if (any(finite_both)) {
+            value_tolerance <- if (date_like) 0 else tolerance
+            equal <- if (is.double(actual_values) || is.double(expected_values)) {
+                all(abs(actual_values[finite_both] - expected_values[finite_both]) <=
+                    value_tolerance)
+            } else identical(actual_values[finite_both], expected_values[finite_both])
         }
     } else {
-        equal <- identical(unclass(actual), unclass(expected))
+        equal <- identical(actual_values, expected_values)
     }
-    if (!equal) fertility_mismatch("value-mismatch", component) else NULL
+    if (!equal) {
+        parts[[length(parts) + 1L]] <- fertility_mismatch_record(
+            fertility_public_mismatch_category(detail), detail, component
+        )
+    }
+    fertility_bind_mismatches(parts)
+}
+
+fertility_compare_pair <- function(actual, expected, tolerance = 1e-7) {
+    parts <- list()
+    if (!identical(nrow(actual), nrow(expected))) {
+        parts[[length(parts) + 1L]] <- fertility_mismatch_record(
+            "metadata-mismatch", "row-count-mismatch"
+        )
+    }
+    if (!identical(ncol(actual), ncol(expected))) {
+        parts[[length(parts) + 1L]] <- fertility_mismatch_record(
+            "metadata-mismatch", "column-count-mismatch"
+        )
+    }
+    if (!identical(names(actual), names(expected))) {
+        parts[[length(parts) + 1L]] <- fertility_mismatch_record(
+            "metadata-mismatch", "name-mismatch"
+        )
+    }
+    parts[[length(parts) + 1L]] <- fertility_compare_attribute_set(
+        actual, expected, NA_integer_, frame = TRUE
+    )
+    count <- min(length(actual), length(expected))
+    if (count > 0L) for (i in seq_len(count)) {
+        if (!identical(typeof(actual[[i]]), typeof(expected[[i]]))) {
+            parts[[length(parts) + 1L]] <- fertility_mismatch_record(
+                "metadata-mismatch", "storage-type-mismatch", i
+            )
+        }
+        parts[[length(parts) + 1L]] <- fertility_compare_attribute_set(
+            actual[[i]], expected[[i]], i
+        )
+        common_length <- min(length(actual[[i]]), length(expected[[i]]))
+        if (common_length > 0L) {
+            parts[[length(parts) + 1L]] <- fertility_compare_column_values(
+                actual[[i]][seq_len(common_length)],
+                expected[[i]][seq_len(common_length)], i, tolerance
+            )
+        }
+    }
+    fertility_bind_mismatches(parts)
+}
+
+fertility_first_result <- function(mismatches, internal = FALSE) {
+    if (!nrow(mismatches)) return(fertility_match())
+    classification <- if (internal) "internal-collector-mismatch" else
+        mismatches$detail[[1L]]
+    list(ok = FALSE, classification = classification,
+         component = mismatches$component[[1L]], mismatches = mismatches)
+}
+
+fertility_compare_internal <- function(direct, rust_vectors, tolerance = 0) {
+    fertility_first_result(
+        fertility_compare_pair(direct, rust_vectors, tolerance), internal = TRUE
+    )
 }
 
 fertility_compare_haven <- function(actual, expected, tolerance = 1e-7) {
-    if (!identical(dim(actual), dim(expected))) {
-        return(fertility_mismatch("dimension-mismatch"))
-    }
-    if (!identical(names(actual), names(expected))) {
-        return(fertility_mismatch("name-mismatch"))
-    }
-    frame_attributes <- function(value) {
-        attributes(value)[setdiff(names(attributes(value)), c("names", "row.names"))]
-    }
-    if (!identical(frame_attributes(actual), frame_attributes(expected))) {
-        return(fertility_mismatch("data-frame-attribute-mismatch"))
-    }
-    for (i in seq_along(actual)) {
-        if (!identical(typeof(actual[[i]]), typeof(expected[[i]]))) {
-            return(fertility_mismatch("storage-type-mismatch", i))
-        }
-        mismatch <- fertility_compare_attributes(actual[[i]], expected[[i]], i)
-        if (!is.null(mismatch)) return(mismatch)
-        mismatch <- fertility_compare_values(actual[[i]], expected[[i]], i, tolerance)
-        if (!is.null(mismatch)) return(mismatch)
-    }
-    fertility_match()
+    fertility_first_result(fertility_compare_pair(actual, expected, tolerance))
 }

--- a/benchmarks/fertility-surveys/compare.R
+++ b/benchmarks/fertility-surveys/compare.R
@@ -78,7 +78,8 @@ fertility_compare_column_values <- function(actual, expected, component,
                 "value-mismatch", "missing-kind-mismatch", component
             )
         }
-        if (!identical(haven::na_tag(actual), haven::na_tag(expected))) {
+        if (is.double(actual) && is.double(expected) &&
+            !identical(haven::na_tag(actual), haven::na_tag(expected))) {
             parts[[length(parts) + 1L]] <- fertility_mismatch_record(
                 "tag-mismatch", "tagged-missing-mismatch", component
             )

--- a/benchmarks/fertility-surveys/merge.R
+++ b/benchmarks/fertility-surveys/merge.R
@@ -39,23 +39,21 @@ for (parent in parents) {
         stop("report CURRENT pointer must not be a symlink")
     }
     if (!file.exists(pointer)) next
-    current <- fertility_current_bundle_paths(
-        parent,
+    current <- fertility_current_bundle_for_family(
+        parent, family_id,
         c(
             provenance = "run-provenance.tsv", results = "results.tsv",
             family_manifest = "family-manifest.tsv"
         ),
         "report shard"
     )
+    if (is.null(current)) next
     provenance_path <- current$paths[["provenance"]]
     results_path <- current$paths[["results"]]
     family_manifest_path <- current$paths[["family_manifest"]]
-    provenance <- tryCatch(read.delim(
+    provenance <- read.delim(
         provenance_path, colClasses = "character", check.names = FALSE
-    ), error = function(error) NULL)
-    if (is.null(provenance) || nrow(provenance) != 1L ||
-        !"family_id" %in% names(provenance) ||
-        !identical(provenance$family_id[[1L]], family_id)) next
+    )
     results <- read.delim(results_path, colClasses = "character", check.names = FALSE)
     family_manifest <- read.delim(
         family_manifest_path, colClasses = "character", check.names = FALSE

--- a/benchmarks/fertility-surveys/merge.R
+++ b/benchmarks/fertility-surveys/merge.R
@@ -80,9 +80,9 @@ snapshot_report_schema_version <- fertility_snapshot_report_schema_version(
     candidate_provenance
 )
 live_inventory <- fertility_build_inventory()
-fertility_validate_canonical_inventory(
+invisible(fertility_validate_canonical_inventory(
     fertility_inventory_manifest(live_inventory), exact = TRUE
-)
+))
 framework_inventory <- fertility_framework_inventory(
     file.path(raw_root, "framework", framework_ids[[1L]]),
     inventory = live_inventory, framework_id = framework_ids[[1L]],

--- a/benchmarks/fertility-surveys/merge.R
+++ b/benchmarks/fertility-surveys/merge.R
@@ -10,14 +10,22 @@ source(file.path(script_dir, "runtime.R"))
 fertility_assert_manual_run()
 arguments <- commandArgs(trailingOnly = TRUE)
 family_arguments <- arguments[startsWith(arguments, "--family-id=")]
-output_arguments <- arguments[startsWith(arguments, "--output-root=")]
-if (length(family_arguments) != 1L || length(output_arguments) > 1L ||
-    length(arguments) != length(family_arguments) + length(output_arguments)) {
-    stop("usage: merge.R --family-id=ID [--output-root=/absolute/path]")
+source_arguments <- arguments[vapply(arguments, function(argument) any(startsWith(
+    argument, c("--cache-root=", "--manifest=", "--output-root=")
+)), logical(1))]
+if (length(family_arguments) != 1L ||
+    length(arguments) != length(family_arguments) + length(source_arguments)) {
+    stop(paste(
+        "usage: merge.R --family-id=ID",
+        "(--cache-root=/absolute/path --manifest=/absolute/path |",
+        "--output-root=/absolute/path)"
+    ))
 }
 family_id <- sub("^[^=]+=", "", family_arguments[[1L]])
 if (!grepl("^[0-9a-f]{64}$", family_id)) stop("invalid family ID")
-output_options <- fertility_parse_arguments(output_arguments)
+source_options <- fertility_validate_source_arguments(
+    fertility_parse_arguments(source_arguments)
+)
 checkout_root <- fertility_checkout_root(script_path)
 raw_root <- fertility_assert_checkout_raw_root(
     file.path(checkout_root, "target", "fertility-surveys", "raw"), checkout_root
@@ -83,10 +91,10 @@ candidate_provenance <- do.call(rbind, lapply(bundles, `[[`, "provenance"))
 snapshot_report_schema_version <- fertility_snapshot_report_schema_version(
     candidate_provenance
 )
-live_inventory <- fertility_build_selected_inventory(output_options, raw_root)
+live_inventory <- fertility_build_selected_inventory(source_options, raw_root)
 invisible(fertility_validate_canonical_inventory(
     fertility_inventory_manifest(live_inventory),
-    exact = !fertility_output_requested(output_options)
+    exact = !fertility_output_requested(source_options)
 ))
 framework_inventory <- fertility_framework_inventory(
     file.path(raw_root, "framework", framework_ids[[1L]]),
@@ -180,11 +188,11 @@ revalidate_merge_sources <- function() {
         stop("source shard bundle identity changed before merged publication")
     }
     current_live_inventory <- fertility_build_selected_inventory(
-        output_options, raw_root
+        source_options, raw_root
     )
     fertility_validate_canonical_inventory(
         fertility_inventory_manifest(current_live_inventory),
-        exact = !fertility_output_requested(output_options)
+        exact = !fertility_output_requested(source_options)
     )
     current_framework <- fertility_framework_inventory(
         file.path(raw_root, "framework", framework_ids[[1L]]),
@@ -197,7 +205,8 @@ revalidate_merge_sources <- function() {
     }
     if (nzchar(provenance$acceptance_commitment_id[[1L]])) {
         fertility_revalidate_accepted_publication(
-            raw_root, current_validated$provenance, current_live_inventory
+            raw_root, current_validated$provenance, current_live_inventory,
+            fertility_required_paths(source_options, raw_root)$datasigs
         )
     }
     invisible(current_live_inventory)

--- a/benchmarks/fertility-surveys/merge.R
+++ b/benchmarks/fertility-surveys/merge.R
@@ -79,9 +79,13 @@ candidate_provenance <- do.call(rbind, lapply(bundles, `[[`, "provenance"))
 snapshot_report_schema_version <- fertility_snapshot_report_schema_version(
     candidate_provenance
 )
+live_inventory <- fertility_build_inventory()
+fertility_validate_canonical_inventory(
+    fertility_inventory_manifest(live_inventory), exact = TRUE
+)
 framework_inventory <- fertility_framework_inventory(
     file.path(raw_root, "framework", framework_ids[[1L]]),
-    framework_id = framework_ids[[1L]],
+    inventory = live_inventory, framework_id = framework_ids[[1L]],
     report_schema_version = snapshot_report_schema_version
 )
 inventory_ids <- unique(vapply(
@@ -170,9 +174,13 @@ revalidate_merge_sources <- function() {
                    merge_provenance$family_manifest_id[[1L]])) {
         stop("source shard bundle identity changed before merged publication")
     }
+    current_live_inventory <- fertility_build_inventory()
+    fertility_validate_canonical_inventory(
+        fertility_inventory_manifest(current_live_inventory), exact = TRUE
+    )
     current_framework <- fertility_framework_inventory(
         file.path(raw_root, "framework", framework_ids[[1L]]),
-        framework_id = framework_ids[[1L]],
+        inventory = current_live_inventory, framework_id = framework_ids[[1L]],
         report_schema_version = snapshot_report_schema_version
     )
     if (!identical(current_framework$provenance$inventory_id[[1L]],
@@ -180,12 +188,11 @@ revalidate_merge_sources <- function() {
         stop("merged publication framework inventory changed")
     }
     if (nzchar(provenance$acceptance_commitment_id[[1L]])) {
-        live_inventory <- fertility_build_inventory()
         fertility_revalidate_accepted_publication(
-            raw_root, current_validated$provenance, live_inventory
+            raw_root, current_validated$provenance, current_live_inventory
         )
     }
-    invisible(current_validated)
+    invisible(current_live_inventory)
 }
 
 invisible(fertility_assert_checkout_raw_root(raw_root, checkout_root))
@@ -219,14 +226,12 @@ merged_bundle_expected <- list(
     family_manifest = validated$family_manifest,
     input_attestation = family_input_attestation
 )
-validate_merged_publication_bundle <- function(path) {
+validate_merged_publication_bundle <- function(path, canonical_inventory) {
     loaded <- fertility_validate_exact_table_bundle(
         path, merged_bundle_files, merged_bundle_expected,
         "merged publication bundle"
     )
-    fertility_validate_merged_bundle(
-        loaded, family_id, framework_inventory$manifest
-    )
+    fertility_validate_merged_bundle(loaded, family_id, canonical_inventory)
     invisible(TRUE)
 }
 run_name <- paste0(format(Sys.time(), "%Y%m%dT%H%M%SZ", tz = "UTC"), "-", Sys.getpid())
@@ -235,8 +240,8 @@ fertility_publication_test_hook(
     "merge-before-bundle-revalidation",
     list(parent = merge_parent, stage = stage, destination = merge_dir)
 )
-invisible(revalidate_merge_sources())
-invisible(validate_merged_publication_bundle(stage))
+current_inventory <- revalidate_merge_sources()
+invisible(validate_merged_publication_bundle(stage, current_inventory))
 invisible(fertility_assert_checkout_raw_root(raw_root, checkout_root))
 merge_parent <- fertility_assert_output_parent(raw_root, "merged", family_id)
 invisible(fertility_assert_existing_directory(
@@ -257,8 +262,8 @@ pointer_ready <- tryCatch({
         list(parent = merge_parent, bundle = merge_dir,
              pointer = file.path(merge_parent, "CURRENT"))
     )
-    revalidate_merge_sources()
-    validate_merged_publication_bundle(merge_dir)
+    current_inventory <- revalidate_merge_sources()
+    validate_merged_publication_bundle(merge_dir, current_inventory)
     fertility_assert_checkout_raw_root(raw_root, checkout_root)
     merge_parent <- fertility_assert_output_parent(raw_root, "merged", family_id)
     fertility_assert_existing_directory(

--- a/benchmarks/fertility-surveys/merge.R
+++ b/benchmarks/fertility-surveys/merge.R
@@ -56,9 +56,14 @@ framework_ids <- unique(vapply(
 if (length(framework_ids) != 1L || !grepl("^[0-9a-f]{64}$", framework_ids)) {
     stop("shard reports have invalid framework provenance")
 }
+candidate_provenance <- do.call(rbind, lapply(bundles, `[[`, "provenance"))
+snapshot_report_schema_version <- fertility_snapshot_report_schema_version(
+    candidate_provenance
+)
 framework_inventory <- fertility_framework_inventory(
     file.path(raw_root, "framework", framework_ids[[1L]]),
-    framework_id = framework_ids[[1L]]
+    framework_id = framework_ids[[1L]],
+    report_schema_version = snapshot_report_schema_version
 )
 inventory_ids <- unique(vapply(
     bundles, function(bundle) bundle$provenance$inventory_id[[1L]], character(1)
@@ -76,9 +81,20 @@ provenance <- validated$provenance
 shard_count <- validated$shard_count
 full_default <- validated$full_default
 summary <- fertility_classification_summary(results)
+family_input_attestation_id <- fertility_family_input_attestation_id(provenance)
+evidence_family_id <- fertility_evidence_family_id(
+    family_id, family_input_attestation_id, provenance$evidence_origin[[1L]],
+    as.integer(provenance$source_corpus_schema_version[[1L]]),
+    provenance$report_schema_id[[1L]]
+)
 merge_provenance <- data.frame(
     schema_version = fertility_schema_version,
-    family_id = family_id,
+    report_schema_version = fertility_report_schema_version,
+    evidence_origin = provenance$evidence_origin[[1L]],
+    source_corpus_schema_version = provenance$source_corpus_schema_version[[1L]],
+    replayed_at_utc = provenance$replayed_at_utc[[1L]],
+    family_id = family_id, evidence_family_id = evidence_family_id,
+    family_input_attestation_id = family_input_attestation_id,
     framework_id = provenance$framework_id[[1L]],
     config_id = provenance$config_id[[1L]],
     build_provenance_id = provenance$build_provenance_id[[1L]],

--- a/benchmarks/fertility-surveys/merge.R
+++ b/benchmarks/fertility-surveys/merge.R
@@ -3,6 +3,7 @@ script_path <- normalizePath(sub("^--file=", "", grep(
 )[[1L]]), winslash = "/")
 script_dir <- dirname(script_path)
 source(file.path(script_dir, "common.R"))
+source(file.path(script_dir, "accepted.R"))
 source(file.path(script_dir, "runner.R"))
 source(file.path(script_dir, "runtime.R"))
 
@@ -14,26 +15,41 @@ if (length(arguments) != 1L || !startsWith(arguments, "--family-id=")) {
 family_id <- sub("^[^=]+=", "", arguments[[1L]])
 if (!grepl("^[0-9a-f]{64}$", family_id)) stop("invalid family ID")
 checkout_root <- fertility_checkout_root(script_path)
-raw_root <- normalizePath(file.path(checkout_root, "target", "fertility-surveys", "raw"),
-                          winslash = "/", mustWork = TRUE)
+raw_root <- fertility_assert_checkout_raw_root(
+    file.path(checkout_root, "target", "fertility-surveys", "raw"), checkout_root
+)
 invisible(fertility_assert_tempdir(raw_root))
 reports_root <- file.path(raw_root, "reports")
+if (dir.exists(reports_root) || fertility_path_is_symlink(reports_root)) {
+    invisible(fertility_assert_direct_child(
+        reports_root, raw_root, "reports output directory"
+    ))
+}
 parents <- if (dir.exists(reports_root))
     list.dirs(reports_root, recursive = FALSE, full.names = TRUE) else character()
 
 bundles <- list()
+source_records <- list()
 for (parent in parents) {
+    invisible(fertility_assert_direct_child(
+        parent, reports_root, "report selection parent"
+    ))
     pointer <- file.path(parent, "CURRENT")
+    if (fertility_path_is_symlink(pointer)) {
+        stop("report CURRENT pointer must not be a symlink")
+    }
     if (!file.exists(pointer)) next
-    run_name <- tryCatch(readLines(pointer, warn = FALSE, n = 1L),
-                         error = function(error) character())
-    if (length(run_name) != 1L || !grepl("^[A-Za-z0-9._-]+$", run_name)) next
-    bundle <- file.path(parent, run_name)
-    provenance_path <- file.path(bundle, "run-provenance.tsv")
-    results_path <- file.path(bundle, "results.tsv")
-    family_manifest_path <- file.path(bundle, "family-manifest.tsv")
-    if (!file.exists(provenance_path) || !file.exists(results_path) ||
-        !file.exists(family_manifest_path)) next
+    current <- fertility_current_bundle_paths(
+        parent,
+        c(
+            provenance = "run-provenance.tsv", results = "results.tsv",
+            family_manifest = "family-manifest.tsv"
+        ),
+        "report shard"
+    )
+    provenance_path <- current$paths[["provenance"]]
+    results_path <- current$paths[["results"]]
+    family_manifest_path <- current$paths[["family_manifest"]]
     provenance <- tryCatch(read.delim(
         provenance_path, colClasses = "character", check.names = FALSE
     ), error = function(error) NULL)
@@ -47,6 +63,11 @@ for (parent in parents) {
     bundles[[length(bundles) + 1L]] <- list(
         provenance = provenance, results = results,
         family_manifest = family_manifest
+    )
+    source_records[[length(source_records) + 1L]] <- list(
+        parent = parent, run_name = current$run_name,
+        evidence_selection_id = provenance$evidence_selection_id[[1L]],
+        input_attestation_id = provenance$input_attestation_id[[1L]]
     )
 }
 if (!length(bundles)) stop("no current shard reports found for family ID")
@@ -81,18 +102,25 @@ provenance <- validated$provenance
 shard_count <- validated$shard_count
 full_default <- validated$full_default
 summary <- fertility_classification_summary(results)
+family_input_attestation <- fertility_family_input_attestation(provenance)
 family_input_attestation_id <- fertility_family_input_attestation_id(provenance)
 evidence_family_id <- fertility_evidence_family_id(
     family_id, family_input_attestation_id, provenance$evidence_origin[[1L]],
     as.integer(provenance$source_corpus_schema_version[[1L]]),
-    provenance$report_schema_id[[1L]]
+    provenance$report_schema_id[[1L]],
+    provenance$acceptance_authority[[1L]],
+    provenance$acceptance_commitment_id[[1L]]
 )
+results_id <- fertility_merged_results_id(results)
 merge_provenance <- data.frame(
     schema_version = fertility_schema_version,
     report_schema_version = fertility_report_schema_version,
     evidence_origin = provenance$evidence_origin[[1L]],
     source_corpus_schema_version = provenance$source_corpus_schema_version[[1L]],
     replayed_at_utc = provenance$replayed_at_utc[[1L]],
+    acceptance_authority = provenance$acceptance_authority[[1L]],
+    acceptance_commitment_id = provenance$acceptance_commitment_id[[1L]],
+    acceptance_artifact_sha256 = provenance$acceptance_artifact_sha256[[1L]],
     family_id = family_id, evidence_family_id = evidence_family_id,
     family_input_attestation_id = family_input_attestation_id,
     framework_id = provenance$framework_id[[1L]],
@@ -101,32 +129,162 @@ merge_provenance <- data.frame(
     inventory_id = provenance$inventory_id[[1L]],
     family_manifest_id = provenance$family_manifest_id[[1L]],
     report_schema_id = fertility_report_schema_id(),
+    results_id = results_id,
+    merge_id = "",
     shard_count = shard_count,
     files = nrow(results),
     full_default_family = full_default,
     created_at_utc = format(Sys.time(), "%Y-%m-%dT%H:%M:%SZ", tz = "UTC"),
     stringsAsFactors = FALSE, check.names = FALSE
 )
-merge_parent <- file.path(raw_root, "merged", family_id)
-dir.create(merge_parent, recursive = TRUE, showWarnings = FALSE, mode = "0700")
+merge_provenance$merge_id <- fertility_merge_identity(merge_provenance)
+merge_provenance <- merge_provenance[fertility_merge_provenance_fields()]
+
+revalidate_merge_sources <- function() {
+    current_bundles <- lapply(source_records, function(source) {
+        current <- fertility_revalidate_current_bundle(
+            source$parent, source$run_name,
+            c(
+                provenance = "run-provenance.tsv", results = "results.tsv",
+                family_manifest = "family-manifest.tsv"
+            ),
+            "source report shard"
+        )
+        bundle <- lapply(current$paths, function(path) read.delim(
+            path, colClasses = "character", check.names = FALSE
+        ))
+        if (!identical(bundle$provenance$evidence_selection_id[[1L]],
+                       source$evidence_selection_id) ||
+            !identical(bundle$provenance$input_attestation_id[[1L]],
+                       source$input_attestation_id)) {
+            stop("source shard evidence identity changed before merged publication")
+        }
+        bundle
+    })
+    current_validated <- fertility_validate_shard_bundles(
+        current_bundles, family_id, framework_inventory$manifest
+    )
+    if (!identical(fertility_merged_results_id(current_validated$results), results_id) ||
+        !identical(fertility_family_input_attestation_id(
+            current_validated$provenance
+        ), family_input_attestation_id) ||
+        !identical(fertility_manifest_id(current_validated$family_manifest),
+                   merge_provenance$family_manifest_id[[1L]])) {
+        stop("source shard bundle identity changed before merged publication")
+    }
+    current_framework <- fertility_framework_inventory(
+        file.path(raw_root, "framework", framework_ids[[1L]]),
+        framework_id = framework_ids[[1L]],
+        report_schema_version = snapshot_report_schema_version
+    )
+    if (!identical(current_framework$provenance$inventory_id[[1L]],
+                   merge_provenance$inventory_id[[1L]])) {
+        stop("merged publication framework inventory changed")
+    }
+    if (nzchar(provenance$acceptance_commitment_id[[1L]])) {
+        live_inventory <- fertility_build_inventory()
+        fertility_revalidate_accepted_publication(
+            raw_root, current_validated$provenance, live_inventory
+        )
+    }
+    invisible(current_validated)
+}
+
+invisible(fertility_assert_checkout_raw_root(raw_root, checkout_root))
+merge_parent <- fertility_assert_output_parent(
+    raw_root, "merged", family_id, create = TRUE
+)
 Sys.chmod(c(file.path(raw_root, "merged"), merge_parent), mode = "0700")
 stage <- tempfile(".merge.", tmpdir = merge_parent)
 dir.create(stage, mode = "0700")
+invisible(fertility_assert_direct_child(
+    stage, merge_parent, "merge staging directory"
+))
 on.exit(unlink(stage, recursive = TRUE), add = TRUE)
 fertility_atomic_write_table(results, file.path(stage, "results.tsv"))
 fertility_atomic_write_table(summary, file.path(stage, "summary.tsv"))
+fertility_atomic_write_table(
+    family_input_attestation, file.path(stage, "input-attestation.tsv")
+)
 fertility_atomic_write_table(
     validated$family_manifest, file.path(stage, "family-manifest.tsv")
 )
 fertility_atomic_write_table(merge_provenance,
                              file.path(stage, "merge-provenance.tsv"))
+merged_bundle_files <- c(
+    provenance = "merge-provenance.tsv", results = "results.tsv",
+    summary = "summary.tsv", family_manifest = "family-manifest.tsv",
+    input_attestation = "input-attestation.tsv"
+)
+merged_bundle_expected <- list(
+    provenance = merge_provenance, results = results, summary = summary,
+    family_manifest = validated$family_manifest,
+    input_attestation = family_input_attestation
+)
+validate_merged_publication_bundle <- function(path) {
+    loaded <- fertility_validate_exact_table_bundle(
+        path, merged_bundle_files, merged_bundle_expected,
+        "merged publication bundle"
+    )
+    fertility_validate_merged_bundle(
+        loaded, family_id, framework_inventory$manifest
+    )
+    invisible(TRUE)
+}
 run_name <- paste0(format(Sys.time(), "%Y%m%dT%H%M%SZ", tz = "UTC"), "-", Sys.getpid())
 merge_dir <- file.path(merge_parent, run_name)
-if (!file.rename(stage, merge_dir)) stop("could not publish merged report bundle")
+fertility_publication_test_hook(
+    "merge-before-bundle-revalidation",
+    list(parent = merge_parent, stage = stage, destination = merge_dir)
+)
+invisible(revalidate_merge_sources())
+invisible(validate_merged_publication_bundle(stage))
+invisible(fertility_assert_checkout_raw_root(raw_root, checkout_root))
+merge_parent <- fertility_assert_output_parent(raw_root, "merged", family_id)
+invisible(fertility_assert_existing_directory(
+    stage, merge_parent, "merge staging directory"
+))
+merge_dir <- fertility_assert_new_destination(
+    merge_dir, merge_parent, "merged publication bundle"
+)
+fertility_atomic_rename_noreplace(
+    stage, merge_dir, "merged publication bundle"
+)
 pointer <- tempfile("CURRENT.", tmpdir = merge_parent)
 writeLines(run_name, pointer, useBytes = TRUE)
 Sys.chmod(pointer, mode = "0600")
-if (!file.rename(pointer, file.path(merge_parent, "CURRENT"))) {
+pointer_ready <- tryCatch({
+    fertility_publication_test_hook(
+        "merge-before-current-revalidation",
+        list(parent = merge_parent, bundle = merge_dir,
+             pointer = file.path(merge_parent, "CURRENT"))
+    )
+    revalidate_merge_sources()
+    validate_merged_publication_bundle(merge_dir)
+    fertility_assert_checkout_raw_root(raw_root, checkout_root)
+    merge_parent <- fertility_assert_output_parent(raw_root, "merged", family_id)
+    fertility_assert_existing_directory(
+        merge_dir, merge_parent, "merged publication bundle"
+    )
+    fertility_assert_existing_file(
+        pointer, merge_parent, "temporary merged pointer"
+    )
+    fertility_assert_direct_child(
+        file.path(merge_parent, "CURRENT"), merge_parent,
+        "merged CURRENT pointer", must_work = FALSE
+    )
+    TRUE
+}, error = function(error) {
+    fertility_remove_confirmed_new_path(
+        merge_dir, merge_parent, "new merged publication bundle"
+    )
+    stop(error)
+})
+if (!isTRUE(pointer_ready) ||
+    !file.rename(pointer, file.path(merge_parent, "CURRENT"))) {
+    fertility_remove_confirmed_new_path(
+        merge_dir, merge_parent, "new merged publication bundle"
+    )
     stop("could not publish merged report pointer")
 }
 message("merged ", nrow(results), " files from ", shard_count, " shards")

--- a/benchmarks/fertility-surveys/merge.R
+++ b/benchmarks/fertility-surveys/merge.R
@@ -9,11 +9,15 @@ source(file.path(script_dir, "runtime.R"))
 
 fertility_assert_manual_run()
 arguments <- commandArgs(trailingOnly = TRUE)
-if (length(arguments) != 1L || !startsWith(arguments, "--family-id=")) {
-    stop("usage: merge.R --family-id=ID")
+family_arguments <- arguments[startsWith(arguments, "--family-id=")]
+output_arguments <- arguments[startsWith(arguments, "--output-root=")]
+if (length(family_arguments) != 1L || length(output_arguments) > 1L ||
+    length(arguments) != length(family_arguments) + length(output_arguments)) {
+    stop("usage: merge.R --family-id=ID [--output-root=/absolute/path]")
 }
-family_id <- sub("^[^=]+=", "", arguments[[1L]])
+family_id <- sub("^[^=]+=", "", family_arguments[[1L]])
 if (!grepl("^[0-9a-f]{64}$", family_id)) stop("invalid family ID")
+output_options <- fertility_parse_arguments(output_arguments)
 checkout_root <- fertility_checkout_root(script_path)
 raw_root <- fertility_assert_checkout_raw_root(
     file.path(checkout_root, "target", "fertility-surveys", "raw"), checkout_root
@@ -79,9 +83,10 @@ candidate_provenance <- do.call(rbind, lapply(bundles, `[[`, "provenance"))
 snapshot_report_schema_version <- fertility_snapshot_report_schema_version(
     candidate_provenance
 )
-live_inventory <- fertility_build_inventory()
+live_inventory <- fertility_build_selected_inventory(output_options, raw_root)
 invisible(fertility_validate_canonical_inventory(
-    fertility_inventory_manifest(live_inventory), exact = TRUE
+    fertility_inventory_manifest(live_inventory),
+    exact = !fertility_output_requested(output_options)
 ))
 framework_inventory <- fertility_framework_inventory(
     file.path(raw_root, "framework", framework_ids[[1L]]),
@@ -174,9 +179,12 @@ revalidate_merge_sources <- function() {
                    merge_provenance$family_manifest_id[[1L]])) {
         stop("source shard bundle identity changed before merged publication")
     }
-    current_live_inventory <- fertility_build_inventory()
+    current_live_inventory <- fertility_build_selected_inventory(
+        output_options, raw_root
+    )
     fertility_validate_canonical_inventory(
-        fertility_inventory_manifest(current_live_inventory), exact = TRUE
+        fertility_inventory_manifest(current_live_inventory),
+        exact = !fertility_output_requested(output_options)
     )
     current_framework <- fertility_framework_inventory(
         file.path(raw_root, "framework", framework_ids[[1L]]),

--- a/benchmarks/fertility-surveys/merge.R
+++ b/benchmarks/fertility-surveys/merge.R
@@ -1,0 +1,116 @@
+script_path <- normalizePath(sub("^--file=", "", grep(
+    "^--file=", commandArgs(trailingOnly = FALSE), value = TRUE
+)[[1L]]), winslash = "/")
+script_dir <- dirname(script_path)
+source(file.path(script_dir, "common.R"))
+source(file.path(script_dir, "runner.R"))
+source(file.path(script_dir, "runtime.R"))
+
+fertility_assert_manual_run()
+arguments <- commandArgs(trailingOnly = TRUE)
+if (length(arguments) != 1L || !startsWith(arguments, "--family-id=")) {
+    stop("usage: merge.R --family-id=ID")
+}
+family_id <- sub("^[^=]+=", "", arguments[[1L]])
+if (!grepl("^[0-9a-f]{64}$", family_id)) stop("invalid family ID")
+checkout_root <- fertility_checkout_root(script_path)
+raw_root <- normalizePath(file.path(checkout_root, "target", "fertility-surveys", "raw"),
+                          winslash = "/", mustWork = TRUE)
+invisible(fertility_assert_tempdir(raw_root))
+reports_root <- file.path(raw_root, "reports")
+parents <- if (dir.exists(reports_root))
+    list.dirs(reports_root, recursive = FALSE, full.names = TRUE) else character()
+
+bundles <- list()
+for (parent in parents) {
+    pointer <- file.path(parent, "CURRENT")
+    if (!file.exists(pointer)) next
+    run_name <- tryCatch(readLines(pointer, warn = FALSE, n = 1L),
+                         error = function(error) character())
+    if (length(run_name) != 1L || !grepl("^[A-Za-z0-9._-]+$", run_name)) next
+    bundle <- file.path(parent, run_name)
+    provenance_path <- file.path(bundle, "run-provenance.tsv")
+    results_path <- file.path(bundle, "results.tsv")
+    family_manifest_path <- file.path(bundle, "family-manifest.tsv")
+    if (!file.exists(provenance_path) || !file.exists(results_path) ||
+        !file.exists(family_manifest_path)) next
+    provenance <- tryCatch(read.delim(
+        provenance_path, colClasses = "character", check.names = FALSE
+    ), error = function(error) NULL)
+    if (is.null(provenance) || nrow(provenance) != 1L ||
+        !"family_id" %in% names(provenance) ||
+        !identical(provenance$family_id[[1L]], family_id)) next
+    results <- read.delim(results_path, colClasses = "character", check.names = FALSE)
+    family_manifest <- read.delim(
+        family_manifest_path, colClasses = "character", check.names = FALSE
+    )
+    bundles[[length(bundles) + 1L]] <- list(
+        provenance = provenance, results = results,
+        family_manifest = family_manifest
+    )
+}
+if (!length(bundles)) stop("no current shard reports found for family ID")
+framework_ids <- unique(vapply(
+    bundles, function(bundle) bundle$provenance$framework_id[[1L]], character(1)
+))
+if (length(framework_ids) != 1L || !grepl("^[0-9a-f]{64}$", framework_ids)) {
+    stop("shard reports have invalid framework provenance")
+}
+framework_inventory <- fertility_framework_inventory(
+    file.path(raw_root, "framework", framework_ids[[1L]]),
+    framework_id = framework_ids[[1L]]
+)
+inventory_ids <- unique(vapply(
+    bundles, function(bundle) bundle$provenance$inventory_id[[1L]], character(1)
+))
+if (length(inventory_ids) != 1L ||
+    !identical(inventory_ids[[1L]],
+               framework_inventory$provenance$inventory_id[[1L]])) {
+    stop("shard reports do not match canonical inventory provenance")
+}
+validated <- fertility_validate_shard_bundles(
+    bundles, family_id, framework_inventory$manifest
+)
+results <- validated$results
+provenance <- validated$provenance
+shard_count <- validated$shard_count
+full_default <- validated$full_default
+summary <- fertility_classification_summary(results)
+merge_provenance <- data.frame(
+    schema_version = fertility_schema_version,
+    family_id = family_id,
+    framework_id = provenance$framework_id[[1L]],
+    config_id = provenance$config_id[[1L]],
+    build_provenance_id = provenance$build_provenance_id[[1L]],
+    inventory_id = provenance$inventory_id[[1L]],
+    family_manifest_id = provenance$family_manifest_id[[1L]],
+    report_schema_id = fertility_report_schema_id(),
+    shard_count = shard_count,
+    files = nrow(results),
+    full_default_family = full_default,
+    created_at_utc = format(Sys.time(), "%Y-%m-%dT%H:%M:%SZ", tz = "UTC"),
+    stringsAsFactors = FALSE, check.names = FALSE
+)
+merge_parent <- file.path(raw_root, "merged", family_id)
+dir.create(merge_parent, recursive = TRUE, showWarnings = FALSE, mode = "0700")
+Sys.chmod(c(file.path(raw_root, "merged"), merge_parent), mode = "0700")
+stage <- tempfile(".merge.", tmpdir = merge_parent)
+dir.create(stage, mode = "0700")
+on.exit(unlink(stage, recursive = TRUE), add = TRUE)
+fertility_atomic_write_table(results, file.path(stage, "results.tsv"))
+fertility_atomic_write_table(summary, file.path(stage, "summary.tsv"))
+fertility_atomic_write_table(
+    validated$family_manifest, file.path(stage, "family-manifest.tsv")
+)
+fertility_atomic_write_table(merge_provenance,
+                             file.path(stage, "merge-provenance.tsv"))
+run_name <- paste0(format(Sys.time(), "%Y%m%dT%H%M%SZ", tz = "UTC"), "-", Sys.getpid())
+merge_dir <- file.path(merge_parent, run_name)
+if (!file.rename(stage, merge_dir)) stop("could not publish merged report bundle")
+pointer <- tempfile("CURRENT.", tmpdir = merge_parent)
+writeLines(run_name, pointer, useBytes = TRUE)
+Sys.chmod(pointer, mode = "0600")
+if (!file.rename(pointer, file.path(merge_parent, "CURRENT"))) {
+    stop("could not publish merged report pointer")
+}
+message("merged ", nrow(results), " files from ", shard_count, " shards")

--- a/benchmarks/fertility-surveys/prepare.R
+++ b/benchmarks/fertility-surveys/prepare.R
@@ -19,6 +19,9 @@ raw_root <- fertility_assert_checkout_raw_root(
 invisible(fertility_assert_tempdir(raw_root))
 library_value <- Sys.getenv("DTAPARSER_FERTILITY_LIBRARY")
 provenance_value <- Sys.getenv("DTAPARSER_FERTILITY_PROVENANCE")
+if (!nzchar(library_value) || !nzchar(provenance_value)) {
+    stop("immutable corpus build library and provenance are required")
+}
 selected_build_id <- basename(dirname(path.expand(provenance_value)))
 build_bundle <- fertility_resolve_build_bundle(
     raw_root, selected_build_id, require_current = TRUE

--- a/benchmarks/fertility-surveys/prepare.R
+++ b/benchmarks/fertility-surveys/prepare.R
@@ -1,0 +1,28 @@
+script_path <- normalizePath(sub("^--file=", "", grep(
+    "^--file=", commandArgs(trailingOnly = FALSE), value = TRUE
+)[[1L]]), winslash = "/")
+script_dir <- dirname(script_path)
+source(file.path(script_dir, "common.R"))
+source(file.path(script_dir, "provenance.R"))
+source(file.path(script_dir, "runner.R"))
+source(file.path(script_dir, "runtime.R"))
+
+fertility_assert_manual_run()
+checkout_root <- fertility_checkout_root(script_path)
+raw_root <- normalizePath(file.path(checkout_root, "target", "fertility-surveys", "raw"),
+                          winslash = "/", mustWork = TRUE)
+invisible(fertility_assert_tempdir(raw_root))
+library <- normalizePath(Sys.getenv("DTAPARSER_FERTILITY_LIBRARY"), winslash = "/",
+                         mustWork = TRUE)
+provenance_path <- normalizePath(
+    Sys.getenv("DTAPARSER_FERTILITY_PROVENANCE"), winslash = "/", mustWork = TRUE
+)
+provenance <- fertility_verify_provenance(checkout_root, library, provenance_path)
+inventory <- fertility_build_inventory()
+framework_id <- fertility_framework_id(
+    provenance$provenance_id[[1L]], fertility_required_paths()$datasigs
+)
+invisible(fertility_prepare_framework_snapshot(
+    script_dir, raw_root, framework_id, inventory
+))
+cat(framework_id)

--- a/benchmarks/fertility-surveys/prepare.R
+++ b/benchmarks/fertility-surveys/prepare.R
@@ -3,26 +3,45 @@ script_path <- normalizePath(sub("^--file=", "", grep(
 )[[1L]]), winslash = "/")
 script_dir <- dirname(script_path)
 source(file.path(script_dir, "common.R"))
+source(file.path(script_dir, "accepted.R"))
 source(file.path(script_dir, "provenance.R"))
 source(file.path(script_dir, "runner.R"))
 source(file.path(script_dir, "runtime.R"))
 
 fertility_assert_manual_run()
+options <- fertility_parse_arguments(commandArgs(trailingOnly = TRUE))
 checkout_root <- fertility_checkout_root(script_path)
-raw_root <- normalizePath(file.path(checkout_root, "target", "fertility-surveys", "raw"),
-                          winslash = "/", mustWork = TRUE)
-invisible(fertility_assert_tempdir(raw_root))
-library <- normalizePath(Sys.getenv("DTAPARSER_FERTILITY_LIBRARY"), winslash = "/",
-                         mustWork = TRUE)
-provenance_path <- normalizePath(
-    Sys.getenv("DTAPARSER_FERTILITY_PROVENANCE"), winslash = "/", mustWork = TRUE
+raw_root <- fertility_assert_checkout_raw_root(
+    file.path(checkout_root, "target", "fertility-surveys", "raw"), checkout_root
 )
+invisible(fertility_assert_tempdir(raw_root))
+library_value <- Sys.getenv("DTAPARSER_FERTILITY_LIBRARY")
+provenance_value <- Sys.getenv("DTAPARSER_FERTILITY_PROVENANCE")
+selected_build_id <- basename(dirname(path.expand(provenance_value)))
+build_bundle <- fertility_resolve_build_bundle(
+    raw_root, selected_build_id, require_current = TRUE
+)
+if (!identical(path.expand(library_value), build_bundle$library) ||
+    !identical(path.expand(provenance_value), build_bundle$provenance)) {
+    stop("immutable corpus build paths escaped the selected build generation")
+}
+library <- build_bundle$library
+provenance_path <- build_bundle$provenance
 provenance <- fertility_verify_provenance(checkout_root, library, provenance_path)
+if (!identical(provenance$provenance_id[[1L]], selected_build_id)) {
+    stop("selected build provenance identity is invalid")
+}
 inventory <- fertility_build_inventory()
+acceptance <- if (nzchar(options$accepted_current_hashes)) {
+    fertility_load_acceptance(raw_root, options$accepted_current_hashes, inventory)
+} else NULL
+family <- fertility_family_selection(inventory, options)
+fertility_validate_accepted_selection(options, family)
+invisible(fertility_validate_acceptance_current(acceptance, inventory))
 framework_id <- fertility_framework_id(
-    provenance$provenance_id[[1L]], fertility_required_paths()$datasigs
+    provenance$provenance_id[[1L]], fertility_required_paths()$datasigs, acceptance
 )
 invisible(fertility_prepare_framework_snapshot(
-    script_dir, raw_root, framework_id, inventory
+    script_dir, raw_root, framework_id, inventory, acceptance
 ))
 cat(framework_id)

--- a/benchmarks/fertility-surveys/prepare.R
+++ b/benchmarks/fertility-surveys/prepare.R
@@ -9,7 +9,9 @@ source(file.path(script_dir, "runner.R"))
 source(file.path(script_dir, "runtime.R"))
 
 fertility_assert_manual_run()
-options <- fertility_parse_arguments(commandArgs(trailingOnly = TRUE))
+options <- fertility_validate_source_arguments(
+    fertility_parse_arguments(commandArgs(trailingOnly = TRUE))
+)
 checkout_root <- fertility_checkout_root(script_path)
 raw_root <- fertility_assert_checkout_raw_root(
     file.path(checkout_root, "target", "fertility-surveys", "raw"), checkout_root

--- a/benchmarks/fertility-surveys/prepare.R
+++ b/benchmarks/fertility-surveys/prepare.R
@@ -31,7 +31,7 @@ provenance <- fertility_verify_provenance(checkout_root, library, provenance_pat
 if (!identical(provenance$provenance_id[[1L]], selected_build_id)) {
     stop("selected build provenance identity is invalid")
 }
-inventory <- fertility_build_inventory()
+inventory <- fertility_build_selected_inventory(options, raw_root)
 acceptance <- if (nzchar(options$accepted_current_hashes)) {
     fertility_load_acceptance(raw_root, options$accepted_current_hashes, inventory)
 } else NULL
@@ -39,7 +39,7 @@ family <- fertility_family_selection(inventory, options)
 fertility_validate_accepted_selection(options, family)
 invisible(fertility_validate_acceptance_current(acceptance, inventory))
 framework_id <- fertility_framework_id(
-    provenance$provenance_id[[1L]], fertility_required_paths()$datasigs, acceptance
+    provenance$provenance_id[[1L]], fertility_required_paths(options, raw_root)$datasigs, acceptance
 )
 invisible(fertility_prepare_framework_snapshot(
     script_dir, raw_root, framework_id, inventory, acceptance

--- a/benchmarks/fertility-surveys/provenance.R
+++ b/benchmarks/fertility-surveys/provenance.R
@@ -13,11 +13,11 @@ fertility_tree_digest <- function(checkout_root, scope) {
     )
     paths <- sort(unique(paths[nzchar(paths)]))
     if (!length(paths)) stop("no provenance inputs found")
-    hashes <- unname(tools::md5sum(file.path(checkout_root, paths)))
+    hashes <- unname(tools::sha256sum(file.path(checkout_root, paths)))
     temporary <- tempfile("fertility-tree-")
     on.exit(unlink(temporary), add = TRUE)
     writeLines(paste(paths, hashes, sep = "\t"), temporary, useBytes = TRUE)
-    unname(tools::md5sum(temporary))
+    unname(tools::sha256sum(temporary))
 }
 
 fertility_directory_digest <- function(directory) {
@@ -27,9 +27,9 @@ fertility_directory_digest <- function(directory) {
     if (!length(paths)) stop("installed package is empty")
     temporary <- tempfile("fertility-installed-")
     on.exit(unlink(temporary), add = TRUE)
-    writeLines(paste(paths, unname(tools::md5sum(file.path(directory, paths))),
+    writeLines(paste(paths, unname(tools::sha256sum(file.path(directory, paths))),
                      sep = "\t"), temporary, useBytes = TRUE)
-    unname(tools::md5sum(temporary))
+    unname(tools::sha256sum(temporary))
 }
 
 fertility_package_path <- function(library) {
@@ -58,7 +58,7 @@ fertility_dependency_provenance <- function(packages) {
             as.character(utils::packageVersion(package))
         record[[paste0(package, "_path")]] <- installed
         record[[paste0(package, "_namespace_path")]] <- namespace
-        record[[paste0(package, "_installed_md5")]] <-
+        record[[paste0(package, "_installed_sha256")]] <-
             fertility_directory_digest(installed)
     }
     as.data.frame(record, stringsAsFactors = FALSE, check.names = FALSE)
@@ -77,11 +77,11 @@ fertility_current_provenance <- function(checkout_root, library) {
         git_commit = fertility_git_lines(checkout_root, c("rev-parse", "HEAD"))[[1L]],
         git_dirty = length(status) > 0L,
         package_version = unname(description[[1L, "Version"]]),
-        package_source_md5 = fertility_tree_digest(checkout_root, "r-package/dtaparser"),
-        framework_source_md5 = fertility_tree_digest(
+        package_source_sha256 = fertility_tree_digest(checkout_root, "r-package/dtaparser"),
+        framework_source_sha256 = fertility_tree_digest(
             checkout_root, "benchmarks/fertility-surveys"
         ),
-        installed_package_md5 = fertility_directory_digest(
+        installed_package_sha256 = fertility_directory_digest(
             fertility_package_path(library)
         ),
         r_version = R.version.string,

--- a/benchmarks/fertility-surveys/provenance.R
+++ b/benchmarks/fertility-surveys/provenance.R
@@ -1,8 +1,15 @@
 fertility_git_lines <- function(checkout_root, arguments) {
+    diagnostics_path <- tempfile("fertility-git-stderr-")
+    on.exit(unlink(diagnostics_path), add = TRUE)
     output <- system2("git", c("-C", shQuote(checkout_root), arguments),
-                      stdout = TRUE, stderr = TRUE)
+                      stdout = TRUE, stderr = diagnostics_path)
     status <- attr(output, "status", exact = TRUE)
-    if (!is.null(status) && status != 0L) stop("git command failed")
+    if (!is.null(status) && status != 0L) {
+        diagnostics <- if (file.exists(diagnostics_path)) {
+            readLines(diagnostics_path, warn = FALSE)
+        } else character()
+        stop("git command failed: ", paste(c(output, diagnostics), collapse = "\n"))
+    }
     output
 }
 

--- a/benchmarks/fertility-surveys/provenance.R
+++ b/benchmarks/fertility-surveys/provenance.R
@@ -21,21 +21,18 @@ fertility_tree_digest <- function(checkout_root, scope) {
 }
 
 fertility_directory_digest <- function(directory) {
-    directory <- normalizePath(directory, winslash = "/", mustWork = TRUE)
-    paths <- sort(list.files(directory, recursive = TRUE, all.files = TRUE,
-                             full.names = FALSE, include.dirs = FALSE, no.. = TRUE))
-    if (!length(paths)) stop("installed package is empty")
+    attestation <- fertility_attest_regular_tree(directory, "installed package")
     temporary <- tempfile("fertility-installed-")
     on.exit(unlink(temporary), add = TRUE)
-    writeLines(paste(paths, unname(tools::sha256sum(file.path(directory, paths))),
-                     sep = "\t"), temporary, useBytes = TRUE)
+    writeLines(paste(attestation$paths, attestation$sha256, sep = "\t"),
+               temporary, useBytes = TRUE)
     unname(tools::sha256sum(temporary))
 }
 
 fertility_package_path <- function(library) {
     library <- normalizePath(library, winslash = "/", mustWork = TRUE)
     lexical <- file.path(library, "dtaparser")
-    if (nzchar(Sys.readlink(lexical))) stop("installed package must not be a symlink")
+    if (fertility_path_is_symlink(lexical)) stop("installed package must not be a symlink")
     resolved <- normalizePath(lexical, winslash = "/", mustWork = TRUE)
     if (!identical(dirname(resolved), library)) stop("installed package escaped library")
     resolved
@@ -202,9 +199,11 @@ fertility_verify_recorded_framework_snapshot <- function(checkout_root, snapshot
     on.exit(unlink(extracted, recursive = TRUE), add = TRUE)
     for (name in c("common.R", "worker.R", "compare.R", "runtime.R")) {
         expected <- file.path(extracted, "benchmarks", "fertility-surveys", name)
-        actual <- file.path(snapshot_root, name)
-        if (!file.exists(actual) ||
-            !identical(unname(tools::sha256sum(expected)),
+        actual <- fertility_assert_existing_file(
+            file.path(snapshot_root, name), snapshot_root,
+            "recorded framework snapshot file"
+        )
+        if (!identical(unname(tools::sha256sum(expected)),
                        unname(tools::sha256sum(actual)))) {
             stop("recorded framework snapshot is not migration-safe")
         }

--- a/benchmarks/fertility-surveys/provenance.R
+++ b/benchmarks/fertility-surveys/provenance.R
@@ -98,10 +98,21 @@ fertility_current_provenance <- function(checkout_root, library) {
     cbind(provenance, fertility_dependency_provenance(runtime_packages))
 }
 
+fertility_source_tarball_sha256 <- function(value) {
+    value <- tolower(as.character(value))
+    if (length(value) != 1L || is.na(value) ||
+        !grepl("^[0-9a-f]{64}$", value)) {
+        stop("source tarball SHA-256 is invalid")
+    }
+    value
+}
+
 fertility_write_provenance <- function(checkout_root, library, path,
                                        source_tarball_sha256) {
     provenance <- fertility_current_provenance(checkout_root, library)
-    provenance$source_tarball_sha256 <- tolower(source_tarball_sha256)
+    provenance$source_tarball_sha256 <- fertility_source_tarball_sha256(
+        source_tarball_sha256
+    )
     provenance$provenance_id <- fertility_stable_id(provenance)
     provenance$created_at_utc <- format(Sys.time(), "%Y-%m-%dT%H:%M:%SZ", tz = "UTC")
     fertility_atomic_write_table(provenance, path)
@@ -119,6 +130,12 @@ fertility_provenance_mismatches <- function(current, recorded) {
 fertility_verify_provenance <- function(checkout_root, library, path) {
     recorded <- read.delim(path, colClasses = "character", check.names = FALSE)
     if (nrow(recorded) != 1L) stop("build provenance must contain exactly one row")
+    if (!"source_tarball_sha256" %in% names(recorded)) {
+        stop("build provenance source tarball SHA-256 is missing")
+    }
+    recorded$source_tarball_sha256 <- fertility_source_tarball_sha256(
+        recorded$source_tarball_sha256
+    )
     current <- fertility_current_provenance(checkout_root, library)
     mismatched <- fertility_provenance_mismatches(current, recorded)
     if (length(mismatched)) stop("stale or foreign corpus package installation")

--- a/benchmarks/fertility-surveys/provenance.R
+++ b/benchmarks/fertility-surveys/provenance.R
@@ -1,0 +1,125 @@
+fertility_git_lines <- function(checkout_root, arguments) {
+    output <- system2("git", c("-C", shQuote(checkout_root), arguments),
+                      stdout = TRUE, stderr = TRUE)
+    status <- attr(output, "status", exact = TRUE)
+    if (!is.null(status) && status != 0L) stop("git command failed")
+    output
+}
+
+fertility_tree_digest <- function(checkout_root, scope) {
+    paths <- fertility_git_lines(
+        checkout_root,
+        c("ls-files", "--cached", "--others", "--exclude-standard", "--", scope)
+    )
+    paths <- sort(unique(paths[nzchar(paths)]))
+    if (!length(paths)) stop("no provenance inputs found")
+    hashes <- unname(tools::md5sum(file.path(checkout_root, paths)))
+    temporary <- tempfile("fertility-tree-")
+    on.exit(unlink(temporary), add = TRUE)
+    writeLines(paste(paths, hashes, sep = "\t"), temporary, useBytes = TRUE)
+    unname(tools::md5sum(temporary))
+}
+
+fertility_directory_digest <- function(directory) {
+    directory <- normalizePath(directory, winslash = "/", mustWork = TRUE)
+    paths <- sort(list.files(directory, recursive = TRUE, all.files = TRUE,
+                             full.names = FALSE, include.dirs = FALSE, no.. = TRUE))
+    if (!length(paths)) stop("installed package is empty")
+    temporary <- tempfile("fertility-installed-")
+    on.exit(unlink(temporary), add = TRUE)
+    writeLines(paste(paths, unname(tools::md5sum(file.path(directory, paths))),
+                     sep = "\t"), temporary, useBytes = TRUE)
+    unname(tools::md5sum(temporary))
+}
+
+fertility_package_path <- function(library) {
+    library <- normalizePath(library, winslash = "/", mustWork = TRUE)
+    lexical <- file.path(library, "dtaparser")
+    if (nzchar(Sys.readlink(lexical))) stop("installed package must not be a symlink")
+    resolved <- normalizePath(lexical, winslash = "/", mustWork = TRUE)
+    if (!identical(dirname(resolved), library)) stop("installed package escaped library")
+    resolved
+}
+
+fertility_dependency_provenance <- function(packages) {
+    record <- list()
+    for (package in packages) {
+        if (!requireNamespace(package, quietly = TRUE)) stop(package, " is required")
+        installed <- normalizePath(find.package(package), winslash = "/",
+                                   mustWork = TRUE)
+        namespace <- normalizePath(
+            getNamespaceInfo(asNamespace(package), "path"),
+            winslash = "/", mustWork = TRUE
+        )
+        if (!identical(installed, namespace)) {
+            stop(package, " installed and loaded namespace paths disagree")
+        }
+        record[[paste0(package, "_version")]] <-
+            as.character(utils::packageVersion(package))
+        record[[paste0(package, "_path")]] <- installed
+        record[[paste0(package, "_namespace_path")]] <- namespace
+        record[[paste0(package, "_installed_md5")]] <-
+            fertility_directory_digest(installed)
+    }
+    as.data.frame(record, stringsAsFactors = FALSE, check.names = FALSE)
+}
+
+fertility_current_provenance <- function(checkout_root, library) {
+    description <- read.dcf(file.path(checkout_root, "r-package", "dtaparser",
+                                      "DESCRIPTION"))
+    status <- fertility_git_lines(
+        checkout_root,
+        c("status", "--porcelain", "--untracked-files=all", "--",
+          "r-package/dtaparser", "benchmarks/fertility-surveys")
+    )
+    provenance <- data.frame(
+        schema_version = fertility_schema_version,
+        git_commit = fertility_git_lines(checkout_root, c("rev-parse", "HEAD"))[[1L]],
+        git_dirty = length(status) > 0L,
+        package_version = unname(description[[1L, "Version"]]),
+        package_source_md5 = fertility_tree_digest(checkout_root, "r-package/dtaparser"),
+        framework_source_md5 = fertility_tree_digest(
+            checkout_root, "benchmarks/fertility-surveys"
+        ),
+        installed_package_md5 = fertility_directory_digest(
+            fertility_package_path(library)
+        ),
+        r_version = R.version.string,
+        stringsAsFactors = FALSE, check.names = FALSE
+    )
+    runtime_packages <- c(
+        "haven", "openssl", "callr", "ps", "readr", "rlang", "tibble", "tidyselect"
+    )
+    cbind(provenance, fertility_dependency_provenance(runtime_packages))
+}
+
+fertility_write_provenance <- function(checkout_root, library, path,
+                                       source_tarball_sha256) {
+    provenance <- fertility_current_provenance(checkout_root, library)
+    provenance$source_tarball_sha256 <- tolower(source_tarball_sha256)
+    provenance$provenance_id <- fertility_stable_id(provenance)
+    provenance$created_at_utc <- format(Sys.time(), "%Y-%m-%dT%H:%M:%SZ", tz = "UTC")
+    fertility_atomic_write_table(provenance, path)
+    invisible(provenance)
+}
+
+fertility_provenance_mismatches <- function(current, recorded) {
+    missing <- setdiff(names(current), names(recorded))
+    if (length(missing)) return(missing)
+    names(current)[!vapply(names(current), function(field) {
+        identical(as.character(current[[field]]), as.character(recorded[[field]]))
+    }, logical(1))]
+}
+
+fertility_verify_provenance <- function(checkout_root, library, path) {
+    recorded <- read.delim(path, colClasses = "character", check.names = FALSE)
+    if (nrow(recorded) != 1L) stop("build provenance must contain exactly one row")
+    current <- fertility_current_provenance(checkout_root, library)
+    mismatched <- fertility_provenance_mismatches(current, recorded)
+    if (length(mismatched)) stop("stale or foreign corpus package installation")
+    stable <- recorded[setdiff(names(recorded), c("provenance_id", "created_at_utc"))]
+    if (!identical(recorded$provenance_id[[1L]], fertility_stable_id(stable))) {
+        stop("invalid corpus build provenance ID")
+    }
+    recorded
+}

--- a/benchmarks/fertility-surveys/provenance.R
+++ b/benchmarks/fertility-surveys/provenance.R
@@ -92,7 +92,8 @@ fertility_current_provenance <- function(checkout_root, library) {
         stringsAsFactors = FALSE, check.names = FALSE
     )
     runtime_packages <- c(
-        "haven", "openssl", "callr", "ps", "readr", "rlang", "tibble", "tidyselect"
+        "haven", "openssl", "callr", "processx", "ps", "readr", "rlang",
+        "tibble", "tidyselect"
     )
     cbind(provenance, fertility_dependency_provenance(runtime_packages))
 }

--- a/benchmarks/fertility-surveys/provenance.R
+++ b/benchmarks/fertility-surveys/provenance.R
@@ -123,3 +123,91 @@ fertility_verify_provenance <- function(checkout_root, library, path) {
     }
     recorded
 }
+
+fertility_commit_tree <- function(checkout_root, commit, scope,
+                                  preserve = FALSE) {
+    archive <- tempfile("fertility-commit-", fileext = ".tar")
+    extracted <- tempfile("fertility-commit-tree-")
+    dir.create(extracted, mode = "0700")
+    on.exit(unlink(archive), add = TRUE)
+    if (!preserve) on.exit(unlink(extracted, recursive = TRUE), add = TRUE)
+    status <- system2("git", c(
+        "-C", shQuote(checkout_root), "archive", "--format=tar",
+        paste0("--output=", shQuote(archive)), shQuote(commit), shQuote(scope)
+    ))
+    if (!identical(status, 0L)) stop("could not materialize recorded git tree")
+    utils::untar(archive, exdir = extracted)
+    paths <- sort(list.files(
+        file.path(extracted, scope), recursive = TRUE, all.files = TRUE,
+        full.names = FALSE, include.dirs = FALSE, no.. = TRUE
+    ))
+    if (!length(paths)) stop("recorded git tree scope is empty")
+    relative <- file.path(scope, paths)
+    temporary <- tempfile("fertility-commit-digest-")
+    on.exit(unlink(temporary), add = TRUE)
+    writeLines(paste(
+        relative, unname(tools::sha256sum(file.path(extracted, relative))), sep = "\t"
+    ), temporary, useBytes = TRUE)
+    list(digest = unname(tools::sha256sum(temporary)), root = extracted)
+}
+
+fertility_verify_recorded_provenance <- function(checkout_root, library, path) {
+    recorded <- read.delim(path, colClasses = "character", check.names = FALSE)
+    if (nrow(recorded) != 1L ||
+        !identical(recorded$schema_version[[1L]],
+                   as.character(fertility_legacy_corpus_schema_version)) ||
+        !identical(recorded$git_dirty[[1L]], "FALSE")) {
+        stop("recorded corpus generation is not migration-safe")
+    }
+    stable <- recorded[setdiff(names(recorded), c("provenance_id", "created_at_utc"))]
+    if (!identical(recorded$provenance_id[[1L]], fertility_stable_id(stable))) {
+        stop("invalid recorded corpus provenance ID")
+    }
+    commit <- recorded$git_commit[[1L]]
+    exists <- system2(
+        "git", c("-C", shQuote(checkout_root), "cat-file", "-e",
+                 shQuote(paste0(commit, "^{commit}"))),
+        stdout = FALSE, stderr = FALSE
+    )
+    if (!identical(exists, 0L)) stop("recorded corpus commit is unavailable")
+    package_tree <- fertility_commit_tree(checkout_root, commit, "r-package/dtaparser")
+    framework_tree <- fertility_commit_tree(
+        checkout_root, commit, "benchmarks/fertility-surveys"
+    )
+    if (!identical(package_tree$digest, recorded$package_source_sha256[[1L]]) ||
+        !identical(framework_tree$digest, recorded$framework_source_sha256[[1L]]) ||
+        !identical(fertility_directory_digest(fertility_package_path(library)),
+                   recorded$installed_package_sha256[[1L]]) ||
+        !identical(R.version.string, recorded$r_version[[1L]])) {
+        stop("recorded corpus generation no longer matches its attestation")
+    }
+    packages <- c(
+        "haven", "openssl", "callr", "ps", "readr", "rlang", "tibble", "tidyselect"
+    )
+    dependencies <- fertility_dependency_provenance(packages)
+    fields <- names(dependencies)
+    if (length(setdiff(fields, names(recorded))) || any(vapply(fields, function(field) {
+        !identical(as.character(dependencies[[field]]), recorded[[field]])
+    }, logical(1)))) stop("recorded corpus dependency provenance changed")
+    recorded
+}
+
+fertility_verify_recorded_framework_snapshot <- function(checkout_root, snapshot_root,
+                                                         recorded) {
+    tree <- fertility_commit_tree(
+        checkout_root, recorded$git_commit[[1L]], "benchmarks/fertility-surveys",
+        preserve = TRUE
+    )
+    extracted <- tree$root
+    on.exit(unlink(extracted, recursive = TRUE), add = TRUE)
+    for (name in c("common.R", "worker.R", "compare.R", "runtime.R")) {
+        expected <- file.path(extracted, "benchmarks", "fertility-surveys", name)
+        actual <- file.path(snapshot_root, name)
+        if (!file.exists(actual) ||
+            !identical(unname(tools::sha256sum(expected)),
+                       unname(tools::sha256sum(actual)))) {
+            stop("recorded framework snapshot is not migration-safe")
+        }
+    }
+    invisible(TRUE)
+}

--- a/benchmarks/fertility-surveys/republish.R
+++ b/benchmarks/fertility-surveys/republish.R
@@ -3,6 +3,7 @@ script_path <- normalizePath(sub("^--file=", "", grep(
 )[[1L]]), winslash = "/")
 script_dir <- dirname(script_path)
 source(file.path(script_dir, "common.R"))
+source(file.path(script_dir, "accepted.R"))
 source(file.path(script_dir, "provenance.R"))
 source(file.path(script_dir, "runner.R"))
 source(file.path(script_dir, "runtime.R"))
@@ -35,43 +36,73 @@ if (!fertility_full_default_family(options) || options$shard_count != 8L) {
 }
 
 checkout_root <- fertility_checkout_root(script_path)
-raw_root <- normalizePath(file.path(checkout_root, "target", "fertility-surveys", "raw"),
-                          winslash = "/", mustWork = TRUE)
+raw_root <- fertility_assert_checkout_raw_root(
+    file.path(checkout_root, "target", "fertility-surveys", "raw"), checkout_root
+)
 invisible(fertility_assert_tempdir(raw_root))
 owner_state <- Sys.getenv("DTAPARSER_FERTILITY_OWNER_STATE")
 if (!nzchar(owner_state)) stop("run benchmark.sh to establish republish ownership")
 owner <- fertility_read_owner(owner_state)
 if (!isTRUE(fertility_owner_alive(owner))) stop("orchestrator owner is not alive")
 
-snapshot_root <- file.path(raw_root, "framework", framework_id)
+framework_root <- fertility_assert_existing_directory(
+    file.path(raw_root, "framework"), raw_root, "framework output directory"
+)
+snapshot_root <- fertility_assert_existing_directory(
+    file.path(framework_root, framework_id), framework_root, "framework snapshot"
+)
 framework_inventory <- fertility_framework_inventory(
     snapshot_root, framework_id = framework_id,
     report_schema_version = fertility_legacy_report_schema_version
 )
 manifest <- framework_inventory$manifest
 configuration <- fertility_tile_configuration(options)
-checkpoint_root <- file.path(raw_root, "checkpoints", framework_id,
-                             configuration$config_id)
-if (!dir.exists(checkpoint_root)) {
-    stop("recorded checkpoint configuration is absent")
-}
-checkpoint_ids <- sort(basename(list.dirs(
-    checkpoint_root, recursive = FALSE, full.names = TRUE
-)))
+checkpoints_root <- fertility_assert_existing_directory(
+    file.path(raw_root, "checkpoints"), raw_root, "checkpoints output directory"
+)
+framework_checkpoint_root <- fertility_assert_existing_directory(
+    file.path(checkpoints_root, framework_id), checkpoints_root,
+    "framework checkpoint directory"
+)
+checkpoint_root <- fertility_assert_existing_directory(
+    file.path(framework_checkpoint_root, configuration$config_id),
+    framework_checkpoint_root, "configuration checkpoint directory"
+)
+checkpoint_ids <- sort(list.files(
+    checkpoint_root, all.files = TRUE, no.. = TRUE
+))
 if (!identical(checkpoint_ids, manifest$id)) {
     stop("recorded checkpoint IDs do not exactly match canonical inventory")
 }
+checkpoint_case_paths <- setNames(lapply(manifest$id, function(id) {
+    fertility_resolve_checkpoint_case(
+        raw_root, framework_id, configuration$config_id, id
+    )
+}), manifest$id)
 
-builds_root <- file.path(raw_root, "builds")
+builds_root <- fertility_assert_existing_directory(
+    file.path(raw_root, "builds"), raw_root, "builds output directory"
+)
+build_current <- file.path(builds_root, "CURRENT")
+if (file.exists(build_current) || dir.exists(build_current) ||
+    fertility_path_is_symlink(build_current)) {
+    fertility_assert_existing_file(
+        build_current, builds_root, "build CURRENT pointer"
+    )
+}
 datasigs_path <- fertility_required_paths()$datasigs
-builds <- list.dirs(builds_root, recursive = FALSE, full.names = TRUE)
+build_entries <- list.files(builds_root, all.files = TRUE, no.. = TRUE)
+build_entries <- setdiff(build_entries, "CURRENT")
 candidates <- list()
-for (build_root in builds) {
+for (entry in build_entries) {
+    build_root <- fertility_assert_existing_directory(
+        file.path(builds_root, entry), builds_root, "build generation"
+    )
     build_id <- basename(build_root)
     if (!grepl("^[0-9a-f]{64}$", build_id)) next
-    provenance_path <- file.path(build_root, "build-provenance.tsv")
-    library <- file.path(build_root, "library")
-    if (!file.exists(provenance_path) || !dir.exists(file.path(library, "dtaparser"))) next
+    build_bundle <- fertility_resolve_build_bundle(raw_root, build_id)
+    provenance_path <- build_bundle$provenance
+    library <- build_bundle$library
     recorded <- tryCatch(
         fertility_verify_recorded_provenance(
             checkout_root, library, provenance_path
@@ -87,7 +118,8 @@ for (build_root in builds) {
     ) -> snapshot_valid
     if (is.null(snapshot_valid)) next
     candidates[[length(candidates) + 1L]] <- list(
-        id = build_id, provenance = recorded, library = library
+        id = build_id, provenance = recorded, library = library,
+        provenance_path = provenance_path, package = build_bundle$package
     )
 }
 if (length(candidates) != 1L) {
@@ -96,9 +128,11 @@ if (length(candidates) != 1L) {
 build <- candidates[[1L]]
 build_id <- build$id
 
-lock_root <- file.path(raw_root, ".locks")
+case_lock_root <- fertility_assert_output_parent(
+    raw_root, ".locks", "cases", create = TRUE
+)
 case_locks <- fertility_acquire_lock_set(file.path(
-    lock_root, "cases", vapply(
+    case_lock_root, vapply(
         manifest$id, fertility_lock_component, character(1), label = "case ID"
     )
 ), owner)
@@ -106,13 +140,47 @@ on.exit(if (!fertility_release_lock_set(case_locks)) {
     warning("could not release every fertility corpus republish case lock")
 }, add = TRUE)
 
+republish_source_files <- c(
+    file.path(snapshot_root, c(
+        "common.R", "worker.R", "compare.R", "runtime.R",
+        "inventory-manifest.tsv", "inventory-manifest-provenance.tsv"
+    )),
+    build$provenance_path,
+    if (file.exists(build_current)) build_current else character()
+)
+accepted_snapshot_path <- file.path(snapshot_root, "accepted.R")
+if (file.exists(accepted_snapshot_path) ||
+    fertility_path_is_symlink(accepted_snapshot_path)) {
+    republish_source_files <- c(
+        republish_source_files,
+        fertility_assert_existing_file(
+            accepted_snapshot_path, snapshot_root,
+            "recorded accepted framework file"
+        )
+    )
+}
+acceptance_snapshot_path <- file.path(snapshot_root, "acceptance-provenance.tsv")
+if (file.exists(acceptance_snapshot_path) ||
+    fertility_path_is_symlink(acceptance_snapshot_path)) {
+    republish_source_files <- c(
+        republish_source_files,
+        fertility_assert_existing_file(
+            acceptance_snapshot_path, snapshot_root,
+            "framework acceptance provenance"
+        )
+    )
+}
+republish_source_files <- vapply(republish_source_files, function(path) {
+    fertility_assert_existing_file(path, dirname(path), "republish source file")
+}, character(1))
 private_results <- vector("list", nrow(manifest))
 recorded_attestations <- vector("list", nrow(manifest))
 expected_signatures <- character(nrow(manifest))
 for (index in seq_len(nrow(manifest))) {
     item <- as.list(manifest[index, , drop = FALSE])
-    file_root <- file.path(checkpoint_root, item$id)
-    result_path <- file.path(file_root, "result.rds")
+    case_paths <- checkpoint_case_paths[[item$id]]
+    file_root <- case_paths$case
+    result_path <- case_paths$result
     recorded <- tryCatch(readRDS(result_path), error = function(error) NULL)
     if (is.null(recorded) || !fertility_recorded_result_valid(
         recorded, item, framework_id, configuration,
@@ -121,9 +189,11 @@ for (index in seq_len(nrow(manifest))) {
     fertility_validate_recorded_input_attestation(recorded)
     expected_signatures[[index]] <- recorded$expected_sha512
     input <- list(input_id = recorded$input_id, actual_sha512 = recorded$actual_sha512)
-    tile_files <- if (dir.exists(file.path(file_root, "tiles"))) list.files(
-        file.path(file_root, "tiles"), pattern = "[.]rds$", full.names = TRUE
-    ) else character()
+    tile_root <- case_paths$tiles
+    tile_files <- fertility_checkpoint_tile_files(case_paths)
+    republish_source_files <- c(
+        republish_source_files, result_path, unname(tile_files)
+    )
     if (identical(recorded$classification, "inventory-hash-error")) {
         fertility_validate_recorded_input_result(recorded, length(tile_files))
         result <- recorded
@@ -163,6 +233,11 @@ for (index in seq_len(nrow(manifest))) {
     private_results[[index]] <- result
     recorded_attestations[[index]] <- recorded
 }
+
+republish_source_attestation <- fertility_attest_existing_files(
+    unique(republish_source_files), "republish source file"
+)
+republish_source_files <- republish_source_attestation$paths
 
 attested_inventory <- manifest
 attested_inventory$expected_sha512 <- expected_signatures
@@ -212,6 +287,8 @@ for (shard_index in seq_len(options$shard_count)) {
         evidence_origin = evidence_origin,
         source_corpus_schema_version = fertility_legacy_corpus_schema_version,
         replayed_at_utc = replayed_at_utc,
+        acceptance_authority = "", acceptance_commitment_id = "",
+        acceptance_artifact_sha256 = "",
         selection_id = selection_id, evidence_selection_id = evidence_selection_id,
         input_attestation_id = input_attestation_id, family_id = family_id,
         family_manifest_id = family_manifest_id, framework_id = framework_id,
@@ -240,14 +317,58 @@ for (shard_index in seq_len(options$shard_count)) {
     )
 }
 invisible(fertility_validate_shard_bundles(bundles, family_id, manifest))
+revalidate_republish_sources <- function() {
+    current_framework <- fertility_framework_inventory(
+        snapshot_root, framework_id = framework_id,
+        report_schema_version = fertility_legacy_report_schema_version
+    )
+    if (!identical(current_framework$manifest, manifest) ||
+        !identical(current_framework$provenance$inventory_id[[1L]],
+                   framework_inventory$provenance$inventory_id[[1L]])) {
+        stop("republish framework inventory changed before publication")
+    }
+    current_build_bundle <- fertility_resolve_build_bundle(raw_root, build_id)
+    current_build <- fertility_verify_recorded_provenance(
+        checkout_root, current_build_bundle$library,
+        current_build_bundle$provenance
+    )
+    if (!identical(current_build, build$provenance) ||
+        !identical(current_build_bundle$library, build$library) ||
+        !identical(current_build_bundle$package, build$package)) {
+        stop("republish build evidence changed before publication")
+    }
+    fertility_verify_recorded_framework_snapshot(
+        checkout_root, snapshot_root, current_build
+    )
+    fertility_revalidate_existing_files(
+        republish_source_attestation,
+        "republish checkpoint or framework evidence"
+    )
+    current_checkpoint_root <- fertility_assert_existing_directory(
+        file.path(framework_checkpoint_root, configuration$config_id),
+        framework_checkpoint_root, "configuration checkpoint directory"
+    )
+    current_ids <- sort(list.files(
+        current_checkpoint_root, all.files = TRUE, no.. = TRUE
+    ))
+    if (!identical(current_ids, manifest$id)) {
+        stop("republish checkpoint hierarchy changed")
+    }
+    fertility_validate_shard_bundles(bundles, family_id, manifest)
+    invisible(TRUE)
+}
+invisible(revalidate_republish_sources())
 if (validate_only) {
     message("revalidated ", nrow(manifest), " files across ", options$shard_count,
             " shards; family ", family_id)
     quit(save = "no", status = 0L)
 }
 
+selection_lock_root <- fertility_assert_output_parent(
+    raw_root, ".locks", "selections", create = TRUE
+)
 selection_locks <- fertility_acquire_lock_set(file.path(
-    lock_root, "selections", vapply(
+    selection_lock_root, vapply(
         selection_ids, fertility_lock_component, character(1), label = "selection ID"
     )
 ), owner)
@@ -256,17 +377,22 @@ on.exit(if (!fertility_release_lock_set(selection_locks)) {
 }, add = TRUE)
 
 stage_specs <- lapply(seq_len(options$shard_count), function(shard_index) {
-    parent <- file.path(raw_root, "reports", selection_ids[[shard_index]])
-    dir.create(parent, recursive = TRUE, showWarnings = FALSE, mode = "0700")
+    parent <- fertility_assert_output_parent(
+        raw_root, "reports", selection_ids[[shard_index]], create = TRUE
+    )
     Sys.chmod(c(file.path(raw_root, "reports"), parent), mode = "0700")
     current_path <- file.path(parent, "CURRENT")
-    old_current <- if (file.exists(current_path)) {
-        value <- readLines(current_path, warn = FALSE, n = 1L)
-        if (length(value) != 1L || !grepl("^[A-Za-z0-9._-]+$", value) ||
-            !dir.exists(file.path(parent, value))) {
-            stop("existing report pointer is malformed")
-        }
-        value
+    old_current <- if (file.exists(current_path) || dir.exists(current_path) ||
+        fertility_path_is_symlink(current_path)) {
+        existing <- fertility_current_bundle_paths(
+            parent,
+            c(
+                provenance = "run-provenance.tsv", results = "results.tsv",
+                summary = "summary.tsv", family_manifest = "family-manifest.tsv"
+            ),
+            "existing report"
+        )
+        existing$run_name
     } else NA_character_
     list(shard_index = shard_index, parent = parent, old_current = old_current,
          bundle = bundles[[shard_index]])
@@ -276,6 +402,9 @@ stages <- fertility_prepare_report_stages(
     create_stage = function(spec) {
         stage <- tempfile(".report.", tmpdir = spec$parent)
         if (!dir.create(stage, mode = "0700")) return(NULL)
+        stage <- fertility_assert_existing_directory(
+            stage, spec$parent, "republish staging directory"
+        )
         list(parent = spec$parent, stage = stage,
              old_current = spec$old_current)
     },
@@ -308,33 +437,135 @@ for (shard_index in seq_len(options$shard_count)) {
         paste0(run_stamp, "-", Sys.getpid(), "-", shard_index)
     )
 }
+validate_generated_bundle <- function(path, shard_index, published = FALSE) {
+    path <- fertility_assert_existing_directory(
+        path, dirname(path), if (published) "republished bundle" else
+            "republish staging directory"
+    )
+    paths <- c(
+        results = "results.tsv", summary = "summary.tsv",
+        family_manifest = "family-manifest.tsv",
+        provenance = "run-provenance.tsv"
+    )
+    loaded <- lapply(paths, function(name) {
+        file <- fertility_assert_existing_file(
+            file.path(path, name), path, "generated report bundle file"
+        )
+        read.delim(file, colClasses = "character", check.names = FALSE)
+    })
+    expected <- bundles[[shard_index]]
+    as_character_frame <- function(value) as.data.frame(
+        lapply(value, as.character), stringsAsFactors = FALSE,
+        check.names = FALSE
+    )
+    if (!identical(loaded$results, as_character_frame(expected$results)) ||
+        !identical(loaded$summary, as_character_frame(
+            fertility_classification_summary(expected$results)
+        )) ||
+        !identical(loaded$family_manifest,
+                   as_character_frame(family_manifest)) ||
+        !identical(loaded$provenance,
+                   as_character_frame(expected$provenance))) {
+        stop("generated report bundle identity changed before publication")
+    }
+    invisible(TRUE)
+}
+
 write_pointer <- function(parent, value) {
     pointer <- tempfile("CURRENT.", tmpdir = parent)
     on.exit(unlink(pointer), add = TRUE)
     result <- tryCatch({
         writeLines(value, pointer, useBytes = TRUE)
         Sys.chmod(pointer, mode = "0600")
+        fertility_assert_direct_child(
+            parent, file.path(raw_root, "reports"), "report publication parent"
+        )
+        fertility_assert_direct_child(
+            pointer, parent, "temporary republish pointer"
+        )
+        fertility_assert_direct_child(
+            file.path(parent, "CURRENT"), parent, "republish CURRENT pointer",
+            must_work = FALSE
+        )
         file.rename(pointer, file.path(parent, "CURRENT"))
     }, error = function(error) FALSE)
     isTRUE(result)
 }
 pointer_state <- function(parent) {
     path <- file.path(parent, "CURRENT")
+    if (fertility_path_is_symlink(path) || dir.exists(path)) return("<malformed>")
     if (!file.exists(path)) return(NA_character_)
+    path <- fertility_assert_existing_file(
+        path, parent, "report CURRENT pointer"
+    )
     value <- tryCatch(readLines(path, warn = FALSE, n = 1L),
                       error = function(error) character())
     if (length(value) == 1L) value else "<malformed>"
 }
 invisible(fertility_publish_pointer_transaction(
     stages,
-    rename_path = function(from, to) file.rename(from, to),
+    rename_path = function(from, to) {
+        parent <- dirname(from)
+        reports_root <- fertility_assert_existing_directory(
+            file.path(raw_root, "reports"), raw_root,
+            "reports output directory"
+        )
+        fertility_assert_existing_directory(
+            parent, reports_root, "report publication parent"
+        )
+        fertility_assert_existing_directory(
+            from, parent, "republish staging directory"
+        )
+        fertility_assert_new_destination(
+            to, parent, "republished bundle"
+        )
+        fertility_atomic_rename_noreplace(
+            from, to, "republished bundle"
+        )
+    },
     write_pointer = write_pointer,
     remove_path = function(path) {
-        unlink(path, recursive = TRUE)
-        !file.exists(path) && !dir.exists(path)
+        parent <- dirname(path)
+        fertility_assert_existing_directory(
+            parent, file.path(raw_root, "reports"),
+            "report publication parent"
+        )
+        if (fertility_path_is_symlink(path)) return(FALSE)
+        if (!file.exists(path) && !dir.exists(path)) return(TRUE)
+        fertility_remove_confirmed_new_path(
+            path, parent, "republish transaction path"
+        )
     },
     pointer_state = pointer_state,
-    path_exists = function(path) file.exists(path) || dir.exists(path)
+    path_exists = function(path) {
+        file.exists(path) || dir.exists(path) || fertility_path_is_symlink(path)
+    },
+    before_rename = function(index, stage) {
+        fertility_publication_test_hook(
+            "republish-before-bundle-revalidation",
+            list(index = index, stage = stage$stage,
+                 destination = stage$published)
+        )
+        revalidate_republish_sources()
+        validate_generated_bundle(stage$stage, index)
+        fertility_assert_new_destination(
+            stage$published, stage$parent, "republished bundle"
+        )
+        TRUE
+    },
+    before_pointer = function(index, stage) {
+        fertility_publication_test_hook(
+            "republish-before-current-revalidation",
+            list(index = index, bundle = stage$published,
+                 pointer = file.path(stage$parent, "CURRENT"))
+        )
+        revalidate_republish_sources()
+        validate_generated_bundle(stage$published, index, published = TRUE)
+        if (!identical(pointer_state(stage$parent), stage$old_current)) {
+            stop("source report CURRENT changed before replacement")
+        }
+        TRUE
+    }
 ))
 stages <- list()
 message("republished ", nrow(manifest), " files across ", options$shard_count,

--- a/benchmarks/fertility-surveys/republish.R
+++ b/benchmarks/fertility-surveys/republish.R
@@ -30,7 +30,9 @@ forbidden <- c(
 if (any(vapply(arguments, function(argument) {
     any(startsWith(argument, forbidden))
 }, logical(1)))) stop("republication is restricted to the complete default family")
-options <- fertility_parse_arguments(c(arguments, "--shard-index=1"))
+options <- fertility_validate_source_arguments(
+    fertility_parse_arguments(c(arguments, "--shard-index=1"))
+)
 if (!fertility_full_default_family(options) || options$shard_count != 8L) {
     stop("republication requires the complete default family in exactly eight shards")
 }
@@ -90,7 +92,7 @@ if (file.exists(build_current) || dir.exists(build_current) ||
         build_current, builds_root, "build CURRENT pointer"
     )
 }
-datasigs_path <- fertility_required_paths()$datasigs
+datasigs_path <- fertility_required_paths(options)$datasigs
 build_entries <- list.files(builds_root, all.files = TRUE, no.. = TRUE)
 build_entries <- setdiff(build_entries, "CURRENT")
 candidates <- list()

--- a/benchmarks/fertility-surveys/republish.R
+++ b/benchmarks/fertility-surveys/republish.R
@@ -123,10 +123,7 @@ for (index in seq_len(nrow(manifest))) {
         file.path(file_root, "tiles"), pattern = "[.]rds$", full.names = TRUE
     ) else character()
     if (identical(recorded$classification, "inventory-hash-error")) {
-        if (length(tile_files) || isTRUE(recorded$complete) ||
-            recorded$mismatch_count != 0L) {
-            stop("recorded input-validation result is inconsistent")
-        }
+        fertility_validate_recorded_input_result(recorded, length(tile_files))
         result <- recorded
     } else if (identical(as.integer(item$release), 111L)) {
         if (length(tile_files) ||

--- a/benchmarks/fertility-surveys/republish.R
+++ b/benchmarks/fertility-surveys/republish.R
@@ -1,0 +1,341 @@
+script_path <- normalizePath(sub("^--file=", "", grep(
+    "^--file=", commandArgs(trailingOnly = FALSE), value = TRUE
+)[[1L]]), winslash = "/")
+script_dir <- dirname(script_path)
+source(file.path(script_dir, "common.R"))
+source(file.path(script_dir, "provenance.R"))
+source(file.path(script_dir, "runner.R"))
+source(file.path(script_dir, "runtime.R"))
+
+fertility_assert_manual_run()
+arguments <- commandArgs(trailingOnly = TRUE)
+validate_only <- "--validate-only" %in% arguments
+arguments <- arguments[arguments != "--validate-only"]
+framework_arguments <- arguments[startsWith(arguments, "--republish-framework=")]
+if (length(framework_arguments) != 1L) {
+    stop("exactly one --republish-framework=ID is required")
+}
+framework_id <- sub("^[^=]+=", "", framework_arguments[[1L]])
+if (!grepl("^[0-9a-f]{64}$", framework_id)) stop("invalid republish framework ID")
+arguments <- setdiff(arguments, framework_arguments)
+if (any(startsWith(arguments, "--shard-index=")) ||
+    sum(startsWith(arguments, "--shard-count=")) != 1L) {
+    stop("republication requires one --shard-count=N and publishes every shard")
+}
+forbidden <- c("--inventory-only", "--retry", "--program=", "--release=", "--id=",
+               "--max-files=")
+if (any(vapply(arguments, function(argument) {
+    any(startsWith(argument, forbidden))
+}, logical(1)))) stop("republication is restricted to the complete default family")
+options <- fertility_parse_arguments(c(arguments, "--shard-index=1"))
+if (!fertility_full_default_family(options) || options$shard_count != 8L) {
+    stop("republication requires the complete default family in exactly eight shards")
+}
+
+checkout_root <- fertility_checkout_root(script_path)
+raw_root <- normalizePath(file.path(checkout_root, "target", "fertility-surveys", "raw"),
+                          winslash = "/", mustWork = TRUE)
+invisible(fertility_assert_tempdir(raw_root))
+owner_state <- Sys.getenv("DTAPARSER_FERTILITY_OWNER_STATE")
+if (!nzchar(owner_state)) stop("run benchmark.sh to establish republish ownership")
+owner <- fertility_read_owner(owner_state)
+if (!isTRUE(fertility_owner_alive(owner))) stop("orchestrator owner is not alive")
+
+snapshot_root <- file.path(raw_root, "framework", framework_id)
+framework_inventory <- fertility_framework_inventory(
+    snapshot_root, framework_id = framework_id,
+    report_schema_version = fertility_legacy_report_schema_version
+)
+manifest <- framework_inventory$manifest
+configuration <- fertility_tile_configuration(options)
+checkpoint_root <- file.path(raw_root, "checkpoints", framework_id,
+                             configuration$config_id)
+if (!dir.exists(checkpoint_root)) {
+    stop("recorded checkpoint configuration is absent")
+}
+checkpoint_ids <- sort(basename(list.dirs(
+    checkpoint_root, recursive = FALSE, full.names = TRUE
+)))
+if (!identical(checkpoint_ids, manifest$id)) {
+    stop("recorded checkpoint IDs do not exactly match canonical inventory")
+}
+
+builds_root <- file.path(raw_root, "builds")
+datasigs_path <- fertility_required_paths()$datasigs
+builds <- list.dirs(builds_root, recursive = FALSE, full.names = TRUE)
+candidates <- list()
+for (build_root in builds) {
+    build_id <- basename(build_root)
+    if (!grepl("^[0-9a-f]{64}$", build_id)) next
+    provenance_path <- file.path(build_root, "build-provenance.tsv")
+    library <- file.path(build_root, "library")
+    if (!file.exists(provenance_path) || !dir.exists(file.path(library, "dtaparser"))) next
+    recorded <- tryCatch(
+        fertility_verify_recorded_provenance(
+            checkout_root, library, provenance_path
+        ), error = function(error) NULL
+    )
+    if (is.null(recorded) ||
+        !identical(recorded$provenance_id[[1L]], build_id) ||
+        !identical(fertility_framework_id(build_id, datasigs_path), framework_id)) next
+    tryCatch(
+        fertility_verify_recorded_framework_snapshot(
+            checkout_root, snapshot_root, recorded
+        ), error = function(error) NULL
+    ) -> snapshot_valid
+    if (is.null(snapshot_valid)) next
+    candidates[[length(candidates) + 1L]] <- list(
+        id = build_id, provenance = recorded, library = library
+    )
+}
+if (length(candidates) != 1L) {
+    stop("recorded framework does not resolve to exactly one attested build")
+}
+build <- candidates[[1L]]
+build_id <- build$id
+
+lock_root <- file.path(raw_root, ".locks")
+case_locks <- fertility_acquire_lock_set(file.path(
+    lock_root, "cases", vapply(
+        manifest$id, fertility_lock_component, character(1), label = "case ID"
+    )
+), owner)
+on.exit(if (!fertility_release_lock_set(case_locks)) {
+    warning("could not release every fertility corpus republish case lock")
+}, add = TRUE)
+
+private_results <- vector("list", nrow(manifest))
+recorded_attestations <- vector("list", nrow(manifest))
+expected_signatures <- character(nrow(manifest))
+for (index in seq_len(nrow(manifest))) {
+    item <- as.list(manifest[index, , drop = FALSE])
+    file_root <- file.path(checkpoint_root, item$id)
+    result_path <- file.path(file_root, "result.rds")
+    recorded <- tryCatch(readRDS(result_path), error = function(error) NULL)
+    if (is.null(recorded) || !fertility_recorded_result_valid(
+        recorded, item, framework_id, configuration,
+        corpus_schema_version = fertility_legacy_corpus_schema_version
+    )) stop("recorded file result is absent or invalid")
+    fertility_validate_recorded_input_attestation(recorded)
+    expected_signatures[[index]] <- recorded$expected_sha512
+    input <- list(input_id = recorded$input_id, actual_sha512 = recorded$actual_sha512)
+    tile_files <- if (dir.exists(file.path(file_root, "tiles"))) list.files(
+        file.path(file_root, "tiles"), pattern = "[.]rds$", full.names = TRUE
+    ) else character()
+    if (identical(recorded$classification, "inventory-hash-error")) {
+        if (length(tile_files) || isTRUE(recorded$complete) ||
+            recorded$mismatch_count != 0L) {
+            stop("recorded input-validation result is inconsistent")
+        }
+        result <- recorded
+    } else if (identical(as.integer(item$release), 111L)) {
+        if (length(tile_files) ||
+            !identical(recorded$classification, "expected-unsupported-111") ||
+            !isTRUE(recorded$complete) || recorded$mismatch_count != 0L) {
+            stop("recorded unsupported-release result is inconsistent")
+        }
+        result <- recorded
+    } else {
+        if (!length(tile_files) ||
+            (nzchar(recorded$expected_sha512) &&
+             !identical(recorded$actual_sha512, recorded$expected_sha512))) {
+            stop("recorded executable input attestation is inconsistent")
+        }
+        replay <- fertility_replay_file_tiles(
+            item, file_root, framework_id, configuration, input,
+            corpus_schema_version = fertility_legacy_corpus_schema_version,
+            allow_legacy_empty_reader_artifact = TRUE
+        )
+        result <- fertility_tiled_result(
+            item, framework_id, configuration, input, replay$tiles,
+            replay$batches, replay$total_rows,
+            allow_legacy_empty_reader_artifact = TRUE
+        )
+        recorded_public <- fertility_result_frame(list(recorded))
+        replayed_public <- fertility_result_frame(list(result))
+        recorded_public$secondary_categories <- gsub(
+            "(^|,)-reader-error(,|$)", "\\1", recorded_public$secondary_categories
+        )
+        recorded_public$secondary_categories <- sub(",+$", "", recorded_public$secondary_categories)
+        if (!identical(recorded_public, replayed_public)) {
+            stop("recorded file result disagrees with replayed tile evidence")
+        }
+    }
+    private_results[[index]] <- result
+    recorded_attestations[[index]] <- recorded
+}
+
+attested_inventory <- manifest
+attested_inventory$expected_sha512 <- expected_signatures
+if (!identical(fertility_inventory_id(attested_inventory),
+               framework_inventory$provenance$inventory_id[[1L]])) {
+    stop("recorded input attestations do not match canonical inventory provenance")
+}
+
+family_manifest <- fertility_family_manifest(manifest, options)
+family_manifest_id <- fertility_manifest_id(family_manifest)
+evidence_origin <- "historical-schema-10-replay"
+family_id <- fertility_selection_family_id(
+    attested_inventory, options, framework_id, configuration$config_id, build_id,
+    fertility_report_schema_id(), evidence_origin,
+    fertility_legacy_corpus_schema_version
+)
+filter_spec <- fertility_filter_spec(options)
+replayed_at_utc <- format(Sys.time(), "%Y-%m-%dT%H:%M:%SZ", tz = "UTC")
+bundles <- vector("list", options$shard_count)
+stages <- list()
+on.exit(for (stage in stages) if (length(stage) && dir.exists(stage$stage)) {
+    unlink(stage$stage, recursive = TRUE)
+}, add = TRUE)
+selection_ids <- character(options$shard_count)
+for (shard_index in seq_len(options$shard_count)) {
+    selected <- family_manifest[family_manifest$shard_index == shard_index,
+                                c("id", "program", "level", "release"), drop = FALSE]
+    positions <- match(selected$id, manifest$id)
+    checkpoints <- private_results[positions]
+    input_attestations <- recorded_attestations[positions]
+    selection_id <- fertility_stable_id(list(
+        family_id = family_id, shard_index = shard_index,
+        selected_ids = paste(selected$id, collapse = ",")
+    ))
+    selection_ids[[shard_index]] <- selection_id
+    results <- fertility_result_frame(checkpoints)
+    results$build_provenance_id <- rep(build_id, nrow(results))
+    fertility_validate_public_results(results)
+    input_attestation_id <- fertility_input_attestation_id(input_attestations)
+    evidence_selection_id <- fertility_evidence_selection_id(
+        selection_id, input_attestation_id, evidence_origin,
+        fertility_legacy_corpus_schema_version, fertility_report_schema_id()
+    )
+    provenance <- data.frame(
+        schema_version = fertility_schema_version,
+        report_schema_version = fertility_report_schema_version,
+        evidence_origin = evidence_origin,
+        source_corpus_schema_version = fertility_legacy_corpus_schema_version,
+        replayed_at_utc = replayed_at_utc,
+        selection_id = selection_id, evidence_selection_id = evidence_selection_id,
+        input_attestation_id = input_attestation_id, family_id = family_id,
+        family_manifest_id = family_manifest_id, framework_id = framework_id,
+        config_id = configuration$config_id, build_provenance_id = build_id,
+        inventory_id = framework_inventory$provenance$inventory_id[[1L]],
+        report_schema_id = fertility_report_schema_id(),
+        selected_files = nrow(selected), expected_family_files = nrow(family_manifest),
+        full_default_family = TRUE, program_filter = filter_spec$program_filter,
+        release_filter = filter_spec$release_filter, id_filter = filter_spec$id_filter,
+        max_files = filter_spec$max_files, shard_index = shard_index,
+        shard_count = options$shard_count, timeout_seconds = options$timeout_seconds,
+        chunk_rows = options$chunk_rows, column_batch = options$column_batch,
+        memory_mib = options$memory_mib, cell_budget = options$cell_budget,
+        max_tiles_per_batch = options$max_tiles_per_batch,
+        beyond_end_windows = options$beyond_end_windows, retry = FALSE,
+        created_at_utc = format(Sys.time(), "%Y-%m-%dT%H:%M:%SZ", tz = "UTC"),
+        stringsAsFactors = FALSE, check.names = FALSE
+    )
+    bundles[[shard_index]] <- list(
+        provenance = as.data.frame(lapply(provenance, as.character),
+                                   stringsAsFactors = FALSE, check.names = FALSE),
+        results = as.data.frame(lapply(results, as.character),
+                                stringsAsFactors = FALSE, check.names = FALSE),
+        family_manifest = family_manifest
+    )
+}
+invisible(fertility_validate_shard_bundles(bundles, family_id, manifest))
+if (validate_only) {
+    message("revalidated ", nrow(manifest), " files across ", options$shard_count,
+            " shards; family ", family_id)
+    quit(save = "no", status = 0L)
+}
+
+selection_locks <- fertility_acquire_lock_set(file.path(
+    lock_root, "selections", vapply(
+        selection_ids, fertility_lock_component, character(1), label = "selection ID"
+    )
+), owner)
+on.exit(if (!fertility_release_lock_set(selection_locks)) {
+    warning("could not release every fertility corpus republish selection lock")
+}, add = TRUE)
+
+stage_specs <- lapply(seq_len(options$shard_count), function(shard_index) {
+    parent <- file.path(raw_root, "reports", selection_ids[[shard_index]])
+    dir.create(parent, recursive = TRUE, showWarnings = FALSE, mode = "0700")
+    Sys.chmod(c(file.path(raw_root, "reports"), parent), mode = "0700")
+    current_path <- file.path(parent, "CURRENT")
+    old_current <- if (file.exists(current_path)) {
+        value <- readLines(current_path, warn = FALSE, n = 1L)
+        if (length(value) != 1L || !grepl("^[A-Za-z0-9._-]+$", value) ||
+            !dir.exists(file.path(parent, value))) {
+            stop("existing report pointer is malformed")
+        }
+        value
+    } else NA_character_
+    list(shard_index = shard_index, parent = parent, old_current = old_current,
+         bundle = bundles[[shard_index]])
+})
+stages <- fertility_prepare_report_stages(
+    stage_specs,
+    create_stage = function(spec) {
+        stage <- tempfile(".report.", tmpdir = spec$parent)
+        if (!dir.create(stage, mode = "0700")) return(NULL)
+        list(parent = spec$parent, stage = stage,
+             old_current = spec$old_current)
+    },
+    write_stage = function(stage, spec) tryCatch({
+        fertility_atomic_write_table(
+            spec$bundle$results, file.path(stage$stage, "results.tsv")
+        )
+        fertility_atomic_write_table(
+            fertility_classification_summary(spec$bundle$results),
+            file.path(stage$stage, "summary.tsv")
+        )
+        fertility_atomic_write_table(
+            family_manifest, file.path(stage$stage, "family-manifest.tsv")
+        )
+        fertility_atomic_write_table(
+            spec$bundle$provenance, file.path(stage$stage, "run-provenance.tsv")
+        )
+        TRUE
+    }, error = function(error) FALSE),
+    remove_path = function(path) {
+        unlink(path, recursive = TRUE)
+        !file.exists(path) && !dir.exists(path)
+    },
+    path_exists = function(path) file.exists(path) || dir.exists(path)
+)
+run_stamp <- format(Sys.time(), "%Y%m%dT%H%M%SZ", tz = "UTC")
+for (shard_index in seq_len(options$shard_count)) {
+    stages[[shard_index]]$published <- file.path(
+        stages[[shard_index]]$parent,
+        paste0(run_stamp, "-", Sys.getpid(), "-", shard_index)
+    )
+}
+write_pointer <- function(parent, value) {
+    pointer <- tempfile("CURRENT.", tmpdir = parent)
+    on.exit(unlink(pointer), add = TRUE)
+    result <- tryCatch({
+        writeLines(value, pointer, useBytes = TRUE)
+        Sys.chmod(pointer, mode = "0600")
+        file.rename(pointer, file.path(parent, "CURRENT"))
+    }, error = function(error) FALSE)
+    isTRUE(result)
+}
+pointer_state <- function(parent) {
+    path <- file.path(parent, "CURRENT")
+    if (!file.exists(path)) return(NA_character_)
+    value <- tryCatch(readLines(path, warn = FALSE, n = 1L),
+                      error = function(error) character())
+    if (length(value) == 1L) value else "<malformed>"
+}
+invisible(fertility_publish_pointer_transaction(
+    stages,
+    rename_path = function(from, to) file.rename(from, to),
+    write_pointer = write_pointer,
+    remove_path = function(path) {
+        unlink(path, recursive = TRUE)
+        !file.exists(path) && !dir.exists(path)
+    },
+    pointer_state = pointer_state,
+    path_exists = function(path) file.exists(path) || dir.exists(path)
+))
+stages <- list()
+message("republished ", nrow(manifest), " files across ", options$shard_count,
+        " shards; family ", family_id)

--- a/benchmarks/fertility-surveys/republish.R
+++ b/benchmarks/fertility-surveys/republish.R
@@ -110,7 +110,10 @@ for (entry in build_entries) {
     )
     if (is.null(recorded) ||
         !identical(recorded$provenance_id[[1L]], build_id) ||
-        !identical(fertility_framework_id(build_id, datasigs_path), framework_id)) next
+        !identical(fertility_framework_id(
+            build_id, datasigs_path,
+            schema_version = fertility_legacy_corpus_schema_version
+        ), framework_id)) next
     tryCatch(
         fertility_verify_recorded_framework_snapshot(
             checkout_root, snapshot_root, recorded

--- a/benchmarks/fertility-surveys/republish.R
+++ b/benchmarks/fertility-surveys/republish.R
@@ -22,8 +22,10 @@ if (any(startsWith(arguments, "--shard-index=")) ||
     sum(startsWith(arguments, "--shard-count=")) != 1L) {
     stop("republication requires one --shard-count=N and publishes every shard")
 }
-forbidden <- c("--inventory-only", "--retry", "--program=", "--release=", "--id=",
-               "--max-files=")
+forbidden <- c(
+    "--inventory-only", "--retry", "--program=", "--release=", "--id=",
+    "--encoding-override=", "--max-files="
+)
 if (any(vapply(arguments, function(argument) {
     any(startsWith(argument, forbidden))
 }, logical(1)))) stop("republication is restricted to the complete default family")
@@ -219,6 +221,7 @@ for (shard_index in seq_len(options$shard_count)) {
         selected_files = nrow(selected), expected_family_files = nrow(family_manifest),
         full_default_family = TRUE, program_filter = filter_spec$program_filter,
         release_filter = filter_spec$release_filter, id_filter = filter_spec$id_filter,
+        encoding_overrides = configuration$encoding_overrides,
         max_files = filter_spec$max_files, shard_index = shard_index,
         shard_count = options$shard_count, timeout_seconds = options$timeout_seconds,
         chunk_rows = options$chunk_rows, column_batch = options$column_batch,

--- a/benchmarks/fertility-surveys/results-2026-07-28.md
+++ b/benchmarks/fertility-surveys/results-2026-07-28.md
@@ -2,23 +2,23 @@
 
 ## Status
 
-Wave 2 completed the privacy-safe fertility corpus framework and an exhaustive
-fresh execution. The strict gate is **BLOCKED**, solely because five external
-manifest/file SHA-512 checks do not agree: `F0633` through `F0637`. Those inputs
-were rejected before reader execution. No corpus file or manifest was modified,
-and this report does not claim full gate success.
+Wave 2 produced an exhaustive fresh family at commit `7c0a0e7`. The strict gate
+remains **BLOCKED**, solely because five external manifest/file SHA-512 checks do
+not agree: `F0633` through `F0637`. Those inputs were classified as
+`inventory-hash-error` before reader execution. The corpus and manifest remained
+unchanged, and this report does not claim full gate success.
 
-Wave 3 has not started.
+Wave 3 has not started. The blocked gate does not authorize it to start.
 
 ## Framework and run identity
 
-The completed manual-only framework provides deterministic inventory and
-sharding, immutable provenance-bound builds and checkpoints, bounded isolated
-three-reader comparison, privacy-safe reports, strict family reconstruction,
-and atomic merged publication. It keeps source paths, names, labels, values,
-reader messages, and source hashes out of tracked output.
+The manual-only framework provides deterministic inventory and sharding,
+provenance-bound builds and checkpoints, bounded isolated three-reader
+comparison, privacy-safe reports, strict family reconstruction, and atomic merged
+publication. Its published TSV schemas omit source paths, survey names, labels,
+values, reader error text, and source hashes.
 
-The exhaustive fresh run used commit:
+The exhaustive fresh run used the clean commit:
 
 ```text
 7c0a0e7c71efa279bff17eeddb399676786b8a2a
@@ -30,11 +30,18 @@ Its merged family ID is:
 7121cb4e1282396fd60b0c9b839bfe39fadcf35371d3c90d540d59120967030b
 ```
 
-The merged target bundle is:
+The merged target bundle is repository-local and ignored by Git:
 
 ```text
-/Users/jmb/repos/dta-parser/target/fertility-surveys/raw/merged/7121cb4e1282396fd60b0c9b839bfe39fadcf35371d3c90d540d59120967030b/20260728T145545Z-14759
+target/fertility-surveys/raw/merged/<family-id>/<run-id>
+run-id: 20260728T145545Z-14759
 ```
+
+Here `<family-id>` is the full merged family ID shown above. Its provenance
+records `fresh-execution`, all eight shards, all 1,004 files, and
+the complete default family. The path is included only to make the local evidence
+reproducible from the checkout that produced it; the raw bundle is not a tracked
+or portable artifact.
 
 ## Privacy-safe aggregate results
 
@@ -50,23 +57,54 @@ The immutable merged raw classifications account for all 1,004 inventory IDs:
 | **Total** | **1,004** |
 
 The five inventory hash errors are exactly `F0633`–`F0637`, the sole strict-gate
-blocker. They are external manifest/file SHA-512 mismatches, not corpus execution
-results. The framework preserved both the corpus and manifest unchanged.
+blocker. They are external manifest/file SHA-512 mismatches, not reader outcomes.
 
-All 869 hash-valid supported files were exhaustively resolved. There was no
-direct-R-versus-Rust mismatch and no confirmed dtaparser defect. Separate
-privacy-safe adjudication found:
+All 869 hash-valid supported inputs reached a raw executable outcome: 459
+`pass`, 409 `metadata-mismatch`, and one `haven-only-error`. The retained raw
+comparison records contained zero Direct-R/Rust mismatches. No dtaparser defect
+was confirmed by this run or by the separate diagnostics below.
 
-- the 409 metadata mismatches are known intentional Haven-side/Stata
-  divergences involving trailing-blank and dataset-label behavior;
-- `F0574`, the one raw Haven-only error, passes when all readers receive the
-  explicit `ISO-8859-1` override supported at commit `c2684db`;
-- the focused `F0574` override result is separate derived evidence and does not
-  rewrite the fresh merged raw classifications.
+Target-local inspection of the 409 metadata-classified inputs found that every
+retained mismatch record was confined to the Direct-R/Haven and Rust/Haven
+pairs. The established private aggregate breakdown covers frame or column labels,
+value-label mappings, character decoding, and a smaller class-difference surface;
+label-related differences dominate. Synthetic tests verify reader-pair
+attribution, fixed-surface classification, and privacy-safe aggregation without
+reading the corpus.
 
-## Verification
+These aggregate observations do not assign fault to Haven, establish which
+reader matches Stata for each file, or prove that one explanation applies to all
+409 inputs. Authorized target-local diagnostics have observed trailing-blank and
+encoding-policy behavior, but that is mechanism evidence rather than complete
+per-file attribution. Class differences are secondary compatibility evidence,
+not proof of a dtaparser defect. Any intentional-divergence attribution requires
+the separate derived adjudication and review described by the framework and does
+not rewrite the raw family.
 
-The following checks passed on the completed framework checkout:
+In the original `7c0a0e7` family, `F0574` had the raw classification
+`haven-only-error` under default decoding. A separate one-ID fresh run from clean
+commit `c2684db4832025107af99d5aa394ed7005d1dfa4`, using the symmetric explicit
+configuration `F0574:ISO-8859-1`, completed all 100 tiles and classified `F0574`
+as `pass`. This is targeted evidence for a known encoding-policy divergence. It
+does not alter the original raw classification, attribute any of the 409 metadata
+mismatches per file, or establish tracked corpus-specific encoding policy.
+
+## Post-run framework hardening
+
+Commit `cd50b598932abe0b1167009b56846ec2f4eda0ea` followed the corpus runs. It
+hardened future classification so a failure in the independent bounded
+source-structure parser is not labeled as a dtaparser reader error, and it added
+synthetic coverage for that privacy-safe unresolved outcome. It also strengthened
+the synthetic terminal-probe assertion that an explicit encoding override reaches
+Direct-R, Rust, and Haven symmetrically.
+
+This is post-run framework hardening. It does not modify, reclassify, or replace
+the fresh evidence for family `7121cb4e`, whose execution identity remains the
+clean `7c0a0e7` build above.
+
+## Verification scope
+
+The verification recorded for the fresh-family framework checkout included:
 
 ```sh
 Rscript --vanilla benchmarks/fertility-surveys/test-framework.R
@@ -75,14 +113,18 @@ cargo fmt --all -- --check
 cargo clippy --workspace --all-targets --locked -- -D warnings
 cargo test --workspace --all-targets --locked
 RUSTDOCFLAGS="-D warnings" cargo doc --workspace --locked --no-deps
-bun test tests/integration/benchmark-config.test.ts tests/integration/fixture-inventory.test.ts tests/integration/r-package-config.test.ts
+bun test tests/integration/benchmark-config.test.ts \
+  tests/integration/fixture-inventory.test.ts \
+  tests/integration/r-package-config.test.ts
 DTA_REQUIRE_R_CONFORMANCE=1 scripts/conformance.sh
 scripts/rebuild-r-vendor.sh
 git diff --exit-code -- r-package/dtaparser/src/rust/vendor.tar.gz
 ```
 
-Results were: fertility synthetic framework tests passed; Rust source/archive
-sync passed; Rust formatting, Clippy, tests, and warning-denied documentation
+Those recorded results were: fertility synthetic framework tests passed; Rust
+source/archive sync, formatting, Clippy, tests, and warning-denied documentation
 passed; Bun integration reported 6 passing and 0 failing tests; required
 TypeScript/native/R/Haven conformance passed, including the R package check; and
-rebuilding the R vendor archive produced no tracked diff.
+rebuilding the R vendor archive produced no tracked diff. These checks describe
+the fresh evidence's verification record; they do not recast `c2684db` or
+`cd50b59` as part of the `7c0a0e7` exhaustive execution.

--- a/benchmarks/fertility-surveys/results-2026-07-28.md
+++ b/benchmarks/fertility-surveys/results-2026-07-28.md
@@ -2,38 +2,60 @@
 
 ## Status
 
-Wave 2 produced an exhaustive fresh family at commit `7c0a0e7`. The strict gate
-remains **BLOCKED**, solely because five external manifest/file SHA-512 checks do
-not agree: `F0633` through `F0637`. Those inputs were classified as
-`inventory-hash-error` before reader execution. The corpus and manifest remained
-unchanged, and this report does not claim full gate success.
+Wave 2 produced an exhaustive fresh family at commit `7c0a0e7`. That original raw
+family remains unchanged. Its authoritative manifest-integrity gate remains
+**BLOCKED** as an auditable fact, solely because the five external manifest/file
+SHA-512 checks for `F0633` through `F0637` do not agree. Those inputs retain their
+original `inventory-hash-error` classifications and five manifest
+`signature-mismatch` reasons; this report does not rewrite or claim manifest
+verification.
 
-Wave 3 has not started. The blocked gate does not authorize it to start.
+The user separately authorized explicit target-local acceptance for exactly
+`F0633` through `F0637` at their current local identities. Under that narrowly
+scoped substitute-evidence policy, the Wave 2 coverage/compatibility gate is
+**SATISFIED UNDER EXPLICIT LOCAL ACCEPTANCE**: all 1,004 files are accounted for;
+130 release-111 files are unsupported; all 874 supported files have exhaustive
+evidence, comprising the original 869 plus the supplemental five; there is no
+unresolved Direct-R/Rust mismatch and no confirmed dtaparser defect.
 
-## Framework and run identity
+This acceptance does not alter the manifest-integrity result and does not
+authorize or start Wave 3. Wave 3 has not started.
+
+## Framework and execution record
 
 The manual-only framework provides deterministic inventory and sharding,
 provenance-bound builds and checkpoints, bounded isolated three-reader
-comparison, privacy-safe reports, strict family reconstruction, and atomic merged
-publication. Its published TSV schemas omit source paths, survey names, labels,
-values, reader error text, and source hashes.
+comparison, privacy-safe reports, strict family reconstruction, accepted-local
+supplementation, dual-gate assessment, and atomic merged publication. Its
+published TSV schemas omit source paths, survey names, labels, values, reader
+error text, and source hashes.
 
-The exhaustive fresh run used the clean commit:
+The original exhaustive family used clean commit `7c0a0e7`. Accepted-local
+support was added in framework commits `49c7058`, `1004566`, and `5890ec1`, with
+corrective execution, merge, and assessment work in `853a695`, `0fbb2b9`,
+`60de684`, `c81ca6a`, and `07c4496`.
+
+At `853a695`, the accepted five-case execution exhaustively completed all five,
+classified all five as `pass`, recorded `complete` as `TRUE`, and found no
+Direct-R/Rust mismatch or confirmed dtaparser defect. A separate one-shard
+accepted merge succeeded. The derived assessment also succeeded using the
+immutable original schema-10/report-schema-2 full bundle together with the
+current accepted bundle. Its gate statuses were:
 
 ```text
-7c0a0e7c71efa279bff17eeddb399676786b8a2a
+manifest_gate=blocked-signature-mismatch
+explicit_local_evidence_gate=validated
 ```
 
-The merged evidence is identified by aggregate, content-bound provenance. It
-records `fresh-execution`, all eight shards, all 1,004 files, and the complete
-default family. No family identifier, checkout-local target path, or mutable
-publication run name is part of this tracked report.
+The corpus and datasigs remained unchanged throughout. No parser source changes
+are claimed.
 
 ## Privacy-safe aggregate results
 
-The immutable merged raw classifications account for all 1,004 inventory IDs:
+The immutable original raw classifications still account for all 1,004 inventory
+IDs:
 
-| Raw classification | Files |
+| Original raw classification | Files |
 | --- | ---: |
 | Unsupported release 111 (`expected-unsupported-111`) | 130 |
 | Inventory hash error | 5 |
@@ -42,30 +64,45 @@ The immutable merged raw classifications account for all 1,004 inventory IDs:
 | Haven-only error | 1 |
 | **Total** | **1,004** |
 
-The five inventory hash errors are exactly `F0633`–`F0637`, the sole strict-gate
-blocker. They are external manifest/file SHA-512 mismatches, not reader outcomes.
+The five inventory hash errors are exactly `F0633`–`F0637`, the sole blocker to
+the authoritative manifest-integrity gate. They are external manifest/file
+SHA-512 mismatches, not reader outcomes.
 
 All 869 hash-valid supported inputs reached a raw executable outcome: 459
 `pass`, 409 `metadata-mismatch`, and one `haven-only-error`. The retained raw
 comparison records contained zero Direct-R/Rust mismatches. No dtaparser defect
 was confirmed by this run or by the separate diagnostics below.
 
+The accepted-local supplement is separate derived evidence and does not replace
+or reclassify any original raw row:
+
+| Accepted-local supplemental classification | Files |
+| --- | ---: |
+| Pass | 5 |
+| **Total** | **5** |
+
+Combining original executable outcomes with that supplemental evidence gives
+complete executable coverage of all 874 supported files:
+
+| Raw-plus-supplemental executable outcome | Files |
+| --- | ---: |
+| Pass | 464 |
+| Metadata mismatch | 409 |
+| Haven-only error | 1 |
+| **Total supported** | **874** |
+
 Target-local inspection of the 409 metadata-classified inputs found that every
 retained mismatch record was confined to the Direct-R/Haven and Rust/Haven
-pairs. The established private aggregate breakdown covers frame or column labels,
+pairs. Cluster-level adjudication of all privacy-safe mismatch signatures, backed
+by representative private inspection and Stata's stored-string semantics,
+resolved these as known intentional/Haven-side compatibility divergences rather
+than dtaparser defects. The aggregate surfaces cover frame or column labels,
 value-label mappings, character decoding, and a smaller class-difference surface;
-label-related differences dominate. Synthetic tests verify reader-pair
-attribution, fixed-surface classification, and privacy-safe aggregation without
-reading the corpus.
-
-These aggregate observations do not assign fault to Haven, establish which
-reader matches Stata for each file, or prove that one explanation applies to all
-409 inputs. Authorized target-local diagnostics have observed trailing-blank and
-encoding-policy behavior, but that is mechanism evidence rather than complete
-per-file attribution. Class differences are secondary compatibility evidence,
-not proof of a dtaparser defect. Any intentional-divergence attribution requires
-the separate derived adjudication and review described by the framework and does
-not rewrite the raw family.
+label-related differences dominate. No single mechanism is claimed for all 409
+inputs, but no collector mismatch remains unresolved after that adjudication.
+Synthetic tests verify reader-pair attribution, fixed-surface classification, and
+privacy-safe aggregation without reading the corpus. This adjudication does not
+rewrite the original raw family.
 
 In the original `7c0a0e7` family, `F0574` had the raw classification
 `haven-only-error` under default decoding. A separate one-ID fresh run from clean
@@ -77,40 +114,38 @@ mismatches per file, or establish tracked corpus-specific encoding policy.
 
 ## Post-run framework hardening
 
-Commit `cd50b598932abe0b1167009b56846ec2f4eda0ea` followed the corpus runs. It
-hardened future classification so a failure in the independent bounded
+Commit `cd50b598932abe0b1167009b56846ec2f4eda0ea` followed the original corpus
+runs. It hardened future classification so a failure in the independent bounded
 source-structure parser is not labeled as a dtaparser reader error, and it added
 synthetic coverage for that privacy-safe unresolved outcome. It also strengthened
 the synthetic terminal-probe assertion that an explicit encoding override reaches
 Direct-R, Rust, and Haven symmetrically.
 
 This is post-run framework hardening. It does not modify, reclassify, or replace
-the aggregate fresh evidence, whose execution identity remains the clean
-`7c0a0e7` build above.
+the original raw family.
 
-## Verification scope
+## Final framework validation
 
-The verification recorded for the fresh-family framework checkout included:
+The final accepted-local framework was validated with:
 
 ```sh
 Rscript --vanilla benchmarks/fertility-surveys/test-framework.R
+sh benchmarks/fertility-surveys/test-benchmark-helpers.sh
+sh -n benchmarks/fertility-surveys/benchmark.sh \
+  benchmarks/fertility-surveys/test-benchmark-helpers.sh
+Rscript --vanilla -e 'files <- list.files("benchmarks/fertility-surveys", pattern = "[.]R$", full.names = TRUE); invisible(lapply(files, parse)); cat(length(files), "R files parsed\n")'
 scripts/check-rust-sync.sh
-cargo fmt --all -- --check
-cargo clippy --workspace --all-targets --locked -- -D warnings
-cargo test --workspace --all-targets --locked
-RUSTDOCFLAGS="-D warnings" cargo doc --workspace --locked --no-deps
-bun test tests/integration/benchmark-config.test.ts \
-  tests/integration/fixture-inventory.test.ts \
-  tests/integration/r-package-config.test.ts
-DTA_REQUIRE_R_CONFORMANCE=1 scripts/conformance.sh
-scripts/rebuild-r-vendor.sh
-git diff --exit-code -- r-package/dtaparser/src/rust/vendor.tar.gz
+git diff --check
 ```
 
-Those recorded results were: fertility synthetic framework tests passed; Rust
-source/archive sync, formatting, Clippy, tests, and warning-denied documentation
-passed; Bun integration reported 6 passing and 0 failing tests; required
-TypeScript/native/R/Haven conformance passed, including the R package check; and
-rebuilding the R vendor archive produced no tracked diff. These checks describe
-the fresh evidence's verification record; they do not recast `c2684db` or
-`cd50b59` as part of the `7c0a0e7` exhaustive execution.
+The full synthetic suite passed. Its expected termination regression emitted a
+SIGKILL diagnostic, and OpenMP emitted temporary-file warnings; both were
+nonfatal and the suite completed successfully. Shell helper tests and shell
+syntax checks passed. All 13 fertility R files parsed successfully, Rust source
+and vendor synchronization passed, and the final diff check passed.
+
+The unchanged parser baseline also retained its previously completed normal
+gates: Rust formatting, warning-denied Clippy, the complete Rust workspace test
+suite, warning-denied Rust documentation, Bun integration tests, required
+TypeScript/native/R/Haven conformance including the R package check, and a
+deterministic R-vendor rebuild with no tracked archive change.

--- a/benchmarks/fertility-surveys/results-2026-07-28.md
+++ b/benchmarks/fertility-surveys/results-2026-07-28.md
@@ -24,24 +24,10 @@ The exhaustive fresh run used the clean commit:
 7c0a0e7c71efa279bff17eeddb399676786b8a2a
 ```
 
-Its merged family ID is:
-
-```text
-7121cb4e1282396fd60b0c9b839bfe39fadcf35371d3c90d540d59120967030b
-```
-
-The merged target bundle is repository-local and ignored by Git:
-
-```text
-target/fertility-surveys/raw/merged/<family-id>/<run-id>
-run-id: 20260728T145545Z-14759
-```
-
-Here `<family-id>` is the full merged family ID shown above. Its provenance
-records `fresh-execution`, all eight shards, all 1,004 files, and
-the complete default family. The path is included only to make the local evidence
-reproducible from the checkout that produced it; the raw bundle is not a tracked
-or portable artifact.
+The merged evidence is identified by aggregate, content-bound provenance. It
+records `fresh-execution`, all eight shards, all 1,004 files, and the complete
+default family. No family identifier, checkout-local target path, or mutable
+publication run name is part of this tracked report.
 
 ## Privacy-safe aggregate results
 
@@ -99,8 +85,8 @@ the synthetic terminal-probe assertion that an explicit encoding override reache
 Direct-R, Rust, and Haven symmetrically.
 
 This is post-run framework hardening. It does not modify, reclassify, or replace
-the fresh evidence for family `7121cb4e`, whose execution identity remains the
-clean `7c0a0e7` build above.
+the aggregate fresh evidence, whose execution identity remains the clean
+`7c0a0e7` build above.
 
 ## Verification scope
 

--- a/benchmarks/fertility-surveys/results-2026-07-28.md
+++ b/benchmarks/fertility-surveys/results-2026-07-28.md
@@ -1,0 +1,88 @@
+# Fertility corpus Wave 2 results (2026-07-28)
+
+## Status
+
+Wave 2 completed the privacy-safe fertility corpus framework and an exhaustive
+fresh execution. The strict gate is **BLOCKED**, solely because five external
+manifest/file SHA-512 checks do not agree: `F0633` through `F0637`. Those inputs
+were rejected before reader execution. No corpus file or manifest was modified,
+and this report does not claim full gate success.
+
+Wave 3 has not started.
+
+## Framework and run identity
+
+The completed manual-only framework provides deterministic inventory and
+sharding, immutable provenance-bound builds and checkpoints, bounded isolated
+three-reader comparison, privacy-safe reports, strict family reconstruction,
+and atomic merged publication. It keeps source paths, names, labels, values,
+reader messages, and source hashes out of tracked output.
+
+The exhaustive fresh run used commit:
+
+```text
+7c0a0e7c71efa279bff17eeddb399676786b8a2a
+```
+
+Its merged family ID is:
+
+```text
+7121cb4e1282396fd60b0c9b839bfe39fadcf35371d3c90d540d59120967030b
+```
+
+The merged target bundle is:
+
+```text
+/Users/jmb/repos/dta-parser/target/fertility-surveys/raw/merged/7121cb4e1282396fd60b0c9b839bfe39fadcf35371d3c90d540d59120967030b/20260728T145545Z-14759
+```
+
+## Privacy-safe aggregate results
+
+The immutable merged raw classifications account for all 1,004 inventory IDs:
+
+| Raw classification | Files |
+| --- | ---: |
+| Unsupported release 111 (`expected-unsupported-111`) | 130 |
+| Inventory hash error | 5 |
+| Pass | 459 |
+| Metadata mismatch | 409 |
+| Haven-only error | 1 |
+| **Total** | **1,004** |
+
+The five inventory hash errors are exactly `F0633`–`F0637`, the sole strict-gate
+blocker. They are external manifest/file SHA-512 mismatches, not corpus execution
+results. The framework preserved both the corpus and manifest unchanged.
+
+All 869 hash-valid supported files were exhaustively resolved. There was no
+direct-R-versus-Rust mismatch and no confirmed dtaparser defect. Separate
+privacy-safe adjudication found:
+
+- the 409 metadata mismatches are known intentional Haven-side/Stata
+  divergences involving trailing-blank and dataset-label behavior;
+- `F0574`, the one raw Haven-only error, passes when all readers receive the
+  explicit `ISO-8859-1` override supported at commit `c2684db`;
+- the focused `F0574` override result is separate derived evidence and does not
+  rewrite the fresh merged raw classifications.
+
+## Verification
+
+The following checks passed on the completed framework checkout:
+
+```sh
+Rscript --vanilla benchmarks/fertility-surveys/test-framework.R
+scripts/check-rust-sync.sh
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets --locked -- -D warnings
+cargo test --workspace --all-targets --locked
+RUSTDOCFLAGS="-D warnings" cargo doc --workspace --locked --no-deps
+bun test tests/integration/benchmark-config.test.ts tests/integration/fixture-inventory.test.ts tests/integration/r-package-config.test.ts
+DTA_REQUIRE_R_CONFORMANCE=1 scripts/conformance.sh
+scripts/rebuild-r-vendor.sh
+git diff --exit-code -- r-package/dtaparser/src/rust/vendor.tar.gz
+```
+
+Results were: fertility synthetic framework tests passed; Rust source/archive
+sync passed; Rust formatting, Clippy, tests, and warning-denied documentation
+passed; Bun integration reported 6 passing and 0 failing tests; required
+TypeScript/native/R/Haven conformance passed, including the R package check; and
+rebuilding the R vendor archive produced no tracked diff.

--- a/benchmarks/fertility-surveys/results-2026-07-28.md
+++ b/benchmarks/fertility-surveys/results-2026-07-28.md
@@ -3,23 +3,24 @@
 ## Status
 
 Wave 2 produced an exhaustive fresh family at commit `7c0a0e7`. That original raw
-family remains unchanged. Its authoritative manifest-integrity gate remains
-**BLOCKED** as an auditable fact, solely because the five external manifest/file
-SHA-512 checks for `F0633` through `F0637` do not agree. Those inputs retain their
-original `inventory-hash-error` classifications and five manifest
-`signature-mismatch` reasons; this report does not rewrite or claim manifest
-verification.
+family remains unchanged. Five caller-supplied external manifest/file SHA-512
+checks for `F0633` through `F0637` do not agree, so those rows retain their original
+`inventory-hash-error` classifications and `signature-mismatch` reasons. Maintaining
+or reconciling the external hashes is outside this repository's parser-compatibility
+responsibility; this report records the supplied provenance outcome without
+rewriting it or claiming manifest verification.
 
 The user separately authorized explicit target-local acceptance for exactly
 `F0633` through `F0637` at their current local identities. Under that narrowly
 scoped substitute-evidence policy, the Wave 2 coverage/compatibility gate is
 **SATISFIED UNDER EXPLICIT LOCAL ACCEPTANCE**: all 1,004 files are accounted for;
-130 release-111 files are unsupported; all 874 supported files have exhaustive
+130 Stata/SE 7 format-111 files are outside dtaparser's current supported range;
+all 874 supported files have exhaustive
 evidence, comprising the original 869 plus the supplemental five; there is no
 unresolved Direct-R/Rust mismatch and no confirmed dtaparser defect.
 
-This acceptance does not alter the manifest-integrity result and does not
-authorize or start Wave 3. Wave 3 has not started.
+This acceptance does not alter the recorded external-provenance result and does
+not authorize or start Wave 3. Wave 3 has not started.
 
 ## Framework and execution record
 
@@ -40,14 +41,17 @@ classified all five as `pass`, recorded `complete` as `TRUE`, and found no
 Direct-R/Rust mismatch or confirmed dtaparser defect. A separate one-shard
 accepted merge succeeded. The derived assessment also succeeded using the
 immutable original schema-10/report-schema-2 full bundle together with the
-current accepted bundle. Its gate statuses were:
+current accepted bundle. Its historically named evidence-status fields were:
 
 ```text
 manifest_gate=blocked-signature-mismatch
 explicit_local_evidence_gate=validated
 ```
 
-The corpus and datasigs remained unchanged throughout. No parser source changes
+The `manifest_gate` field records only whether the caller-supplied external hash
+assertion was established; reconciling it is not a dtaparser parser gate or
+repository responsibility. The corpus and datasigs remained unchanged throughout.
+No parser source changes
 are claimed.
 
 ## Privacy-safe aggregate results
@@ -57,16 +61,16 @@ IDs:
 
 | Original raw classification | Files |
 | --- | ---: |
-| Unsupported release 111 (`expected-unsupported-111`) | 130 |
+| Stata/SE 7 format 111, outside current dtaparser range (`expected-unsupported-111`) | 130 |
 | Inventory hash error | 5 |
 | Pass | 459 |
 | Metadata mismatch | 409 |
 | Haven-only error | 1 |
 | **Total** | **1,004** |
 
-The five inventory hash errors are exactly `F0633`–`F0637`, the sole blocker to
-the authoritative manifest-integrity gate. They are external manifest/file
-SHA-512 mismatches, not reader outcomes.
+The five inventory hash errors are exactly `F0633`–`F0637`. They record a
+disagreement between caller-supplied external manifest hashes and current file
+bytes, not reader outcomes or a dtaparser responsibility.
 
 All 869 hash-valid supported inputs reached a raw executable outcome: 459
 `pass`, 409 `metadata-mismatch`, and one `haven-only-error`. The retained raw

--- a/benchmarks/fertility-surveys/results-2026-07-29.md
+++ b/benchmarks/fertility-surveys/results-2026-07-29.md
@@ -112,11 +112,24 @@ Final schema-13 provenance is:
 | Family ID | `49846e36fd5d6fef3068851bdb89d827ac165549a25b7bf1d02afc640f400d5d` |
 | Evidence family ID | `b077cf2cf7de3e887b2b8a3ce6440e6287f9e94612a233934594f2533842749f` |
 | Build provenance ID | `1d1920ac0ac496e74de8c040b2a80ad43d7ec110117ec5eb247d798bc48a4e7b` |
+| Execution commit | `fed5293695525cad56d0eac5019b765ced841b1b` |
+| Execution `git_dirty` | `TRUE` |
+| Package source SHA-256 | `23cb840215512b7e91fc4b07e2453ecf22189223f798d771b3969f778b8745ba` |
+| Framework source SHA-256 | `bf269f17582bda5064415356da6e1d210a9642f6f074563e988221c01d745955` |
+| Source tarball SHA-256 | `56998e84aa5b7e64b8d5944a4acba8036271892c041c856957c54027dbc0b6bf` |
+| Installed package SHA-256 | `930223e95b075710187449dd721399019f558a36aac3cfa9de16454f686dc119` |
 | Inventory ID | `99f1c8ed91cd42fa523d630267d6a7c09c1f54ef873d6311da531e87ded4f529` |
 | Family manifest ID | `8ba7c871e6840ec607ff158b1024af74b721a420d834f79e99b913e2f23a0565` |
 | Results ID | `11ba16249228d749064e7fd5120e9e14c5c7469dab3fd9d3b5519706bfebd849` |
 | Results TSV SHA-256 | `7147e280a5645f4f1a7ef256f3f982a864caec85b53196b569449d5db059c99c` |
 | Merge ID | `dac73bb8ddb8bf015e3d2c7719021c0520f56d0dc9c493438ba8b14fbd304479` |
+
+The authoritative build provenance records `git_dirty=TRUE`. At build time the
+sole tracked working-tree modification was this public dated results report; the
+parser, synchronized vendor sources, and executable benchmark framework matched
+commit `fed5293`. The immutable package-source, framework-source, source-tarball,
+and installed-package digests above bind the exact code used by every worker, so
+the report-only dirty state does not make execution source ambiguous.
 
 The immutable merged bundle is:
 

--- a/benchmarks/fertility-surveys/results-2026-07-29.md
+++ b/benchmarks/fertility-surveys/results-2026-07-29.md
@@ -2,26 +2,31 @@
 
 ## Status
 
-The Wave 3 output-corpus gate is **SATISFIED**. The frozen recursive inventory
+The Wave 3 generated-output gate is **SATISFIED**. The frozen recursive inventory
 contains exactly 1,226 regular DTA files totaling 70,748,321,626 bytes. All eight
-deterministic shards published, strict family reconstruction accounted for every
-ID from `F0001` through `F1226`, and the merged full-family validator passed.
+deterministic schema-13 shards published, strict family reconstruction accounted
+for every ID from `F0001` through `F1226`, and the merged full-family validator
+passed.
 
 All 130 release-111 inputs received the expected unsupported classification. All
 1,096 supported inputs reached an exhaustive terminal outcome with exact
 completed-versus-expected tile accounting: 691 `pass`, 404
 `metadata-mismatch`, and one `haven-only-error`. There were no missing or
-duplicate IDs, no timeout, memory-limit, crash, unresolved, inventory-hash,
+duplicate IDs and no timeout, memory-limit, crash, unresolved, inventory-hash,
 Direct-R/Rust-vector, value, tag, date, row-termination, or dtaparser-only
-outcomes, and no confirmed dtaparser defect.
+outcomes. No dtaparser parser defect was confirmed.
 
 ## Frozen inventory
 
 The allowed source root was exactly the configured fertility output directory.
 The inventory walk was recursive, accepted regular files with case-insensitive
-`.dta` extensions, ignored non-DTA entries, refused symlinks and path escapes,
-and froze canonical relative paths and private file metadata only under the
-checkout-local ignored target.
+`.dta` extensions, included top-level aggregates and nested surveys, ignored
+ordinary non-DTA entries, and added no exclusions. Root and ancestor directories
+were pinned with retained no-follow descriptors; each file was opened relative to
+its pinned parent and revalidated by device, inode, mode, size, modification time,
+and change time around descriptor-bound hashing and release reads. Canonical
+relative paths and private metadata were frozen only under the checkout-local
+ignored target.
 
 | Inventory dimension | Files | Bytes |
 | --- | ---: | ---: |
@@ -41,6 +46,14 @@ files and eight aggregate files. The frozen release distribution was:
 | 118 | 581 |
 | **Total** | **1,226** |
 
+The private frozen inventory is:
+
+`/Users/jmb/repos/dta-parser/target/fertility-surveys/raw/output-inventory/wave3/inventory.rds`
+
+The superseded schema-1 inventory authority is retained privately at:
+
+`/Users/jmb/repos/dta-parser/target/fertility-surveys/raw/output-inventory/wave3/inventory-schema1.rds`
+
 ## Qualification and exhaustive execution
 
 The small supported smoke input `F0537` was release 118 with 7,199 rows and 19
@@ -49,13 +62,13 @@ it as `pass`.
 
 The largest aggregate qualification used `F0579`, a release-115 input with
 14,410,276 rows and 288 columns. It completed all 292/292 bounded tiles,
-classified as `pass`, and took 705.987 seconds. This separately qualified the
+classified as `pass`, and took 615.061 seconds. This separately qualified the
 10,332,252,930-byte maximum before the full family was merged.
 
-The authoritative family used eight deterministic shards and this execution
-configuration:
+The authoritative family used eight deterministic shards and this configuration:
 
 ```text
+shard_count=8
 timeout_seconds=1800
 chunk_rows=250000
 column_batch=64
@@ -63,10 +76,14 @@ memory_mib=4096
 cell_budget=100000000
 max_tiles_per_batch=100000
 beyond_end_windows=1
+retry=FALSE
 ```
 
-Shard membership was 154, 154, 153, 153, 153, 153, 153, and 153 files. The
-merged classification totals were:
+Shard membership was 154, 154, 153, 153, 153, 153, 153, and 153 files.
+Interrupted wrappers produced no report publication; the same schema-13
+checkpoints were resumed without reset until each shard published. The strict
+merge reported `merged 1226 files from 8 shards` and verified 24,500/24,500
+planned tiles.
 
 | Classification | Files |
 | --- | ---: |
@@ -86,75 +103,129 @@ Supported outcomes by release were:
 | 118 | 313 | 268 | 0 | 581 |
 | **Total** | **691** | **404** | **1** | **1,096** |
 
-The raw family ID is
-`3cc55c3c94f1217f92b606a7749ad8f7c9f1765ded7cd81f6294d6a1154ca3bd`.
-The merged bundle records eight shards, 1,226 files, and
-`full_default_family=TRUE`.
+Final schema-13 provenance is:
+
+| Identity | Value |
+| --- | --- |
+| Framework ID | `f0418daff8ee2d34a17ff68be6c61a5e86fe2a5912578e74849a9c84d8f7a19c` |
+| Configuration ID | `113783903948bd61ecdfa69d55652784a2d8a01fa7750877e7c39e6865cef09b` |
+| Family ID | `49846e36fd5d6fef3068851bdb89d827ac165549a25b7bf1d02afc640f400d5d` |
+| Evidence family ID | `b077cf2cf7de3e887b2b8a3ce6440e6287f9e94612a233934594f2533842749f` |
+| Build provenance ID | `1d1920ac0ac496e74de8c040b2a80ad43d7ec110117ec5eb247d798bc48a4e7b` |
+| Inventory ID | `99f1c8ed91cd42fa523d630267d6a7c09c1f54ef873d6311da531e87ded4f529` |
+| Family manifest ID | `8ba7c871e6840ec607ff158b1024af74b721a420d834f79e99b913e2f23a0565` |
+| Results ID | `11ba16249228d749064e7fd5120e9e14c5c7469dab3fd9d3b5519706bfebd849` |
+| Results TSV SHA-256 | `7147e280a5645f4f1a7ef256f3f982a864caec85b53196b569449d5db059c99c` |
+| Merge ID | `dac73bb8ddb8bf015e3d2c7719021c0520f56d0dc9c493438ba8b14fbd304479` |
+
+The immutable merged bundle is:
+
+`/Users/jmb/repos/dta-parser/target/fertility-surveys/raw/merged/49846e36fd5d6fef3068851bdb89d827ac165549a25b7bf1d02afc640f400d5d/20260729T212535Z-4519`
 
 ## Difference investigation and ownership
 
-The 404 metadata-classified inputs contained 11,820 private mismatch records.
-Every record was confined to one of two fixed metadata surfaces:
+The 404 metadata-classified inputs contained 11,820 unchanged private mismatch
+records. Canonical public signatures and raw counts were:
 
-| Privacy-safe surface | Records |
-| --- | ---: |
-| `attribute-label-mismatch` | 7,924 |
-| `attribute-labels-mismatch` | 3,896 |
-| **Total** | **11,820** |
+| Public signature | Reader pair | Files | Records |
+| --- | --- | ---: | ---: |
+| `a1d5a4e65585b94789686d101c410a400089faa000b5bc3bfd9efaf8b5fb5133` | Direct-R/Haven | 404 | 5,910 |
+| `7f2979da47ed8aa97005be94eb32098ed7120b9fda891b913f08a9daddd0d561` | Rust-vector/Haven | 404 | 5,910 |
 
-Reader-pair attribution was exactly 5,910 Direct-R/Haven records and 5,910
-Rust-vector/Haven records. Direct-R and Rust-vector remained identical.
-Target-local investigation found invalid UTF-8 in Haven's affected textual
-metadata, while dtaparser returned valid replacement-decoded UTF-8. Applying
-UTF-8 replacement coercion to Haven's observed strings restored parity on both
-surfaces.
+Every record belonged to one of two fixed metadata surfaces:
 
-A legal synthetic release-118 reproduction wrote a synthetic DTA and patched
-only known synthetic text with malformed UTF-8. Direct-R and Rust-vector again
-agreed, Haven exposed invalid UTF-8, and replacement coercion restored parity.
-This assigns the observed metadata differences to malformed upstream textual
-metadata produced in the forced-append workflow plus Haven's decoding policy,
-not to a dtaparser parser defect.
+| Privacy-safe surface | Reader pair | Files | Records |
+| --- | --- | ---: | ---: |
+| `attribute-label-mismatch` | Direct-R/Haven | 282 | 3,962 |
+| `attribute-label-mismatch` | Rust-vector/Haven | 282 | 3,962 |
+| `attribute-labels-mismatch` | Direct-R/Haven | 299 | 1,948 |
+| `attribute-labels-mismatch` | Rust-vector/Haven | 299 | 1,948 |
+| **Total** |  | **404 unique** | **11,820** |
+
+Direct-R and Rust-vector remained identical: there were zero Direct-R/Rust-vector
+records and zero Direct-R/Rust-vector file outcomes. Target-local analytical
+coercion found invalid UTF-8 in Haven's affected textual metadata while dtaparser
+returned valid replacement-decoded UTF-8. Applying UTF-8 replacement coercion to
+Haven's observed strings restored parity on both surfaces.
+
+A legal synthetic release-118 reproduction patched only known synthetic text with
+malformed UTF-8. Direct-R and Rust-vector again agreed, Haven exposed invalid
+UTF-8, and replacement coercion restored parity. This assigns the metadata
+clusters to malformed upstream textual metadata from the forced-append workflow
+plus Haven's decoding policy, not to a dtaparser parser defect.
 
 The sole raw `haven-only-error`, `F1145`, was release 113. Direct-R and
-Rust-vector completed the file, while Haven failed consistently; the exhaustive
-raw result still attempted all 51/51 planned tiles. The public `complete=FALSE`
-value records that not every reader produced a valid projection, not partial
-execution. A separate symmetric `ISO-8859-1` override run completed 51/51 tiles
-and classified the same input as `pass`. This is targeted encoding-policy
-evidence only: it does not rewrite the raw family, add an exclusion, or establish
-a corpus-specific parser default.
+Rust-vector completed it while Haven failed under defaults; the raw exhaustive
+result attempted all 51/51 planned tiles. A fresh schema-13 symmetric
+`ISO-8859-1` override qualification, selection
+`4f61ebae9a3003a4eda91d77621a22431159a0bff16b4c6d152ab62f8dd3dd88`,
+completed 51/51 tiles and classified the input as `pass`. This is targeted
+encoding-policy evidence only: it does not rewrite the raw family, add an
+exclusion, or establish a corpus-specific default.
 
-No Direct-R/Rust-vector disagreement was found anywhere in Wave 3. No parser
-source or synchronized vendor code was changed.
+The final privacy-safe ownership adjudication binds the schema-13 framework,
+configuration, family, build, inventory, manifest, results, merge, canonical
+signatures, record/file counts, fixed surfaces, Direct-R/Rust-vector parity,
+coercion modes, synthetic evidence, F1145 qualification, and independent review:
 
-## Framework hardening and review
+`/Users/jmb/repos/dta-parser/target/fertility-surveys/raw/wave3-adjudication/ownership-adjudication.rds`
 
-Wave 3 reused the Wave 2 framework. Commits `537d403`, `30124b5`, `4aad99e`,
-`db633b9`, and `9b3d3d0` added the output inventory, merge mode, documentation,
-strict full-output-family validation, and completed-divergence accounting.
+Its SHA-256 is
+`5293d957d99d4ba4d443c4d66a69b7a1cfc28bf25b0a2fff3f6c2fc35109bf29`.
+The independent machine-readable second review is:
 
-Independent review then found that merged validation referenced a provenance
-field that the merged schema did not contain, and that one positive terminal
-classification test derived its expected values from the production allowlist.
-Commit `a057b82` derived output-family status from the already validated merged
-results, added a complete 1,226-row merged-bundle regression, and made the
-terminal allowlist expectation independent. The exhaustive comparison family
-was executed from clean commit `a057b82`.
+`/Users/jmb/repos/dta-parser/target/fertility-surveys/raw/wave3-adjudication/second-review.rds`
 
-The raw family exposed one further gate-semantics issue: explicit terminal reader
-errors can have `complete=FALSE` even after every planned tile is attempted,
-because `complete` records all-reader projection success. Commit `a1e1d95`
-therefore requires exact positive tile accounting for every supported terminal
-outcome, continues to require `complete=TRUE` for `pass`, and rejects timeout,
-memory, crash, unresolved, inventory-hash, partial-tile, and false-complete pass
-rows. It added positive and negative regressions and did not alter parser or raw
-comparison evidence. The strict merge then succeeded for all 1,226 files.
+Its SHA-256 is
+`cb1dc963f0dd787e00234095a73568930643915448ce79286e1707516ca7cf58`.
+The verdict was `CLEAN`: exact classifications, 24,500/24,500 tiles, all mismatch
+counts and canonical signatures, ownership, F1145 51/51 qualification, and
+privacy safety were independently reproduced. The review found
+`dtaparser_defect=FALSE`.
+
+No parser source or synchronized vendor code was changed.
+
+## Framework hardening
+
+Wave 3 reused and minimally extended the Wave 2 framework; no duplicate framework
+was created. Commits `537d403`, `30124b5`, `4aad99e`, `db633b9`, `9b3d3d0`,
+`a057b82`, and `a1e1d95` added generated-output inventory, shard merging, strict
+1,226-file family validation, and terminal divergence accounting.
+
+Independent review then drove fail-closed execution and filesystem hardening:
+
+- `36800e4` made expected tile counts independent and hardened output execution
+  accounting.
+- `c300bde` batched output attestation without weakening inventory checks.
+- `67c6e68` validated terminal framework and projection plans even when a reader
+  ended in error.
+- `a9df83c` bound input stat, hash, and release reads to descriptors.
+- `2709d17` versioned current descriptor-bound evidence as corpus schema 11,
+  retained schema 10 only for historical replay, and rejected duplicate modern
+  release markers.
+- `2b0c3d8` pinned root and ancestor directory descriptors, opened descendants
+  relative to retained parents, added change-time identity, and added root and
+  nested-parent substitution regressions.
+- `ca629f1` bound worker reads to the captured input descriptor and isolated
+  production readers behind target-local descriptor-derived snapshots.
+- `3613975` preserved explicit schema-10 historical replay identity after the
+  current corpus schema advanced.
+- `39f48e9` made unavailable snapshot creation a run-level failure, retained
+  parent-known timeout cleanup, and enforced zero tiles for unsupported inputs.
+- `8f92dcd` versioned the descriptor-bound output inventory as schema 2 while
+  retaining the superseded schema-1 authority under ignored target.
+- `fed5293` made transient input-change evidence canonical and replaceable under
+  `--retry`, enforced its recorded-tile contract, and advanced current evidence
+  to corpus schema 13.
+
+The authoritative family was executed from commit `fed5293`. Final review
+reported no actionable code-path defects.
 
 ## Commands and validation
 
-The manual execution used the explicit proprietary-data opt-in, with CI and
-GitHub variables removed. Representative commands were:
+Manual execution used
+`DTAPARSER_FERTILITY_CORPUS=I_UNDERSTAND_THIS_READS_PROPRIETARY_DATA`; CI and
+GitHub environments remained refused. Representative commands were:
 
 ```sh
 benchmarks/fertility-surveys/benchmark.sh \
@@ -165,12 +236,18 @@ benchmarks/fertility-surveys/benchmark.sh \
   --max-tiles-per-batch=100000 --beyond-end-windows=1
 
 benchmarks/fertility-surveys/benchmark.sh \
-  --family-id=3cc55c3c94f1217f92b606a7749ad8f7c9f1765ded7cd81f6294d6a1154ca3bd \
+  --family-id=49846e36fd5d6fef3068851bdb89d827ac165549a25b7bf1d02afc640f400d5d \
   --output-root=/Users/jmb/repos/fertility_surveys/output
+
+benchmarks/fertility-surveys/benchmark.sh \
+  --output-root=/Users/jmb/repos/fertility_surveys/output \
+  --id=F1145 --encoding-override=F1145:ISO-8859-1 \
+  --timeout-seconds=1800 --chunk-rows=250000 --column-batch=64 \
+  --memory-mib=4096 --cell-budget=100000000 \
+  --max-tiles-per-batch=100000 --beyond-end-windows=1
 ```
 
-The merge reported `merged 1226 files from 8 shards`. Framework and parser gates
-used:
+Framework and parser gates used:
 
 ```sh
 Rscript benchmarks/fertility-surveys/test-framework.R
@@ -189,14 +266,14 @@ git diff --check
 ```
 
 The synthetic framework suite passed, including its expected child SIGKILL
-regression. Shell helpers and syntax passed; all 13 fertility R files parsed;
-Rust source/vendor synchronization passed; all Rust workspace tests passed;
-formatting, warning-denied Clippy, and warning-denied documentation passed; all
-214 Bun tests passed; cross-language fixture/native/R/Haven conformance passed;
-and the built R package completed `R CMD check` with status OK. OpenMP temporary-
-file warnings were nonfatal. An explicit CI probe was refused with exit status 2.
+regression. Shell helpers and syntax passed; fertility R files parsed; Rust
+source/vendor synchronization passed; native, TypeScript, R, and Haven
+conformance passed; the built R package completed `R CMD check` with status OK;
+and OpenMP temporary-file warnings were nonfatal. The final documentation-only
+update was rechecked with the applicable framework, parsing, hygiene, privacy,
+and repository gates.
 
 All raw source files and the upstream fertility repository remained unchanged.
 Private inventories, checkpoints, mismatch records, synthetic reproductions,
-logs, shard reports, and the merged bundle remain exclusively under the ignored
-checkout-local target.
+coercion evidence, logs, shard reports, merged evidence, adjudication, and review
+remain exclusively under ignored checkout-local `target`.

--- a/benchmarks/fertility-surveys/results-2026-07-29.md
+++ b/benchmarks/fertility-surveys/results-2026-07-29.md
@@ -1,0 +1,202 @@
+# Fertility output corpus Wave 3 results (2026-07-29)
+
+## Status
+
+The Wave 3 output-corpus gate is **SATISFIED**. The frozen recursive inventory
+contains exactly 1,226 regular DTA files totaling 70,748,321,626 bytes. All eight
+deterministic shards published, strict family reconstruction accounted for every
+ID from `F0001` through `F1226`, and the merged full-family validator passed.
+
+All 130 release-111 inputs received the expected unsupported classification. All
+1,096 supported inputs reached an exhaustive terminal outcome with exact
+completed-versus-expected tile accounting: 691 `pass`, 404
+`metadata-mismatch`, and one `haven-only-error`. There were no missing or
+duplicate IDs, no timeout, memory-limit, crash, unresolved, inventory-hash,
+Direct-R/Rust-vector, value, tag, date, row-termination, or dtaparser-only
+outcomes, and no confirmed dtaparser defect.
+
+## Frozen inventory
+
+The allowed source root was exactly the configured fertility output directory.
+The inventory walk was recursive, accepted regular files with case-insensitive
+`.dta` extensions, ignored non-DTA entries, refused symlinks and path escapes,
+and froze canonical relative paths and private file metadata only under the
+checkout-local ignored target.
+
+| Inventory dimension | Files | Bytes |
+| --- | ---: | ---: |
+| Lowercase `.dta` | 742 | 29,962,646,056 |
+| Uppercase `.DTA` | 484 | 40,785,675,570 |
+| **Total** | **1,226** | **70,748,321,626** |
+
+The largest input was 10,332,252,930 bytes. Level accounting was 1,218 survey
+files and eight aggregate files. The frozen release distribution was:
+
+| DTA release | Files |
+| --- | ---: |
+| 111 | 130 |
+| 113 | 486 |
+| 114 | 24 |
+| 115 | 5 |
+| 118 | 581 |
+| **Total** | **1,226** |
+
+## Qualification and exhaustive execution
+
+The small supported smoke input `F0537` was release 118 with 7,199 rows and 19
+columns. Direct-R, Rust-vector, and Haven completed all 3/3 tiles and classified
+it as `pass`.
+
+The largest aggregate qualification used `F0579`, a release-115 input with
+14,410,276 rows and 288 columns. It completed all 292/292 bounded tiles,
+classified as `pass`, and took 705.987 seconds. This separately qualified the
+10,332,252,930-byte maximum before the full family was merged.
+
+The authoritative family used eight deterministic shards and this execution
+configuration:
+
+```text
+timeout_seconds=1800
+chunk_rows=250000
+column_batch=64
+memory_mib=4096
+cell_budget=100000000
+max_tiles_per_batch=100000
+beyond_end_windows=1
+```
+
+Shard membership was 154, 154, 153, 153, 153, 153, 153, and 153 files. The
+merged classification totals were:
+
+| Classification | Files |
+| --- | ---: |
+| `expected-unsupported-111` | 130 |
+| `pass` | 691 |
+| `metadata-mismatch` | 404 |
+| `haven-only-error` | 1 |
+| **Total** | **1,226** |
+
+Supported outcomes by release were:
+
+| Release | Pass | Metadata mismatch | Haven-only error | Supported total |
+| --- | ---: | ---: | ---: | ---: |
+| 113 | 359 | 126 | 1 | 486 |
+| 114 | 15 | 9 | 0 | 24 |
+| 115 | 4 | 1 | 0 | 5 |
+| 118 | 313 | 268 | 0 | 581 |
+| **Total** | **691** | **404** | **1** | **1,096** |
+
+The raw family ID is
+`3cc55c3c94f1217f92b606a7749ad8f7c9f1765ded7cd81f6294d6a1154ca3bd`.
+The merged bundle records eight shards, 1,226 files, and
+`full_default_family=TRUE`.
+
+## Difference investigation and ownership
+
+The 404 metadata-classified inputs contained 11,820 private mismatch records.
+Every record was confined to one of two fixed metadata surfaces:
+
+| Privacy-safe surface | Records |
+| --- | ---: |
+| `attribute-label-mismatch` | 7,924 |
+| `attribute-labels-mismatch` | 3,896 |
+| **Total** | **11,820** |
+
+Reader-pair attribution was exactly 5,910 Direct-R/Haven records and 5,910
+Rust-vector/Haven records. Direct-R and Rust-vector remained identical.
+Target-local investigation found invalid UTF-8 in Haven's affected textual
+metadata, while dtaparser returned valid replacement-decoded UTF-8. Applying
+UTF-8 replacement coercion to Haven's observed strings restored parity on both
+surfaces.
+
+A legal synthetic release-118 reproduction wrote a synthetic DTA and patched
+only known synthetic text with malformed UTF-8. Direct-R and Rust-vector again
+agreed, Haven exposed invalid UTF-8, and replacement coercion restored parity.
+This assigns the observed metadata differences to malformed upstream textual
+metadata produced in the forced-append workflow plus Haven's decoding policy,
+not to a dtaparser parser defect.
+
+The sole raw `haven-only-error`, `F1145`, was release 113. Direct-R and
+Rust-vector completed the file, while Haven failed consistently; the exhaustive
+raw result still attempted all 51/51 planned tiles. The public `complete=FALSE`
+value records that not every reader produced a valid projection, not partial
+execution. A separate symmetric `ISO-8859-1` override run completed 51/51 tiles
+and classified the same input as `pass`. This is targeted encoding-policy
+evidence only: it does not rewrite the raw family, add an exclusion, or establish
+a corpus-specific parser default.
+
+No Direct-R/Rust-vector disagreement was found anywhere in Wave 3. No parser
+source or synchronized vendor code was changed.
+
+## Framework hardening and review
+
+Wave 3 reused the Wave 2 framework. Commits `537d403`, `30124b5`, `4aad99e`,
+`db633b9`, and `9b3d3d0` added the output inventory, merge mode, documentation,
+strict full-output-family validation, and completed-divergence accounting.
+
+Independent review then found that merged validation referenced a provenance
+field that the merged schema did not contain, and that one positive terminal
+classification test derived its expected values from the production allowlist.
+Commit `a057b82` derived output-family status from the already validated merged
+results, added a complete 1,226-row merged-bundle regression, and made the
+terminal allowlist expectation independent. The exhaustive comparison family
+was executed from clean commit `a057b82`.
+
+The raw family exposed one further gate-semantics issue: explicit terminal reader
+errors can have `complete=FALSE` even after every planned tile is attempted,
+because `complete` records all-reader projection success. Commit `a1e1d95`
+therefore requires exact positive tile accounting for every supported terminal
+outcome, continues to require `complete=TRUE` for `pass`, and rejects timeout,
+memory, crash, unresolved, inventory-hash, partial-tile, and false-complete pass
+rows. It added positive and negative regressions and did not alter parser or raw
+comparison evidence. The strict merge then succeeded for all 1,226 files.
+
+## Commands and validation
+
+The manual execution used the explicit proprietary-data opt-in, with CI and
+GitHub variables removed. Representative commands were:
+
+```sh
+benchmarks/fertility-surveys/benchmark.sh \
+  --output-root=/Users/jmb/repos/fertility_surveys/output \
+  --shard-index=N --shard-count=8 \
+  --timeout-seconds=1800 --chunk-rows=250000 --column-batch=64 \
+  --memory-mib=4096 --cell-budget=100000000 \
+  --max-tiles-per-batch=100000 --beyond-end-windows=1
+
+benchmarks/fertility-surveys/benchmark.sh \
+  --family-id=3cc55c3c94f1217f92b606a7749ad8f7c9f1765ded7cd81f6294d6a1154ca3bd \
+  --output-root=/Users/jmb/repos/fertility_surveys/output
+```
+
+The merge reported `merged 1226 files from 8 shards`. Framework and parser gates
+used:
+
+```sh
+Rscript benchmarks/fertility-surveys/test-framework.R
+sh benchmarks/fertility-surveys/test-benchmark-helpers.sh
+sh -n benchmarks/fertility-surveys/benchmark.sh \
+  benchmarks/fertility-surveys/test-benchmark-helpers.sh
+Rscript -e 'files <- list.files("benchmarks/fertility-surveys", pattern="[.]R$", full.names=TRUE); invisible(lapply(files, parse))'
+scripts/check-rust-sync.sh
+scripts/conformance.sh
+cargo test --workspace
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets -- -D warnings
+RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps
+bun test
+git diff --check
+```
+
+The synthetic framework suite passed, including its expected child SIGKILL
+regression. Shell helpers and syntax passed; all 13 fertility R files parsed;
+Rust source/vendor synchronization passed; all Rust workspace tests passed;
+formatting, warning-denied Clippy, and warning-denied documentation passed; all
+214 Bun tests passed; cross-language fixture/native/R/Haven conformance passed;
+and the built R package completed `R CMD check` with status OK. OpenMP temporary-
+file warnings were nonfatal. An explicit CI probe was refused with exit status 2.
+
+All raw source files and the upstream fertility repository remained unchanged.
+Private inventories, checkpoints, mismatch records, synthetic reproductions,
+logs, shard reports, and the merged bundle remain exclusively under the ignored
+checkout-local target.

--- a/benchmarks/fertility-surveys/results-2026-07-29.md
+++ b/benchmarks/fertility-surveys/results-2026-07-29.md
@@ -8,8 +8,9 @@ deterministic schema-13 shards published, strict family reconstruction accounted
 for every ID from `F0001` through `F1226`, and the merged full-family validator
 passed.
 
-All 130 release-111 inputs received the expected unsupported classification. All
-1,096 supported inputs reached an exhaustive terminal outcome with exact
+All 130 Stata/SE 7 format-111 inputs were identified as outside dtaparser's
+current supported format range. All 1,096 supported inputs reached an exhaustive
+terminal outcome with exact
 completed-versus-expected tile accounting: 691 `pass`, 404
 `metadata-mismatch`, and one `haven-only-error`. There were no missing or
 duplicate IDs and no timeout, memory-limit, crash, unresolved, inventory-hash,

--- a/benchmarks/fertility-surveys/results-2026-07-29.md
+++ b/benchmarks/fertility-surveys/results-2026-07-29.md
@@ -46,13 +46,9 @@ files and eight aggregate files. The frozen release distribution was:
 | 118 | 581 |
 | **Total** | **1,226** |
 
-The private frozen inventory is:
-
-`/Users/jmb/repos/dta-parser/target/fertility-surveys/raw/output-inventory/wave3/inventory.rds`
-
-The superseded schema-1 inventory authority is retained privately at:
-
-`/Users/jmb/repos/dta-parser/target/fertility-surveys/raw/output-inventory/wave3/inventory-schema1.rds`
+The private frozen inventory and superseded schema-1 authority remain as
+content-bound artifacts beneath the ignored checkout-local private artifact root;
+their mutable checkout locations are not published.
 
 ## Qualification and exhaustive execution
 
@@ -131,9 +127,8 @@ commit `fed5293`. The immutable package-source, framework-source, source-tarball
 and installed-package digests above bind the exact code used by every worker, so
 the report-only dirty state does not make execution source ambiguous.
 
-The immutable merged bundle is:
-
-`/Users/jmb/repos/dta-parser/target/fertility-surveys/raw/merged/49846e36fd5d6fef3068851bdb89d827ac165549a25b7bf1d02afc640f400d5d/20260729T212535Z-4519`
+The immutable merged bundle is identified publicly by the family, evidence-family,
+results, and merge identities above. Its private checkout location is not published.
 
 ## Difference investigation and ownership
 
@@ -181,15 +176,11 @@ configuration, family, build, inventory, manifest, results, merge, canonical
 signatures, record/file counts, fixed surfaces, Direct-R/Rust-vector parity,
 coercion modes, synthetic evidence, F1145 qualification, and independent review:
 
-`/Users/jmb/repos/dta-parser/target/fertility-surveys/raw/wave3-adjudication/ownership-adjudication.rds`
-
-Its SHA-256 is
+The private ownership-adjudication artifact remains beneath the ignored artifact
+root. Its SHA-256 is
 `5293d957d99d4ba4d443c4d66a69b7a1cfc28bf25b0a2fff3f6c2fc35109bf29`.
-The independent machine-readable second review is:
-
-`/Users/jmb/repos/dta-parser/target/fertility-surveys/raw/wave3-adjudication/second-review.rds`
-
-Its SHA-256 is
+The independent machine-readable second-review artifact also remains beneath the
+ignored artifact root. Its SHA-256 is
 `cb1dc963f0dd787e00234095a73568930643915448ce79286e1707516ca7cf58`.
 The verdict was `CLEAN`: exact classifications, 24,500/24,500 tiles, all mismatch
 counts and canonical signatures, ownership, F1145 51/51 qualification, and
@@ -238,11 +229,13 @@ reported no actionable code-path defects.
 
 Manual execution used
 `DTAPARSER_FERTILITY_CORPUS=I_UNDERSTAND_THIS_READS_PROPRIETARY_DATA`; CI and
-GitHub environments remained refused. Representative commands were:
+GitHub environments remained refused. `OUTPUT_ROOT` named the authorized private
+canonical generated-output root; its concrete path is not published.
+Representative commands were:
 
 ```sh
 benchmarks/fertility-surveys/benchmark.sh \
-  --output-root=/Users/jmb/repos/fertility_surveys/output \
+  --output-root="$OUTPUT_ROOT" \
   --shard-index=N --shard-count=8 \
   --timeout-seconds=1800 --chunk-rows=250000 --column-batch=64 \
   --memory-mib=4096 --cell-budget=100000000 \
@@ -250,10 +243,10 @@ benchmarks/fertility-surveys/benchmark.sh \
 
 benchmarks/fertility-surveys/benchmark.sh \
   --family-id=49846e36fd5d6fef3068851bdb89d827ac165549a25b7bf1d02afc640f400d5d \
-  --output-root=/Users/jmb/repos/fertility_surveys/output
+  --output-root="$OUTPUT_ROOT"
 
 benchmarks/fertility-surveys/benchmark.sh \
-  --output-root=/Users/jmb/repos/fertility_surveys/output \
+  --output-root="$OUTPUT_ROOT" \
   --id=F1145 --encoding-override=F1145:ISO-8859-1 \
   --timeout-seconds=1800 --chunk-rows=250000 --column-batch=64 \
   --memory-mib=4096 --cell-budget=100000000 \

--- a/benchmarks/fertility-surveys/run.R
+++ b/benchmarks/fertility-surveys/run.R
@@ -1,0 +1,204 @@
+script_path <- normalizePath(sub("^--file=", "", grep(
+    "^--file=", commandArgs(trailingOnly = FALSE), value = TRUE
+)[[1L]]), winslash = "/")
+script_dir <- dirname(script_path)
+source(file.path(script_dir, "common.R"))
+source(file.path(script_dir, "provenance.R"))
+source(file.path(script_dir, "runner.R"))
+source(file.path(script_dir, "runtime.R"))
+
+fertility_assert_manual_run()
+options <- fertility_parse_arguments(commandArgs(trailingOnly = TRUE))
+checkout_root <- fertility_checkout_root(script_path)
+raw_root <- normalizePath(file.path(checkout_root, "target", "fertility-surveys", "raw"),
+                          winslash = "/", mustWork = FALSE)
+dir.create(raw_root, recursive = TRUE, showWarnings = FALSE, mode = "0700")
+Sys.chmod(raw_root, mode = "0700")
+if (!identical(normalizePath(raw_root, winslash = "/", mustWork = TRUE),
+               file.path(checkout_root, "target", "fertility-surveys", "raw"))) {
+    stop("outputs must remain under target/fertility-surveys/raw")
+}
+invisible(fertility_assert_tempdir(raw_root))
+
+inventory <- fertility_build_inventory()
+selected <- fertility_filter_inventory(inventory, options)
+fertility_atomic_write_table(fertility_public_inventory(inventory),
+                             file.path(raw_root, "inventory.tsv"))
+release_summary <- as.data.frame(table(release = inventory$release),
+                                 stringsAsFactors = FALSE)
+names(release_summary)[[2L]] <- "files"
+fertility_atomic_write_table(release_summary,
+                             file.path(raw_root, "inventory-summary.tsv"))
+message("inventory: 1,004 files; selected: ", nrow(selected))
+if (options$inventory_only) quit(save = "no", status = 0L)
+if (!nrow(selected)) stop("filters selected no corpus files")
+
+library <- file.path(raw_root, "library")
+provenance_path <- file.path(raw_root, "build-provenance.tsv")
+if (!file.exists(provenance_path)) stop("run benchmark.sh to create package provenance")
+provenance <- fertility_verify_provenance(checkout_root, library, provenance_path)
+expected_package_path <- fertility_package_path(library)
+.libPaths(c(library, .libPaths()))
+for (package in c("dtaparser", "haven", "openssl", "callr")) {
+    if (!requireNamespace(package, quietly = TRUE)) stop(package, " is required")
+}
+if (!identical(normalizePath(getNamespaceInfo(asNamespace("dtaparser"), "path"),
+                             winslash = "/"), expected_package_path)) {
+    stop("dtaparser was not loaded from the checkout-local corpus library")
+}
+datasigs_sha256 <- tolower(as.character(openssl::sha256(file(
+    fertility_required_paths()$datasigs
+))))
+framework_id <- fertility_stable_id(list(
+    schema_version = fertility_schema_version,
+    provenance_id = provenance$provenance_id[[1L]],
+    datasigs_sha256 = datasigs_sha256,
+    comparator_tolerance = "1e-7"
+))
+snapshot_root <- file.path(raw_root, "framework", framework_id)
+dir.create(snapshot_root, recursive = TRUE, showWarnings = FALSE, mode = "0700")
+Sys.chmod(c(file.path(raw_root, "framework"), snapshot_root), mode = "0700")
+for (name in c("common.R", "worker.R", "compare.R", "runtime.R")) {
+    source_path <- file.path(script_dir, name)
+    snapshot_path <- file.path(snapshot_root, name)
+    if (!file.exists(snapshot_path)) {
+        temporary <- tempfile(paste0(name, "."), tmpdir = snapshot_root)
+        if (!file.copy(source_path, temporary, overwrite = TRUE)) {
+            stop("could not snapshot corpus framework")
+        }
+        Sys.chmod(temporary, mode = "0600")
+        if (!file.rename(temporary, snapshot_path)) {
+            stop("could not publish corpus framework snapshot")
+        }
+    }
+    if (!identical(unname(tools::md5sum(source_path)),
+                   unname(tools::md5sum(snapshot_path)))) {
+        stop("corpus framework snapshot does not match its provenance")
+    }
+}
+checkpoint_root <- file.path(raw_root, "checkpoints", framework_id)
+dir.create(checkpoint_root, recursive = TRUE, showWarnings = FALSE, mode = "0700")
+Sys.chmod(c(file.path(raw_root, "checkpoints"), checkpoint_root), mode = "0700")
+
+execute_item <- function(item, input) {
+    started <- proc.time()[["elapsed"]]
+    tryCatch(
+        callr::r(
+            function(common_script, runtime_script, worker_script, compare_script,
+                     item, package_library, expected_package_path, framework_id,
+                     timeout_seconds, parent_sha512, raw_root) {
+                source(common_script, local = environment())
+                source(runtime_script, local = environment())
+                invisible(fertility_assert_tempdir(raw_root))
+                source(worker_script, local = environment())
+                fertility_worker(item, compare_script, package_library,
+                                 expected_package_path, framework_id,
+                                 timeout_seconds, parent_sha512)
+            },
+            args = list(
+                file.path(snapshot_root, "common.R"),
+                file.path(snapshot_root, "runtime.R"),
+                file.path(snapshot_root, "worker.R"),
+                file.path(snapshot_root, "compare.R"), item, library,
+                expected_package_path, framework_id, options$timeout_seconds,
+                input$actual_sha512, raw_root
+            ),
+            libpath = .libPaths(), timeout = options$timeout_seconds,
+            spinner = FALSE, show = FALSE, user_profile = FALSE,
+            system_profile = FALSE,
+            env = c(R_ENVIRON_USER = "/dev/null", R_PROFILE_USER = "/dev/null",
+                    TMPDIR = Sys.getenv("TMPDIR"))
+        ),
+        error = function(error) {
+            classification <- if (inherits(error, "callr_timeout_error"))
+                "timeout" else "subprocess-error"
+            fertility_base_result(
+                item, framework_id, options$timeout_seconds, input,
+                classification,
+                unname(proc.time()[["elapsed"]] - started)
+            )
+        }
+    )
+}
+
+for (index in seq_len(nrow(selected))) {
+    item <- as.list(selected[index, , drop = FALSE])
+    checkpoint_path <- file.path(checkpoint_root, paste0(item$id, ".rds"))
+    processed <- fertility_process_item(
+        item, checkpoint_path, framework_id, options$timeout_seconds,
+        options$retry, execute_item
+    )
+    message(item$id, if (processed$resumed) ": resumed " else ": ",
+            processed$result$classification)
+}
+
+checkpoints <- lapply(selected$id, function(id) {
+    checkpoint <- readRDS(file.path(checkpoint_root, paste0(id, ".rds")))
+    item <- as.list(selected[selected$id == id, , drop = FALSE])
+    if (!fertility_checkpoint_valid(
+        checkpoint, item, framework_id, fertility_capture_input(item),
+        options$timeout_seconds
+    )) {
+        stop("checkpoint validation failed")
+    }
+    checkpoint
+})
+# Detect source, dependency, or installed-package changes before publication.
+final_provenance <- fertility_verify_provenance(
+    checkout_root, library, provenance_path
+)
+if (!identical(final_provenance$provenance_id[[1L]],
+               provenance$provenance_id[[1L]])) {
+    stop("corpus build provenance changed during the run")
+}
+results <- fertility_result_frame(checkpoints)
+results$build_provenance_id <- provenance$provenance_id[[1L]]
+summary <- as.data.frame(table(classification = results$classification),
+                         stringsAsFactors = FALSE)
+names(summary)[[2L]] <- "files"
+selection_id <- fertility_stable_id(list(
+    framework_id = framework_id,
+    programs = paste(options$programs, collapse = ","),
+    releases = paste(options$releases, collapse = ","),
+    ids = paste(options$ids, collapse = ","),
+    shard_index = options$shard_index,
+    shard_count = options$shard_count,
+    max_files = as.character(options$max_files),
+    timeout_seconds = options$timeout_seconds,
+    selected_ids = paste(selected$id, collapse = ",")
+))
+report_parent <- file.path(raw_root, "reports", selection_id)
+dir.create(report_parent, recursive = TRUE, showWarnings = FALSE, mode = "0700")
+Sys.chmod(c(file.path(raw_root, "reports"), report_parent), mode = "0700")
+report_stage <- tempfile(".report.", tmpdir = report_parent)
+dir.create(report_stage, mode = "0700")
+on.exit(unlink(report_stage, recursive = TRUE), add = TRUE)
+results <- fertility_publish_results(
+    checkpoints, provenance$provenance_id[[1L]],
+    file.path(report_stage, "results.tsv")
+)
+fertility_atomic_write_table(summary, file.path(report_stage, "summary.tsv"))
+run_provenance <- data.frame(
+    schema_version = fertility_schema_version,
+    selection_id = selection_id,
+    framework_id = framework_id,
+    build_provenance_id = provenance$provenance_id[[1L]],
+    selected_files = nrow(selected),
+    shard_index = options$shard_index,
+    shard_count = options$shard_count,
+    timeout_seconds = options$timeout_seconds,
+    retry = options$retry,
+    created_at_utc = format(Sys.time(), "%Y-%m-%dT%H:%M:%SZ", tz = "UTC"),
+    stringsAsFactors = FALSE, check.names = FALSE
+)
+fertility_atomic_write_table(run_provenance,
+                             file.path(report_stage, "run-provenance.tsv"))
+run_name <- paste0(format(Sys.time(), "%Y%m%dT%H%M%SZ", tz = "UTC"), "-", Sys.getpid())
+report_dir <- file.path(report_parent, run_name)
+if (!file.rename(report_stage, report_dir)) stop("could not publish report bundle")
+current <- file.path(report_parent, "CURRENT")
+temporary_current <- tempfile("CURRENT.", tmpdir = report_parent)
+writeLines(run_name, temporary_current, useBytes = TRUE)
+Sys.chmod(temporary_current, mode = "0600")
+if (!file.rename(temporary_current, current)) stop("could not publish report pointer")
+message("completed ", nrow(results), " selected files; report ", selection_id)

--- a/benchmarks/fertility-surveys/run.R
+++ b/benchmarks/fertility-surveys/run.R
@@ -3,6 +3,7 @@ script_path <- normalizePath(sub("^--file=", "", grep(
 )[[1L]]), winslash = "/")
 script_dir <- dirname(script_path)
 source(file.path(script_dir, "common.R"))
+source(file.path(script_dir, "accepted.R"))
 source(file.path(script_dir, "provenance.R"))
 source(file.path(script_dir, "runner.R"))
 source(file.path(script_dir, "runtime.R"))
@@ -10,20 +11,22 @@ source(file.path(script_dir, "runtime.R"))
 fertility_assert_manual_run()
 options <- fertility_parse_arguments(commandArgs(trailingOnly = TRUE))
 checkout_root <- fertility_checkout_root(script_path)
-raw_root <- normalizePath(file.path(checkout_root, "target", "fertility-surveys", "raw"),
-                          winslash = "/", mustWork = FALSE)
-dir.create(raw_root, recursive = TRUE, showWarnings = FALSE, mode = "0700")
+raw_root <- fertility_assert_checkout_raw_root(
+    file.path(checkout_root, "target", "fertility-surveys", "raw"),
+    checkout_root, create = TRUE
+)
 Sys.chmod(raw_root, mode = "0700")
-if (!identical(normalizePath(raw_root, winslash = "/", mustWork = TRUE),
-               file.path(checkout_root, "target", "fertility-surveys", "raw"))) {
-    stop("outputs must remain under target/fertility-surveys/raw")
-}
 invisible(fertility_assert_tempdir(raw_root))
 
 inventory <- fertility_build_inventory()
+acceptance <- if (nzchar(options$accepted_current_hashes)) {
+    fertility_load_acceptance(raw_root, options$accepted_current_hashes, inventory)
+} else NULL
 selected <- fertility_filter_inventory(inventory, options)
 family_selection <- fertility_family_selection(inventory, options)
+fertility_validate_accepted_selection(options, family_selection)
 fertility_validate_encoding_overrides(options$encoding_overrides, family_selection)
+invisible(fertility_validate_acceptance_current(acceptance, inventory))
 fertility_atomic_write_table(fertility_public_inventory(inventory),
                              file.path(raw_root, "inventory.tsv"))
 release_summary <- as.data.frame(table(release = inventory$release),
@@ -42,11 +45,28 @@ if (!nzchar(library_value) || !nzchar(provenance_value) ||
     !nzchar(prepared_framework_id) || !nzchar(owner_state)) {
     stop("run benchmark.sh to create immutable corpus setup")
 }
-library <- normalizePath(library_value, winslash = "/", mustWork = TRUE)
-provenance_path <- normalizePath(provenance_value, winslash = "/", mustWork = TRUE)
+selected_build_id <- basename(dirname(path.expand(provenance_value)))
+build_bundle <- fertility_resolve_build_bundle(
+    raw_root, selected_build_id, require_current = TRUE
+)
+if (!identical(path.expand(library_value), build_bundle$library) ||
+    !identical(path.expand(provenance_value), build_bundle$provenance)) {
+    stop("immutable corpus build paths escaped the selected build generation")
+}
+library <- build_bundle$library
+provenance_path <- build_bundle$provenance
 provenance <- fertility_verify_provenance(checkout_root, library, provenance_path)
-expected_package_path <- fertility_package_path(library)
+if (!identical(provenance$provenance_id[[1L]], selected_build_id)) {
+    stop("selected build provenance identity is invalid")
+}
+expected_package_path <- build_bundle$package
+package_attestation <- fertility_attest_regular_tree(
+    expected_package_path, "installed dtaparser package"
+)
 .libPaths(c(library, .libPaths()))
+fertility_revalidate_regular_tree(
+    package_attestation, "installed dtaparser package"
+)
 for (package in c("dtaparser", "haven", "openssl", "callr")) {
     if (!requireNamespace(package, quietly = TRUE)) stop(package, " is required")
 }
@@ -55,13 +75,15 @@ if (!identical(normalizePath(getNamespaceInfo(asNamespace("dtaparser"), "path"),
     stop("dtaparser was not loaded from the immutable corpus library")
 }
 framework_id <- fertility_framework_id(
-    provenance$provenance_id[[1L]], fertility_required_paths()$datasigs
+    provenance$provenance_id[[1L]], fertility_required_paths()$datasigs, acceptance
 )
 if (!identical(framework_id, prepared_framework_id)) {
     stop("prepared corpus framework identity changed before execution")
 }
-snapshot_root <- fertility_verify_framework_snapshot(script_dir, raw_root, framework_id, inventory)
-configuration <- fertility_tile_configuration(options)
+snapshot_root <- fertility_verify_framework_snapshot(
+    script_dir, raw_root, framework_id, inventory, acceptance
+)
+configuration <- fertility_tile_configuration(options, acceptance)
 inventory_id <- fertility_inventory_id(inventory)
 family_manifest <- fertility_family_manifest(inventory, options)
 family_manifest_id <- fertility_manifest_id(family_manifest)
@@ -76,13 +98,19 @@ selection_id <- fertility_stable_id(list(
 ))
 owner <- fertility_read_owner(owner_state)
 if (!isTRUE(fertility_owner_alive(owner))) stop("orchestrator owner is not alive")
-lock_root <- file.path(raw_root, ".locks")
+invisible(fertility_assert_checkout_raw_root(raw_root, checkout_root))
+selection_lock_root <- fertility_assert_output_parent(
+    raw_root, ".locks", "selections", create = TRUE
+)
+case_lock_root <- fertility_assert_output_parent(
+    raw_root, ".locks", "cases", create = TRUE
+)
 selection_lock <- file.path(
-    lock_root, "selections", fertility_lock_component(selection_id, "selection ID")
+    selection_lock_root, fertility_lock_component(selection_id, "selection ID")
 )
 case_locks <- file.path(
-    lock_root, "cases", vapply(selected$id, fertility_lock_component, character(1),
-                                label = "case ID")
+    case_lock_root, vapply(selected$id, fertility_lock_component, character(1),
+                           label = "case ID")
 )
 run_locks <- fertility_acquire_lock_set(c(selection_lock, case_locks), owner)
 on.exit({
@@ -91,8 +119,10 @@ on.exit({
     }
 }, add = TRUE)
 
-checkpoint_root <- file.path(raw_root, "checkpoints", framework_id)
-dir.create(checkpoint_root, recursive = TRUE, showWarnings = FALSE, mode = "0700")
+invisible(fertility_assert_checkout_raw_root(raw_root, checkout_root))
+checkpoint_root <- fertility_assert_output_parent(
+    raw_root, "checkpoints", framework_id, create = TRUE
+)
 Sys.chmod(c(file.path(raw_root, "checkpoints"), checkpoint_root), mode = "0700")
 
 execute_tile <- function(item, tile, input) {
@@ -241,7 +271,7 @@ planning_failure_tile <- function(item, batch, detail) list(
     elapsed_seconds = 0
 )
 
-simple_result <- function(item, input, classification, reason = "") list(
+simple_result <- function(item, input, classification, reason = "") c(list(
     schema_version = fertility_schema_version, framework_id = framework_id,
     config_id = configuration$config_id, input_id = input$input_id,
     id = item$id, program = item$program, level = item$level,
@@ -252,7 +282,7 @@ simple_result <- function(item, input, classification, reason = "") list(
     tiles_expected = 0L, tiles_completed = 0L,
     complete = identical(classification, "expected-unsupported-111"),
     actual_sha512 = input$actual_sha512, elapsed_seconds = NA_real_
-)
+), fertility_result_acceptance_fields(input))
 
 checkpoints <- vector("list", nrow(selected))
 for (index in seq_len(nrow(selected))) {
@@ -260,14 +290,29 @@ for (index in seq_len(nrow(selected))) {
     if (item$id %in% names(options$encoding_overrides)) {
         item$encoding_override <- unname(options$encoding_overrides[[item$id]])
     }
-    input <- fertility_capture_input(item)
+    input <- fertility_capture_input(item, acceptance)
     preflight <- fertility_inventory_preflight(item, input)
-    file_root <- file.path(checkpoint_root, configuration$config_id, item$id)
+    file_root <- fertility_assert_output_parent(
+        checkpoint_root, configuration$config_id, item$id, create = TRUE
+    )
     tile_root <- file.path(file_root, "tiles")
-    result_path <- file.path(file_root, "result.rds")
-    dir.create(tile_root, recursive = TRUE, showWarnings = FALSE, mode = "0700")
+    invisible(fertility_assert_direct_child(
+        tile_root, file_root, "tile checkpoint directory", must_work = FALSE
+    ))
+    if (!dir.exists(tile_root) &&
+        !dir.create(tile_root, showWarnings = FALSE, mode = "0700")) {
+        stop("could not create tile checkpoint directory")
+    }
+    invisible(fertility_assert_direct_child(
+        tile_root, file_root, "tile checkpoint directory"
+    ))
+    result_path <- fertility_assert_checkpoint_file(
+        file.path(file_root, "result.rds"), "file result checkpoint"
+    )
     existing <- if (file.exists(result_path)) tryCatch(
-        readRDS(result_path), error = function(error) NULL
+        readRDS(fertility_assert_checkpoint_file(
+            result_path, "file result checkpoint", must_exist = TRUE
+        )), error = function(error) NULL
     ) else NULL
     resumed <- !options$retry &&
         fertility_file_result_valid(
@@ -378,7 +423,7 @@ for (index in seq_len(nrow(selected))) {
         result <- fertility_tiled_result(
             item, framework_id, configuration, input, tiles, batches, total_rows
         )
-        final_input <- fertility_capture_input(item)
+        final_input <- fertility_capture_input(item, acceptance)
         if (!identical(final_input$input_id, input$input_id)) {
             result <- simple_result(
                 item, final_input, "inventory-hash-error",
@@ -387,38 +432,90 @@ for (index in seq_len(nrow(selected))) {
             result$complete <- FALSE
         }
     }
-    if (!resumed) fertility_atomic_save_rds(result, result_path)
+    if (!resumed) {
+        fertility_assert_checkpoint_file(result_path, "file result checkpoint")
+        fertility_atomic_save_rds(result, result_path)
+    }
     checkpoints[[index]] <- result
     message(item$id, if (resumed) ": resumed " else ": ", result$classification)
 }
-# Detect source, dependency, or installed-package changes before publication.
-final_provenance <- fertility_verify_provenance(
-    checkout_root, library, provenance_path
-)
-if (!identical(final_provenance$provenance_id[[1L]],
-               provenance$provenance_id[[1L]])) {
-    stop("corpus build provenance changed during the run")
-}
-invisible(fertility_verify_framework_snapshot(script_dir, raw_root, framework_id, inventory))
-if (!identical(
-    fertility_framework_id(final_provenance$provenance_id[[1L]],
-                           fertility_required_paths()$datasigs),
-    framework_id
-)) stop("corpus framework or inventory provenance changed during the run")
-for (index in seq_len(nrow(selected))) {
-    current_input <- fertility_capture_input(as.list(selected[index, , drop = FALSE]))
-    if (!identical(current_input$input_id, checkpoints[[index]]$input_id)) {
-        stop("corpus input changed before report publication")
+# Close over every source of publication authority and rerun this immediately
+# before both immutable bundle publication and CURRENT replacement.
+revalidate_run_evidence <- function(publication_provenance = NULL) {
+    live_inventory <- fertility_build_inventory()
+    fertility_validate_canonical_inventory(
+        fertility_inventory_manifest(live_inventory), exact = TRUE
+    )
+    if (!identical(fertility_inventory_id(live_inventory), inventory_id)) {
+        stop("canonical inventory changed before report publication")
     }
+    current_build <- fertility_resolve_build_bundle(
+        raw_root, provenance$provenance_id[[1L]], require_current = TRUE
+    )
+    final_provenance <- fertility_verify_provenance(
+        checkout_root, current_build$library, current_build$provenance
+    )
+    if (!identical(final_provenance$provenance_id[[1L]],
+                   provenance$provenance_id[[1L]]) ||
+        !identical(current_build$library, library) ||
+        !identical(current_build$package, expected_package_path)) {
+        stop("corpus build provenance changed during the run")
+    }
+    reloaded_acceptance <- if (is.null(acceptance)) NULL else
+        fertility_load_acceptance(
+            raw_root, acceptance$commitment_id, live_inventory
+        )
+    if (!identical(acceptance, reloaded_acceptance)) {
+        stop("accepted-current-hash artifact changed before publication")
+    }
+    invisible(fertility_validate_acceptance_current(
+        reloaded_acceptance, live_inventory
+    ))
+    invisible(fertility_verify_framework_snapshot(
+        script_dir, raw_root, framework_id, live_inventory, reloaded_acceptance
+    ))
+    if (!identical(
+        fertility_framework_id(
+            final_provenance$provenance_id[[1L]],
+            fertility_required_paths()$datasigs, reloaded_acceptance
+        ), framework_id
+    )) stop("corpus framework or inventory provenance changed during the run")
+    live_selected <- fertility_filter_inventory(live_inventory, options)
+    if (!identical(as.character(live_selected$id), as.character(selected$id))) {
+        stop("selected inventory changed before report publication")
+    }
+    for (index in seq_len(nrow(live_selected))) {
+        current_input <- fertility_capture_input(
+            as.list(live_selected[index, , drop = FALSE]), reloaded_acceptance
+        )
+        if (!identical(current_input$input_id, checkpoints[[index]]$input_id)) {
+            stop("corpus input changed before report publication")
+        }
+    }
+    if (!is.null(publication_provenance) && !is.null(reloaded_acceptance)) {
+        fertility_revalidate_accepted_publication(
+            raw_root, publication_provenance, live_inventory
+        )
+    }
+    invisible(list(
+        inventory = live_inventory, acceptance = reloaded_acceptance,
+        build = final_provenance
+    ))
 }
+invisible(revalidate_run_evidence())
 results <- fertility_result_frame(checkpoints)
 results$build_provenance_id <- rep(provenance$provenance_id[[1L]], nrow(results))
 summary <- fertility_classification_summary(results)
-report_parent <- file.path(raw_root, "reports", selection_id)
-dir.create(report_parent, recursive = TRUE, showWarnings = FALSE, mode = "0700")
+invisible(fertility_assert_checkout_raw_root(raw_root, checkout_root))
+report_parent <- fertility_assert_output_parent(
+    raw_root, "reports", selection_id, create = TRUE
+)
 Sys.chmod(c(file.path(raw_root, "reports"), report_parent), mode = "0700")
 report_stage <- tempfile(".report.", tmpdir = report_parent)
 dir.create(report_stage, mode = "0700")
+invisible(fertility_assert_direct_child(
+    report_stage, report_parent, "report staging directory"
+))
 on.exit(unlink(report_stage, recursive = TRUE), add = TRUE)
 results <- fertility_publish_results(
     checkpoints, provenance$provenance_id[[1L]],
@@ -431,9 +528,12 @@ fertility_atomic_write_table(
 filter_spec <- fertility_filter_spec(options)
 evidence_origin <- "fresh-execution"
 input_attestation_id <- fertility_input_attestation_id(checkpoints)
+acceptance_authority <- if (is.null(acceptance)) "" else acceptance$authority
+acceptance_commitment_id <- if (is.null(acceptance)) "" else acceptance$commitment_id
 evidence_selection_id <- fertility_evidence_selection_id(
     selection_id, input_attestation_id, evidence_origin,
-    fertility_schema_version, fertility_report_schema_id()
+    fertility_schema_version, fertility_report_schema_id(),
+    acceptance_authority, acceptance_commitment_id
 )
 run_provenance <- data.frame(
     schema_version = fertility_schema_version,
@@ -441,6 +541,10 @@ run_provenance <- data.frame(
     evidence_origin = evidence_origin,
     source_corpus_schema_version = fertility_schema_version,
     replayed_at_utc = "",
+    acceptance_authority = acceptance_authority,
+    acceptance_commitment_id = acceptance_commitment_id,
+    acceptance_artifact_sha256 = if (is.null(acceptance)) "" else
+        acceptance$artifact_sha256,
     selection_id = selection_id,
     evidence_selection_id = evidence_selection_id,
     input_attestation_id = input_attestation_id,
@@ -474,12 +578,72 @@ run_provenance <- data.frame(
 )
 fertility_atomic_write_table(run_provenance,
                              file.path(report_stage, "run-provenance.tsv"))
+report_bundle_files <- c(
+    results = "results.tsv", summary = "summary.tsv",
+    family_manifest = "family-manifest.tsv",
+    provenance = "run-provenance.tsv"
+)
+report_bundle_expected <- list(
+    results = results, summary = summary,
+    family_manifest = family_manifest, provenance = run_provenance
+)
+validate_report_bundle <- function(path) fertility_validate_exact_table_bundle(
+    path, report_bundle_files, report_bundle_expected, "report bundle"
+)
 run_name <- paste0(format(Sys.time(), "%Y%m%dT%H%M%SZ", tz = "UTC"), "-", Sys.getpid())
 report_dir <- file.path(report_parent, run_name)
-if (!file.rename(report_stage, report_dir)) stop("could not publish report bundle")
+fertility_publication_test_hook(
+    "run-before-bundle-revalidation",
+    list(parent = report_parent, stage = report_stage, destination = report_dir)
+)
+invisible(revalidate_run_evidence(run_provenance))
+invisible(validate_report_bundle(report_stage))
+invisible(fertility_assert_checkout_raw_root(raw_root, checkout_root))
+report_parent <- fertility_assert_output_parent(raw_root, "reports", selection_id)
+invisible(fertility_assert_existing_directory(
+    report_stage, report_parent, "report staging directory"
+))
+report_dir <- fertility_assert_new_destination(
+    report_dir, report_parent, "report publication bundle"
+)
+fertility_atomic_rename_noreplace(
+    report_stage, report_dir, "report publication bundle"
+)
 current <- file.path(report_parent, "CURRENT")
 temporary_current <- tempfile("CURRENT.", tmpdir = report_parent)
 writeLines(run_name, temporary_current, useBytes = TRUE)
 Sys.chmod(temporary_current, mode = "0600")
-if (!file.rename(temporary_current, current)) stop("could not publish report pointer")
+pointer_ready <- tryCatch({
+    fertility_publication_test_hook(
+        "run-before-current-revalidation",
+        list(parent = report_parent, bundle = report_dir, pointer = current)
+    )
+    revalidate_run_evidence(run_provenance)
+    validate_report_bundle(report_dir)
+    fertility_assert_checkout_raw_root(raw_root, checkout_root)
+    report_parent <- fertility_assert_output_parent(
+        raw_root, "reports", selection_id
+    )
+    fertility_assert_existing_directory(
+        report_dir, report_parent, "report publication bundle"
+    )
+    fertility_assert_existing_file(
+        temporary_current, report_parent, "temporary report pointer"
+    )
+    fertility_assert_direct_child(
+        current, report_parent, "report CURRENT pointer", must_work = FALSE
+    )
+    TRUE
+}, error = function(error) {
+    fertility_remove_confirmed_new_path(
+        report_dir, report_parent, "new report publication bundle"
+    )
+    stop(error)
+})
+if (!isTRUE(pointer_ready) || !file.rename(temporary_current, current)) {
+    fertility_remove_confirmed_new_path(
+        report_dir, report_parent, "new report publication bundle"
+    )
+    stop("could not publish report pointer")
+}
 message("completed ", nrow(results), " selected files; report ", selection_id)

--- a/benchmarks/fertility-surveys/run.R
+++ b/benchmarks/fertility-surveys/run.R
@@ -22,6 +22,8 @@ invisible(fertility_assert_tempdir(raw_root))
 
 inventory <- fertility_build_inventory()
 selected <- fertility_filter_inventory(inventory, options)
+family_selection <- fertility_family_selection(inventory, options)
+fertility_validate_encoding_overrides(options$encoding_overrides, family_selection)
 fertility_atomic_write_table(fertility_public_inventory(inventory),
                              file.path(raw_root, "inventory.tsv"))
 release_summary <- as.data.frame(table(release = inventory$release),
@@ -61,7 +63,6 @@ if (!identical(framework_id, prepared_framework_id)) {
 snapshot_root <- fertility_verify_framework_snapshot(script_dir, raw_root, framework_id, inventory)
 configuration <- fertility_tile_configuration(options)
 inventory_id <- fertility_inventory_id(inventory)
-family_selection <- fertility_family_selection(inventory, options)
 family_manifest <- fertility_family_manifest(inventory, options)
 family_manifest_id <- fertility_manifest_id(family_manifest)
 family_id <- fertility_selection_family_id(
@@ -256,6 +257,9 @@ simple_result <- function(item, input, classification, reason = "") list(
 checkpoints <- vector("list", nrow(selected))
 for (index in seq_len(nrow(selected))) {
     item <- as.list(selected[index, , drop = FALSE])
+    if (item$id %in% names(options$encoding_overrides)) {
+        item$encoding_override <- unname(options$encoding_overrides[[item$id]])
+    }
     input <- fertility_capture_input(item)
     preflight <- fertility_inventory_preflight(item, input)
     file_root <- file.path(checkpoint_root, configuration$config_id, item$id)
@@ -453,6 +457,7 @@ run_provenance <- data.frame(
     program_filter = filter_spec$program_filter,
     release_filter = filter_spec$release_filter,
     id_filter = filter_spec$id_filter,
+    encoding_overrides = configuration$encoding_overrides,
     max_files = filter_spec$max_files,
     shard_index = options$shard_index,
     shard_count = options$shard_count,

--- a/benchmarks/fertility-surveys/run.R
+++ b/benchmarks/fertility-surveys/run.R
@@ -150,16 +150,20 @@ execute_tile <- function(item, tile, input) {
     stat_before <- fertility_file_stat(item$path)
     worker_item <- item
     worker_item$path <- fertility_bound_input_path()
+    worker_snapshot <- tempfile(
+        "bound-worker-input-", tmpdir = Sys.getenv("TMPDIR"), fileext = ".dta"
+    )
+    on.exit(unlink(worker_snapshot), add = TRUE)
     result <- tryCatch(
         callr::r(
             function(common_script, runtime_script, worker_script, compare_script,
                      item, tile, input, package_library, expected_package_path,
-                     framework_id, timeout_seconds, raw_root) {
+                     framework_id, timeout_seconds, raw_root, worker_snapshot) {
                 source(common_script, local = environment())
                 source(runtime_script, local = environment())
                 invisible(fertility_assert_tempdir(raw_root))
                 item$path <- fertility_materialize_bound_input(
-                    item$path, input, raw_root
+                    item$path, input, raw_root, worker_snapshot
                 )
                 on.exit(unlink(item$path), add = TRUE)
                 source(worker_script, local = environment())
@@ -182,7 +186,7 @@ execute_tile <- function(item, tile, input) {
                 file.path(snapshot_root, "worker.R"),
                 file.path(snapshot_root, "compare.R"), worker_item, tile, input, library,
                 expected_package_path, framework_id, options$timeout_seconds,
-                raw_root
+                raw_root, worker_snapshot
             ),
             libpath = .libPaths(), timeout = options$timeout_seconds,
             connections = list(bound_input_connection), poll_connection = FALSE,

--- a/benchmarks/fertility-surveys/run.R
+++ b/benchmarks/fertility-surveys/run.R
@@ -18,7 +18,7 @@ raw_root <- fertility_assert_checkout_raw_root(
 Sys.chmod(raw_root, mode = "0700")
 invisible(fertility_assert_tempdir(raw_root))
 
-inventory <- fertility_build_inventory()
+inventory <- fertility_build_selected_inventory(options, raw_root)
 acceptance <- if (nzchar(options$accepted_current_hashes)) {
     fertility_load_acceptance(raw_root, options$accepted_current_hashes, inventory)
 } else NULL
@@ -34,7 +34,7 @@ release_summary <- as.data.frame(table(release = inventory$release),
 names(release_summary)[[2L]] <- "files"
 fertility_atomic_write_table(release_summary,
                              file.path(raw_root, "inventory-summary.tsv"))
-message("inventory: 1,004 files; selected: ", nrow(selected))
+message("inventory: ", nrow(inventory), " files; selected: ", nrow(selected))
 if (options$inventory_only) quit(save = "no", status = 0L)
 
 library_value <- Sys.getenv("DTAPARSER_FERTILITY_LIBRARY")
@@ -75,7 +75,7 @@ if (!identical(normalizePath(getNamespaceInfo(asNamespace("dtaparser"), "path"),
     stop("dtaparser was not loaded from the immutable corpus library")
 }
 framework_id <- fertility_framework_id(
-    provenance$provenance_id[[1L]], fertility_required_paths()$datasigs, acceptance
+    provenance$provenance_id[[1L]], fertility_required_paths(options, raw_root)$datasigs, acceptance
 )
 if (!identical(framework_id, prepared_framework_id)) {
     stop("prepared corpus framework identity changed before execution")
@@ -442,9 +442,10 @@ for (index in seq_len(nrow(selected))) {
 # Close over every source of publication authority and rerun this immediately
 # before both immutable bundle publication and CURRENT replacement.
 revalidate_run_evidence <- function(publication_provenance = NULL) {
-    live_inventory <- fertility_build_inventory()
+    live_inventory <- fertility_build_selected_inventory(options, raw_root)
     fertility_validate_canonical_inventory(
-        fertility_inventory_manifest(live_inventory), exact = TRUE
+        fertility_inventory_manifest(live_inventory),
+        exact = !fertility_output_requested(options)
     )
     if (!identical(fertility_inventory_id(live_inventory), inventory_id)) {
         stop("canonical inventory changed before report publication")
@@ -477,7 +478,7 @@ revalidate_run_evidence <- function(publication_provenance = NULL) {
     if (!identical(
         fertility_framework_id(
             final_provenance$provenance_id[[1L]],
-            fertility_required_paths()$datasigs, reloaded_acceptance
+            fertility_required_paths(options, raw_root)$datasigs, reloaded_acceptance
         ), framework_id
     )) stop("corpus framework or inventory provenance changed during the run")
     live_selected <- fertility_filter_inventory(live_inventory, options)

--- a/benchmarks/fertility-surveys/run.R
+++ b/benchmarks/fertility-surveys/run.R
@@ -192,8 +192,15 @@ execute_tile <- function(item, tile, input) {
                     TMPDIR = Sys.getenv("TMPDIR"),
                     R_MAX_VSIZE = paste0(configuration$memory_mib, "M"))
         ),
-        error = function(error) list(
-            schema_version = fertility_schema_version, framework_id = framework_id,
+        error = function(error) {
+            if (grepl(
+                "could not materialize descriptor-bound worker input",
+                conditionMessage(error), fixed = TRUE
+            )) {
+                stop("descriptor-bound worker input is unavailable", call. = FALSE)
+            }
+            list(
+                schema_version = fertility_schema_version, framework_id = framework_id,
             id = item$id, tile_id = tile$tile_id, tile_type = tile$type,
             batch = tile$batch, skip = tile$skip, n_max = tile$n_max,
             classification = if (inherits(error, "callr_timeout_error"))
@@ -215,7 +222,8 @@ execute_tile <- function(item, tile, input) {
             projection_ok = setNames(rep(FALSE, 3L),
                                      c("direct", "rust", "haven")),
             elapsed_seconds = unname(proc.time()[["elapsed"]] - started)
-        )
+            )
+        }
     )
     if (identical(tile$type, "sizing")) {
         payload <- if (!is.null(result$payload_bytes_per_row))

--- a/benchmarks/fertility-surveys/run.R
+++ b/benchmarks/fertility-surveys/run.R
@@ -125,17 +125,43 @@ checkpoint_root <- fertility_assert_output_parent(
 )
 Sys.chmod(c(file.path(raw_root, "checkpoints"), checkpoint_root), mode = "0700")
 
+bound_input_connection <- NULL
+bound_input_id <- NULL
+on.exit(fertility_close_bound_input_connection(bound_input_connection), add = TRUE)
+activate_bound_input <- function(item, input) {
+    fertility_close_bound_input_connection(bound_input_connection)
+    bound_input_connection <<- fertility_open_bound_input_connection(item$path, input)
+    bound_input_id <<- input$input_id
+    invisible(NULL)
+}
+deactivate_bound_input <- function() {
+    fertility_close_bound_input_connection(bound_input_connection)
+    bound_input_connection <<- NULL
+    bound_input_id <<- NULL
+    invisible(NULL)
+}
+
 execute_tile <- function(item, tile, input) {
+    if (is.null(bound_input_connection) ||
+        !identical(bound_input_id, input$input_id)) {
+        stop("worker input descriptor is not bound to the captured input")
+    }
     started <- proc.time()[["elapsed"]]
     stat_before <- fertility_file_stat(item$path)
+    worker_item <- item
+    worker_item$path <- fertility_bound_input_path()
     result <- tryCatch(
         callr::r(
             function(common_script, runtime_script, worker_script, compare_script,
-                     item, tile, package_library, expected_package_path,
+                     item, tile, input, package_library, expected_package_path,
                      framework_id, timeout_seconds, raw_root) {
                 source(common_script, local = environment())
                 source(runtime_script, local = environment())
                 invisible(fertility_assert_tempdir(raw_root))
+                item$path <- fertility_materialize_bound_input(
+                    item$path, input, raw_root
+                )
+                on.exit(unlink(item$path), add = TRUE)
                 source(worker_script, local = environment())
                 result <- fertility_worker_tile(
                     item, tile, compare_script, package_library,
@@ -154,11 +180,12 @@ execute_tile <- function(item, tile, input) {
                 file.path(snapshot_root, "common.R"),
                 file.path(snapshot_root, "runtime.R"),
                 file.path(snapshot_root, "worker.R"),
-                file.path(snapshot_root, "compare.R"), item, tile, library,
+                file.path(snapshot_root, "compare.R"), worker_item, tile, input, library,
                 expected_package_path, framework_id, options$timeout_seconds,
                 raw_root
             ),
             libpath = .libPaths(), timeout = options$timeout_seconds,
+            connections = list(bound_input_connection), poll_connection = FALSE,
             spinner = FALSE, show = FALSE, user_profile = FALSE,
             system_profile = FALSE,
             env = c(R_ENVIRON_USER = "/dev/null", R_PROFILE_USER = "/dev/null",
@@ -221,9 +248,10 @@ worker_smoke_item <- list(
     path = normalizePath(worker_smoke_path, winslash = "/", mustWork = TRUE),
     expected_sha512 = ""
 )
+worker_smoke_input <- fertility_capture_input(worker_smoke_item)
+activate_bound_input(worker_smoke_item, worker_smoke_input)
 worker_smoke <- execute_tile(
-    worker_smoke_item, fertility_metadata_tile(),
-    fertility_capture_input(worker_smoke_item)
+    worker_smoke_item, fertility_metadata_tile(), worker_smoke_input
 )
 if (!is.list(worker_smoke) || worker_smoke$classification %in%
         c("timeout", "memory-limit", "crash", "dtaparser-only-error",
@@ -236,7 +264,7 @@ if (!is.list(worker_smoke) || worker_smoke$classification %in%
 worker_sizing_smoke <- execute_tile(
     worker_smoke_item,
     fertility_sizing_tile(1L, "synthetic_long", 100, configuration$strl_sample_count),
-    fertility_capture_input(worker_smoke_item)
+    worker_smoke_input
 )
 if (!is.list(worker_sizing_smoke) ||
     !identical(worker_sizing_smoke$classification, "pass") ||
@@ -247,6 +275,7 @@ if (!is.list(worker_sizing_smoke) ||
     !is.finite(worker_sizing_smoke$chosen_rows) || worker_sizing_smoke$chosen_rows <= 1L) {
     stop("post-build isolated strL sizing regression failed")
 }
+deactivate_bound_input()
 unlink(worker_smoke_path)
 message("post-build isolated worker regressions passed")
 
@@ -286,6 +315,7 @@ simple_result <- function(item, input, classification, reason = "") c(list(
 
 checkpoints <- vector("list", nrow(selected))
 for (index in seq_len(nrow(selected))) {
+    deactivate_bound_input()
     item <- as.list(selected[index, , drop = FALSE])
     if (item$id %in% names(options$encoding_overrides)) {
         item$encoding_override <- unname(options$encoding_overrides[[item$id]])
@@ -328,6 +358,7 @@ for (index in seq_len(nrow(selected))) {
     } else if (!(item$release %in% fertility_supported_releases)) {
         result <- simple_result(item, input, "expected-unsupported-111")
     } else {
+        activate_bound_input(item, input)
         metadata_tile <- fertility_metadata_tile()
         metadata <- fertility_process_tile(
             item, metadata_tile, file.path(tile_root, "metadata.rds"), framework_id,
@@ -431,6 +462,7 @@ for (index in seq_len(nrow(selected))) {
             tiles_expected = tiles_expected
         )
         final_input <- fertility_capture_input(item, acceptance)
+        deactivate_bound_input()
         if (!identical(final_input$input_id, input$input_id)) {
             result <- simple_result(
                 item, final_input, "inventory-hash-error",

--- a/benchmarks/fertility-surveys/run.R
+++ b/benchmarks/fertility-surveys/run.R
@@ -80,69 +80,206 @@ checkpoint_root <- file.path(raw_root, "checkpoints", framework_id)
 dir.create(checkpoint_root, recursive = TRUE, showWarnings = FALSE, mode = "0700")
 Sys.chmod(c(file.path(raw_root, "checkpoints"), checkpoint_root), mode = "0700")
 
-execute_item <- function(item, input) {
+configuration <- fertility_tile_configuration(options)
+
+execute_tile <- function(item, tile, input) {
     started <- proc.time()[["elapsed"]]
-    tryCatch(
+    stat_before <- fertility_file_stat(item$path)
+    result <- tryCatch(
         callr::r(
             function(common_script, runtime_script, worker_script, compare_script,
-                     item, package_library, expected_package_path, framework_id,
-                     timeout_seconds, parent_sha512, raw_root) {
+                     item, tile, package_library, expected_package_path,
+                     framework_id, timeout_seconds, raw_root) {
                 source(common_script, local = environment())
                 source(runtime_script, local = environment())
                 invisible(fertility_assert_tempdir(raw_root))
                 source(worker_script, local = environment())
-                fertility_worker(item, compare_script, package_library,
-                                 expected_package_path, framework_id,
-                                 timeout_seconds, parent_sha512)
+                fertility_worker_tile(
+                    item, tile, compare_script, package_library,
+                    expected_package_path, framework_id, timeout_seconds
+                )
             },
             args = list(
                 file.path(snapshot_root, "common.R"),
                 file.path(snapshot_root, "runtime.R"),
                 file.path(snapshot_root, "worker.R"),
-                file.path(snapshot_root, "compare.R"), item, library,
+                file.path(snapshot_root, "compare.R"), item, tile, library,
                 expected_package_path, framework_id, options$timeout_seconds,
-                input$actual_sha512, raw_root
+                raw_root
             ),
             libpath = .libPaths(), timeout = options$timeout_seconds,
             spinner = FALSE, show = FALSE, user_profile = FALSE,
             system_profile = FALSE,
             env = c(R_ENVIRON_USER = "/dev/null", R_PROFILE_USER = "/dev/null",
-                    TMPDIR = Sys.getenv("TMPDIR"))
+                    TMPDIR = Sys.getenv("TMPDIR"),
+                    R_MAX_VSIZE = paste0(configuration$memory_mib, "M"))
         ),
-        error = function(error) {
-            classification <- if (inherits(error, "callr_timeout_error"))
-                "timeout" else "subprocess-error"
-            fertility_base_result(
-                item, framework_id, options$timeout_seconds, input,
-                classification,
-                unname(proc.time()[["elapsed"]] - started)
-            )
-        }
+        error = function(error) list(
+            schema_version = fertility_schema_version, framework_id = framework_id,
+            id = item$id, tile_id = tile$tile_id, tile_type = tile$type,
+            batch = tile$batch, skip = tile$skip, n_max = tile$n_max,
+            classification = if (inherits(error, "callr_timeout_error"))
+                "timeout" else if (fertility_memory_error(error))
+                "memory-limit" else "crash",
+            secondary = character(), mismatches = data.frame(), rows = NA_integer_,
+            reader_rows = setNames(rep(NA_integer_, 3L),
+                                   c("direct", "rust", "haven")),
+            columns = NA_integer_, column_names = character(), storage = character(),
+            structural_rows = NA_real_, column_bytes = numeric(), strl = logical(),
+            projection_expected_count = if (tile$type %in% c("value", "terminal"))
+                length(tile$column_names) else NA_integer_,
+            projection_expected_hash = if (tile$type %in% c("value", "terminal"))
+                fertility_projection_hash(tile$column_names, framework_id) else NA_character_,
+            projection_counts = setNames(rep(NA_integer_, 3L),
+                                         c("direct", "rust", "haven")),
+            projection_hashes = setNames(rep(NA_character_, 3L),
+                                         c("direct", "rust", "haven")),
+            projection_ok = setNames(rep(FALSE, 3L),
+                                     c("direct", "rust", "haven")),
+            elapsed_seconds = unname(proc.time()[["elapsed"]] - started)
+        )
     )
+    stat_after <- fertility_file_stat(item$path)
+    if (is.null(stat_before) || is.null(stat_after) ||
+        !identical(stat_before, stat_after)) result$classification <- "input-changed"
+    result
 }
 
+planning_failure_tile <- function(item, batch, detail) list(
+    schema_version = fertility_schema_version, framework_id = framework_id,
+    id = item$id, tile_id = paste0("planning-", batch), tile_type = "planning",
+    batch = as.integer(batch), skip = 0, n_max = 0L,
+    classification = "unresolved", secondary = detail,
+    mismatches = data.frame(category = "unresolved", detail = detail,
+                            component = NA_integer_, pair = NA_character_,
+                            stringsAsFactors = FALSE),
+    rows = NA_integer_, reader_rows = setNames(rep(NA_integer_, 3L),
+                                                c("direct", "rust", "haven")),
+    columns = NA_integer_, column_names = character(), storage = character(),
+    structural_rows = NA_real_, column_bytes = numeric(), strl = logical(),
+    projection_expected_count = NA_integer_, projection_expected_hash = NA_character_,
+    projection_counts = setNames(rep(NA_integer_, 3L),
+                                 c("direct", "rust", "haven")),
+    projection_hashes = setNames(rep(NA_character_, 3L),
+                                 c("direct", "rust", "haven")),
+    projection_ok = setNames(rep(FALSE, 3L), c("direct", "rust", "haven")),
+    elapsed_seconds = 0
+)
+
+simple_result <- function(item, input, classification) list(
+    schema_version = fertility_schema_version, framework_id = framework_id,
+    config_id = configuration$config_id, input_id = input$input_id,
+    id = item$id, program = item$program, level = item$level,
+    release = as.integer(item$release), expected_sha512 = item$expected_sha512,
+    timeout_seconds = options$timeout_seconds, classification = classification,
+    secondary_categories = "", mismatch_count = 0L, mismatch_categories = "",
+    mismatch_signatures = "", rows = NA_real_, columns = NA_integer_,
+    tiles_expected = 0L, tiles_completed = 0L,
+    complete = identical(classification, "expected-unsupported-111"),
+    actual_sha512 = input$actual_sha512, elapsed_seconds = NA_real_
+)
+
+checkpoints <- vector("list", nrow(selected))
 for (index in seq_len(nrow(selected))) {
     item <- as.list(selected[index, , drop = FALSE])
-    checkpoint_path <- file.path(checkpoint_root, paste0(item$id, ".rds"))
-    processed <- fertility_process_item(
-        item, checkpoint_path, framework_id, options$timeout_seconds,
-        options$retry, execute_item
-    )
-    message(item$id, if (processed$resumed) ": resumed " else ": ",
-            processed$result$classification)
-}
-
-checkpoints <- lapply(selected$id, function(id) {
-    checkpoint <- readRDS(file.path(checkpoint_root, paste0(id, ".rds")))
-    item <- as.list(selected[selected$id == id, , drop = FALSE])
-    if (!fertility_checkpoint_valid(
-        checkpoint, item, framework_id, fertility_capture_input(item),
-        options$timeout_seconds
-    )) {
-        stop("checkpoint validation failed")
+    input <- fertility_capture_input(item)
+    file_root <- file.path(checkpoint_root, configuration$config_id, item$id)
+    tile_root <- file.path(file_root, "tiles")
+    result_path <- file.path(file_root, "result.rds")
+    dir.create(tile_root, recursive = TRUE, showWarnings = FALSE, mode = "0700")
+    existing <- if (file.exists(result_path)) tryCatch(
+        readRDS(result_path), error = function(error) NULL
+    ) else NULL
+    resumed <- !options$retry &&
+        fertility_file_result_valid(
+            existing, item, framework_id, configuration, input
+        ) && existing$classification %in%
+            c("expected-unsupported-111", "inventory-hash-error")
+    if (resumed) {
+        result <- existing
+    } else if (identical(input$hash_status, "error")) {
+        result <- simple_result(item, input, "inventory-hash-error")
+    } else if (nzchar(item$expected_sha512) &&
+               !identical(input$actual_sha512, tolower(item$expected_sha512))) {
+        result <- simple_result(item, input, "inventory-hash-error")
+    } else if (!(item$release %in% fertility_supported_releases)) {
+        result <- simple_result(item, input, "expected-unsupported-111")
+    } else {
+        metadata_tile <- fertility_metadata_tile()
+        metadata <- fertility_process_tile(
+            item, metadata_tile, file.path(tile_root, "metadata.rds"), framework_id,
+            configuration, input, options$retry, execute_tile
+        )
+        tiles <- list(metadata$result)
+        column_names <- metadata$result$column_names
+        column_bytes <- metadata$result$column_bytes
+        batches <- fertility_structural_batches(
+            column_names, configuration$column_batch, column_bytes,
+            metadata$result$columns
+        )
+        total_rows <- metadata$result$structural_rows
+        structurally_valid <- is.finite(total_rows) && total_rows >= 0 &&
+            identical(as.integer(metadata$result$columns),
+                      as.integer(length(column_names))) &&
+            length(column_bytes) == length(column_names)
+        if (length(batches) && isTRUE(structurally_valid)) {
+            for (batch in seq_along(batches)) {
+                bytes <- fertility_batch_bytes(
+                    batches[[batch]], column_names, column_bytes
+                )
+                rows_per_tile <- fertility_adaptive_rows(bytes, configuration)
+                reserved_probes <- if (batch == 1L)
+                    configuration$beyond_end_windows else 0L
+                plan <- fertility_plan_offsets(
+                    total_rows, rows_per_tile,
+                    configuration$max_tiles_per_batch - reserved_probes
+                )
+                if (plan$ceiling) {
+                    tiles[[length(tiles) + 1L]] <- planning_failure_tile(
+                        item, batch, "tile-ceiling-reached"
+                    )
+                    next
+                }
+                for (offset in plan$offsets) {
+                    tile <- fertility_value_tile(
+                        batch, offset, rows_per_tile, batches[[batch]]
+                    )
+                    processed <- fertility_process_tile(
+                        item, tile, file.path(tile_root, paste0(tile$tile_id, ".rds")),
+                        framework_id, configuration, input, options$retry, execute_tile
+                    )
+                    tiles[[length(tiles) + 1L]] <- processed$result
+                }
+                if (batch == 1L) for (probe in seq_len(configuration$beyond_end_windows)) {
+                    tile <- fertility_value_tile(
+                        batch, total_rows + (probe - 1L),
+                        1L, batches[[batch]], type = "terminal", probe = probe
+                    )
+                    processed <- fertility_process_tile(
+                        item, tile, file.path(tile_root, paste0(tile$tile_id, ".rds")),
+                        framework_id, configuration, input, options$retry, execute_tile
+                    )
+                    tiles[[length(tiles) + 1L]] <- processed$result
+                }
+            }
+        } else if (length(batches)) {
+            tiles[[length(tiles) + 1L]] <- planning_failure_tile(
+                item, 0L, "structural-metadata-unavailable"
+            )
+        }
+        result <- fertility_tiled_result(
+            item, framework_id, configuration, input, tiles, batches, total_rows
+        )
+        final_input <- fertility_capture_input(item)
+        if (!identical(final_input$input_id, input$input_id)) {
+            result <- simple_result(item, final_input, "inventory-hash-error")
+            result$complete <- FALSE
+        }
     }
-    checkpoint
-})
+    if (!resumed) fertility_atomic_save_rds(result, result_path)
+    checkpoints[[index]] <- result
+    message(item$id, if (resumed) ": resumed " else ": ", result$classification)
+}
 # Detect source, dependency, or installed-package changes before publication.
 final_provenance <- fertility_verify_provenance(
     checkout_root, library, provenance_path
@@ -150,6 +287,12 @@ final_provenance <- fertility_verify_provenance(
 if (!identical(final_provenance$provenance_id[[1L]],
                provenance$provenance_id[[1L]])) {
     stop("corpus build provenance changed during the run")
+}
+for (index in seq_len(nrow(selected))) {
+    current_input <- fertility_capture_input(as.list(selected[index, , drop = FALSE]))
+    if (!identical(current_input$input_id, checkpoints[[index]]$input_id)) {
+        stop("corpus input changed before report publication")
+    }
 }
 results <- fertility_result_frame(checkpoints)
 results$build_provenance_id <- provenance$provenance_id[[1L]]
@@ -165,6 +308,7 @@ selection_id <- fertility_stable_id(list(
     shard_count = options$shard_count,
     max_files = as.character(options$max_files),
     timeout_seconds = options$timeout_seconds,
+    config_id = configuration$config_id,
     selected_ids = paste(selected$id, collapse = ",")
 ))
 report_parent <- file.path(raw_root, "reports", selection_id)
@@ -182,11 +326,16 @@ run_provenance <- data.frame(
     schema_version = fertility_schema_version,
     selection_id = selection_id,
     framework_id = framework_id,
+    config_id = configuration$config_id,
     build_provenance_id = provenance$provenance_id[[1L]],
     selected_files = nrow(selected),
     shard_index = options$shard_index,
     shard_count = options$shard_count,
     timeout_seconds = options$timeout_seconds,
+    chunk_rows = options$chunk_rows,
+    column_batch = options$column_batch,
+    memory_mib = options$memory_mib,
+    cell_budget = options$cell_budget,
     retry = options$retry,
     created_at_utc = format(Sys.time(), "%Y-%m-%dT%H:%M:%SZ", tz = "UTC"),
     stringsAsFactors = FALSE, check.names = FALSE

--- a/benchmarks/fertility-surveys/run.R
+++ b/benchmarks/fertility-surveys/run.R
@@ -94,10 +94,18 @@ execute_tile <- function(item, tile, input) {
                 source(runtime_script, local = environment())
                 invisible(fertility_assert_tempdir(raw_root))
                 source(worker_script, local = environment())
-                fertility_worker_tile(
+                result <- fertility_worker_tile(
                     item, tile, compare_script, package_library,
                     expected_package_path, framework_id, timeout_seconds
                 )
+                comparator_helpers <- c(
+                    "fertility_bind_mismatches", "fertility_compare_available_pairs"
+                )
+                if (any(vapply(comparator_helpers, exists, logical(1),
+                               envir = globalenv(), inherits = FALSE))) {
+                    stop("comparator helpers escaped the isolated callback")
+                }
+                result
             },
             args = list(
                 file.path(snapshot_root, "common.R"),
@@ -145,6 +153,33 @@ execute_tile <- function(item, tile, input) {
     result
 }
 
+# Mandatory post-build regression using the exact immutable callback path above.
+# This fixture is synthetic and remains inside the private target-local TMPDIR.
+worker_smoke_path <- tempfile("worker-smoke-", tmpdir = Sys.getenv("TMPDIR"),
+                              fileext = ".dta")
+haven::write_dta(data.frame(synthetic_number = 1:3), worker_smoke_path,
+                 version = 14)
+on.exit(unlink(worker_smoke_path), add = TRUE)
+worker_smoke_item <- list(
+    id = "FTEST", program = "dhs", level = "women", release = 118L,
+    path = normalizePath(worker_smoke_path, winslash = "/", mustWork = TRUE),
+    expected_sha512 = ""
+)
+worker_smoke <- execute_tile(
+    worker_smoke_item, fertility_metadata_tile(),
+    fertility_capture_input(worker_smoke_item)
+)
+if (!is.list(worker_smoke) || worker_smoke$classification %in%
+        c("timeout", "memory-limit", "crash", "dtaparser-only-error",
+          "haven-only-error", "shared-reader-error", "unresolved") ||
+    !identical(as.integer(worker_smoke$rows), 3L) ||
+    !identical(as.integer(worker_smoke$columns), 1L) ||
+    !identical(as.double(worker_smoke$structural_rows), 3)) {
+    stop("post-build isolated worker regression failed")
+}
+unlink(worker_smoke_path)
+message("post-build isolated worker regression passed")
+
 planning_failure_tile <- function(item, batch, detail) list(
     schema_version = fertility_schema_version, framework_id = framework_id,
     id = item$id, tile_id = paste0("planning-", batch), tile_type = "planning",
@@ -166,13 +201,13 @@ planning_failure_tile <- function(item, batch, detail) list(
     elapsed_seconds = 0
 )
 
-simple_result <- function(item, input, classification) list(
+simple_result <- function(item, input, classification, reason = "") list(
     schema_version = fertility_schema_version, framework_id = framework_id,
     config_id = configuration$config_id, input_id = input$input_id,
     id = item$id, program = item$program, level = item$level,
     release = as.integer(item$release), expected_sha512 = item$expected_sha512,
     timeout_seconds = options$timeout_seconds, classification = classification,
-    secondary_categories = "", mismatch_count = 0L, mismatch_categories = "",
+    secondary_categories = reason, mismatch_count = 0L, mismatch_categories = "",
     mismatch_signatures = "", rows = NA_real_, columns = NA_integer_,
     tiles_expected = 0L, tiles_completed = 0L,
     complete = identical(classification, "expected-unsupported-111"),
@@ -183,6 +218,7 @@ checkpoints <- vector("list", nrow(selected))
 for (index in seq_len(nrow(selected))) {
     item <- as.list(selected[index, , drop = FALSE])
     input <- fertility_capture_input(item)
+    preflight <- fertility_inventory_preflight(item, input)
     file_root <- file.path(checkpoint_root, configuration$config_id, item$id)
     tile_root <- file.path(file_root, "tiles")
     result_path <- file.path(file_root, "result.rds")
@@ -197,11 +233,10 @@ for (index in seq_len(nrow(selected))) {
             c("expected-unsupported-111", "inventory-hash-error")
     if (resumed) {
         result <- existing
-    } else if (identical(input$hash_status, "error")) {
-        result <- simple_result(item, input, "inventory-hash-error")
-    } else if (nzchar(item$expected_sha512) &&
-               !identical(input$actual_sha512, tolower(item$expected_sha512))) {
-        result <- simple_result(item, input, "inventory-hash-error")
+    } else if (!is.null(preflight)) {
+        result <- simple_result(
+            item, input, preflight$classification, preflight$reason
+        )
     } else if (!(item$release %in% fertility_supported_releases)) {
         result <- simple_result(item, input, "expected-unsupported-111")
     } else {
@@ -272,7 +307,9 @@ for (index in seq_len(nrow(selected))) {
         )
         final_input <- fertility_capture_input(item)
         if (!identical(final_input$input_id, input$input_id)) {
-            result <- simple_result(item, final_input, "inventory-hash-error")
+            result <- simple_result(
+                item, final_input, "inventory-hash-error", "input-changed"
+            )
             result$complete <- FALSE
         }
     }

--- a/benchmarks/fertility-surveys/run.R
+++ b/benchmarks/fertility-surveys/run.R
@@ -377,7 +377,8 @@ for (index in seq_len(nrow(selected))) {
         final_input <- fertility_capture_input(item)
         if (!identical(final_input$input_id, input$input_id)) {
             result <- simple_result(
-                item, final_input, "inventory-hash-error", "input-changed"
+                item, final_input, "inventory-hash-error",
+                fertility_changed_input_reason(final_input)
             )
             result$complete <- FALSE
         }
@@ -424,9 +425,21 @@ fertility_atomic_write_table(
     family_manifest, file.path(report_stage, "family-manifest.tsv")
 )
 filter_spec <- fertility_filter_spec(options)
+evidence_origin <- "fresh-execution"
+input_attestation_id <- fertility_input_attestation_id(checkpoints)
+evidence_selection_id <- fertility_evidence_selection_id(
+    selection_id, input_attestation_id, evidence_origin,
+    fertility_schema_version, fertility_report_schema_id()
+)
 run_provenance <- data.frame(
     schema_version = fertility_schema_version,
+    report_schema_version = fertility_report_schema_version,
+    evidence_origin = evidence_origin,
+    source_corpus_schema_version = fertility_schema_version,
+    replayed_at_utc = "",
     selection_id = selection_id,
+    evidence_selection_id = evidence_selection_id,
+    input_attestation_id = input_attestation_id,
     family_id = family_id,
     family_manifest_id = family_manifest_id,
     framework_id = framework_id,

--- a/benchmarks/fertility-surveys/run.R
+++ b/benchmarks/fertility-surveys/run.R
@@ -9,7 +9,9 @@ source(file.path(script_dir, "runner.R"))
 source(file.path(script_dir, "runtime.R"))
 
 fertility_assert_manual_run()
-options <- fertility_parse_arguments(commandArgs(trailingOnly = TRUE))
+options <- fertility_validate_source_arguments(
+    fertility_parse_arguments(commandArgs(trailingOnly = TRUE))
+)
 checkout_root <- fertility_checkout_root(script_path)
 raw_root <- fertility_assert_checkout_raw_root(
     file.path(checkout_root, "target", "fertility-surveys", "raw"),
@@ -548,7 +550,8 @@ revalidate_run_evidence <- function(publication_provenance = NULL) {
     }
     if (!is.null(publication_provenance) && !is.null(reloaded_acceptance)) {
         fertility_revalidate_accepted_publication(
-            raw_root, publication_provenance, live_inventory
+            raw_root, publication_provenance, live_inventory,
+            fertility_required_paths(options, raw_root)$datasigs
         )
     }
     invisible(list(

--- a/benchmarks/fertility-surveys/run.R
+++ b/benchmarks/fertility-surveys/run.R
@@ -334,6 +334,7 @@ for (index in seq_len(nrow(selected))) {
             configuration, input, options$retry, execute_tile
         )
         tiles <- list(metadata$result)
+        tiles_expected <- 1L
         column_names <- metadata$result$column_names
         column_bytes <- metadata$result$column_bytes
         batches <- fertility_structural_batches(
@@ -369,6 +370,7 @@ for (index in seq_len(nrow(selected))) {
                 available_tiles <- configuration$max_tiles_per_batch -
                     reserved_probes - if (is_strl_batch) 1L else 0L
                 if (available_tiles < 1L) {
+                    tiles_expected <- tiles_expected + 1L
                     tiles[[length(tiles) + 1L]] <- planning_failure_tile(
                         item, batch, "tile-ceiling-reached"
                     )
@@ -378,6 +380,7 @@ for (index in seq_len(nrow(selected))) {
                     total_rows, rows_per_tile, available_tiles
                 )
                 if (plan$ceiling) {
+                    tiles_expected <- tiles_expected + 1L
                     tiles[[length(tiles) + 1L]] <- planning_failure_tile(
                         item, batch, "tile-ceiling-reached"
                     )
@@ -401,6 +404,7 @@ for (index in seq_len(nrow(selected))) {
                         batch, offset, requested, batches[[batch]],
                         process_value_tile, split_budget
                     )
+                    tiles_expected <- tiles_expected + length(leaves)
                     tiles <- c(tiles, leaves)
                 }
                 if (batch == 1L) for (probe in seq_len(configuration$beyond_end_windows)) {
@@ -412,16 +416,19 @@ for (index in seq_len(nrow(selected))) {
                         item, tile, file.path(tile_root, paste0(tile$tile_id, ".rds")),
                         framework_id, configuration, input, options$retry, execute_tile
                     )
+                    tiles_expected <- tiles_expected + 1L
                     tiles[[length(tiles) + 1L]] <- processed$result
                 }
             }
         } else if (length(batches)) {
+            tiles_expected <- tiles_expected + 1L
             tiles[[length(tiles) + 1L]] <- planning_failure_tile(
                 item, 0L, "structural-metadata-unavailable"
             )
         }
         result <- fertility_tiled_result(
-            item, framework_id, configuration, input, tiles, batches, total_rows
+            item, framework_id, configuration, input, tiles, batches, total_rows,
+            tiles_expected = tiles_expected
         )
         final_input <- fertility_capture_input(item, acceptance)
         if (!identical(final_input$input_id, input$input_id)) {

--- a/benchmarks/fertility-surveys/run.R
+++ b/benchmarks/fertility-surveys/run.R
@@ -31,11 +31,17 @@ fertility_atomic_write_table(release_summary,
                              file.path(raw_root, "inventory-summary.tsv"))
 message("inventory: 1,004 files; selected: ", nrow(selected))
 if (options$inventory_only) quit(save = "no", status = 0L)
-if (!nrow(selected)) stop("filters selected no corpus files")
 
-library <- file.path(raw_root, "library")
-provenance_path <- file.path(raw_root, "build-provenance.tsv")
-if (!file.exists(provenance_path)) stop("run benchmark.sh to create package provenance")
+library_value <- Sys.getenv("DTAPARSER_FERTILITY_LIBRARY")
+provenance_value <- Sys.getenv("DTAPARSER_FERTILITY_PROVENANCE")
+prepared_framework_id <- Sys.getenv("DTAPARSER_FERTILITY_FRAMEWORK_ID")
+owner_state <- Sys.getenv("DTAPARSER_FERTILITY_OWNER_STATE")
+if (!nzchar(library_value) || !nzchar(provenance_value) ||
+    !nzchar(prepared_framework_id) || !nzchar(owner_state)) {
+    stop("run benchmark.sh to create immutable corpus setup")
+}
+library <- normalizePath(library_value, winslash = "/", mustWork = TRUE)
+provenance_path <- normalizePath(provenance_value, winslash = "/", mustWork = TRUE)
 provenance <- fertility_verify_provenance(checkout_root, library, provenance_path)
 expected_package_path <- fertility_package_path(library)
 .libPaths(c(library, .libPaths()))
@@ -44,43 +50,49 @@ for (package in c("dtaparser", "haven", "openssl", "callr")) {
 }
 if (!identical(normalizePath(getNamespaceInfo(asNamespace("dtaparser"), "path"),
                              winslash = "/"), expected_package_path)) {
-    stop("dtaparser was not loaded from the checkout-local corpus library")
+    stop("dtaparser was not loaded from the immutable corpus library")
 }
-datasigs_sha256 <- tolower(as.character(openssl::sha256(file(
-    fertility_required_paths()$datasigs
-))))
-framework_id <- fertility_stable_id(list(
-    schema_version = fertility_schema_version,
-    provenance_id = provenance$provenance_id[[1L]],
-    datasigs_sha256 = datasigs_sha256,
-    comparator_tolerance = "1e-7"
+framework_id <- fertility_framework_id(
+    provenance$provenance_id[[1L]], fertility_required_paths()$datasigs
+)
+if (!identical(framework_id, prepared_framework_id)) {
+    stop("prepared corpus framework identity changed before execution")
+}
+snapshot_root <- fertility_verify_framework_snapshot(script_dir, raw_root, framework_id, inventory)
+configuration <- fertility_tile_configuration(options)
+inventory_id <- fertility_inventory_id(inventory)
+family_selection <- fertility_family_selection(inventory, options)
+family_manifest <- fertility_family_manifest(inventory, options)
+family_manifest_id <- fertility_manifest_id(family_manifest)
+family_id <- fertility_selection_family_id(
+    inventory, options, framework_id, configuration$config_id,
+    provenance$provenance_id[[1L]]
+)
+selection_id <- fertility_stable_id(list(
+    family_id = family_id,
+    shard_index = options$shard_index,
+    selected_ids = paste(selected$id, collapse = ",")
 ))
-snapshot_root <- file.path(raw_root, "framework", framework_id)
-dir.create(snapshot_root, recursive = TRUE, showWarnings = FALSE, mode = "0700")
-Sys.chmod(c(file.path(raw_root, "framework"), snapshot_root), mode = "0700")
-for (name in c("common.R", "worker.R", "compare.R", "runtime.R")) {
-    source_path <- file.path(script_dir, name)
-    snapshot_path <- file.path(snapshot_root, name)
-    if (!file.exists(snapshot_path)) {
-        temporary <- tempfile(paste0(name, "."), tmpdir = snapshot_root)
-        if (!file.copy(source_path, temporary, overwrite = TRUE)) {
-            stop("could not snapshot corpus framework")
-        }
-        Sys.chmod(temporary, mode = "0600")
-        if (!file.rename(temporary, snapshot_path)) {
-            stop("could not publish corpus framework snapshot")
-        }
+owner <- fertility_read_owner(owner_state)
+if (!isTRUE(fertility_owner_alive(owner))) stop("orchestrator owner is not alive")
+lock_root <- file.path(raw_root, ".locks")
+selection_lock <- file.path(
+    lock_root, "selections", fertility_lock_component(selection_id, "selection ID")
+)
+case_locks <- file.path(
+    lock_root, "cases", vapply(selected$id, fertility_lock_component, character(1),
+                                label = "case ID")
+)
+run_locks <- fertility_acquire_lock_set(c(selection_lock, case_locks), owner)
+on.exit({
+    if (!fertility_release_lock_set(run_locks)) {
+        warning("could not release every fertility corpus run lock")
     }
-    if (!identical(unname(tools::md5sum(source_path)),
-                   unname(tools::md5sum(snapshot_path)))) {
-        stop("corpus framework snapshot does not match its provenance")
-    }
-}
+}, add = TRUE)
+
 checkpoint_root <- file.path(raw_root, "checkpoints", framework_id)
 dir.create(checkpoint_root, recursive = TRUE, showWarnings = FALSE, mode = "0700")
 Sys.chmod(c(file.path(raw_root, "checkpoints"), checkpoint_root), mode = "0700")
-
-configuration <- fertility_tile_configuration(options)
 
 execute_tile <- function(item, tile, input) {
     started <- proc.time()[["elapsed"]]
@@ -147,6 +159,17 @@ execute_tile <- function(item, tile, input) {
             elapsed_seconds = unname(proc.time()[["elapsed"]] - started)
         )
     )
+    if (identical(tile$type, "sizing")) {
+        payload <- if (!is.null(result$payload_bytes_per_row))
+            result$payload_bytes_per_row else NA_real_
+        result$chosen_rows <- fertility_strl_rows(
+            payload, length(tile$column_names), configuration
+        )
+        result$sample_offsets_hash <- fertility_stable_id(list(
+            offsets = paste(format(tile$sample_offsets, scientific = FALSE),
+                            collapse = ",")
+        ))
+    }
     stat_after <- fertility_file_stat(item$path)
     if (is.null(stat_before) || is.null(stat_after) ||
         !identical(stat_before, stat_after)) result$classification <- "input-changed"
@@ -157,8 +180,10 @@ execute_tile <- function(item, tile, input) {
 # This fixture is synthetic and remains inside the private target-local TMPDIR.
 worker_smoke_path <- tempfile("worker-smoke-", tmpdir = Sys.getenv("TMPDIR"),
                               fileext = ".dta")
-haven::write_dta(data.frame(synthetic_number = 1:3), worker_smoke_path,
-                 version = 14)
+haven::write_dta(data.frame(
+    synthetic_number = seq_len(100L),
+    synthetic_long = c(rep("x", 99L), strrep("y", 3000L))
+), worker_smoke_path, version = 14)
 on.exit(unlink(worker_smoke_path), add = TRUE)
 worker_smoke_item <- list(
     id = "FTEST", program = "dhs", level = "women", release = 118L,
@@ -172,13 +197,27 @@ worker_smoke <- execute_tile(
 if (!is.list(worker_smoke) || worker_smoke$classification %in%
         c("timeout", "memory-limit", "crash", "dtaparser-only-error",
           "haven-only-error", "shared-reader-error", "unresolved") ||
-    !identical(as.integer(worker_smoke$rows), 3L) ||
-    !identical(as.integer(worker_smoke$columns), 1L) ||
-    !identical(as.double(worker_smoke$structural_rows), 3)) {
+    !identical(as.integer(worker_smoke$rows), 100L) ||
+    !identical(as.integer(worker_smoke$columns), 2L) ||
+    !identical(as.double(worker_smoke$structural_rows), 100)) {
     stop("post-build isolated worker regression failed")
 }
+worker_sizing_smoke <- execute_tile(
+    worker_smoke_item,
+    fertility_sizing_tile(1L, "synthetic_long", 100, configuration$strl_sample_count),
+    fertility_capture_input(worker_smoke_item)
+)
+if (!is.list(worker_sizing_smoke) ||
+    !identical(worker_sizing_smoke$classification, "pass") ||
+    !identical(as.integer(worker_sizing_smoke$samples_completed),
+               as.integer(configuration$strl_sample_count)) ||
+    !is.finite(worker_sizing_smoke$payload_bytes_per_row) ||
+    worker_sizing_smoke$payload_bytes_per_row < 9000 ||
+    !is.finite(worker_sizing_smoke$chosen_rows) || worker_sizing_smoke$chosen_rows <= 1L) {
+    stop("post-build isolated strL sizing regression failed")
+}
 unlink(worker_smoke_path)
-message("post-build isolated worker regression passed")
+message("post-build isolated worker regressions passed")
 
 planning_failure_tile <- function(item, batch, detail) list(
     schema_version = fertility_schema_version, framework_id = framework_id,
@@ -263,11 +302,31 @@ for (index in seq_len(nrow(selected))) {
                     batches[[batch]], column_names, column_bytes
                 )
                 rows_per_tile <- fertility_adaptive_rows(bytes, configuration)
+                is_strl_batch <- any(!is.finite(bytes))
+                if (is_strl_batch) {
+                    sizing_tile <- fertility_sizing_tile(
+                        batch, batches[[batch]], total_rows,
+                        configuration$strl_sample_count
+                    )
+                    sizing <- fertility_process_tile(
+                        item, sizing_tile,
+                        file.path(tile_root, paste0(sizing_tile$tile_id, ".rds")),
+                        framework_id, configuration, input, options$retry, execute_tile
+                    )
+                    rows_per_tile <- as.integer(sizing$result$chosen_rows)
+                }
                 reserved_probes <- if (batch == 1L)
                     configuration$beyond_end_windows else 0L
+                available_tiles <- configuration$max_tiles_per_batch -
+                    reserved_probes - if (is_strl_batch) 1L else 0L
+                if (available_tiles < 1L) {
+                    tiles[[length(tiles) + 1L]] <- planning_failure_tile(
+                        item, batch, "tile-ceiling-reached"
+                    )
+                    next
+                }
                 plan <- fertility_plan_offsets(
-                    total_rows, rows_per_tile,
-                    configuration$max_tiles_per_batch - reserved_probes
+                    total_rows, rows_per_tile, available_tiles
                 )
                 if (plan$ceiling) {
                     tiles[[length(tiles) + 1L]] <- planning_failure_tile(
@@ -275,15 +334,25 @@ for (index in seq_len(nrow(selected))) {
                     )
                     next
                 }
-                for (offset in plan$offsets) {
-                    tile <- fertility_value_tile(
-                        batch, offset, rows_per_tile, batches[[batch]]
-                    )
-                    processed <- fertility_process_tile(
+                split_budget <- new.env(parent = emptyenv())
+                split_budget$remaining <- as.integer(
+                    available_tiles - length(plan$offsets)
+                )
+                process_value_tile <- function(tile) {
+                    fertility_process_tile(
                         item, tile, file.path(tile_root, paste0(tile$tile_id, ".rds")),
                         framework_id, configuration, input, options$retry, execute_tile
+                    )$result
+                }
+                for (offset in plan$offsets) {
+                    requested <- if (total_rows == 0) 1L else as.integer(min(
+                        rows_per_tile, total_rows - offset
+                    ))
+                    leaves <- fertility_process_adaptive_range(
+                        batch, offset, requested, batches[[batch]],
+                        process_value_tile, split_budget
                     )
-                    tiles[[length(tiles) + 1L]] <- processed$result
+                    tiles <- c(tiles, leaves)
                 }
                 if (batch == 1L) for (probe in seq_len(configuration$beyond_end_windows)) {
                     tile <- fertility_value_tile(
@@ -325,6 +394,12 @@ if (!identical(final_provenance$provenance_id[[1L]],
                provenance$provenance_id[[1L]])) {
     stop("corpus build provenance changed during the run")
 }
+invisible(fertility_verify_framework_snapshot(script_dir, raw_root, framework_id, inventory))
+if (!identical(
+    fertility_framework_id(final_provenance$provenance_id[[1L]],
+                           fertility_required_paths()$datasigs),
+    framework_id
+)) stop("corpus framework or inventory provenance changed during the run")
 for (index in seq_len(nrow(selected))) {
     current_input <- fertility_capture_input(as.list(selected[index, , drop = FALSE]))
     if (!identical(current_input$input_id, checkpoints[[index]]$input_id)) {
@@ -332,22 +407,8 @@ for (index in seq_len(nrow(selected))) {
     }
 }
 results <- fertility_result_frame(checkpoints)
-results$build_provenance_id <- provenance$provenance_id[[1L]]
-summary <- as.data.frame(table(classification = results$classification),
-                         stringsAsFactors = FALSE)
-names(summary)[[2L]] <- "files"
-selection_id <- fertility_stable_id(list(
-    framework_id = framework_id,
-    programs = paste(options$programs, collapse = ","),
-    releases = paste(options$releases, collapse = ","),
-    ids = paste(options$ids, collapse = ","),
-    shard_index = options$shard_index,
-    shard_count = options$shard_count,
-    max_files = as.character(options$max_files),
-    timeout_seconds = options$timeout_seconds,
-    config_id = configuration$config_id,
-    selected_ids = paste(selected$id, collapse = ",")
-))
+results$build_provenance_id <- rep(provenance$provenance_id[[1L]], nrow(results))
+summary <- fertility_classification_summary(results)
 report_parent <- file.path(raw_root, "reports", selection_id)
 dir.create(report_parent, recursive = TRUE, showWarnings = FALSE, mode = "0700")
 Sys.chmod(c(file.path(raw_root, "reports"), report_parent), mode = "0700")
@@ -359,13 +420,27 @@ results <- fertility_publish_results(
     file.path(report_stage, "results.tsv")
 )
 fertility_atomic_write_table(summary, file.path(report_stage, "summary.tsv"))
+fertility_atomic_write_table(
+    family_manifest, file.path(report_stage, "family-manifest.tsv")
+)
+filter_spec <- fertility_filter_spec(options)
 run_provenance <- data.frame(
     schema_version = fertility_schema_version,
     selection_id = selection_id,
+    family_id = family_id,
+    family_manifest_id = family_manifest_id,
     framework_id = framework_id,
     config_id = configuration$config_id,
     build_provenance_id = provenance$provenance_id[[1L]],
+    inventory_id = inventory_id,
+    report_schema_id = fertility_report_schema_id(),
     selected_files = nrow(selected),
+    expected_family_files = nrow(family_selection),
+    full_default_family = fertility_full_default_family(options),
+    program_filter = filter_spec$program_filter,
+    release_filter = filter_spec$release_filter,
+    id_filter = filter_spec$id_filter,
+    max_files = filter_spec$max_files,
     shard_index = options$shard_index,
     shard_count = options$shard_count,
     timeout_seconds = options$timeout_seconds,
@@ -373,6 +448,8 @@ run_provenance <- data.frame(
     column_batch = options$column_batch,
     memory_mib = options$memory_mib,
     cell_budget = options$cell_budget,
+    max_tiles_per_batch = options$max_tiles_per_batch,
+    beyond_end_windows = options$beyond_end_windows,
     retry = options$retry,
     created_at_utc = format(Sys.time(), "%Y-%m-%dT%H:%M:%SZ", tz = "UTC"),
     stringsAsFactors = FALSE, check.names = FALSE

--- a/benchmarks/fertility-surveys/run.R
+++ b/benchmarks/fertility-surveys/run.R
@@ -242,7 +242,9 @@ execute_tile <- function(item, tile, input) {
     }
     stat_after <- fertility_file_stat(item$path)
     if (is.null(stat_before) || is.null(stat_after) ||
-        !identical(stat_before, stat_after)) result$classification <- "input-changed"
+        !identical(stat_before, stat_after)) {
+        result <- fertility_mark_tile_input_changed(result)
+    }
     result
 }
 

--- a/benchmarks/fertility-surveys/runner.R
+++ b/benchmarks/fertility-surveys/runner.R
@@ -9,7 +9,7 @@ fertility_usage <- function() {
         "[--shard-index=N --shard-count=N] [--max-files=N]",
         "[--timeout-seconds=N] [--chunk-rows=N] [--column-batch=N]",
         "[--memory-mib=N] [--cell-budget=N] [--max-tiles-per-batch=N]",
-        "[--beyond-end-windows=N] [--retry]"
+        "[--beyond-end-windows=N] [--accepted-current-hashes=ID] [--retry]"
     )
 }
 
@@ -91,7 +91,8 @@ fertility_parse_arguments <- function(arguments) {
         max_files = Inf, timeout_seconds = 600L, chunk_rows = 10000L,
         column_batch = 16L, memory_mib = 256L, cell_budget = 1000000L,
         max_tiles_per_batch = 100000L, beyond_end_windows = 1L,
-        encoding_overrides = setNames(character(), character()), retry = FALSE
+        encoding_overrides = setNames(character(), character()),
+        accepted_current_hashes = "", retry = FALSE
     )
     seen_shard_index <- seen_shard_count <- FALSE
     encoding_override_values <- character()
@@ -155,6 +156,14 @@ fertility_parse_arguments <- function(arguments) {
             options$beyond_end_windows <- fertility_parse_positive_integer(
                 sub("^[^=]+=", "", argument), "--beyond-end-windows"
             )
+        } else if (startsWith(argument, "--accepted-current-hashes=")) {
+            if (nzchar(options$accepted_current_hashes)) {
+                stop("--accepted-current-hashes may be supplied only once")
+            }
+            options$accepted_current_hashes <- sub("^[^=]+=", "", argument)
+            if (!grepl("^[0-9a-f]{64}$", options$accepted_current_hashes)) {
+                stop("--accepted-current-hashes requires an exact commitment ID")
+            }
         } else stop(fertility_usage())
     }
     options$encoding_overrides <- fertility_parse_encoding_overrides(
@@ -359,7 +368,7 @@ fertility_full_default_family <- function(options) {
         !length(options$ids) && !is.finite(options$max_files)
 }
 
-fertility_capture_input <- function(item) {
+fertility_capture_input <- function(item, acceptance = NULL) {
     info <- file.info(item$path)
     if (!nrow(info) || is.na(info$size[[1L]])) {
         size <- NA_character_
@@ -371,20 +380,60 @@ fertility_capture_input <- function(item) {
     actual <- tryCatch(suppressWarnings(fertility_file_sha512(item$path)),
                        error = function(error) NA_character_)
     hash_status <- if (is.na(actual)) "error" else "ok"
-    identity <- fertility_stable_id(list(
+    identity_fields <- list(
         id = item$id, release = as.integer(item$release),
         expected_sha512 = item$expected_sha512, hash_status = hash_status,
         actual_sha512 = if (is.na(actual)) "" else actual,
         size = size, modified = modified
-    ))
-    list(input_id = identity, hash_status = hash_status,
-         actual_sha512 = actual, size = size, modified = modified)
+    )
+    accepted_sha512 <- ""
+    manifest_hash_status <- if (identical(hash_status, "error")) "hash-read-error" else
+        if (nzchar(item$expected_sha512) &&
+            !identical(actual, tolower(item$expected_sha512))) "signature-mismatch" else
+        if (nzchar(item$expected_sha512)) "signature-match" else "empty-manifest-signature"
+    local_evidence_status <- "not-requested"
+    if (!is.null(acceptance)) {
+        position <- match(item$id, acceptance$entries$id)
+        if (is.na(position)) stop("accepted-current-hash case is outside the commitment")
+        accepted_sha512 <- acceptance$entries$accepted_sha512[[position]]
+        local_evidence_status <- if (identical(hash_status, "ok") &&
+            identical(actual, accepted_sha512)) "accepted-current-sha512-match" else
+            "accepted-current-sha512-mismatch"
+        identity_fields$acceptance_authority <- acceptance$authority
+        identity_fields$acceptance_commitment_id <- acceptance$commitment_id
+        identity_fields$acceptance_artifact_sha256 <- acceptance$artifact_sha256
+        identity_fields$accepted_sha512 <- accepted_sha512
+        identity_fields$manifest_hash_status <- manifest_hash_status
+        identity_fields$local_evidence_status <- local_evidence_status
+    }
+    identity <- fertility_stable_id(identity_fields)
+    list(
+        input_id = identity, hash_status = hash_status, actual_sha512 = actual,
+        size = size, modified = modified, accepted_sha512 = accepted_sha512,
+        manifest_hash_status = manifest_hash_status,
+        local_evidence_status = local_evidence_status,
+        acceptance_authority = if (is.null(acceptance)) "" else acceptance$authority,
+        acceptance_commitment_id = if (is.null(acceptance)) "" else
+            acceptance$commitment_id,
+        acceptance_artifact_sha256 = if (is.null(acceptance)) "" else
+            acceptance$artifact_sha256
+    )
 }
 
 fertility_inventory_preflight <- function(item, input) {
     if (identical(input$hash_status, "error")) {
         return(list(classification = "inventory-hash-error",
                     reason = "hash-read-error"))
+    }
+    if (!is.null(input$acceptance_commitment_id) &&
+        nzchar(input$acceptance_commitment_id)) {
+        if (!identical(input$manifest_hash_status, "signature-mismatch") ||
+            !identical(input$local_evidence_status,
+                       "accepted-current-sha512-match")) {
+            return(list(classification = "inventory-hash-error",
+                        reason = "signature-mismatch"))
+        }
+        return(NULL)
     }
     if (nzchar(item$expected_sha512) &&
         !identical(input$actual_sha512, tolower(item$expected_sha512))) {
@@ -442,10 +491,23 @@ fertility_checkpoint_input_current <- function(checkpoint, item) {
     )
 }
 
+fertility_result_acceptance_fields <- function(input) {
+    if (is.null(input$acceptance_commitment_id) ||
+        !nzchar(input$acceptance_commitment_id)) return(list())
+    list(
+        acceptance_authority = input$acceptance_authority,
+        acceptance_commitment_id = input$acceptance_commitment_id,
+        acceptance_artifact_sha256 = input$acceptance_artifact_sha256,
+        accepted_sha512 = input$accepted_sha512,
+        manifest_hash_status = input$manifest_hash_status,
+        local_evidence_status = input$local_evidence_status
+    )
+}
+
 fertility_base_result <- function(item, framework_id, timeout_seconds, input,
                                   classification, elapsed_seconds = NA_real_,
                                   secondary_categories = "") {
-    list(
+    c(list(
         schema_version = fertility_schema_version,
         framework_id = framework_id, input_id = input$input_id,
         id = item$id, program = item$program, level = item$level,
@@ -457,14 +519,19 @@ fertility_base_result <- function(item, framework_id, timeout_seconds, input,
         columns = NA_integer_, tiles_expected = 0L, tiles_completed = 0L,
         complete = FALSE, actual_sha512 = input$actual_sha512,
         elapsed_seconds = elapsed_seconds
-    )
+    ), fertility_result_acceptance_fields(input))
 }
 
 fertility_process_item <- function(item, checkpoint_path, framework_id,
                                    timeout_seconds, retry, execute) {
     input_before <- fertility_capture_input(item)
+    checkpoint_path <- fertility_assert_checkpoint_file(
+        checkpoint_path, "file checkpoint"
+    )
     checkpoint <- if (file.exists(checkpoint_path)) tryCatch(
-        readRDS(checkpoint_path), error = function(error) NULL
+        readRDS(fertility_assert_checkpoint_file(
+            checkpoint_path, "file checkpoint", must_exist = TRUE
+        )), error = function(error) NULL
     ) else NULL
     if (!is.null(checkpoint) &&
         fertility_checkpoint_valid(
@@ -494,6 +561,7 @@ fertility_process_item <- function(item, checkpoint_path, framework_id,
             result$actual_sha512 <- input_before$actual_sha512
         }
     }
+    fertility_assert_checkpoint_file(checkpoint_path, "file checkpoint")
     fertility_atomic_save_rds(result, checkpoint_path)
     list(result = result, resumed = FALSE)
 }
@@ -504,7 +572,8 @@ fertility_should_retry <- function(checkpoint) {
 
 fertility_run_provenance_fields <- function() c(
     "schema_version", "report_schema_version", "evidence_origin",
-    "source_corpus_schema_version", "replayed_at_utc", "selection_id",
+    "source_corpus_schema_version", "replayed_at_utc", "acceptance_authority",
+    "acceptance_commitment_id", "acceptance_artifact_sha256", "selection_id",
     "evidence_selection_id", "input_attestation_id", "family_id",
     "family_manifest_id", "framework_id", "config_id", "build_provenance_id",
     "inventory_id", "report_schema_id", "selected_files", "expected_family_files",
@@ -733,6 +802,187 @@ fertility_publish_results <- function(checkpoints, build_provenance_id, path) {
     results
 }
 
+fertility_merged_results_id <- function(results) {
+    fertility_manifest_id(
+        fertility_manifest_character(results, fertility_result_fields()),
+        fertility_result_fields(), fertility_report_schema_version
+    )
+}
+
+fertility_merge_identity <- function(provenance) {
+    fields <- c(
+        "schema_version", "report_schema_version", "evidence_origin",
+        "source_corpus_schema_version", "replayed_at_utc",
+        "acceptance_authority", "acceptance_commitment_id",
+        "acceptance_artifact_sha256", "family_id", "evidence_family_id",
+        "family_input_attestation_id", "framework_id", "config_id",
+        "build_provenance_id", "inventory_id", "family_manifest_id",
+        "report_schema_id", "results_id", "shard_count", "files",
+        "full_default_family"
+    )
+    if (!is.data.frame(provenance) || nrow(provenance) != 1L ||
+        !all(fields %in% names(provenance))) {
+        stop("merge identity provenance is invalid")
+    }
+    fertility_stable_id(as.list(provenance[1L, fields, drop = FALSE]))
+}
+
+fertility_merge_provenance_fields <- function() c(
+    "schema_version", "report_schema_version", "evidence_origin",
+    "source_corpus_schema_version", "replayed_at_utc",
+    "acceptance_authority", "acceptance_commitment_id",
+    "acceptance_artifact_sha256", "family_id", "evidence_family_id",
+    "family_input_attestation_id", "framework_id", "config_id",
+    "build_provenance_id", "inventory_id", "family_manifest_id",
+    "report_schema_id", "results_id", "merge_id", "shard_count", "files",
+    "full_default_family", "created_at_utc"
+)
+
+fertility_validate_merged_bundle <- function(bundle, family_id,
+                                              canonical_inventory) {
+    required <- c(
+        "provenance", "results", "summary", "family_manifest", "input_attestation"
+    )
+    if (!is.list(bundle) || !identical(sort(names(bundle)), sort(required)) ||
+        !all(vapply(bundle, is.data.frame, logical(1)))) {
+        stop("merged report bundle schema is invalid")
+    }
+    provenance <- fertility_manifest_character(
+        bundle$provenance, fertility_merge_provenance_fields()
+    )
+    if (nrow(provenance) != 1L || !identical(provenance$family_id[[1L]], family_id)) {
+        stop("merged report family provenance is invalid")
+    }
+    hash_fields <- c(
+        "family_id", "evidence_family_id", "family_input_attestation_id",
+        "framework_id", "config_id", "build_provenance_id", "inventory_id",
+        "family_manifest_id", "report_schema_id", "results_id", "merge_id"
+    )
+    accepted <- nzchar(provenance$acceptance_commitment_id[[1L]])
+    acceptance_valid <- if (accepted) {
+        identical(provenance$acceptance_authority[[1L]],
+                  fertility_acceptance_authority()) &&
+            grepl("^[0-9a-f]{64}$", provenance$acceptance_commitment_id[[1L]]) &&
+            grepl("^[0-9a-f]{64}$", provenance$acceptance_artifact_sha256[[1L]])
+    } else {
+        !nzchar(provenance$acceptance_authority[[1L]]) &&
+            !nzchar(provenance$acceptance_artifact_sha256[[1L]])
+    }
+    fresh <- identical(provenance$evidence_origin[[1L]], "fresh-execution")
+    historical <- identical(
+        provenance$evidence_origin[[1L]], "historical-schema-10-replay"
+    )
+    origin_valid <- (fresh &&
+        identical(provenance$source_corpus_schema_version[[1L]],
+                  as.character(fertility_schema_version)) &&
+        !nzchar(provenance$replayed_at_utc[[1L]])) ||
+        (historical &&
+         identical(provenance$source_corpus_schema_version[[1L]],
+                   as.character(fertility_legacy_corpus_schema_version)) &&
+         grepl("^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$",
+               provenance$replayed_at_utc[[1L]]))
+    if (any(vapply(hash_fields, function(field) {
+            !grepl("^[0-9a-f]{64}$", provenance[[field]][[1L]])
+        }, logical(1))) || !acceptance_valid || !origin_valid ||
+        (accepted && !fresh) ||
+        !identical(provenance$schema_version[[1L]],
+                   as.character(fertility_schema_version)) ||
+        !identical(provenance$report_schema_version[[1L]],
+                   as.character(fertility_report_schema_version)) ||
+        !identical(provenance$report_schema_id[[1L]], fertility_report_schema_id()) ||
+        !grepl("^[1-9][0-9]*$", provenance$shard_count[[1L]]) ||
+        !grepl("^(0|[1-9][0-9]*)$", provenance$files[[1L]]) ||
+        !provenance$full_default_family[[1L]] %in% c("TRUE", "FALSE") ||
+        !grepl("^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$",
+               provenance$created_at_utc[[1L]])) {
+        stop("merged report provenance contains an invalid scalar")
+    }
+    live_inventory_id <- fertility_inventory_id(canonical_inventory)
+    canonical <- fertility_validate_canonical_inventory(
+        fertility_inventory_manifest(canonical_inventory)
+    )
+    if (!identical(provenance$inventory_id[[1L]], live_inventory_id)) {
+        stop("merged report does not match canonical inventory authority")
+    }
+    shard_count <- as.integer(provenance$shard_count[[1L]])
+    manifest <- fertility_manifest_character(
+        bundle$family_manifest,
+        c("id", "program", "level", "release", "shard_index")
+    )
+    manifest_shards <- suppressWarnings(as.integer(manifest$shard_index))
+    expected_members <- canonical[
+        match(manifest$id, canonical$id),
+        c("id", "program", "level", "release"), drop = FALSE
+    ]
+    rownames(expected_members) <- NULL
+    if (anyDuplicated(manifest$id) || anyNA(manifest_shards) ||
+        any(!grepl("^[1-9][0-9]*$", manifest$shard_index)) ||
+        any(manifest_shards > shard_count) ||
+        !identical(manifest[c("id", "program", "level", "release")],
+                   expected_members) ||
+        !identical(fertility_manifest_id(manifest),
+                   provenance$family_manifest_id[[1L]])) {
+        stop("merged family manifest is not canonical")
+    }
+    results <- fertility_manifest_character(bundle$results, fertility_result_fields())
+    fertility_validate_public_results(results)
+    if (nrow(results) != as.integer(provenance$files[[1L]]) ||
+        !identical(results[c("id", "program", "level", "release")],
+                   manifest[c("id", "program", "level", "release")]) ||
+        any(results$framework_id != provenance$framework_id[[1L]]) ||
+        any(results$build_provenance_id != provenance$build_provenance_id[[1L]]) ||
+        !identical(fertility_merged_results_id(results), provenance$results_id[[1L]])) {
+        stop("merged results are not bound to family provenance")
+    }
+    input_attestation <- fertility_manifest_character(
+        bundle$input_attestation,
+        c("shard_index", "input_attestation_id", "evidence_selection_id")
+    )
+    if (nrow(input_attestation) != shard_count || !identical(
+        fertility_family_input_attestation_id(input_attestation),
+        provenance$family_input_attestation_id[[1L]]
+    )) stop("merged family input attestation identity is invalid")
+    summary <- fertility_manifest_character(
+        bundle$summary, c("classification", "files")
+    )
+    expected_summary <- fertility_manifest_character(
+        fertility_classification_summary(results), c("classification", "files")
+    )
+    if (!identical(summary, expected_summary)) {
+        stop("merged classification summary is invalid")
+    }
+    expected_evidence <- fertility_evidence_family_id(
+        family_id, provenance$family_input_attestation_id[[1L]],
+        provenance$evidence_origin[[1L]],
+        as.integer(provenance$source_corpus_schema_version[[1L]]),
+        provenance$report_schema_id[[1L]],
+        provenance$acceptance_authority[[1L]],
+        provenance$acceptance_commitment_id[[1L]]
+    )
+    if (!identical(provenance$evidence_family_id[[1L]], expected_evidence) ||
+        !identical(provenance$merge_id[[1L]],
+                   fertility_merge_identity(provenance))) {
+        stop("merged evidence family identity is invalid")
+    }
+    full_default <- identical(provenance$full_default_family[[1L]], "TRUE")
+    if (full_default && !identical(results$id,
+                                   sprintf("F%04d", seq_len(fertility_expected_rows)))) {
+        stop("merged full family membership is invalid")
+    }
+    if (accepted && (full_default || provenance$shard_count[[1L]] != "1" ||
+        !identical(results$id, fertility_accepted_ids()))) {
+        stop("merged accepted family membership is invalid")
+    }
+    list(
+        results = results, summary = summary, family_manifest = manifest,
+        input_attestation = input_attestation,
+        provenance = provenance, full_default = full_default,
+        evidence_family_id = provenance$evidence_family_id[[1L]],
+        family_input_attestation_id = provenance$family_input_attestation_id[[1L]],
+        merge_id = provenance$merge_id[[1L]]
+    )
+}
+
 fertility_manifest_character <- function(manifest, fields) {
     if (!is.data.frame(manifest) || !identical(names(manifest), fields)) {
         stop("manifest schema is not canonical")
@@ -748,6 +998,19 @@ fertility_validate_shard_bundles <- function(bundles, family_id,
                                                canonical_inventory) {
     if (!length(bundles)) stop("no current shard reports found for family ID")
     required <- fertility_run_provenance_fields()
+    acceptance_fields <- c(
+        "acceptance_authority", "acceptance_commitment_id",
+        "acceptance_artifact_sha256"
+    )
+    legacy_required <- setdiff(required, acceptance_fields)
+    bundles <- lapply(bundles, function(bundle) {
+        if (is.list(bundle) && is.data.frame(bundle$provenance) &&
+            identical(names(bundle$provenance), legacy_required)) {
+            for (field in acceptance_fields) bundle$provenance[[field]] <- ""
+            bundle$provenance <- bundle$provenance[required]
+        }
+        bundle
+    })
     if (any(vapply(bundles, function(bundle) {
         !is.list(bundle) || !is.data.frame(bundle$provenance) ||
             nrow(bundle$provenance) != 1L ||
@@ -765,7 +1028,12 @@ fertility_validate_shard_bundles <- function(bundles, family_id,
             as.character(fertility_report_schema_version)) ||
         any(vapply(hash_fields, function(field) {
             any(!grepl("^[0-9a-f]{64}$", provenance[[field]]))
-        }, logical(1))) || any(!provenance$retry %in% c("TRUE", "FALSE")) ||
+        }, logical(1))) ||
+        any(nzchar(provenance$acceptance_commitment_id) &
+            !grepl("^[0-9a-f]{64}$", provenance$acceptance_commitment_id)) ||
+        any(nzchar(provenance$acceptance_artifact_sha256) &
+            !grepl("^[0-9a-f]{64}$", provenance$acceptance_artifact_sha256)) ||
+        any(!provenance$retry %in% c("TRUE", "FALSE")) ||
         any(!grepl("^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$",
                    provenance$created_at_utc))) {
         stop("shard report provenance contains an invalid scalar")
@@ -776,6 +1044,15 @@ fertility_validate_shard_bundles <- function(bundles, family_id,
     fresh <- origins == "fresh-execution"
     historical <- origins == "historical-schema-10-replay"
     timestamp <- "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$"
+    accepted <- nzchar(provenance$acceptance_commitment_id)
+    acceptance_valid <- (!accepted & !nzchar(provenance$acceptance_authority) &
+                         !nzchar(provenance$acceptance_artifact_sha256)) |
+        (accepted &
+         provenance$acceptance_authority == fertility_acceptance_authority() &
+         grepl("^[0-9a-f]{64}$", provenance$acceptance_artifact_sha256))
+    if (!all(acceptance_valid) || length(unique(accepted)) != 1L) {
+        stop("shard acceptance provenance is invalid")
+    }
     if (any(!(fresh | historical)) ||
         any(fresh & (source_schemas != as.character(fertility_schema_version) |
                      nzchar(replayed))) ||
@@ -786,7 +1063,9 @@ fertility_validate_shard_bundles <- function(bundles, family_id,
     if (any(provenance$family_id != family_id)) stop("shard report family ID disagrees")
     stable_fields <- c(
         "schema_version", "report_schema_version", "evidence_origin",
-        "source_corpus_schema_version", "replayed_at_utc", "family_id",
+        "source_corpus_schema_version", "replayed_at_utc",
+        "acceptance_authority", "acceptance_commitment_id",
+        "acceptance_artifact_sha256", "family_id",
         "family_manifest_id", "framework_id",
         "config_id", "build_provenance_id", "inventory_id", "report_schema_id",
         "expected_family_files", "full_default_family", "program_filter",
@@ -837,12 +1116,21 @@ fertility_validate_shard_bundles <- function(bundles, family_id,
         "timeout_seconds", "chunk_rows", "column_batch", "memory_mib",
         "cell_budget", "max_tiles_per_batch", "beyond_end_windows"
     )) options[[field]] <- integer_field(field, positive = TRUE)[[1L]]
+    acceptance <- if (accepted[[1L]]) list(
+        authority = provenance$acceptance_authority[[1L]],
+        commitment_id = provenance$acceptance_commitment_id[[1L]],
+        artifact_sha256 = provenance$acceptance_artifact_sha256[[1L]]
+    ) else NULL
     if (!identical(provenance$config_id[[1L]],
-                   fertility_tile_configuration(options)$config_id)) {
+                   fertility_tile_configuration(options, acceptance)$config_id)) {
         stop("configuration provenance identity is invalid")
     }
     if (!identical(full_default, fertility_full_default_family(options))) {
         stop("full-default provenance disagrees with filter provenance")
+    }
+    if (accepted[[1L]] && identical(provenance$evidence_origin[[1L]],
+                                    "historical-schema-10-replay")) {
+        stop("historical replay cannot claim accepted-current-hash evidence")
     }
     if (identical(provenance$evidence_origin[[1L]],
                   "historical-schema-10-replay")) {
@@ -930,7 +1218,9 @@ fertility_validate_shard_bundles <- function(bundles, family_id,
             expected_selection_id, provenance$input_attestation_id[[index]],
             provenance$evidence_origin[[index]],
             as.integer(provenance$source_corpus_schema_version[[index]]),
-            provenance$report_schema_id[[index]]
+            provenance$report_schema_id[[index]],
+            provenance$acceptance_authority[[index]],
+            provenance$acceptance_commitment_id[[index]]
         )
         if (!identical(provenance$evidence_selection_id[[index]],
                        expected_evidence_selection_id)) {
@@ -945,6 +1235,17 @@ fertility_validate_shard_bundles <- function(bundles, family_id,
         !identical(results[c("id", "program", "level", "release")],
                    expected_family[c("id", "program", "level", "release")])) {
         stop("shard reports do not provide exact family accounting")
+    }
+    if (accepted[[1L]]) {
+        if (full_default || shard_count != 1L || length(options$programs) ||
+            length(options$releases) || is.finite(options$max_files) ||
+            !identical(sort(options$ids), fertility_accepted_ids()) ||
+            !identical(results$id, fertility_accepted_ids()) ||
+            any(results$classification %in% c(
+                "inventory-hash-error", "expected-unsupported-111"
+            ))) {
+            stop("accepted-current-hash family is not the exact executable five-ID family")
+        }
     }
     if (full_default) {
         if (!identical(results$id, sprintf("F%04d", seq_len(fertility_expected_rows)))) {
@@ -972,14 +1273,64 @@ fertility_validate_shard_bundles <- function(bundles, family_id,
          full_default = full_default, family_manifest = expected_family)
 }
 
-fertility_framework_id <- function(provenance_id, datasigs_path) {
+fertility_validate_assessment_families <- function(full, accepted) {
+    required <- c("results", "provenance", "full_default", "evidence_family_id")
+    if (!is.list(full) || !is.list(accepted) ||
+        !all(required %in% names(full)) || !all(required %in% names(accepted))) {
+        stop("assessment family evidence is invalid")
+    }
+    supported_hash_error_rows <- full$results[
+        full$results$release != "111" &
+            full$results$classification == "inventory-hash-error",
+        c("id", "secondary_categories"), drop = FALSE
+    ]
+    unsupported <- full$results$release == "111"
+    if (!isTRUE(full$full_default) || nrow(full$results) != fertility_expected_rows ||
+        !all(full$results$classification[unsupported] == "expected-unsupported-111") ||
+        any(full$results$classification[!unsupported] == "expected-unsupported-111") ||
+        any(unsupported & full$results$classification == "inventory-hash-error") ||
+        nrow(supported_hash_error_rows) != length(fertility_accepted_ids()) ||
+        !identical(supported_hash_error_rows$id, fertility_accepted_ids()) ||
+        !identical(supported_hash_error_rows$secondary_categories,
+                   rep("signature-mismatch", length(fertility_accepted_ids()))) ||
+        any(nzchar(full$provenance$acceptance_commitment_id))) {
+        stop("assessment original full family is not the preserved manifest-gated family")
+    }
+    if (isTRUE(accepted$full_default) ||
+        !identical(accepted$results$id, fertility_accepted_ids()) ||
+        any(accepted$results$classification %in% c(
+            "inventory-hash-error", "expected-unsupported-111"
+        )) || !all(nzchar(accepted$provenance$acceptance_commitment_id))) {
+        stop("assessment accepted family is not valid explicit local evidence")
+    }
+    if (!identical(unique(full$provenance$inventory_id),
+                   unique(accepted$provenance$inventory_id))) {
+        stop("assessment families do not share inventory authority")
+    }
+    list(
+        manifest_gate = "blocked-signature-mismatch",
+        explicit_local_evidence_gate = "validated",
+        acceptance_authority = accepted$provenance$acceptance_authority[[1L]],
+        acceptance_commitment_id =
+            accepted$provenance$acceptance_commitment_id[[1L]]
+    )
+}
+
+fertility_framework_id <- function(provenance_id, datasigs_path,
+                                   acceptance = NULL) {
     datasigs_sha256 <- tolower(as.character(openssl::sha256(file(datasigs_path))))
-    fertility_stable_id(list(
+    fields <- list(
         schema_version = fertility_schema_version,
         provenance_id = provenance_id,
         datasigs_sha256 = datasigs_sha256,
         comparator_tolerance = "1e-7"
-    ))
+    )
+    if (!is.null(acceptance)) {
+        fields$acceptance_authority <- acceptance$authority
+        fields$acceptance_commitment_id <- acceptance$commitment_id
+        fields$acceptance_artifact_sha256 <- acceptance$artifact_sha256
+    }
+    fertility_stable_id(fields)
 }
 
 fertility_validate_canonical_inventory <- function(manifest, exact = FALSE) {
@@ -1014,11 +1365,18 @@ fertility_framework_inventory <- function(
     snapshot_root, inventory = NULL, framework_id = NULL,
     report_schema_version = fertility_report_schema_version
 ) {
-    manifest_path <- file.path(snapshot_root, "inventory-manifest.tsv")
-    provenance_path <- file.path(snapshot_root, "inventory-manifest-provenance.tsv")
-    if (!file.exists(manifest_path) || !file.exists(provenance_path)) {
-        stop("canonical inventory manifest is absent")
-    }
+    snapshot_parent <- dirname(snapshot_root)
+    snapshot_root <- fertility_assert_existing_directory(
+        snapshot_root, snapshot_parent, "framework snapshot"
+    )
+    manifest_path <- fertility_assert_existing_file(
+        file.path(snapshot_root, "inventory-manifest.tsv"), snapshot_root,
+        "canonical inventory manifest"
+    )
+    provenance_path <- fertility_assert_existing_file(
+        file.path(snapshot_root, "inventory-manifest-provenance.tsv"), snapshot_root,
+        "canonical inventory manifest provenance"
+    )
     manifest <- read.delim(manifest_path, colClasses = "character",
                            check.names = FALSE)
     manifest <- fertility_validate_canonical_inventory(manifest, exact = TRUE)
@@ -1065,23 +1423,56 @@ fertility_framework_inventory <- function(
             stop("canonical inventory manifest does not match the live inventory")
         }
     }
-    list(manifest = manifest, provenance = provenance)
+    acceptance_path <- file.path(snapshot_root, "acceptance-provenance.tsv")
+    acceptance_provenance <- NULL
+    if (file.exists(acceptance_path) || dir.exists(acceptance_path) ||
+        fertility_path_is_symlink(acceptance_path)) {
+        acceptance_path <- fertility_assert_existing_file(
+            acceptance_path, snapshot_root, "framework acceptance provenance"
+        )
+        acceptance_provenance <- read.delim(
+            acceptance_path, colClasses = "character", check.names = FALSE
+        )
+        if (nrow(acceptance_provenance) != 1L || !identical(
+            names(acceptance_provenance),
+            c("authority", "commitment_id", "artifact_sha256")
+        ) || !identical(acceptance_provenance$authority[[1L]],
+                        fertility_acceptance_authority()) ||
+            any(!grepl("^[0-9a-f]{64}$", unlist(
+                acceptance_provenance[c("commitment_id", "artifact_sha256")],
+                use.names = FALSE
+            )))) stop("corpus framework acceptance provenance is invalid")
+    }
+    list(
+        manifest = manifest, provenance = provenance,
+        acceptance_provenance = acceptance_provenance
+    )
 }
 
 fertility_prepare_framework_snapshot <- function(script_dir, raw_root, framework_id,
-                                                 inventory) {
-    snapshot_root <- file.path(raw_root, "framework", framework_id)
-    dir.create(snapshot_root, recursive = TRUE, showWarnings = FALSE, mode = "0700")
+                                                 inventory, acceptance = NULL) {
+    snapshot_root <- fertility_assert_output_parent(
+        raw_root, "framework", framework_id, create = TRUE
+    )
     Sys.chmod(c(file.path(raw_root, "framework"), snapshot_root), mode = "0700")
-    for (name in c("common.R", "worker.R", "compare.R", "runtime.R")) {
-        source_path <- file.path(script_dir, name)
+    for (name in c("common.R", "accepted.R", "worker.R", "compare.R", "runtime.R")) {
+        source_path <- fertility_assert_existing_file(
+            file.path(script_dir, name), script_dir, "framework source file"
+        )
         snapshot_path <- file.path(snapshot_root, name)
-        if (!file.exists(snapshot_path)) {
+        if (!file.exists(snapshot_path) && !dir.exists(snapshot_path) &&
+            !fertility_path_is_symlink(snapshot_path)) {
             temporary <- tempfile(paste0(name, "."), tmpdir = snapshot_root)
             if (!file.copy(source_path, temporary, overwrite = TRUE)) {
                 stop("could not snapshot corpus framework")
             }
             Sys.chmod(temporary, mode = "0600")
+            fertility_assert_existing_file(
+                temporary, snapshot_root, "temporary framework snapshot file"
+            )
+            fertility_assert_new_destination(
+                snapshot_path, snapshot_root, "framework snapshot file"
+            )
             if (!file.rename(temporary, snapshot_path)) {
                 unlink(temporary)
                 if (!file.exists(snapshot_path)) {
@@ -1089,6 +1480,9 @@ fertility_prepare_framework_snapshot <- function(script_dir, raw_root, framework
                 }
             }
         }
+        snapshot_path <- fertility_assert_existing_file(
+            snapshot_path, snapshot_root, "framework snapshot file"
+        )
         if (!identical(unname(tools::sha256sum(source_path)),
                        unname(tools::sha256sum(snapshot_path)))) {
             stop("corpus framework snapshot does not match its provenance")
@@ -1106,9 +1500,52 @@ fertility_prepare_framework_snapshot <- function(script_dir, raw_root, framework
     )
     manifest_path <- file.path(snapshot_root, "inventory-manifest.tsv")
     provenance_path <- file.path(snapshot_root, "inventory-manifest-provenance.tsv")
-    if (!file.exists(manifest_path)) fertility_atomic_write_table(manifest, manifest_path)
-    if (!file.exists(provenance_path)) {
+    if (!file.exists(manifest_path) && !dir.exists(manifest_path) &&
+        !fertility_path_is_symlink(manifest_path)) {
+        fertility_assert_new_destination(
+            manifest_path, snapshot_root, "canonical inventory manifest"
+        )
+        fertility_atomic_write_table(manifest, manifest_path)
+    } else fertility_assert_existing_file(
+        manifest_path, snapshot_root, "canonical inventory manifest"
+    )
+    if (!file.exists(provenance_path) && !dir.exists(provenance_path) &&
+        !fertility_path_is_symlink(provenance_path)) {
+        fertility_assert_new_destination(
+            provenance_path, snapshot_root,
+            "canonical inventory manifest provenance"
+        )
         fertility_atomic_write_table(manifest_provenance, provenance_path)
+    } else fertility_assert_existing_file(
+        provenance_path, snapshot_root,
+        "canonical inventory manifest provenance"
+    )
+    acceptance_path <- file.path(snapshot_root, "acceptance-provenance.tsv")
+    if (!is.null(acceptance)) {
+        acceptance_provenance <- data.frame(
+            authority = acceptance$authority,
+            commitment_id = acceptance$commitment_id,
+            artifact_sha256 = acceptance$artifact_sha256,
+            stringsAsFactors = FALSE, check.names = FALSE
+        )
+        if (!file.exists(acceptance_path) && !dir.exists(acceptance_path) &&
+            !fertility_path_is_symlink(acceptance_path)) {
+            fertility_assert_new_destination(
+                acceptance_path, snapshot_root, "framework acceptance provenance"
+            )
+            fertility_atomic_write_table(acceptance_provenance, acceptance_path)
+        }
+        acceptance_path <- fertility_assert_existing_file(
+            acceptance_path, snapshot_root, "framework acceptance provenance"
+        )
+        recorded_acceptance <- read.delim(
+            acceptance_path, colClasses = "character", check.names = FALSE
+        )
+        if (!identical(recorded_acceptance, acceptance_provenance)) {
+            stop("corpus framework acceptance provenance is invalid")
+        }
+    } else if (file.exists(acceptance_path)) {
+        stop("unaccepted corpus framework contains acceptance provenance")
     }
     invisible(fertility_framework_inventory(
         snapshot_root, inventory = inventory, framework_id = framework_id
@@ -1117,16 +1554,48 @@ fertility_prepare_framework_snapshot <- function(script_dir, raw_root, framework
 }
 
 fertility_verify_framework_snapshot <- function(script_dir, raw_root, framework_id,
-                                                inventory = NULL) {
-    snapshot_root <- file.path(raw_root, "framework", framework_id)
-    if (!dir.exists(snapshot_root)) stop("corpus framework snapshot is absent")
-    for (name in c("common.R", "worker.R", "compare.R", "runtime.R")) {
+                                                inventory = NULL,
+                                                acceptance = NULL) {
+    framework_root <- fertility_assert_existing_directory(
+        file.path(raw_root, "framework"), raw_root, "framework output directory"
+    )
+    snapshot_root <- fertility_assert_existing_directory(
+        file.path(framework_root, framework_id), framework_root,
+        "framework snapshot"
+    )
+    for (name in c("common.R", "accepted.R", "worker.R", "compare.R", "runtime.R")) {
         source_path <- file.path(script_dir, name)
-        snapshot_path <- file.path(snapshot_root, name)
-        if (!file.exists(snapshot_path) ||
-            !identical(unname(tools::sha256sum(source_path)),
+        snapshot_path <- fertility_assert_existing_file(
+            file.path(snapshot_root, name), snapshot_root,
+            "framework snapshot file"
+        )
+        if (!identical(unname(tools::sha256sum(source_path)),
                        unname(tools::sha256sum(snapshot_path)))) {
             stop("corpus framework snapshot does not match its provenance")
+        }
+    }
+    acceptance_path <- file.path(snapshot_root, "acceptance-provenance.tsv")
+    if (is.null(acceptance)) {
+        if (file.exists(acceptance_path)) {
+            stop("unaccepted corpus framework contains acceptance provenance")
+        }
+    } else {
+        recorded <- if (file.exists(acceptance_path) && !dir.exists(acceptance_path)) {
+            acceptance_path <- fertility_assert_existing_file(
+                acceptance_path, snapshot_root, "framework acceptance provenance"
+            )
+            read.delim(
+                acceptance_path, colClasses = "character", check.names = FALSE
+            )
+        } else NULL
+        expected <- data.frame(
+            authority = acceptance$authority,
+            commitment_id = acceptance$commitment_id,
+            artifact_sha256 = acceptance$artifact_sha256,
+            stringsAsFactors = FALSE, check.names = FALSE
+        )
+        if (is.null(recorded) || !identical(recorded, expected)) {
+            stop("corpus framework acceptance provenance is invalid")
         }
     }
     invisible(fertility_framework_inventory(
@@ -1135,7 +1604,7 @@ fertility_verify_framework_snapshot <- function(script_dir, raw_root, framework_
     snapshot_root
 }
 
-fertility_tile_configuration <- function(options) {
+fertility_tile_configuration <- function(options, acceptance = NULL) {
     fields <- list(
         chunk_rows = options$chunk_rows, column_batch = options$column_batch,
         memory_mib = options$memory_mib, cell_budget = options$cell_budget,
@@ -1152,8 +1621,16 @@ fertility_tile_configuration <- function(options) {
     if (nzchar(encoding_overrides)) {
         identity_fields$encoding_overrides <- encoding_overrides
     }
-    c(fields, list(
-        encoding_overrides = encoding_overrides,
+    acceptance_fields <- list()
+    if (!is.null(acceptance)) {
+        acceptance_fields <- list(
+            acceptance_authority = acceptance$authority,
+            acceptance_commitment_id = acceptance$commitment_id,
+            acceptance_artifact_sha256 = acceptance$artifact_sha256
+        )
+        identity_fields <- c(identity_fields, acceptance_fields)
+    }
+    c(fields, list(encoding_overrides = encoding_overrides), acceptance_fields, list(
         config_id = fertility_stable_id(identity_fields)
     ))
 }
@@ -1321,7 +1798,25 @@ fertility_recorded_result_valid <- function(
         "tiles_expected", "tiles_completed", "complete", "actual_sha512",
         "elapsed_seconds"
     )
-    is.list(result) && setequal(names(result), required) &&
+    acceptance_fields <- c(
+        "acceptance_authority", "acceptance_commitment_id",
+        "acceptance_artifact_sha256", "accepted_sha512",
+        "manifest_hash_status", "local_evidence_status"
+    )
+    accepted <- all(acceptance_fields %in% names(result))
+    schema_valid <- setequal(
+        names(result), c(required, if (accepted) acceptance_fields else character())
+    )
+    acceptance_valid <- !accepted || (
+        identical(result$acceptance_authority, fertility_acceptance_authority()) &&
+        grepl("^[0-9a-f]{64}$", result$acceptance_commitment_id) &&
+        grepl("^[0-9a-f]{64}$", result$acceptance_artifact_sha256) &&
+        grepl("^[0-9a-f]{128}$", result$accepted_sha512) &&
+        identical(result$manifest_hash_status, "signature-mismatch") &&
+        identical(result$local_evidence_status,
+                  "accepted-current-sha512-match")
+    )
+    is.list(result) && schema_valid && acceptance_valid &&
         identical(result$schema_version, as.integer(corpus_schema_version)) &&
         identical(result$framework_id, framework_id) &&
         identical(result$config_id, configuration$config_id) &&
@@ -1370,13 +1865,28 @@ fertility_validate_recorded_input_attestation <- function(result) {
                   result$secondary_categories %in% reasons) {
         result$secondary_categories
     } else ""
+    accepted <- all(c(
+        "acceptance_authority", "acceptance_commitment_id",
+        "acceptance_artifact_sha256", "accepted_sha512",
+        "manifest_hash_status", "local_evidence_status"
+    ) %in% names(result))
+    accepted_valid <- accepted &&
+        identical(result$acceptance_authority, fertility_acceptance_authority()) &&
+        grepl("^[0-9a-f]{64}$", result$acceptance_commitment_id) &&
+        grepl("^[0-9a-f]{64}$", result$acceptance_artifact_sha256) &&
+        grepl("^[0-9a-f]{128}$", result$accepted_sha512) &&
+        identical(result$manifest_hash_status, "signature-mismatch") &&
+        identical(result$local_evidence_status,
+                  "accepted-current-sha512-match") &&
+        expected_valid && nzchar(expected) && actual_valid &&
+        !identical(actual, expected) && identical(actual, result$accepted_sha512)
     valid_reason <- switch(
         reason,
         "hash-read-error" = actual_missing,
         "signature-mismatch" = expected_valid && nzchar(expected) &&
             actual_valid && !identical(actual, expected),
         "input-changed" = expected_valid && actual_valid && input_id_valid,
-        expected_valid && actual_valid &&
+        if (accepted) accepted_valid else expected_valid && actual_valid &&
             (!nzchar(expected) || identical(actual, expected))
     )
     if (!input_id_valid ||
@@ -1408,18 +1918,30 @@ fertility_input_attestation_id <- function(results) {
     }
     commitments <- vapply(results, function(result) {
         fertility_validate_recorded_input_attestation(result)
+        accepted <- "acceptance_commitment_id" %in% names(result)
         status <- if (identical(result$classification, "inventory-hash-error")) {
             result$secondary_categories
+        } else if (accepted) {
+            "explicit-local-current-sha512"
         } else if (nzchar(result$expected_sha512)) {
             "verified-signature"
         } else "verified-empty-expected"
-        fertility_stable_id(list(
+        fields <- list(
             id = result$id, input_id = result$input_id,
             expected_sha512 = result$expected_sha512,
             actual_sha512 = if (is.na(result$actual_sha512)) "" else
                 result$actual_sha512,
             status = status
-        ))
+        )
+        if (accepted) {
+            fields$acceptance_authority <- result$acceptance_authority
+            fields$acceptance_commitment_id <- result$acceptance_commitment_id
+            fields$acceptance_artifact_sha256 <- result$acceptance_artifact_sha256
+            fields$accepted_sha512 <- result$accepted_sha512
+            fields$manifest_hash_status <- result$manifest_hash_status
+            fields$local_evidence_status <- result$local_evidence_status
+        }
+        fertility_stable_id(fields)
     }, character(1))
     fertility_stable_id(list(
         ids = paste(ids, collapse = ","),
@@ -1429,32 +1951,47 @@ fertility_input_attestation_id <- function(results) {
 
 fertility_evidence_selection_id <- function(
     selection_id, input_attestation_id, evidence_origin,
-    source_corpus_schema_version, report_schema_id
+    source_corpus_schema_version, report_schema_id,
+    acceptance_authority = "", acceptance_commitment_id = ""
 ) {
-    fertility_stable_id(list(
+    fields <- list(
         selection_id = selection_id, input_attestation_id = input_attestation_id,
         evidence_origin = evidence_origin,
         source_corpus_schema_version = as.integer(source_corpus_schema_version),
         report_schema_id = report_schema_id
-    ))
+    )
+    if (nzchar(acceptance_commitment_id)) {
+        fields$acceptance_authority <- acceptance_authority
+        fields$acceptance_commitment_id <- acceptance_commitment_id
+    }
+    fertility_stable_id(fields)
+}
+
+fertility_family_input_attestation <- function(provenance) {
+    fields <- c("shard_index", "input_attestation_id", "evidence_selection_id")
+    if (!is.data.frame(provenance) || !all(fields %in% names(provenance))) {
+        stop("family input attestation provenance is invalid")
+    }
+    attestation <- fertility_manifest_character(provenance[fields], fields)
+    indexes <- suppressWarnings(as.integer(attestation$shard_index))
+    ordering <- order(indexes)
+    if (anyNA(indexes) || !identical(indexes[ordering], seq_along(indexes)) ||
+        any(!grepl("^[0-9a-f]{64}$", attestation$input_attestation_id)) ||
+        any(!grepl("^[0-9a-f]{64}$", attestation$evidence_selection_id))) {
+        stop("family input attestations are not in canonical shard order")
+    }
+    attestation[ordering, , drop = FALSE]
 }
 
 fertility_family_input_attestation_id <- function(provenance) {
-    if (!is.data.frame(provenance) || !all(c(
-        "shard_index", "input_attestation_id", "evidence_selection_id"
-    ) %in% names(provenance))) stop("family input attestation provenance is invalid")
-    indexes <- suppressWarnings(as.integer(provenance$shard_index))
-    ordering <- order(indexes)
-    if (anyNA(indexes) || !identical(indexes[ordering], seq_along(indexes))) {
-        stop("family input attestations are not in canonical shard order")
-    }
+    attestation <- fertility_family_input_attestation(provenance)
     fertility_stable_id(list(
-        shard_indexes = paste(indexes[ordering], collapse = ","),
+        shard_indexes = paste(attestation$shard_index, collapse = ","),
         input_attestation_ids = paste(
-            provenance$input_attestation_id[ordering], collapse = ","
+            attestation$input_attestation_id, collapse = ","
         ),
         evidence_selection_ids = paste(
-            provenance$evidence_selection_id[ordering], collapse = ","
+            attestation$evidence_selection_id, collapse = ","
         )
     ))
 }
@@ -1485,11 +2022,17 @@ fertility_prepare_report_stages <- function(
 }
 
 fertility_publish_pointer_transaction <- function(
-    stages, rename_path, write_pointer, remove_path, pointer_state, path_exists
+    stages, rename_path, write_pointer, remove_path, pointer_state, path_exists,
+    before_rename = function(index, stage) TRUE,
+    before_pointer = function(index, stage) TRUE
 ) {
     renamed <- integer()
     for (index in seq_along(stages)) {
-        if (!isTRUE(rename_path(stages[[index]]$stage, stages[[index]]$published))) {
+        ready <- tryCatch(
+            before_rename(index, stages[[index]]), error = function(error) FALSE
+        )
+        if (!isTRUE(ready) ||
+            !isTRUE(rename_path(stages[[index]]$stage, stages[[index]]$published))) {
             for (rollback in rev(renamed)) remove_path(stages[[rollback]]$published)
             if (any(vapply(stages[renamed], function(stage) {
                 path_exists(stage$published)
@@ -1501,7 +2044,10 @@ fertility_publish_pointer_transaction <- function(
     pointed <- integer()
     pointer_failure <- FALSE
     for (index in seq_along(stages)) {
-        if (!isTRUE(write_pointer(
+        ready <- tryCatch(
+            before_pointer(index, stages[[index]]), error = function(error) FALSE
+        )
+        if (!isTRUE(ready) || !isTRUE(write_pointer(
             stages[[index]]$parent, basename(stages[[index]]$published)
         ))) {
             pointer_failure <- TRUE
@@ -1536,15 +2082,21 @@ fertility_publish_pointer_transaction <- function(
 
 fertility_evidence_family_id <- function(
     family_id, family_input_attestation_id, evidence_origin,
-    source_corpus_schema_version, report_schema_id
+    source_corpus_schema_version, report_schema_id,
+    acceptance_authority = "", acceptance_commitment_id = ""
 ) {
-    fertility_stable_id(list(
+    fields <- list(
         family_id = family_id,
         family_input_attestation_id = family_input_attestation_id,
         evidence_origin = evidence_origin,
         source_corpus_schema_version = as.integer(source_corpus_schema_version),
         report_schema_id = report_schema_id
-    ))
+    )
+    if (nzchar(acceptance_commitment_id)) {
+        fields$acceptance_authority <- acceptance_authority
+        fields$acceptance_commitment_id <- acceptance_commitment_id
+    }
+    fertility_stable_id(fields)
 }
 
 fertility_validate_recorded_tile <- function(
@@ -1566,12 +2118,26 @@ fertility_validate_recorded_tile <- function(
         "samples_completed", "payload_bytes_per_row", "chosen_rows",
         "sample_offsets_hash"
     )
+    acceptance_extra <- c(
+        "acceptance_authority", "acceptance_commitment_id",
+        "acceptance_artifact_sha256"
+    )
     if (!is.list(checkpoint) || !checkpoint$tile_type %in%
         c("metadata", "value", "terminal", "sizing")) {
         stop("recorded tile checkpoint schema is invalid")
     }
-    expected <- c(common, if (identical(checkpoint$tile_type, "sizing")) sizing_extra)
-    if (!setequal(names(checkpoint), expected) ||
+    accepted <- all(acceptance_extra %in% names(checkpoint))
+    expected <- c(
+        common, if (identical(checkpoint$tile_type, "sizing")) sizing_extra,
+        if (accepted) acceptance_extra
+    )
+    acceptance_valid <- !accepted || (
+        identical(checkpoint$acceptance_authority,
+                  fertility_acceptance_authority()) &&
+        grepl("^[0-9a-f]{64}$", checkpoint$acceptance_commitment_id) &&
+        grepl("^[0-9a-f]{64}$", checkpoint$acceptance_artifact_sha256)
+    )
+    if (!setequal(names(checkpoint), expected) || !acceptance_valid ||
         !identical(checkpoint$schema_version, as.integer(corpus_schema_version)) ||
         !is.character(checkpoint$input_id) || length(checkpoint$input_id) != 1L ||
         !grepl("^[0-9a-f]{64}$", checkpoint$input_id) ||
@@ -1590,7 +2156,8 @@ fertility_validate_recorded_tile <- function(
     allowed_secondary <- c(
         fertility_classifications(), fertility_mismatch_categories(),
         "direct-reader-error", "rust-reader-error", "haven-reader-error",
-        "metadata-reader-error", "row-termination-mismatch"
+        "metadata-reader-error", "row-termination-mismatch",
+        "structural-metadata-unavailable"
     )
     if ((any(legacy_artifact) && !legacy_artifact_allowed) ||
         any(!legacy_artifact & !checkpoint$secondary %in% allowed_secondary) ||
@@ -1616,8 +2183,17 @@ fertility_replay_file_tiles <- function(
     corpus_schema_version = fertility_schema_version,
     allow_legacy_empty_reader_artifact = FALSE
 ) {
-    tile_root <- file.path(file_root, "tiles")
+    file_parent <- dirname(file_root)
+    file_root <- fertility_assert_existing_directory(
+        file_root, file_parent, "checkpoint case directory"
+    )
+    tile_root <- fertility_assert_existing_directory(
+        file.path(file_root, "tiles"), file_root, "checkpoint tile directory"
+    )
     load_tile <- function(tile, path) {
+        path <- fertility_assert_existing_file(
+            path, tile_root, "checkpoint tile file"
+        )
         checkpoint <- tryCatch(readRDS(path), error = function(error) NULL)
         if (is.null(checkpoint)) stop("recorded tile checkpoint is absent or invalid")
         fertility_validate_recorded_tile(
@@ -1758,8 +2334,13 @@ fertility_tile_should_retry <- function(checkpoint) {
 
 fertility_process_tile <- function(item, tile, checkpoint_path, framework_id,
                                    configuration, input, retry, execute) {
+    checkpoint_path <- fertility_assert_checkpoint_file(
+        checkpoint_path, "tile checkpoint"
+    )
     checkpoint <- if (file.exists(checkpoint_path)) tryCatch(
-        readRDS(checkpoint_path), error = function(error) NULL
+        readRDS(fertility_assert_checkpoint_file(
+            checkpoint_path, "tile checkpoint", must_exist = TRUE
+        )), error = function(error) NULL
     ) else NULL
     valid <- !is.null(checkpoint) && fertility_tile_checkpoint_valid(
         checkpoint, item, tile, framework_id, configuration$config_id,
@@ -1771,8 +2352,15 @@ fertility_process_tile <- function(item, tile, checkpoint_path, framework_id,
     result <- execute(item, tile, input)
     result$config_id <- configuration$config_id
     result$input_id <- input$input_id
+    if (!is.null(input$acceptance_commitment_id) &&
+        nzchar(input$acceptance_commitment_id)) {
+        result$acceptance_authority <- input$acceptance_authority
+        result$acceptance_commitment_id <- input$acceptance_commitment_id
+        result$acceptance_artifact_sha256 <- input$acceptance_artifact_sha256
+    }
     result$column_hash <- tile$column_hash
     result$timeout_seconds <- configuration$timeout_seconds
+    fertility_assert_checkpoint_file(checkpoint_path, "tile checkpoint")
     fertility_atomic_save_rds(result, checkpoint_path)
     list(result = result, resumed = FALSE)
 }
@@ -1967,7 +2555,7 @@ fertility_tiled_result <- function(
             if (is.data.frame(tile$mismatches)) tile$mismatches$category else character()
         }), use.names = FALSE)
     )))
-    list(
+    c(list(
         schema_version = fertility_schema_version, framework_id = framework_id,
         config_id = configuration$config_id, input_id = input$input_id,
         id = item$id, program = item$program, level = item$level,
@@ -1984,5 +2572,5 @@ fertility_tiled_result <- function(
         complete = complete, actual_sha512 = input$actual_sha512,
         elapsed_seconds = sum(vapply(tiles, function(tile) tile$elapsed_seconds,
                                      numeric(1)), na.rm = TRUE)
-    )
+    ), fertility_result_acceptance_fields(input))
 }

--- a/benchmarks/fertility-surveys/runner.R
+++ b/benchmarks/fertility-surveys/runner.R
@@ -147,6 +147,19 @@ fertility_capture_input <- function(item) {
          actual_sha512 = actual, size = size, modified = modified)
 }
 
+fertility_inventory_preflight <- function(item, input) {
+    if (identical(input$hash_status, "error")) {
+        return(list(classification = "inventory-hash-error",
+                    reason = "hash-read-error"))
+    }
+    if (nzchar(item$expected_sha512) &&
+        !identical(input$actual_sha512, tolower(item$expected_sha512))) {
+        return(list(classification = "inventory-hash-error",
+                    reason = "signature-mismatch"))
+    }
+    NULL
+}
+
 fertility_file_stat <- function(path) {
     info <- file.info(path)
     if (!nrow(info) || is.na(info$size[[1L]]) || is.na(info$mtime[[1L]])) return(NULL)

--- a/benchmarks/fertility-surveys/runner.R
+++ b/benchmarks/fertility-surveys/runner.R
@@ -5,7 +5,8 @@ fertility_legacy_corpus_schema_version <- 10L
 fertility_usage <- function() {
     paste(
         "usage: run.R [--inventory-only] [--program=a,b] [--release=113,118]",
-        "[--id=F0001,F0002] [--shard-index=N --shard-count=N] [--max-files=N]",
+        "[--id=F0001,F0002] [--encoding-override=F0001:ENCODING]",
+        "[--shard-index=N --shard-count=N] [--max-files=N]",
         "[--timeout-seconds=N] [--chunk-rows=N] [--column-batch=N]",
         "[--memory-mib=N] [--cell-budget=N] [--max-tiles-per-batch=N]",
         "[--beyond-end-windows=N] [--retry]"
@@ -19,6 +20,70 @@ fertility_parse_positive_integer <- function(value, option) {
     as.integer(number)
 }
 
+fertility_canonical_encoding <- function(value) {
+    if (!is.character(value) || length(value) != 1L || is.na(value) ||
+        !nzchar(value)) {
+        stop("encoding override must contain one non-empty encoding")
+    }
+    key <- tolower(gsub("[-_ ]", "", value))
+    canonical <- switch(
+        key,
+        utf8 = "UTF-8",
+        windows1252 = "Windows-1252",
+        cp1252 = "Windows-1252",
+        iso88591 = "ISO-8859-1",
+        latin1 = "ISO-8859-1",
+        NULL
+    )
+    if (is.null(canonical)) {
+        stop(paste(
+            "unsupported encoding override; use UTF-8, Windows-1252,",
+            "or ISO-8859-1"
+        ))
+    }
+    canonical
+}
+
+fertility_parse_encoding_overrides <- function(values) {
+    if (!length(values)) return(setNames(character(), character()))
+    if (!is.character(values) || anyNA(values)) {
+        stop("encoding overrides must be character values")
+    }
+    entries <- unlist(strsplit(values, ",", fixed = TRUE), use.names = FALSE)
+    if (!length(entries) || any(!nzchar(entries))) {
+        stop("--encoding-override contains an empty entry")
+    }
+    pieces <- strsplit(entries, ":", fixed = TRUE)
+    if (any(lengths(pieces) != 2L)) {
+        stop("--encoding-override entries must have the form F0001:ENCODING")
+    }
+    ids <- vapply(pieces, `[[`, character(1), 1L)
+    encodings <- vapply(pieces, `[[`, character(1), 2L)
+    if (any(!grepl("^F[0-9]{4}$", ids))) {
+        stop("invalid --encoding-override ID")
+    }
+    if (anyDuplicated(ids)) stop("duplicate --encoding-override ID")
+    encodings <- vapply(encodings, fertility_canonical_encoding, character(1))
+    ordering <- order(ids)
+    setNames(encodings[ordering], ids[ordering])
+}
+
+fertility_encoding_overrides_text <- function(overrides) {
+    if (!length(overrides)) return("")
+    paste(names(overrides), overrides, sep = ":", collapse = ",")
+}
+
+fertility_validate_encoding_overrides <- function(overrides, family) {
+    canonical <- if (length(overrides)) fertility_parse_encoding_overrides(
+        fertility_encoding_overrides_text(overrides)
+    ) else setNames(character(), character())
+    if (!identical(overrides, canonical)) stop("encoding overrides are not canonical")
+    if (length(setdiff(names(overrides), family$id))) {
+        stop("encoding override IDs are outside the complete selected family")
+    }
+    invisible(overrides)
+}
+
 fertility_parse_arguments <- function(arguments) {
     options <- list(
         inventory_only = FALSE, programs = character(), releases = integer(),
@@ -26,9 +91,10 @@ fertility_parse_arguments <- function(arguments) {
         max_files = Inf, timeout_seconds = 600L, chunk_rows = 10000L,
         column_batch = 16L, memory_mib = 256L, cell_budget = 1000000L,
         max_tiles_per_batch = 100000L, beyond_end_windows = 1L,
-        retry = FALSE
+        encoding_overrides = setNames(character(), character()), retry = FALSE
     )
     seen_shard_index <- seen_shard_count <- FALSE
+    encoding_override_values <- character()
     for (argument in arguments) {
         if (identical(argument, "--inventory-only")) options$inventory_only <- TRUE
         else if (identical(argument, "--retry")) options$retry <- TRUE
@@ -43,6 +109,10 @@ fertility_parse_arguments <- function(arguments) {
             options$ids <- unique(strsplit(sub("^[^=]+=", "", argument),
                                            ",", fixed = TRUE)[[1L]])
             if (any(!grepl("^F[0-9]{4}$", options$ids))) stop("invalid --id value")
+        } else if (startsWith(argument, "--encoding-override=")) {
+            encoding_override_values <- c(
+                encoding_override_values, sub("^[^=]+=", "", argument)
+            )
         } else if (startsWith(argument, "--shard-index=")) {
             options$shard_index <- fertility_parse_positive_integer(
                 sub("^[^=]+=", "", argument), "--shard-index"
@@ -87,6 +157,9 @@ fertility_parse_arguments <- function(arguments) {
             )
         } else stop(fertility_usage())
     }
+    options$encoding_overrides <- fertility_parse_encoding_overrides(
+        encoding_override_values
+    )
     if (xor(seen_shard_index, seen_shard_count)) {
         stop("--shard-index and --shard-count must be supplied together")
     }
@@ -235,9 +308,18 @@ fertility_options_from_filter_spec <- function(provenance) {
     if (!grepl("^[1-9][0-9]*$", shard_value)) stop("invalid shard-count provenance")
     shard_count <- suppressWarnings(as.integer(shard_value))
     if (is.na(shard_count)) stop("invalid shard-count provenance")
+    encoding_text <- provenance$encoding_overrides[[1L]]
+    encoding_overrides <- if (nzchar(encoding_text)) {
+        fertility_parse_encoding_overrides(encoding_text)
+    } else setNames(character(), character())
+    if (!identical(fertility_encoding_overrides_text(encoding_overrides),
+                   encoding_text)) {
+        stop("encoding override provenance is not canonical")
+    }
     list(
         programs = programs, releases = releases, ids = ids,
-        shard_index = 1L, shard_count = shard_count, max_files = max_files
+        shard_index = 1L, shard_count = shard_count, max_files = max_files,
+        encoding_overrides = encoding_overrides
     )
 }
 
@@ -427,7 +509,7 @@ fertility_run_provenance_fields <- function() c(
     "family_manifest_id", "framework_id", "config_id", "build_provenance_id",
     "inventory_id", "report_schema_id", "selected_files", "expected_family_files",
     "full_default_family", "program_filter", "release_filter", "id_filter",
-    "max_files", "shard_index", "shard_count", "timeout_seconds",
+    "encoding_overrides", "max_files", "shard_index", "shard_count", "timeout_seconds",
     "chunk_rows", "column_batch", "memory_mib", "cell_budget",
     "max_tiles_per_batch", "beyond_end_windows", "retry", "created_at_utc"
 )
@@ -708,8 +790,8 @@ fertility_validate_shard_bundles <- function(bundles, family_id,
         "family_manifest_id", "framework_id",
         "config_id", "build_provenance_id", "inventory_id", "report_schema_id",
         "expected_family_files", "full_default_family", "program_filter",
-        "release_filter", "id_filter", "max_files", "shard_count",
-        "timeout_seconds", "chunk_rows", "column_batch", "memory_mib",
+        "release_filter", "id_filter", "encoding_overrides", "max_files",
+        "shard_count", "timeout_seconds", "chunk_rows", "column_batch", "memory_mib",
         "cell_budget", "max_tiles_per_batch", "beyond_end_windows"
     )
     for (field in stable_fields) {
@@ -749,6 +831,16 @@ fertility_validate_shard_bundles <- function(bundles, family_id,
     shard_indexes <- shard_indexes[ordering]
     canonical <- fertility_validate_canonical_inventory(canonical_inventory)
     options <- fertility_options_from_filter_spec(provenance[1L, , drop = FALSE])
+    family_selection <- fertility_family_selection(canonical, options)
+    fertility_validate_encoding_overrides(options$encoding_overrides, family_selection)
+    for (field in c(
+        "timeout_seconds", "chunk_rows", "column_batch", "memory_mib",
+        "cell_budget", "max_tiles_per_batch", "beyond_end_windows"
+    )) options[[field]] <- integer_field(field, positive = TRUE)[[1L]]
+    if (!identical(provenance$config_id[[1L]],
+                   fertility_tile_configuration(options)$config_id)) {
+        stop("configuration provenance identity is invalid")
+    }
     if (!identical(full_default, fertility_full_default_family(options))) {
         stop("full-default provenance disagrees with filter provenance")
     }
@@ -1053,7 +1145,17 @@ fertility_tile_configuration <- function(options) {
         readers_per_tile = 3L, strl_sample_count = 16L,
         strl_safety_factor = 8, strl_fallback_rows = 64L
     )
-    c(fields, list(config_id = fertility_stable_id(fields)))
+    encoding_overrides <- fertility_encoding_overrides_text(
+        options$encoding_overrides
+    )
+    identity_fields <- fields
+    if (nzchar(encoding_overrides)) {
+        identity_fields$encoding_overrides <- encoding_overrides
+    }
+    c(fields, list(
+        encoding_overrides = encoding_overrides,
+        config_id = fertility_stable_id(identity_fields)
+    ))
 }
 
 fertility_adaptive_rows <- function(column_bytes, configuration) {

--- a/benchmarks/fertility-surveys/runner.R
+++ b/benchmarks/fertility-surveys/runner.R
@@ -361,14 +361,16 @@ fertility_checkpoint_input_current <- function(checkpoint, item) {
 }
 
 fertility_base_result <- function(item, framework_id, timeout_seconds, input,
-                                  classification, elapsed_seconds = NA_real_) {
+                                  classification, elapsed_seconds = NA_real_,
+                                  secondary_categories = "") {
     list(
         schema_version = fertility_schema_version,
         framework_id = framework_id, input_id = input$input_id,
         id = item$id, program = item$program, level = item$level,
         release = as.integer(item$release), expected_sha512 = item$expected_sha512,
         timeout_seconds = timeout_seconds, classification = classification,
-        component = NA_integer_, secondary_categories = "", mismatch_count = 0L,
+        component = NA_integer_, secondary_categories = secondary_categories,
+        mismatch_count = 0L,
         mismatch_categories = "", mismatch_signatures = "", rows = NA_real_,
         columns = NA_integer_, tiles_expected = 0L, tiles_completed = 0L,
         complete = FALSE, actual_sha512 = input$actual_sha512,
@@ -389,16 +391,12 @@ fertility_process_item <- function(item, checkpoint_path, framework_id,
         (!retry || !fertility_should_retry(checkpoint))) {
         return(list(result = checkpoint, resumed = TRUE))
     }
-    if (identical(input_before$hash_status, "error")) {
-        result <- fertility_base_result(
-            item, framework_id, timeout_seconds, input_before, "inventory-hash-error"
-        )
-    } else if (nzchar(item$expected_sha512) &&
-               !identical(input_before$actual_sha512,
-                          tolower(item$expected_sha512))) {
+    preflight <- fertility_inventory_preflight(item, input_before)
+    if (!is.null(preflight)) {
         result <- fertility_base_result(
             item, framework_id, timeout_seconds, input_before,
-            "inventory-hash-error"
+            preflight$classification,
+            secondary_categories = preflight$reason
         )
     } else {
         result <- execute(item, input_before)
@@ -406,7 +404,8 @@ fertility_process_item <- function(item, checkpoint_path, framework_id,
         if (!identical(input_after$input_id, input_before$input_id)) {
             result <- fertility_base_result(
                 item, framework_id, timeout_seconds, input_after,
-                "input-changed-during-subprocess"
+                "inventory-hash-error",
+                secondary_categories = fertility_changed_input_reason(input_after)
             )
         } else {
             result$input_id <- input_before$input_id
@@ -1234,7 +1233,9 @@ fertility_recorded_result_valid <- function(
         ((is.character(result$actual_sha512) &&
           length(result$actual_sha512) == 1L &&
           grepl("^[0-9a-f]{128}$", result$actual_sha512)) ||
-         (is.na(result$actual_sha512) &&
+         (is.character(result$actual_sha512) &&
+          length(result$actual_sha512) == 1L &&
+          is.na(result$actual_sha512) &&
           identical(result$classification, "inventory-hash-error") &&
           identical(result$secondary_categories, "hash-read-error"))) &&
         identical(as.integer(result$timeout_seconds),
@@ -1250,9 +1251,10 @@ fertility_validate_recorded_input_attestation <- function(result) {
     actual <- result$actual_sha512
     expected_valid <- is.character(expected) && length(expected) == 1L &&
         grepl("^([0-9a-f]{128})?$", expected)
-    actual_missing <- length(actual) != 1L || is.na(actual)
-    actual_valid <- !actual_missing && is.character(actual) &&
-        grepl("^[0-9a-f]{128}$", actual)
+    actual_missing <- is.character(actual) && length(actual) == 1L &&
+        is.na(actual)
+    actual_valid <- is.character(actual) && length(actual) == 1L &&
+        !is.na(actual) && grepl("^[0-9a-f]{128}$", actual)
     input_id_valid <- is.character(result$input_id) && length(result$input_id) == 1L &&
         grepl("^[0-9a-f]{64}$", result$input_id)
     inventory_hash_error <- identical(
@@ -1275,7 +1277,8 @@ fertility_validate_recorded_input_attestation <- function(result) {
         expected_valid && actual_valid &&
             (!nzchar(expected) || identical(actual, expected))
     )
-    if (!identical(inventory_hash_error, nzchar(reason)) || !valid_reason) {
+    if (!input_id_valid ||
+        !identical(inventory_hash_error, nzchar(reason)) || !valid_reason) {
         stop("recorded input preflight attestation is inconsistent")
     }
     invisible(TRUE)
@@ -1284,11 +1287,12 @@ fertility_validate_recorded_input_attestation <- function(result) {
 fertility_validate_recorded_input_result <- function(result, tile_count) {
     fertility_validate_recorded_input_attestation(result)
     if (!identical(result$classification, "inventory-hash-error") ||
-        length(tile_count) != 1L || is.na(tile_count) || tile_count < 0L ||
-        !identical(as.integer(tile_count), tile_count) ||
+        !is.integer(tile_count) || length(tile_count) != 1L ||
+        is.na(tile_count) || tile_count < 0L ||
         (!identical(result$secondary_categories, "input-changed") &&
          tile_count != 0L) ||
-        isTRUE(result$complete) || result$mismatch_count != 0L) {
+        !identical(result$complete, FALSE) ||
+        !identical(result$mismatch_count, 0L)) {
         stop("recorded input-validation result is inconsistent")
     }
     invisible(TRUE)

--- a/benchmarks/fertility-surveys/runner.R
+++ b/benchmarks/fertility-surveys/runner.R
@@ -2,7 +2,9 @@ fertility_usage <- function() {
     paste(
         "usage: run.R [--inventory-only] [--program=a,b] [--release=113,118]",
         "[--id=F0001,F0002] [--shard-index=N --shard-count=N] [--max-files=N]",
-        "[--timeout-seconds=N] [--retry]"
+        "[--timeout-seconds=N] [--chunk-rows=N] [--column-batch=N]",
+        "[--memory-mib=N] [--cell-budget=N] [--max-tiles-per-batch=N]",
+        "[--beyond-end-windows=N] [--retry]"
     )
 }
 
@@ -17,7 +19,10 @@ fertility_parse_arguments <- function(arguments) {
     options <- list(
         inventory_only = FALSE, programs = character(), releases = integer(),
         ids = character(), shard_index = 1L, shard_count = 1L,
-        max_files = Inf, timeout_seconds = 600L, retry = FALSE
+        max_files = Inf, timeout_seconds = 600L, chunk_rows = 10000L,
+        column_batch = 16L, memory_mib = 256L, cell_budget = 1000000L,
+        max_tiles_per_batch = 100000L, beyond_end_windows = 1L,
+        retry = FALSE
     )
     seen_shard_index <- seen_shard_count <- FALSE
     for (argument in arguments) {
@@ -52,6 +57,30 @@ fertility_parse_arguments <- function(arguments) {
             options$timeout_seconds <- fertility_parse_positive_integer(
                 sub("^[^=]+=", "", argument), "--timeout-seconds"
             )
+        } else if (startsWith(argument, "--chunk-rows=")) {
+            options$chunk_rows <- fertility_parse_positive_integer(
+                sub("^[^=]+=", "", argument), "--chunk-rows"
+            )
+        } else if (startsWith(argument, "--column-batch=")) {
+            options$column_batch <- fertility_parse_positive_integer(
+                sub("^[^=]+=", "", argument), "--column-batch"
+            )
+        } else if (startsWith(argument, "--memory-mib=")) {
+            options$memory_mib <- fertility_parse_positive_integer(
+                sub("^[^=]+=", "", argument), "--memory-mib"
+            )
+        } else if (startsWith(argument, "--cell-budget=")) {
+            options$cell_budget <- fertility_parse_positive_integer(
+                sub("^[^=]+=", "", argument), "--cell-budget"
+            )
+        } else if (startsWith(argument, "--max-tiles-per-batch=")) {
+            options$max_tiles_per_batch <- fertility_parse_positive_integer(
+                sub("^[^=]+=", "", argument), "--max-tiles-per-batch"
+            )
+        } else if (startsWith(argument, "--beyond-end-windows=")) {
+            options$beyond_end_windows <- fertility_parse_positive_integer(
+                sub("^[^=]+=", "", argument), "--beyond-end-windows"
+            )
         } else stop(fertility_usage())
     }
     if (xor(seen_shard_index, seen_shard_count)) {
@@ -59,6 +88,12 @@ fertility_parse_arguments <- function(arguments) {
     }
     if (options$shard_index > options$shard_count) {
         stop("--shard-index must not exceed --shard-count")
+    }
+    if (options$memory_mib < 128L) {
+        stop("--memory-mib must be at least 128 for an enforceable R vector limit")
+    }
+    if (options$beyond_end_windows > 8L) {
+        stop("--beyond-end-windows must not exceed 8")
     }
     options
 }
@@ -110,6 +145,13 @@ fertility_capture_input <- function(item) {
     ))
     list(input_id = identity, hash_status = hash_status,
          actual_sha512 = actual, size = size, modified = modified)
+}
+
+fertility_file_stat <- function(path) {
+    info <- file.info(path)
+    if (!nrow(info) || is.na(info$size[[1L]]) || is.na(info$mtime[[1L]])) return(NULL)
+    list(size = as.character(info$size[[1L]]),
+         modified = format(info$mtime[[1L]], "%Y-%m-%dT%H:%M:%OS6Z", tz = "UTC"))
 }
 
 fertility_checkpoint_valid <- function(checkpoint, item, framework_id,
@@ -195,11 +237,17 @@ fertility_should_retry <- function(checkpoint) {
 }
 
 fertility_result_frame <- function(checkpoints) {
-    fields <- c("framework_id", "id", "program", "level", "release",
-                "classification", "component", "rows", "columns",
-                "elapsed_seconds")
+    fields <- c(
+        "framework_id", "id", "program", "level", "release", "classification",
+        "secondary_categories", "mismatch_count", "mismatch_categories",
+        "mismatch_signatures", "rows", "columns", "tiles_expected",
+        "tiles_completed", "complete", "elapsed_seconds"
+    )
     rows <- lapply(checkpoints, function(value) {
-        as.data.frame(value[fields], stringsAsFactors = FALSE, optional = TRUE)
+        row <- setNames(lapply(fields, function(field) {
+            if (is.null(value[[field]])) NA else value[[field]]
+        }), fields)
+        as.data.frame(row, stringsAsFactors = FALSE, optional = TRUE)
     })
     result <- do.call(rbind, rows)
     rownames(result) <- NULL
@@ -211,4 +259,324 @@ fertility_publish_results <- function(checkpoints, build_provenance_id, path) {
     results$build_provenance_id <- build_provenance_id
     fertility_atomic_write_table(results, path)
     results
+}
+
+fertility_tile_configuration <- function(options) {
+    fields <- list(
+        chunk_rows = options$chunk_rows, column_batch = options$column_batch,
+        memory_mib = options$memory_mib, cell_budget = options$cell_budget,
+        max_tiles_per_batch = options$max_tiles_per_batch,
+        beyond_end_windows = options$beyond_end_windows,
+        timeout_seconds = options$timeout_seconds, object_overhead_bytes = 64L,
+        readers_per_tile = 3L
+    )
+    c(fields, list(config_id = fertility_stable_id(fields)))
+}
+
+fertility_adaptive_rows <- function(column_bytes, configuration) {
+    column_bytes <- as.double(column_bytes)
+    if (!length(column_bytes)) column_bytes <- 8
+    if (any(!is.finite(column_bytes))) return(1L)
+    per_row <- sum(pmax(column_bytes, 1) + configuration$object_overhead_bytes)
+    readers <- as.double(configuration$readers_per_tile)
+    memory_bytes <- as.double(configuration$memory_mib) * 1024^2
+    by_memory <- floor(memory_bytes / (readers * per_row))
+    by_cells <- floor(as.double(configuration$cell_budget) /
+                      (readers * length(column_bytes)))
+    as.integer(max(1, min(configuration$chunk_rows, by_memory, by_cells)))
+}
+
+fertility_metadata_tile <- function() {
+    list(tile_id = "metadata", type = "metadata", batch = 0L, skip = 0L,
+         n_max = 0L, column_names = character(), column_hash = "all")
+}
+
+fertility_value_tile <- function(batch, skip, n_max, column_names,
+                                 type = "value", probe = 0L) {
+    list(
+        tile_id = sprintf("b%05d-%s%02d-r%015.0f", as.integer(batch),
+                          if (identical(type, "value")) "v" else "p",
+                          as.integer(probe), as.double(skip)),
+        type = type, batch = as.integer(batch), skip = as.double(skip),
+        n_max = as.integer(n_max), column_names = column_names,
+        column_hash = fertility_stable_id(list(
+            batch = as.integer(batch), type = type, probe = as.integer(probe),
+            names = paste(column_names, collapse = "\037")
+        ))
+    )
+}
+
+fertility_column_batches <- function(column_names, batch_size, column_bytes = NULL) {
+    if (!length(column_names)) return(list())
+    if (is.null(column_bytes) || length(column_bytes) != length(column_names)) {
+        column_bytes <- rep(8, length(column_names))
+    }
+    batches <- list()
+    current <- character()
+    for (i in seq_along(column_names)) {
+        strl <- !is.finite(column_bytes[[i]])
+        if (length(current) && (length(current) >= batch_size || strl)) {
+            batches[[length(batches) + 1L]] <- current
+            current <- character()
+        }
+        current <- c(current, column_names[[i]])
+        if (strl) {
+            batches[[length(batches) + 1L]] <- current
+            current <- character()
+        }
+    }
+    if (length(current)) batches[[length(batches) + 1L]] <- current
+    batches
+}
+
+fertility_structural_batches <- function(column_names, batch_size, column_bytes,
+                                         declared_columns) {
+    if (identical(as.integer(declared_columns), 0L) && !length(column_names)) {
+        return(list(character()))
+    }
+    fertility_column_batches(column_names, batch_size, column_bytes)
+}
+
+fertility_batch_bytes <- function(column_names, all_names, column_bytes) {
+    column_bytes[match(column_names, all_names)]
+}
+
+fertility_projection_hash <- function(column_names, framework_id) {
+    fertility_stable_id(list(
+        framework_id = framework_id,
+        ordered_names = paste(column_names, collapse = "\037")
+    ))
+}
+
+fertility_plan_offsets <- function(total_rows, rows_per_tile, max_tiles) {
+    if (!is.finite(total_rows) || total_rows < 0) {
+        return(list(offsets = numeric(), ceiling = TRUE))
+    }
+    needed <- if (total_rows == 0) 1 else ceiling(total_rows / rows_per_tile)
+    if (needed > max_tiles) return(list(offsets = numeric(), ceiling = TRUE))
+    list(offsets = if (total_rows == 0) 0 else
+             seq(0, total_rows - 1, by = rows_per_tile), ceiling = FALSE)
+}
+
+fertility_memory_error <- function(error) {
+    grepl("vector memory exhausted|cannot allocate|memory limit|out of memory",
+          conditionMessage(error), ignore.case = TRUE)
+}
+
+fertility_tile_checkpoint_valid <- function(checkpoint, item, tile, framework_id,
+                                              config_id, input_id,
+                                              timeout_seconds) {
+    is.list(checkpoint) &&
+        identical(checkpoint$schema_version, fertility_schema_version) &&
+        identical(checkpoint$framework_id, framework_id) &&
+        identical(checkpoint$config_id, config_id) &&
+        identical(checkpoint$input_id, input_id) &&
+        identical(checkpoint$id, item$id) &&
+        identical(checkpoint$tile_id, tile$tile_id) &&
+        identical(checkpoint$tile_type, tile$type) &&
+        identical(as.integer(checkpoint$batch), as.integer(tile$batch)) &&
+        identical(as.double(checkpoint$skip), as.double(tile$skip)) &&
+        identical(as.integer(checkpoint$n_max), as.integer(tile$n_max)) &&
+        identical(checkpoint$column_hash, tile$column_hash) &&
+        identical(as.integer(checkpoint$timeout_seconds), as.integer(timeout_seconds))
+}
+
+fertility_tile_should_retry <- function(checkpoint) {
+    checkpoint$classification %in% c(
+        "timeout", "crash", "dtaparser-only-error", "haven-only-error",
+        "shared-reader-error", "memory-limit", "unresolved"
+    )
+}
+
+fertility_process_tile <- function(item, tile, checkpoint_path, framework_id,
+                                   configuration, input, retry, execute) {
+    checkpoint <- if (file.exists(checkpoint_path)) tryCatch(
+        readRDS(checkpoint_path), error = function(error) NULL
+    ) else NULL
+    valid <- !is.null(checkpoint) && fertility_tile_checkpoint_valid(
+        checkpoint, item, tile, framework_id, configuration$config_id,
+        input$input_id, configuration$timeout_seconds
+    )
+    if (valid && (!retry || !fertility_tile_should_retry(checkpoint))) {
+        return(list(result = checkpoint, resumed = TRUE))
+    }
+    result <- execute(item, tile, input)
+    result$config_id <- configuration$config_id
+    result$input_id <- input$input_id
+    result$column_hash <- tile$column_hash
+    result$timeout_seconds <- configuration$timeout_seconds
+    fertility_atomic_save_rds(result, checkpoint_path)
+    list(result = result, resumed = FALSE)
+}
+
+fertility_mismatch_summary <- function(tiles) {
+    mismatches <- lapply(tiles, function(tile) tile$mismatches)
+    mismatches <- mismatches[vapply(
+        mismatches, function(value) is.data.frame(value) && nrow(value) > 0L,
+        logical(1)
+    )]
+    if (!length(mismatches)) return(list(count = 0L, categories = "", signatures = ""))
+    mismatches <- do.call(rbind, mismatches)
+    if (!nrow(mismatches)) return(list(count = 0L, categories = "", signatures = ""))
+    keys <- paste(mismatches$category, mismatches$detail,
+                  ifelse(is.na(mismatches$component), "", mismatches$component),
+                  if ("pair" %in% names(mismatches)) mismatches$pair else "",
+                  sep = ":")
+    counts <- sort(table(keys), decreasing = TRUE)
+    categories <- sort(table(mismatches$category), decreasing = TRUE)
+    list(
+        count = as.integer(sum(counts)),
+        categories = paste(names(categories), as.integer(categories), sep = "=",
+                           collapse = ","),
+        signatures = paste(vapply(names(counts), function(key) {
+            fertility_stable_id(list(signature = key))
+        }, character(1)), as.integer(counts), sep = "=", collapse = ",")
+    )
+}
+
+fertility_aggregate_classification <- function(tiles, complete) {
+    classes <- vapply(tiles, `[[`, character(1), "classification")
+    secondary <- unique(unlist(lapply(tiles, `[[`, "secondary"), use.names = FALSE))
+    if (any(classes == "input-changed")) return("inventory-hash-error")
+    if (any(classes == "timeout")) return("timeout")
+    if (any(classes == "memory-limit")) return("memory-limit")
+    if (any(classes == "crash")) return("crash")
+    for (classification in c("shared-reader-error", "dtaparser-only-error",
+                             "haven-only-error")) {
+        if (classification %in% classes) return(classification)
+    }
+    if (any(classes == "unresolved")) return("unresolved")
+    if ("row-termination-mismatch" %in% c(classes, secondary)) {
+        return("row-termination-mismatch")
+    }
+    if ("direct-vs-rust-mismatch" %in% c(classes, secondary)) {
+        return("direct-vs-rust-mismatch")
+    }
+    for (classification in c("metadata-mismatch", "tag-mismatch", "date-mismatch",
+                             "encoding-mismatch", "value-mismatch",
+                             "known-intentional-divergence")) {
+        if (classification %in% c(classes, secondary)) return(classification)
+    }
+    if (!complete) "unresolved" else "pass"
+}
+
+fertility_validate_tile_completeness <- function(tiles, batches, total_rows,
+                                                 configuration) {
+    if (!length(tiles) || !identical(tiles[[1L]]$tile_type, "metadata")) return(FALSE)
+    if (is.na(total_rows) || !length(batches) ||
+        is.null(configuration$beyond_end_windows)) return(FALSE)
+    terminal_tiles <- tiles[vapply(
+        tiles, function(tile) identical(tile$tile_type, "terminal"), logical(1)
+    )]
+    expected_probes <- as.integer(configuration$beyond_end_windows)
+    if (length(terminal_tiles) != expected_probes) return(FALSE)
+    terminal_tiles <- terminal_tiles[order(vapply(
+        terminal_tiles, `[[`, numeric(1), "skip"
+    ))]
+    expected_terminal_skips <- as.double(total_rows) + seq.int(0, expected_probes - 1L)
+    expected_count <- length(batches[[1L]])
+    readers <- c("direct", "rust", "haven")
+    for (probe in seq_len(expected_probes)) {
+        tile <- terminal_tiles[[probe]]
+        expected_hash <- if (!is.null(tile$framework_id))
+            fertility_projection_hash(batches[[1L]], tile$framework_id) else
+            NA_character_
+        attested <- identical(as.integer(tile$batch), 1L) &&
+            identical(as.double(tile$skip), expected_terminal_skips[[probe]]) &&
+            identical(as.integer(tile$n_max), 1L) &&
+            identical(as.integer(tile$rows), 0L) &&
+            identical(names(tile$reader_rows), readers) &&
+            all(tile$reader_rows == 0L) &&
+            identical(as.integer(tile$projection_expected_count),
+                      as.integer(expected_count)) &&
+            identical(tile$projection_expected_hash, expected_hash) &&
+            identical(names(tile$projection_counts), readers) &&
+            identical(names(tile$projection_hashes), readers) &&
+            identical(names(tile$projection_ok), readers) &&
+            all(tile$projection_ok) &&
+            all(tile$projection_counts == expected_count) &&
+            all(tile$projection_hashes == expected_hash)
+        if (!isTRUE(attested)) return(FALSE)
+    }
+    value_tiles <- tiles[vapply(tiles, function(tile) identical(tile$tile_type, "value"),
+                                logical(1))]
+    if (length(batches) != length(unique(vapply(value_tiles, `[[`, integer(1), "batch")))) {
+        return(FALSE)
+    }
+    for (batch in seq_along(batches)) {
+        current <- value_tiles[vapply(value_tiles, function(tile) tile$batch == batch,
+                                      logical(1))]
+        current <- current[order(vapply(current, `[[`, numeric(1), "skip"))]
+        expected_skip <- 0
+        expected_count <- length(batches[[batch]])
+        for (tile in current) {
+            expected_hash <- if (!is.null(tile$framework_id))
+                fertility_projection_hash(batches[[batch]], tile$framework_id) else
+                NA_character_
+            readers <- c("direct", "rust", "haven")
+            attested <- identical(as.integer(tile$projection_expected_count),
+                                  as.integer(expected_count)) &&
+                is.character(tile$projection_expected_hash) &&
+                length(tile$projection_expected_hash) == 1L &&
+                !is.na(expected_hash) &&
+                identical(tile$projection_expected_hash, expected_hash) &&
+                identical(names(tile$projection_counts), readers) &&
+                identical(names(tile$projection_hashes), readers) &&
+                identical(names(tile$projection_ok), readers) &&
+                all(tile$projection_ok) &&
+                all(tile$projection_counts == expected_count) &&
+                all(tile$projection_hashes == expected_hash)
+            if (!isTRUE(attested) ||
+                !identical(as.double(tile$skip), as.double(expected_skip)) ||
+                is.na(tile$rows)) return(FALSE)
+            expected_rows <- min(tile$n_max, total_rows - expected_skip)
+            if (!identical(as.integer(tile$rows), as.integer(expected_rows))) return(FALSE)
+            expected_skip <- expected_skip + tile$rows
+        }
+        if (!identical(as.double(expected_skip), as.double(total_rows))) return(FALSE)
+    }
+    TRUE
+}
+
+fertility_file_result_valid <- function(result, item, framework_id,
+                                         configuration, input) {
+    is.list(result) &&
+        identical(result$schema_version, fertility_schema_version) &&
+        identical(result$framework_id, framework_id) &&
+        identical(result$config_id, configuration$config_id) &&
+        identical(result$input_id, input$input_id) &&
+        identical(result$id, item$id) &&
+        identical(as.integer(result$release), as.integer(item$release)) &&
+        identical(as.integer(result$timeout_seconds),
+                  as.integer(configuration$timeout_seconds))
+}
+
+fertility_tiled_result <- function(item, framework_id, configuration, input, tiles,
+                                    batches, total_rows) {
+    complete <- fertility_validate_tile_completeness(
+        tiles, batches, total_rows, configuration
+    )
+    mismatch <- fertility_mismatch_summary(tiles)
+    secondary <- sort(unique(c(
+        unlist(lapply(tiles, `[[`, "secondary"), use.names = FALSE),
+        unlist(lapply(tiles, function(tile) {
+            if (is.data.frame(tile$mismatches)) tile$mismatches$category else character()
+        }), use.names = FALSE)
+    )))
+    list(
+        schema_version = fertility_schema_version, framework_id = framework_id,
+        config_id = configuration$config_id, input_id = input$input_id,
+        id = item$id, program = item$program, level = item$level,
+        release = as.integer(item$release), expected_sha512 = item$expected_sha512,
+        timeout_seconds = configuration$timeout_seconds,
+        classification = fertility_aggregate_classification(tiles, complete),
+        secondary_categories = paste(secondary, collapse = ","),
+        mismatch_count = mismatch$count, mismatch_categories = mismatch$categories,
+        mismatch_signatures = mismatch$signatures,
+        rows = as.double(total_rows), columns = length(unlist(batches)),
+        tiles_expected = length(tiles), tiles_completed = length(tiles),
+        complete = complete, actual_sha512 = input$actual_sha512,
+        elapsed_seconds = sum(vapply(tiles, function(tile) tile$elapsed_seconds,
+                                     numeric(1)), na.rm = TRUE)
+    )
 }

--- a/benchmarks/fertility-surveys/runner.R
+++ b/benchmarks/fertility-surveys/runner.R
@@ -4,8 +4,9 @@ fertility_legacy_corpus_schema_version <- 10L
 
 fertility_usage <- function() {
     paste(
-        "usage: run.R [--inventory-only] [--program=a,b] [--release=113,118]",
-        "[--id=F0001,F0002] [--encoding-override=F0001:ENCODING]",
+        "usage: run.R [--inventory-only] [--output-root=/absolute/path]",
+        "[--program=a,b] [--release=113,118] [--id=F0001,F0002]",
+        "[--encoding-override=F0001:ENCODING]",
         "[--shard-index=N --shard-count=N] [--max-files=N]",
         "[--timeout-seconds=N] [--chunk-rows=N] [--column-batch=N]",
         "[--memory-mib=N] [--cell-budget=N] [--max-tiles-per-batch=N]",
@@ -92,14 +93,22 @@ fertility_parse_arguments <- function(arguments) {
         column_batch = 16L, memory_mib = 256L, cell_budget = 1000000L,
         max_tiles_per_batch = 100000L, beyond_end_windows = 1L,
         encoding_overrides = setNames(character(), character()),
-        accepted_current_hashes = "", retry = FALSE
+        accepted_current_hashes = "", output_root = "", retry = FALSE
     )
     seen_shard_index <- seen_shard_count <- FALSE
+    seen_program <- FALSE
     encoding_override_values <- character()
     for (argument in arguments) {
         if (identical(argument, "--inventory-only")) options$inventory_only <- TRUE
         else if (identical(argument, "--retry")) options$retry <- TRUE
-        else if (startsWith(argument, "--program=")) {
+        else if (startsWith(argument, "--output-root=")) {
+            if (nzchar(options$output_root)) stop("--output-root may be supplied only once")
+            options$output_root <- sub("^[^=]+=", "", argument)
+            if (!startsWith(options$output_root, "/")) {
+                stop("--output-root must be absolute")
+            }
+        } else if (startsWith(argument, "--program=")) {
+            seen_program <- TRUE
             options$programs <- unique(strsplit(tolower(sub("^[^=]+=", "", argument)),
                                                 ",", fixed = TRUE)[[1L]])
         } else if (startsWith(argument, "--release=")) {
@@ -169,6 +178,14 @@ fertility_parse_arguments <- function(arguments) {
     options$encoding_overrides <- fertility_parse_encoding_overrides(
         encoding_override_values
     )
+    if (nzchar(options$output_root)) {
+        fertility_assert_output_root(options$output_root)
+        if (seen_program) stop("--program cannot be combined with --output-root")
+        if (nzchar(options$accepted_current_hashes)) {
+            stop("accepted-current-hash evidence cannot be combined with --output-root")
+        }
+        options$programs <- "output"
+    }
     if (xor(seen_shard_index, seen_shard_count)) {
         stop("--shard-index and --shard-count must be supplied together")
     }
@@ -1582,7 +1599,7 @@ fertility_framework_inventory <- function(
     )
     manifest <- read.delim(manifest_path, colClasses = "character",
                            check.names = FALSE)
-    manifest <- fertility_validate_canonical_inventory(manifest, exact = TRUE)
+    manifest <- fertility_validate_canonical_inventory(manifest, exact = FALSE)
     provenance <- read.delim(provenance_path, colClasses = "character",
                              check.names = FALSE)
     report_schema_version <- as.integer(report_schema_version)

--- a/benchmarks/fertility-surveys/runner.R
+++ b/benchmarks/fertility-surveys/runner.R
@@ -1,3 +1,7 @@
+fertility_report_schema_version <- 2L
+fertility_legacy_report_schema_version <- 1L
+fertility_legacy_corpus_schema_version <- 10L
+
 fertility_usage <- function() {
     paste(
         "usage: run.R [--inventory-only] [--program=a,b] [--release=113,118]",
@@ -161,13 +165,15 @@ fertility_inventory_id <- function(inventory) {
     ))
 }
 
-fertility_manifest_id <- function(manifest, fields = names(manifest)) {
+fertility_manifest_id <- function(
+    manifest, fields = names(manifest), schema_version = fertility_schema_version
+) {
     if (!identical(names(manifest), fields)) stop("manifest schema is not canonical")
     rows <- if (!nrow(manifest)) character() else apply(
         manifest, 1L, function(row) paste(as.character(row), collapse = "\037")
     )
     fertility_stable_id(list(
-        schema_version = fertility_schema_version,
+        schema_version = as.integer(schema_version),
         fields = paste(fields, collapse = ","),
         rows = paste(rows, collapse = "\036")
     ))
@@ -237,23 +243,32 @@ fertility_options_from_filter_spec <- function(provenance) {
 
 fertility_family_id_from_manifest <- function(
     manifest, framework_id, config_id, build_provenance_id, inventory_id,
-    shard_count, max_files
+    shard_count, max_files, report_schema_id = fertility_report_schema_id(),
+    evidence_origin = "fresh-execution",
+    source_corpus_schema_version = fertility_schema_version
 ) {
     fertility_stable_id(list(
         framework_id = framework_id, config_id = config_id,
         build_provenance_id = build_provenance_id,
-        inventory_id = inventory_id,
+        inventory_id = inventory_id, report_schema_id = report_schema_id,
+        evidence_origin = evidence_origin,
+        source_corpus_schema_version = as.integer(source_corpus_schema_version),
         family_manifest_id = fertility_manifest_id(manifest),
         shard_count = as.integer(shard_count), max_files = as.character(max_files)
     ))
 }
 
-fertility_selection_family_id <- function(inventory, options, framework_id,
-                                          config_id, build_provenance_id) {
+fertility_selection_family_id <- function(
+    inventory, options, framework_id, config_id, build_provenance_id,
+    report_schema_id = fertility_report_schema_id(),
+    evidence_origin = "fresh-execution",
+    source_corpus_schema_version = fertility_schema_version
+) {
     fertility_family_id_from_manifest(
         fertility_family_manifest(inventory, options), framework_id, config_id,
         build_provenance_id, fertility_inventory_id(inventory),
-        options$shard_count, options$max_files
+        options$shard_count, options$max_files, report_schema_id,
+        evidence_origin, source_corpus_schema_version
     )
 }
 
@@ -295,6 +310,23 @@ fertility_inventory_preflight <- function(item, input) {
                     reason = "signature-mismatch"))
     }
     NULL
+}
+
+fertility_changed_input_reason <- function(input) {
+    input_id_valid <- is.character(input$input_id) && length(input$input_id) == 1L &&
+        grepl("^[0-9a-f]{64}$", input$input_id)
+    hash_missing <- length(input$actual_sha512) != 1L ||
+        is.na(input$actual_sha512)
+    if (!input_id_valid) stop("changed input identity is invalid")
+    if (identical(input$hash_status, "error") && hash_missing) {
+        return("hash-read-error")
+    }
+    if (identical(input$hash_status, "ok") && !hash_missing &&
+        is.character(input$actual_sha512) &&
+        grepl("^[0-9a-f]{128}$", input$actual_sha512)) {
+        return("input-changed")
+    }
+    stop("changed input capture is inconsistent")
 }
 
 fertility_file_stat <- function(path) {
@@ -390,14 +422,33 @@ fertility_should_retry <- function(checkpoint) {
 }
 
 fertility_run_provenance_fields <- function() c(
-    "schema_version", "selection_id", "family_id", "family_manifest_id",
-    "framework_id", "config_id", "build_provenance_id", "inventory_id",
-    "report_schema_id", "selected_files", "expected_family_files",
+    "schema_version", "report_schema_version", "evidence_origin",
+    "source_corpus_schema_version", "replayed_at_utc", "selection_id",
+    "evidence_selection_id", "input_attestation_id", "family_id",
+    "family_manifest_id", "framework_id", "config_id", "build_provenance_id",
+    "inventory_id", "report_schema_id", "selected_files", "expected_family_files",
     "full_default_family", "program_filter", "release_filter", "id_filter",
     "max_files", "shard_index", "shard_count", "timeout_seconds",
     "chunk_rows", "column_batch", "memory_mib", "cell_budget",
     "max_tiles_per_batch", "beyond_end_windows", "retry", "created_at_utc"
 )
+
+fertility_snapshot_report_schema_version <- function(provenance) {
+    if (!is.data.frame(provenance) || !all(c(
+        "evidence_origin", "source_corpus_schema_version"
+    ) %in% names(provenance))) stop("shard evidence origin is unavailable")
+    origins <- unique(provenance$evidence_origin)
+    source_schemas <- unique(provenance$source_corpus_schema_version)
+    if (length(origins) != 1L || length(source_schemas) != 1L) {
+        stop("shard reports have mixed evidence origins")
+    }
+    if (identical(origins, "historical-schema-10-replay") &&
+        identical(source_schemas,
+                  as.character(fertility_legacy_corpus_schema_version))) {
+        return(fertility_legacy_report_schema_version)
+    }
+    fertility_report_schema_version
+}
 
 fertility_result_fields <- function(include_build = TRUE) {
     fields <- c(
@@ -409,16 +460,30 @@ fertility_result_fields <- function(include_build = TRUE) {
     if (include_build) c(fields, "build_provenance_id") else fields
 }
 
-fertility_report_schema_id <- function() {
+fertility_report_schema_id <- function(
+    report_schema_version = fertility_report_schema_version
+) {
+    report_schema_version <- as.integer(report_schema_version)
+    contract <- paste(
+        "hash,id,enum,manifest-release,enum,fixed-categories,count,",
+        "fixed-counts,fixed-category-pair-hashed-counts-v2,",
+        "optional-number,optional-count,count,",
+        "count,boolean,optional-number,hash", sep = ""
+    )
+    if (identical(report_schema_version, fertility_legacy_report_schema_version)) {
+        return(fertility_stable_id(list(
+            schema_version = fertility_legacy_corpus_schema_version,
+            fields = paste(fertility_result_fields(), collapse = ","),
+            contract = contract
+        )))
+    }
+    if (!identical(report_schema_version, fertility_report_schema_version)) {
+        stop("unsupported public report schema version")
+    }
     fertility_stable_id(list(
-        schema_version = fertility_schema_version,
+        report_schema_version = report_schema_version,
         fields = paste(fertility_result_fields(), collapse = ","),
-        contract = paste(
-            "hash,id,enum,manifest-release,enum,fixed-categories,count,",
-            "fixed-counts,fixed-category-pair-hashed-counts-v2,",
-            "optional-number,optional-count,count,",
-            "count,boolean,optional-number,hash", sep = ""
-        )
+        contract = contract
     ))
 }
 
@@ -610,10 +675,13 @@ fertility_validate_shard_bundles <- function(bundles, family_id,
     }, logical(1)))) stop("shard report provenance schema is invalid")
     provenance <- do.call(rbind, lapply(bundles, `[[`, "provenance"))
     hash_fields <- c(
-        "selection_id", "family_id", "family_manifest_id", "framework_id",
-        "config_id", "build_provenance_id", "inventory_id", "report_schema_id"
+        "selection_id", "evidence_selection_id", "input_attestation_id",
+        "family_id", "family_manifest_id", "framework_id", "config_id",
+        "build_provenance_id", "inventory_id", "report_schema_id"
     )
     if (any(provenance$schema_version != as.character(fertility_schema_version)) ||
+        any(provenance$report_schema_version !=
+            as.character(fertility_report_schema_version)) ||
         any(vapply(hash_fields, function(field) {
             any(!grepl("^[0-9a-f]{64}$", provenance[[field]]))
         }, logical(1))) || any(!provenance$retry %in% c("TRUE", "FALSE")) ||
@@ -621,9 +689,24 @@ fertility_validate_shard_bundles <- function(bundles, family_id,
                    provenance$created_at_utc))) {
         stop("shard report provenance contains an invalid scalar")
     }
+    origins <- provenance$evidence_origin
+    source_schemas <- provenance$source_corpus_schema_version
+    replayed <- provenance$replayed_at_utc
+    fresh <- origins == "fresh-execution"
+    historical <- origins == "historical-schema-10-replay"
+    timestamp <- "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$"
+    if (any(!(fresh | historical)) ||
+        any(fresh & (source_schemas != as.character(fertility_schema_version) |
+                     nzchar(replayed))) ||
+        any(historical & (
+            source_schemas != as.character(fertility_legacy_corpus_schema_version) |
+            !grepl(timestamp, replayed)
+        ))) stop("shard evidence-origin provenance contains a false claim")
     if (any(provenance$family_id != family_id)) stop("shard report family ID disagrees")
     stable_fields <- c(
-        "schema_version", "family_id", "family_manifest_id", "framework_id",
+        "schema_version", "report_schema_version", "evidence_origin",
+        "source_corpus_schema_version", "replayed_at_utc", "family_id",
+        "family_manifest_id", "framework_id",
         "config_id", "build_provenance_id", "inventory_id", "report_schema_id",
         "expected_family_files", "full_default_family", "program_filter",
         "release_filter", "id_filter", "max_files", "shard_count",
@@ -670,6 +753,29 @@ fertility_validate_shard_bundles <- function(bundles, family_id,
     if (!identical(full_default, fertility_full_default_family(options))) {
         stop("full-default provenance disagrees with filter provenance")
     }
+    if (identical(provenance$evidence_origin[[1L]],
+                  "historical-schema-10-replay")) {
+        replay_options <- fertility_parse_arguments(c(
+            "--shard-index=1", "--shard-count=8", "--timeout-seconds=600",
+            "--chunk-rows=50000", "--column-batch=32", "--memory-mib=1024",
+            "--cell-budget=10000000", "--max-tiles-per-batch=100000",
+            "--beyond-end-windows=1"
+        ))
+        exact_replay <- shard_count == 8L && full_default &&
+            identical(provenance$config_id[[1L]],
+                      fertility_tile_configuration(replay_options)$config_id) &&
+            all(provenance$retry == "FALSE") &&
+            identical(provenance$timeout_seconds[[1L]], "600") &&
+            identical(provenance$chunk_rows[[1L]], "50000") &&
+            identical(provenance$column_batch[[1L]], "32") &&
+            identical(provenance$memory_mib[[1L]], "1024") &&
+            identical(provenance$cell_budget[[1L]], "10000000") &&
+            identical(provenance$max_tiles_per_batch[[1L]], "100000") &&
+            identical(provenance$beyond_end_windows[[1L]], "1")
+        if (!isTRUE(exact_replay)) {
+            stop("historical schema-10 replay claim is not the exact eight-shard run")
+        }
+    }
     expected_family <- fertility_family_manifest(canonical, options)
     expected_family <- fertility_manifest_character(
         expected_family, c("id", "program", "level", "release", "shard_index")
@@ -688,7 +794,9 @@ fertility_validate_shard_bundles <- function(bundles, family_id,
     expected_family_id <- fertility_family_id_from_manifest(
         expected_family, provenance$framework_id[[1L]],
         provenance$config_id[[1L]], provenance$build_provenance_id[[1L]],
-        provenance$inventory_id[[1L]], shard_count, provenance$max_files[[1L]]
+        provenance$inventory_id[[1L]], shard_count, provenance$max_files[[1L]],
+        provenance$report_schema_id[[1L]], provenance$evidence_origin[[1L]],
+        as.integer(provenance$source_corpus_schema_version[[1L]])
     )
     if (!identical(family_id, expected_family_id)) {
         stop("family ID is not bound to the canonical manifest")
@@ -726,6 +834,16 @@ fertility_validate_shard_bundles <- function(bundles, family_id,
         ))
         if (!identical(provenance$selection_id[[index]], expected_selection_id)) {
             stop("shard selection identity disagrees with canonical membership")
+        }
+        expected_evidence_selection_id <- fertility_evidence_selection_id(
+            expected_selection_id, provenance$input_attestation_id[[index]],
+            provenance$evidence_origin[[index]],
+            as.integer(provenance$source_corpus_schema_version[[index]]),
+            provenance$report_schema_id[[index]]
+        )
+        if (!identical(provenance$evidence_selection_id[[index]],
+                       expected_evidence_selection_id)) {
+            stop("shard evidence selection identity is invalid")
         }
         bundles[[index]]$results <- results
     }
@@ -801,8 +919,10 @@ fertility_validate_canonical_inventory <- function(manifest, exact = FALSE) {
     values
 }
 
-fertility_framework_inventory <- function(snapshot_root, inventory = NULL,
-                                          framework_id = NULL) {
+fertility_framework_inventory <- function(
+    snapshot_root, inventory = NULL, framework_id = NULL,
+    report_schema_version = fertility_report_schema_version
+) {
     manifest_path <- file.path(snapshot_root, "inventory-manifest.tsv")
     provenance_path <- file.path(snapshot_root, "inventory-manifest-provenance.tsv")
     if (!file.exists(manifest_path) || !file.exists(provenance_path)) {
@@ -813,18 +933,31 @@ fertility_framework_inventory <- function(snapshot_root, inventory = NULL,
     manifest <- fertility_validate_canonical_inventory(manifest, exact = TRUE)
     provenance <- read.delim(provenance_path, colClasses = "character",
                              check.names = FALSE)
-    fields <- c("schema_version", "framework_id", "inventory_id",
-                "inventory_manifest_id", "report_schema_id", "files")
+    report_schema_version <- as.integer(report_schema_version)
+    legacy <- identical(report_schema_version, fertility_legacy_report_schema_version)
+    fields <- c(
+        "schema_version",
+        if (!legacy) "report_schema_version",
+        "framework_id", "inventory_id", "inventory_manifest_id",
+        "report_schema_id", "files"
+    )
+    corpus_schema_version <- if (legacy) fertility_legacy_corpus_schema_version else
+        fertility_schema_version
     if (nrow(provenance) != 1L || !identical(names(provenance), fields) ||
         !identical(provenance$schema_version[[1L]],
-                   as.character(fertility_schema_version)) ||
+                   as.character(corpus_schema_version)) ||
+        (!legacy && !identical(provenance$report_schema_version[[1L]],
+                               as.character(report_schema_version))) ||
         any(!grepl("^[0-9a-f]{64}$", unlist(provenance[c(
             "framework_id", "inventory_id", "inventory_manifest_id",
             "report_schema_id"
         )], use.names = FALSE))) ||
         !identical(provenance$inventory_manifest_id[[1L]],
-                   fertility_manifest_id(manifest)) ||
-        !identical(provenance$report_schema_id[[1L]], fertility_report_schema_id()) ||
+                   fertility_manifest_id(
+                       manifest, schema_version = corpus_schema_version
+                   )) ||
+        !identical(provenance$report_schema_id[[1L]],
+                   fertility_report_schema_id(report_schema_version)) ||
         !identical(provenance$files[[1L]], as.character(nrow(manifest)))) {
         stop("canonical inventory manifest provenance is invalid")
     }
@@ -873,6 +1006,7 @@ fertility_prepare_framework_snapshot <- function(script_dir, raw_root, framework
     manifest <- fertility_inventory_manifest(inventory)
     manifest_provenance <- data.frame(
         schema_version = fertility_schema_version,
+        report_schema_version = fertility_report_schema_version,
         framework_id = framework_id,
         inventory_id = fertility_inventory_id(inventory),
         inventory_manifest_id = fertility_manifest_id(manifest),
@@ -1074,16 +1208,428 @@ fertility_process_adaptive_range <- function(batch, skip, n_max, column_names,
     list(result)
 }
 
+fertility_recorded_result_valid <- function(
+    result, item, framework_id, configuration,
+    corpus_schema_version = fertility_schema_version
+) {
+    required <- c(
+        "schema_version", "framework_id", "config_id", "input_id", "id",
+        "program", "level", "release", "expected_sha512", "timeout_seconds",
+        "classification", "secondary_categories", "mismatch_count",
+        "mismatch_categories", "mismatch_signatures", "rows", "columns",
+        "tiles_expected", "tiles_completed", "complete", "actual_sha512",
+        "elapsed_seconds"
+    )
+    is.list(result) && setequal(names(result), required) &&
+        identical(result$schema_version, as.integer(corpus_schema_version)) &&
+        identical(result$framework_id, framework_id) &&
+        identical(result$config_id, configuration$config_id) &&
+        is.character(result$input_id) && length(result$input_id) == 1L &&
+        grepl("^[0-9a-f]{64}$", result$input_id) &&
+        identical(result$id, item$id) && identical(result$program, item$program) &&
+        identical(result$level, item$level) &&
+        identical(as.integer(result$release), as.integer(item$release)) &&
+        is.character(result$expected_sha512) && length(result$expected_sha512) == 1L &&
+        grepl("^([0-9a-f]{128})?$", result$expected_sha512) &&
+        ((is.character(result$actual_sha512) &&
+          length(result$actual_sha512) == 1L &&
+          grepl("^[0-9a-f]{128}$", result$actual_sha512)) ||
+         (is.na(result$actual_sha512) &&
+          identical(result$classification, "inventory-hash-error") &&
+          identical(result$secondary_categories, "hash-read-error"))) &&
+        identical(as.integer(result$timeout_seconds),
+                  as.integer(configuration$timeout_seconds)) &&
+        is.character(result$classification) && length(result$classification) == 1L &&
+        result$classification %in% fertility_classifications() &&
+        is.logical(result$complete) && length(result$complete) == 1L &&
+        !is.na(result$complete)
+}
+
+fertility_validate_recorded_input_attestation <- function(result) {
+    expected <- result$expected_sha512
+    actual <- result$actual_sha512
+    expected_valid <- is.character(expected) && length(expected) == 1L &&
+        grepl("^([0-9a-f]{128})?$", expected)
+    actual_missing <- length(actual) != 1L || is.na(actual)
+    actual_valid <- !actual_missing && is.character(actual) &&
+        grepl("^[0-9a-f]{128}$", actual)
+    input_id_valid <- is.character(result$input_id) && length(result$input_id) == 1L &&
+        grepl("^[0-9a-f]{64}$", result$input_id)
+    inventory_hash_error <- identical(
+        result$classification, "inventory-hash-error"
+    )
+    reasons <- c(
+        "hash-read-error", "signature-mismatch", "input-changed"
+    )
+    reason <- if (is.character(result$secondary_categories) &&
+                  length(result$secondary_categories) == 1L &&
+                  result$secondary_categories %in% reasons) {
+        result$secondary_categories
+    } else ""
+    valid_reason <- switch(
+        reason,
+        "hash-read-error" = actual_missing,
+        "signature-mismatch" = expected_valid && nzchar(expected) &&
+            actual_valid && !identical(actual, expected),
+        "input-changed" = expected_valid && actual_valid && input_id_valid,
+        expected_valid && actual_valid &&
+            (!nzchar(expected) || identical(actual, expected))
+    )
+    if (!identical(inventory_hash_error, nzchar(reason)) || !valid_reason) {
+        stop("recorded input preflight attestation is inconsistent")
+    }
+    invisible(TRUE)
+}
+
+fertility_validate_recorded_input_result <- function(result, tile_count) {
+    fertility_validate_recorded_input_attestation(result)
+    if (!identical(result$classification, "inventory-hash-error") ||
+        length(tile_count) != 1L || is.na(tile_count) || tile_count < 0L ||
+        !identical(as.integer(tile_count), tile_count) ||
+        (!identical(result$secondary_categories, "input-changed") &&
+         tile_count != 0L) ||
+        isTRUE(result$complete) || result$mismatch_count != 0L) {
+        stop("recorded input-validation result is inconsistent")
+    }
+    invisible(TRUE)
+}
+
+fertility_input_attestation_id <- function(results) {
+    if (!length(results)) return(fertility_stable_id(list(cases = "")))
+    ids <- vapply(results, `[[`, character(1), "id")
+    if (anyDuplicated(ids) || !identical(ids, sort(ids))) {
+        stop("input attestations are not in canonical case order")
+    }
+    commitments <- vapply(results, function(result) {
+        fertility_validate_recorded_input_attestation(result)
+        status <- if (identical(result$classification, "inventory-hash-error")) {
+            result$secondary_categories
+        } else if (nzchar(result$expected_sha512)) {
+            "verified-signature"
+        } else "verified-empty-expected"
+        fertility_stable_id(list(
+            id = result$id, input_id = result$input_id,
+            expected_sha512 = result$expected_sha512,
+            actual_sha512 = if (is.na(result$actual_sha512)) "" else
+                result$actual_sha512,
+            status = status
+        ))
+    }, character(1))
+    fertility_stable_id(list(
+        ids = paste(ids, collapse = ","),
+        commitments = paste(commitments, collapse = ",")
+    ))
+}
+
+fertility_evidence_selection_id <- function(
+    selection_id, input_attestation_id, evidence_origin,
+    source_corpus_schema_version, report_schema_id
+) {
+    fertility_stable_id(list(
+        selection_id = selection_id, input_attestation_id = input_attestation_id,
+        evidence_origin = evidence_origin,
+        source_corpus_schema_version = as.integer(source_corpus_schema_version),
+        report_schema_id = report_schema_id
+    ))
+}
+
+fertility_family_input_attestation_id <- function(provenance) {
+    if (!is.data.frame(provenance) || !all(c(
+        "shard_index", "input_attestation_id", "evidence_selection_id"
+    ) %in% names(provenance))) stop("family input attestation provenance is invalid")
+    indexes <- suppressWarnings(as.integer(provenance$shard_index))
+    ordering <- order(indexes)
+    if (anyNA(indexes) || !identical(indexes[ordering], seq_along(indexes))) {
+        stop("family input attestations are not in canonical shard order")
+    }
+    fertility_stable_id(list(
+        shard_indexes = paste(indexes[ordering], collapse = ","),
+        input_attestation_ids = paste(
+            provenance$input_attestation_id[ordering], collapse = ","
+        ),
+        evidence_selection_ids = paste(
+            provenance$evidence_selection_id[ordering], collapse = ","
+        )
+    ))
+}
+
+fertility_prepare_report_stages <- function(
+    items, create_stage, write_stage, remove_path, path_exists
+) {
+    stages <- list()
+    complete <- FALSE
+    on.exit(if (!complete) {
+        cleanup_ok <- TRUE
+        for (stage in rev(stages)) {
+            removed <- isTRUE(remove_path(stage$stage)) || !path_exists(stage$stage)
+            cleanup_ok <- cleanup_ok && removed
+        }
+        if (!cleanup_ok) warning("report staging cleanup did not remove every stage")
+    }, add = TRUE)
+    for (item in items) {
+        stage <- create_stage(item)
+        if (!is.list(stage) || is.null(stage$stage)) {
+            stop("could not create report stage")
+        }
+        stages[[length(stages) + 1L]] <- stage
+        if (!isTRUE(write_stage(stage, item))) stop("could not write report stage")
+    }
+    complete <- TRUE
+    stages
+}
+
+fertility_publish_pointer_transaction <- function(
+    stages, rename_path, write_pointer, remove_path, pointer_state, path_exists
+) {
+    renamed <- integer()
+    for (index in seq_along(stages)) {
+        if (!isTRUE(rename_path(stages[[index]]$stage, stages[[index]]$published))) {
+            for (rollback in rev(renamed)) remove_path(stages[[rollback]]$published)
+            if (any(vapply(stages[renamed], function(stage) {
+                path_exists(stage$published)
+            }, logical(1)))) stop("report bundle rename rollback failed")
+            stop("could not atomically publish every report bundle")
+        }
+        renamed <- c(renamed, index)
+    }
+    pointed <- integer()
+    pointer_failure <- FALSE
+    for (index in seq_along(stages)) {
+        if (!isTRUE(write_pointer(
+            stages[[index]]$parent, basename(stages[[index]]$published)
+        ))) {
+            pointer_failure <- TRUE
+            break
+        }
+        pointed <- c(pointed, index)
+    }
+    if (!pointer_failure) return(invisible(TRUE))
+    rollback_ok <- TRUE
+    for (index in rev(pointed)) {
+        stage <- stages[[index]]
+        restored <- if (is.na(stage$old_current)) {
+            isTRUE(remove_path(file.path(stage$parent, "CURRENT"))) ||
+                is.na(pointer_state(stage$parent))
+        } else isTRUE(write_pointer(stage$parent, stage$old_current))
+        rollback_ok <- rollback_ok && restored
+    }
+    for (index in rev(renamed)) {
+        removed <- isTRUE(remove_path(stages[[index]]$published)) ||
+            !path_exists(stages[[index]]$published)
+        rollback_ok <- rollback_ok && removed
+    }
+    states_ok <- vapply(stages, function(stage) {
+        identical(pointer_state(stage$parent), stage$old_current) &&
+            !path_exists(stage$published)
+    }, logical(1))
+    if (!rollback_ok || !all(states_ok)) {
+        stop("report publication rollback did not restore every prior state")
+    }
+    stop("could not atomically publish every republished shard pointer")
+}
+
+fertility_evidence_family_id <- function(
+    family_id, family_input_attestation_id, evidence_origin,
+    source_corpus_schema_version, report_schema_id
+) {
+    fertility_stable_id(list(
+        family_id = family_id,
+        family_input_attestation_id = family_input_attestation_id,
+        evidence_origin = evidence_origin,
+        source_corpus_schema_version = as.integer(source_corpus_schema_version),
+        report_schema_id = report_schema_id
+    ))
+}
+
+fertility_validate_recorded_tile <- function(
+    checkpoint, corpus_schema_version = fertility_schema_version,
+    allow_legacy_empty_reader_artifact = FALSE
+) {
+    explicit_corpus_schema <- !missing(corpus_schema_version)
+    common <- c(
+        "schema_version", "framework_id", "config_id", "input_id", "id",
+        "tile_id", "tile_type", "batch", "skip", "n_max", "column_hash",
+        "timeout_seconds", "classification", "secondary", "mismatches", "rows",
+        "reader_rows", "columns", "column_names", "storage", "structural_rows",
+        "column_bytes", "strl", "projection_expected_count",
+        "projection_expected_hash", "projection_counts", "projection_hashes",
+        "projection_ok", "elapsed_seconds"
+    )
+    sizing_extra <- c(
+        "program", "level", "release", "expected_sha512", "samples_requested",
+        "samples_completed", "payload_bytes_per_row", "chosen_rows",
+        "sample_offsets_hash"
+    )
+    if (!is.list(checkpoint) || !checkpoint$tile_type %in%
+        c("metadata", "value", "terminal", "sizing")) {
+        stop("recorded tile checkpoint schema is invalid")
+    }
+    expected <- c(common, if (identical(checkpoint$tile_type, "sizing")) sizing_extra)
+    if (!setequal(names(checkpoint), expected) ||
+        !identical(checkpoint$schema_version, as.integer(corpus_schema_version)) ||
+        !is.character(checkpoint$input_id) || length(checkpoint$input_id) != 1L ||
+        !grepl("^[0-9a-f]{64}$", checkpoint$input_id) ||
+        !is.character(checkpoint$classification) ||
+        length(checkpoint$classification) != 1L ||
+        !checkpoint$classification %in% c(
+            fertility_classifications(), "input-changed"
+        ) || !is.character(checkpoint$secondary) || anyNA(checkpoint$secondary)) {
+        stop("recorded tile checkpoint schema is invalid")
+    }
+    legacy_artifact <- checkpoint$secondary == "-reader-error"
+    legacy_artifact_allowed <- isTRUE(allow_legacy_empty_reader_artifact) &&
+        explicit_corpus_schema &&
+        identical(as.integer(corpus_schema_version),
+                  fertility_legacy_corpus_schema_version)
+    allowed_secondary <- c(
+        fertility_classifications(), fertility_mismatch_categories(),
+        "direct-reader-error", "rust-reader-error", "haven-reader-error",
+        "metadata-reader-error", "row-termination-mismatch"
+    )
+    if ((any(legacy_artifact) && !legacy_artifact_allowed) ||
+        any(!legacy_artifact & !checkpoint$secondary %in% allowed_secondary) ||
+        !is.data.frame(checkpoint$mismatches) ||
+        !identical(names(checkpoint$mismatches),
+                   c("category", "detail", "component", "pair"))) {
+        stop("recorded tile checkpoint contains malformed or non-canonical detail")
+    }
+    mismatches <- checkpoint$mismatches
+    if (nrow(mismatches) && (
+        any(!mismatches$category %in% fertility_mismatch_categories()) ||
+        anyNA(mismatches$detail) || !is.character(mismatches$detail) ||
+        any(!is.na(mismatches$component) &
+            (!is.finite(mismatches$component) | mismatches$component < 1)) ||
+        any(!is.na(mismatches$pair) & !mismatches$pair %in%
+            c("direct-rust", "direct-haven", "rust-haven"))
+    )) stop("recorded tile checkpoint contains malformed or non-canonical detail")
+    invisible(TRUE)
+}
+
+fertility_replay_file_tiles <- function(
+    item, file_root, framework_id, configuration, input,
+    corpus_schema_version = fertility_schema_version,
+    allow_legacy_empty_reader_artifact = FALSE
+) {
+    tile_root <- file.path(file_root, "tiles")
+    load_tile <- function(tile, path) {
+        checkpoint <- tryCatch(readRDS(path), error = function(error) NULL)
+        if (is.null(checkpoint)) stop("recorded tile checkpoint is absent or invalid")
+        fertility_validate_recorded_tile(
+            checkpoint, corpus_schema_version,
+            allow_legacy_empty_reader_artifact
+        )
+        if (!fertility_tile_checkpoint_valid(
+            checkpoint, item, tile, framework_id, configuration$config_id,
+            input$input_id, configuration$timeout_seconds,
+            corpus_schema_version = corpus_schema_version
+        )) stop("recorded tile checkpoint is absent or invalid")
+        checkpoint
+    }
+    metadata_tile <- fertility_metadata_tile()
+    metadata <- load_tile(metadata_tile, file.path(tile_root, "metadata.rds"))
+    tiles <- list(metadata)
+    column_names <- metadata$column_names
+    column_bytes <- metadata$column_bytes
+    batches <- fertility_structural_batches(
+        column_names, configuration$column_batch, column_bytes, metadata$columns
+    )
+    total_rows <- metadata$structural_rows
+    structurally_valid <- is.finite(total_rows) && total_rows >= 0 &&
+        identical(as.integer(metadata$columns), as.integer(length(column_names))) &&
+        length(column_bytes) == length(column_names)
+    planning_failure <- function(batch, detail) list(
+        schema_version = as.integer(corpus_schema_version), framework_id = framework_id,
+        id = item$id, tile_id = paste0("planning-", batch), tile_type = "planning",
+        batch = as.integer(batch), skip = 0, n_max = 0L,
+        classification = "unresolved", secondary = detail,
+        mismatches = data.frame(
+            category = "unresolved", detail = detail, component = NA_integer_,
+            pair = NA_character_, stringsAsFactors = FALSE
+        ), rows = NA_integer_, elapsed_seconds = 0
+    )
+    if (length(batches) && isTRUE(structurally_valid)) {
+        for (batch in seq_along(batches)) {
+            bytes <- fertility_batch_bytes(
+                batches[[batch]], column_names, column_bytes
+            )
+            rows_per_tile <- fertility_adaptive_rows(bytes, configuration)
+            is_strl_batch <- any(!is.finite(bytes))
+            if (is_strl_batch) {
+                sizing_tile <- fertility_sizing_tile(
+                    batch, batches[[batch]], total_rows,
+                    configuration$strl_sample_count
+                )
+                sizing <- load_tile(
+                    sizing_tile, file.path(tile_root, paste0(sizing_tile$tile_id, ".rds"))
+                )
+                expected_rows <- fertility_strl_rows(
+                    sizing$payload_bytes_per_row, length(sizing_tile$column_names),
+                    configuration
+                )
+                if (!identical(as.integer(sizing$chosen_rows), expected_rows)) {
+                    stop("recorded strL sizing checkpoint is inconsistent")
+                }
+                rows_per_tile <- expected_rows
+            }
+            reserved_probes <- if (batch == 1L)
+                configuration$beyond_end_windows else 0L
+            available_tiles <- configuration$max_tiles_per_batch - reserved_probes -
+                if (is_strl_batch) 1L else 0L
+            if (available_tiles < 1L) {
+                tiles[[length(tiles) + 1L]] <- planning_failure(
+                    batch, "tile-ceiling-reached"
+                )
+                next
+            }
+            plan <- fertility_plan_offsets(total_rows, rows_per_tile, available_tiles)
+            if (plan$ceiling) {
+                tiles[[length(tiles) + 1L]] <- planning_failure(
+                    batch, "tile-ceiling-reached"
+                )
+                next
+            }
+            split_budget <- new.env(parent = emptyenv())
+            split_budget$remaining <- as.integer(available_tiles - length(plan$offsets))
+            process <- function(tile) load_tile(
+                tile, file.path(tile_root, paste0(tile$tile_id, ".rds"))
+            )
+            for (offset in plan$offsets) {
+                requested <- if (total_rows == 0) 1L else as.integer(min(
+                    rows_per_tile, total_rows - offset
+                ))
+                tiles <- c(tiles, fertility_process_adaptive_range(
+                    batch, offset, requested, batches[[batch]], process, split_budget
+                ))
+            }
+            if (batch == 1L) for (probe in seq_len(configuration$beyond_end_windows)) {
+                tile <- fertility_value_tile(
+                    batch, total_rows + (probe - 1L), 1L, batches[[batch]],
+                    type = "terminal", probe = probe
+                )
+                tiles[[length(tiles) + 1L]] <- load_tile(
+                    tile, file.path(tile_root, paste0(tile$tile_id, ".rds"))
+                )
+            }
+        }
+    } else if (length(batches)) {
+        tiles[[length(tiles) + 1L]] <- planning_failure(
+            0L, "structural-metadata-unavailable"
+        )
+    }
+    list(tiles = tiles, batches = batches, total_rows = total_rows)
+}
+
 fertility_memory_error <- function(error) {
     grepl("vector memory exhausted|cannot allocate|memory limit|out of memory",
           conditionMessage(error), ignore.case = TRUE)
 }
 
-fertility_tile_checkpoint_valid <- function(checkpoint, item, tile, framework_id,
-                                              config_id, input_id,
-                                              timeout_seconds) {
+fertility_tile_checkpoint_valid <- function(
+    checkpoint, item, tile, framework_id, config_id, input_id, timeout_seconds,
+    corpus_schema_version = fertility_schema_version
+) {
     is.list(checkpoint) &&
-        identical(checkpoint$schema_version, fertility_schema_version) &&
+        identical(checkpoint$schema_version, as.integer(corpus_schema_version)) &&
         identical(checkpoint$framework_id, framework_id) &&
         identical(checkpoint$config_id, config_id) &&
         identical(checkpoint$input_id, input_id) &&
@@ -1145,11 +1691,14 @@ fertility_mismatch_summary <- function(tiles) {
         fertility_stable_id(list(signature = key))
     }, character(1))
     signature_order <- order(-as.integer(counts), signature_hashes)
-    categories <- sort(table(mismatches$category), decreasing = TRUE)
+    category_counts <- table(mismatches$category)
+    category_order <- order(-as.integer(category_counts), names(category_counts))
     list(
         count = as.integer(sum(counts)),
-        categories = paste(names(categories), as.integer(categories), sep = "=",
-                           collapse = ","),
+        categories = paste(
+            names(category_counts)[category_order],
+            as.integer(category_counts)[category_order], sep = "=", collapse = ","
+        ),
         signatures = paste(
             signature_hashes[signature_order], as.integer(counts)[signature_order],
             sep = "=", collapse = ","
@@ -1157,9 +1706,33 @@ fertility_mismatch_summary <- function(tiles) {
     )
 }
 
-fertility_aggregate_classification <- function(tiles, complete) {
+fertility_tile_secondary <- function(
+    tiles, allow_legacy_empty_reader_artifact = FALSE
+) {
+    values <- unlist(lapply(tiles, `[[`, "secondary"), use.names = FALSE)
+    artifact <- values == "-reader-error"
+    canonical_reader_errors <- c(
+        "direct-reader-error", "rust-reader-error", "haven-reader-error",
+        "metadata-reader-error"
+    )
+    malformed_reader_error <- grepl("reader-error", values, fixed = TRUE) &
+        !artifact & !values %in% canonical_reader_errors
+    if (any(malformed_reader_error)) {
+        stop("non-canonical reader-error category is not allowed")
+    }
+    if (any(artifact) && !isTRUE(allow_legacy_empty_reader_artifact)) {
+        stop("legacy empty-reader artifact is not allowed for current evidence")
+    }
+    values[!artifact]
+}
+
+fertility_aggregate_classification <- function(
+    tiles, complete, allow_legacy_empty_reader_artifact = FALSE
+) {
     classes <- vapply(tiles, `[[`, character(1), "classification")
-    secondary <- unique(unlist(lapply(tiles, `[[`, "secondary"), use.names = FALSE))
+    secondary <- unique(fertility_tile_secondary(
+        tiles, allow_legacy_empty_reader_artifact
+    ))
     if (any(classes == "input-changed")) return("inventory-hash-error")
     if (any(classes == "timeout")) return("timeout")
     if (any(classes == "memory-limit")) return("memory-limit")
@@ -1274,14 +1847,16 @@ fertility_file_result_valid <- function(result, item, framework_id,
                   as.integer(configuration$timeout_seconds))
 }
 
-fertility_tiled_result <- function(item, framework_id, configuration, input, tiles,
-                                    batches, total_rows) {
+fertility_tiled_result <- function(
+    item, framework_id, configuration, input, tiles, batches, total_rows,
+    allow_legacy_empty_reader_artifact = FALSE
+) {
     complete <- fertility_validate_tile_completeness(
         tiles, batches, total_rows, configuration
     )
     mismatch <- fertility_mismatch_summary(tiles)
     secondary <- sort(unique(c(
-        unlist(lapply(tiles, `[[`, "secondary"), use.names = FALSE),
+        fertility_tile_secondary(tiles, allow_legacy_empty_reader_artifact),
         unlist(lapply(tiles, function(tile) {
             if (is.data.frame(tile$mismatches)) tile$mismatches$category else character()
         }), use.names = FALSE)
@@ -1292,7 +1867,9 @@ fertility_tiled_result <- function(item, framework_id, configuration, input, til
         id = item$id, program = item$program, level = item$level,
         release = as.integer(item$release), expected_sha512 = item$expected_sha512,
         timeout_seconds = configuration$timeout_seconds,
-        classification = fertility_aggregate_classification(tiles, complete),
+        classification = fertility_aggregate_classification(
+            tiles, complete, allow_legacy_empty_reader_artifact
+        ),
         secondary_categories = paste(secondary, collapse = ","),
         mismatch_count = mismatch$count, mismatch_categories = mismatch$categories,
         mismatch_signatures = mismatch$signatures,

--- a/benchmarks/fertility-surveys/runner.R
+++ b/benchmarks/fertility-surveys/runner.R
@@ -838,6 +838,42 @@ fertility_merge_provenance_fields <- function() c(
     "full_default_family", "created_at_utc"
 )
 
+fertility_assessment_legacy_provenance_fields <- function() c(
+    "schema_version", "report_schema_version", "evidence_origin",
+    "source_corpus_schema_version", "replayed_at_utc", "family_id",
+    "evidence_family_id", "family_input_attestation_id", "framework_id",
+    "config_id", "build_provenance_id", "inventory_id", "family_manifest_id",
+    "report_schema_id", "shard_count", "files", "full_default_family",
+    "created_at_utc"
+)
+
+fertility_assessment_bundle_files <- function(format = c("current", "legacy-original")) {
+    format <- match.arg(format)
+    files <- c(
+        provenance = "merge-provenance.tsv", results = "results.tsv",
+        summary = "summary.tsv", family_manifest = "family-manifest.tsv"
+    )
+    if (identical(format, "current")) {
+        files <- c(files, input_attestation = "input-attestation.tsv")
+    }
+    files
+}
+
+fertility_assessment_bundle_format <- function(entries, role = c("original", "accepted")) {
+    role <- match.arg(role)
+    if (!is.character(entries) || anyNA(entries) || anyDuplicated(entries)) {
+        stop("assessment merged-family bundle shape is invalid")
+    }
+    entries <- sort(entries)
+    current <- sort(unname(fertility_assessment_bundle_files("current")))
+    legacy <- sort(unname(fertility_assessment_bundle_files("legacy-original")))
+    if (identical(entries, current)) return("current-merged-report-v2")
+    if (identical(role, "original") && identical(entries, legacy)) {
+        return("legacy-original-merged-report-v2")
+    }
+    stop("assessment merged-family bundle has an unsupported exact file set")
+}
+
 fertility_validate_merged_bundle <- function(bundle, family_id,
                                               canonical_inventory) {
     required <- c(
@@ -979,7 +1015,9 @@ fertility_validate_merged_bundle <- function(bundle, family_id,
         provenance = provenance, full_default = full_default,
         evidence_family_id = provenance$evidence_family_id[[1L]],
         family_input_attestation_id = provenance$family_input_attestation_id[[1L]],
-        merge_id = provenance$merge_id[[1L]]
+        merge_id = provenance$merge_id[[1L]],
+        source_format = "current-merged-report-v2",
+        source_id = provenance$merge_id[[1L]]
     )
 }
 
@@ -992,6 +1030,163 @@ fertility_manifest_character <- function(manifest, fields) {
     names(result) <- fields
     rownames(result) <- NULL
     result
+}
+
+fertility_validate_original_assessment_results <- function(results) {
+    unsupported <- results$release == "111"
+    supported_hash_errors <- results[
+        !unsupported & results$classification == "inventory-hash-error",
+        c("id", "secondary_categories"), drop = FALSE
+    ]
+    if (nrow(results) != fertility_expected_rows ||
+        !all(results$classification[unsupported] == "expected-unsupported-111") ||
+        any(results$classification[!unsupported] == "expected-unsupported-111") ||
+        any(unsupported & results$classification == "inventory-hash-error") ||
+        nrow(supported_hash_errors) != length(fertility_accepted_ids()) ||
+        !identical(supported_hash_errors$id, fertility_accepted_ids()) ||
+        !identical(supported_hash_errors$secondary_categories,
+                   rep("signature-mismatch", length(fertility_accepted_ids())))) {
+        stop("assessment original full family is not the preserved manifest-gated family")
+    }
+    invisible(TRUE)
+}
+
+fertility_assessment_legacy_source_identity <- function(
+    provenance, results, summary, family_manifest
+) {
+    provenance_fields <- fertility_assessment_legacy_provenance_fields()
+    provenance <- fertility_manifest_character(provenance, provenance_fields)
+    results <- fertility_manifest_character(results, fertility_result_fields())
+    summary <- fertility_manifest_character(summary, c("classification", "files"))
+    family_manifest <- fertility_manifest_character(
+        family_manifest, c("id", "program", "level", "release", "shard_index")
+    )
+    provenance_id <- fertility_manifest_id(
+        provenance, provenance_fields, fertility_schema_version
+    )
+    results_id <- fertility_merged_results_id(results)
+    summary_id <- fertility_manifest_id(
+        summary, c("classification", "files"), fertility_report_schema_version
+    )
+    family_manifest_id <- fertility_manifest_id(family_manifest)
+    source_id <- fertility_stable_id(list(
+        source_contract = "assessment-legacy-original-schema10-report2-four-file-v1",
+        provenance_id = provenance_id, results_id = results_id,
+        summary_id = summary_id, family_manifest_id = family_manifest_id
+    ))
+    list(
+        source_id = source_id, provenance_id = provenance_id,
+        results_id = results_id, summary_id = summary_id,
+        family_manifest_id = family_manifest_id
+    )
+}
+
+fertility_validate_assessment_legacy_original_bundle <- function(
+    bundle, family_id, canonical_inventory
+) {
+    required <- c("provenance", "results", "summary", "family_manifest")
+    if (!is.list(bundle) || !identical(sort(names(bundle)), sort(required)) ||
+        !all(vapply(bundle, is.data.frame, logical(1)))) {
+        stop("legacy assessment original bundle schema is invalid")
+    }
+    provenance <- fertility_manifest_character(
+        bundle$provenance, fertility_assessment_legacy_provenance_fields()
+    )
+    hash_fields <- c(
+        "family_id", "evidence_family_id", "family_input_attestation_id",
+        "framework_id", "config_id", "build_provenance_id", "inventory_id",
+        "family_manifest_id", "report_schema_id"
+    )
+    if (nrow(provenance) != 1L ||
+        !identical(provenance$family_id[[1L]], family_id) ||
+        any(vapply(hash_fields, function(field) {
+            !grepl("^[0-9a-f]{64}$", provenance[[field]][[1L]])
+        }, logical(1))) ||
+        !identical(provenance$schema_version[[1L]],
+                   as.character(fertility_schema_version)) ||
+        !identical(provenance$report_schema_version[[1L]],
+                   as.character(fertility_report_schema_version)) ||
+        !identical(provenance$evidence_origin[[1L]], "fresh-execution") ||
+        !identical(provenance$source_corpus_schema_version[[1L]],
+                   as.character(fertility_schema_version)) ||
+        nzchar(provenance$replayed_at_utc[[1L]]) ||
+        !identical(provenance$report_schema_id[[1L]], fertility_report_schema_id()) ||
+        !identical(provenance$shard_count[[1L]], "8") ||
+        !identical(provenance$files[[1L]],
+                   as.character(fertility_expected_rows)) ||
+        !identical(provenance$full_default_family[[1L]], "TRUE") ||
+        !grepl("^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$",
+               provenance$created_at_utc[[1L]])) {
+        stop("legacy assessment original provenance is invalid")
+    }
+    live_inventory_id <- fertility_inventory_id(canonical_inventory)
+    canonical <- fertility_validate_canonical_inventory(
+        fertility_inventory_manifest(canonical_inventory), exact = TRUE
+    )
+    if (!identical(provenance$inventory_id[[1L]], live_inventory_id)) {
+        stop("legacy assessment original does not match canonical inventory authority")
+    }
+    expected_manifest <- canonical
+    expected_manifest$shard_index <- fertility_shard_index(
+        expected_manifest$id, canonical$id, 8L
+    )
+    manifest <- fertility_manifest_character(
+        bundle$family_manifest,
+        c("id", "program", "level", "release", "shard_index")
+    )
+    expected_manifest <- fertility_manifest_character(expected_manifest, names(manifest))
+    if (!identical(manifest, expected_manifest) ||
+        !identical(fertility_manifest_id(manifest),
+                   provenance$family_manifest_id[[1L]])) {
+        stop("legacy assessment original family manifest is not canonical")
+    }
+    expected_family_id <- fertility_family_id_from_manifest(
+        manifest, provenance$framework_id[[1L]], provenance$config_id[[1L]],
+        provenance$build_provenance_id[[1L]], provenance$inventory_id[[1L]],
+        8L, Inf, provenance$report_schema_id[[1L]], "fresh-execution",
+        fertility_schema_version
+    )
+    if (!identical(family_id, expected_family_id)) {
+        stop("legacy assessment original family identity is invalid")
+    }
+    results <- fertility_manifest_character(bundle$results, fertility_result_fields())
+    fertility_validate_public_results(results)
+    if (nrow(results) != fertility_expected_rows ||
+        !identical(results[c("id", "program", "level", "release")],
+                   manifest[c("id", "program", "level", "release")]) ||
+        any(results$framework_id != provenance$framework_id[[1L]]) ||
+        any(results$build_provenance_id != provenance$build_provenance_id[[1L]])) {
+        stop("legacy assessment original results are not bound to family provenance")
+    }
+    fertility_validate_original_assessment_results(results)
+    summary <- fertility_manifest_character(
+        bundle$summary, c("classification", "files")
+    )
+    expected_summary <- fertility_manifest_character(
+        fertility_classification_summary(results), c("classification", "files")
+    )
+    if (!identical(summary, expected_summary)) {
+        stop("legacy assessment original classification summary is invalid")
+    }
+    expected_evidence <- fertility_evidence_family_id(
+        family_id, provenance$family_input_attestation_id[[1L]],
+        "fresh-execution", fertility_schema_version,
+        provenance$report_schema_id[[1L]]
+    )
+    if (!identical(provenance$evidence_family_id[[1L]], expected_evidence)) {
+        stop("legacy assessment original evidence family identity is invalid")
+    }
+    identity <- fertility_assessment_legacy_source_identity(
+        provenance, results, summary, manifest
+    )
+    list(
+        results = results, summary = summary, family_manifest = manifest,
+        input_attestation = NULL, provenance = provenance, full_default = TRUE,
+        evidence_family_id = provenance$evidence_family_id[[1L]],
+        family_input_attestation_id = provenance$family_input_attestation_id[[1L]],
+        merge_id = "", source_format = "legacy-original-merged-report-v2",
+        source_id = identity$source_id, source_content_ids = identity
+    )
 }
 
 fertility_validate_shard_bundles <- function(bundles, family_id,
@@ -1274,33 +1469,41 @@ fertility_validate_shard_bundles <- function(bundles, family_id,
 }
 
 fertility_validate_assessment_families <- function(full, accepted) {
-    required <- c("results", "provenance", "full_default", "evidence_family_id")
+    required <- c(
+        "results", "provenance", "full_default", "evidence_family_id",
+        "source_format", "source_id"
+    )
     if (!is.list(full) || !is.list(accepted) ||
-        !all(required %in% names(full)) || !all(required %in% names(accepted))) {
+        !all(required %in% names(full)) || !all(required %in% names(accepted)) ||
+        !full$source_format %in% c(
+            "current-merged-report-v2", "legacy-original-merged-report-v2"
+        ) || !identical(accepted$source_format, "current-merged-report-v2") ||
+        !grepl("^[0-9a-f]{64}$", full$source_id) ||
+        !grepl("^[0-9a-f]{64}$", accepted$source_id)) {
         stop("assessment family evidence is invalid")
     }
-    supported_hash_error_rows <- full$results[
-        full$results$release != "111" &
-            full$results$classification == "inventory-hash-error",
-        c("id", "secondary_categories"), drop = FALSE
-    ]
-    unsupported <- full$results$release == "111"
-    if (!isTRUE(full$full_default) || nrow(full$results) != fertility_expected_rows ||
-        !all(full$results$classification[unsupported] == "expected-unsupported-111") ||
-        any(full$results$classification[!unsupported] == "expected-unsupported-111") ||
-        any(unsupported & full$results$classification == "inventory-hash-error") ||
-        nrow(supported_hash_error_rows) != length(fertility_accepted_ids()) ||
-        !identical(supported_hash_error_rows$id, fertility_accepted_ids()) ||
-        !identical(supported_hash_error_rows$secondary_categories,
-                   rep("signature-mismatch", length(fertility_accepted_ids()))) ||
-        any(nzchar(full$provenance$acceptance_commitment_id))) {
+    fertility_validate_original_assessment_results(full$results)
+    original_acceptance <- intersect(
+        c("acceptance_authority", "acceptance_commitment_id",
+          "acceptance_artifact_sha256"), names(full$provenance)
+    )
+    if (!isTRUE(full$full_default) ||
+        (length(original_acceptance) && any(nzchar(unlist(
+            full$provenance[original_acceptance], use.names = FALSE
+        ))))) {
         stop("assessment original full family is not the preserved manifest-gated family")
     }
-    if (isTRUE(accepted$full_default) ||
-        !identical(accepted$results$id, fertility_accepted_ids()) ||
+    if (isTRUE(accepted$full_default) || !is.data.frame(accepted$input_attestation) ||
+        !identical(names(accepted$provenance), fertility_merge_provenance_fields()) ||
+        !identical(names(accepted$input_attestation), c(
+            "shard_index", "input_attestation_id", "evidence_selection_id"
+        )) || !identical(accepted$results$id, fertility_accepted_ids()) ||
         any(accepted$results$classification %in% c(
             "inventory-hash-error", "expected-unsupported-111"
-        )) || !all(nzchar(accepted$provenance$acceptance_commitment_id))) {
+        )) || !all(nzchar(accepted$provenance$acceptance_commitment_id)) ||
+        !all(accepted$provenance$acceptance_authority ==
+             fertility_acceptance_authority()) ||
+        !all(accepted$provenance$evidence_origin == "fresh-execution")) {
         stop("assessment accepted family is not valid explicit local evidence")
     }
     if (!identical(unique(full$provenance$inventory_id),

--- a/benchmarks/fertility-surveys/runner.R
+++ b/benchmarks/fertility-surveys/runner.R
@@ -400,7 +400,7 @@ fertility_output_terminal_classifications <- function() c(
     "pass", "direct-vs-rust-mismatch", "dtaparser-only-error",
     "haven-only-error", "shared-reader-error", "metadata-mismatch",
     "value-mismatch", "tag-mismatch", "date-mismatch", "encoding-mismatch",
-    "row-termination-mismatch"
+    "row-termination-mismatch", "known-intentional-divergence"
 )
 
 fertility_validate_full_output_results <- function(results) {

--- a/benchmarks/fertility-surveys/runner.R
+++ b/benchmarks/fertility-surveys/runner.R
@@ -4,7 +4,9 @@ fertility_legacy_corpus_schema_version <- 10L
 
 fertility_usage <- function() {
     paste(
-        "usage: run.R [--inventory-only] [--output-root=/absolute/path]",
+        "usage: run.R [--inventory-only]",
+        "(--cache-root=/absolute/path --manifest=/absolute/path |",
+        " --output-root=/absolute/path)",
         "[--program=a,b] [--release=113,118] [--id=F0001,F0002]",
         "[--encoding-override=F0001:ENCODING]",
         "[--shard-index=N --shard-count=N] [--max-files=N]",
@@ -93,15 +95,31 @@ fertility_parse_arguments <- function(arguments) {
         column_batch = 16L, memory_mib = 256L, cell_budget = 1000000L,
         max_tiles_per_batch = 100000L, beyond_end_windows = 1L,
         encoding_overrides = setNames(character(), character()),
-        accepted_current_hashes = "", output_root = "", retry = FALSE
+        accepted_current_hashes = "", cache_root = "", manifest = "",
+        output_root = "", retry = FALSE
     )
     seen_shard_index <- seen_shard_count <- FALSE
     seen_program <- FALSE
+    seen_cache_root <- seen_manifest <- FALSE
     encoding_override_values <- character()
     for (argument in arguments) {
         if (identical(argument, "--inventory-only")) options$inventory_only <- TRUE
         else if (identical(argument, "--retry")) options$retry <- TRUE
-        else if (startsWith(argument, "--output-root=")) {
+        else if (startsWith(argument, "--cache-root=")) {
+            if (seen_cache_root) stop("--cache-root may be supplied only once")
+            options$cache_root <- sub("^[^=]+=", "", argument)
+            seen_cache_root <- TRUE
+            if (!startsWith(options$cache_root, "/")) {
+                stop("--cache-root must be absolute")
+            }
+        } else if (startsWith(argument, "--manifest=")) {
+            if (seen_manifest) stop("--manifest may be supplied only once")
+            options$manifest <- sub("^[^=]+=", "", argument)
+            seen_manifest <- TRUE
+            if (!startsWith(options$manifest, "/")) {
+                stop("--manifest must be absolute")
+            }
+        } else if (startsWith(argument, "--output-root=")) {
             if (nzchar(options$output_root)) stop("--output-root may be supplied only once")
             options$output_root <- sub("^[^=]+=", "", argument)
             if (!startsWith(options$output_root, "/")) {
@@ -198,6 +216,36 @@ fertility_parse_arguments <- function(arguments) {
     if (options$beyond_end_windows > 8L) {
         stop("--beyond-end-windows must not exceed 8")
     }
+    options
+}
+
+fertility_validate_source_arguments <- function(options) {
+    raw_arguments <- c(cache_root = options$cache_root, manifest = options$manifest)
+    supplied_raw <- nzchar(raw_arguments)
+    if (fertility_output_requested(options)) {
+        if (any(supplied_raw)) {
+            stop("--cache-root and --manifest are invalid with --output-root")
+        }
+        return(options)
+    }
+    if (!all(supplied_raw)) {
+        stop("raw fertility mode requires explicit --cache-root and --manifest")
+    }
+    cache_root <- fertility_assert_canonical_components(
+        options$cache_root, "fertility cache root"
+    )
+    if (!dir.exists(cache_root) || fertility_path_is_symlink(cache_root)) {
+        stop("fertility cache root must be a canonical non-symlink directory")
+    }
+    manifest <- fertility_assert_canonical_components(
+        options$manifest, "fertility manifest"
+    )
+    if (!file.exists(manifest) || dir.exists(manifest) ||
+        fertility_path_is_symlink(manifest) || !isTRUE(file_test("-f", manifest))) {
+        stop("fertility manifest must be a canonical non-symlink regular file")
+    }
+    options$cache_root <- cache_root
+    options$manifest <- manifest
     options
 }
 

--- a/benchmarks/fertility-surveys/runner.R
+++ b/benchmarks/fertility-surveys/runner.R
@@ -459,7 +459,7 @@ fertility_capture_input <- function(item, acceptance = NULL) {
         error = function(error) NULL
     )
     if (is.null(captured)) {
-        device <- inode <- mode <- ""
+        device <- inode <- mode <- changed_ns <- ""
         size <- NA_character_
         modified <- NA_character_
         actual <- NA_character_
@@ -467,6 +467,7 @@ fertility_capture_input <- function(item, acceptance = NULL) {
         device <- captured$device
         inode <- captured$inode
         mode <- captured$mode
+        changed_ns <- captured$changed_ns
         size <- captured$size
         modified <- fertility_descriptor_timestamp(captured$modified_seconds)
         actual <- captured$sha512
@@ -476,7 +477,7 @@ fertility_capture_input <- function(item, acceptance = NULL) {
         id = item$id, release = as.integer(item$release),
         expected_sha512 = item$expected_sha512, hash_status = hash_status,
         actual_sha512 = if (is.na(actual)) "" else actual,
-        device = device, inode = inode, mode = mode,
+        device = device, inode = inode, mode = mode, changed_ns = changed_ns,
         size = size, modified = modified
     )
     accepted_sha512 <- ""

--- a/benchmarks/fertility-surveys/runner.R
+++ b/benchmarks/fertility-surveys/runner.R
@@ -435,9 +435,19 @@ fertility_validate_full_output_results <- function(results) {
         any(values$classification[supported] == "expected-unsupported-111")) {
         stop("full output family unsupported-release classifications are invalid")
     }
-    if (any(values$complete != "TRUE") ||
-        any(!(values$classification[supported] %in%
-              fertility_output_terminal_classifications()))) {
+    tiles_expected <- suppressWarnings(as.integer(values$tiles_expected))
+    tiles_completed <- suppressWarnings(as.integer(values$tiles_completed))
+    supported_terminal <- values$classification[supported] %in%
+        fertility_output_terminal_classifications()
+    supported_tiles_complete <- !is.na(tiles_expected[supported]) &
+        tiles_expected[supported] > 0L &
+        !is.na(tiles_completed[supported]) &
+        tiles_completed[supported] == tiles_expected[supported]
+    supported_pass_complete <- values$classification[supported] != "pass" |
+        values$complete[supported] == "TRUE"
+    if (any(values$complete[unsupported] != "TRUE") ||
+        any(!supported_terminal) || any(!supported_tiles_complete) ||
+        any(!supported_pass_complete)) {
         stop("full output family executable accounting is invalid")
     }
     invisible(TRUE)

--- a/benchmarks/fertility-surveys/runner.R
+++ b/benchmarks/fertility-surveys/runner.R
@@ -2482,7 +2482,7 @@ fertility_validate_recorded_tile <- function(
         fertility_classifications(), fertility_mismatch_categories(),
         "direct-reader-error", "rust-reader-error", "haven-reader-error",
         "metadata-reader-error", "row-termination-mismatch",
-        "structural-metadata-unavailable"
+        "structural-metadata-unavailable", "input-changed"
     )
     if ((any(legacy_artifact) && !legacy_artifact_allowed) ||
         any(!legacy_artifact & !checkpoint$secondary %in% allowed_secondary) ||
@@ -2492,6 +2492,13 @@ fertility_validate_recorded_tile <- function(
         stop("recorded tile checkpoint contains malformed or non-canonical detail")
     }
     mismatches <- checkpoint$mismatches
+    input_changed <- identical(checkpoint$classification, "input-changed")
+    input_changed_secondary <- any(checkpoint$secondary == "input-changed")
+    if ((input_changed && !identical(checkpoint$secondary, "input-changed")) ||
+        (!input_changed && input_changed_secondary) ||
+        (input_changed && nrow(mismatches))) {
+        stop("recorded tile checkpoint contains malformed or non-canonical detail")
+    }
     if (nrow(mismatches) && (
         any(!mismatches$category %in% fertility_mismatch_categories()) ||
         anyNA(mismatches$detail) || !is.character(mismatches$detail) ||
@@ -2650,10 +2657,19 @@ fertility_tile_checkpoint_valid <- function(
         identical(as.integer(checkpoint$timeout_seconds), as.integer(timeout_seconds))
 }
 
+fertility_mark_tile_input_changed <- function(result) {
+    result$classification <- "input-changed"
+    result$secondary <- "input-changed"
+    if (is.data.frame(result$mismatches)) {
+        result$mismatches <- result$mismatches[0L, , drop = FALSE]
+    }
+    result
+}
+
 fertility_tile_should_retry <- function(checkpoint) {
     checkpoint$classification %in% c(
         "timeout", "crash", "dtaparser-only-error", "haven-only-error",
-        "shared-reader-error", "memory-limit", "unresolved"
+        "shared-reader-error", "memory-limit", "unresolved", "input-changed"
     )
 }
 
@@ -3002,13 +3018,29 @@ fertility_tiled_result <- function(
     complete <- execution_complete && fertility_validate_tile_completeness(
         tiles, batches, total_rows, configuration
     )
-    mismatch <- fertility_mismatch_summary(tiles)
-    secondary <- sort(unique(c(
-        fertility_tile_secondary(tiles, allow_legacy_empty_reader_artifact),
-        unlist(lapply(tiles, function(tile) {
-            if (is.data.frame(tile$mismatches)) tile$mismatches$category else character()
-        }), use.names = FALSE)
-    )))
+    input_changed <- any(vapply(
+        tiles, function(tile) identical(tile$classification, "input-changed"),
+        logical(1)
+    ))
+    mismatch <- if (input_changed) {
+        list(count = 0L, categories = "", signatures = "")
+    } else {
+        fertility_mismatch_summary(tiles)
+    }
+    secondary <- if (input_changed) {
+        "input-changed"
+    } else {
+        sort(unique(c(
+            fertility_tile_secondary(tiles, allow_legacy_empty_reader_artifact),
+            unlist(lapply(tiles, function(tile) {
+                if (is.data.frame(tile$mismatches)) {
+                    tile$mismatches$category
+                } else {
+                    character()
+                }
+            }), use.names = FALSE)
+        )))
+    }
     c(list(
         schema_version = fertility_schema_version, framework_id = framework_id,
         config_id = configuration$config_id, input_id = input$input_id,

--- a/benchmarks/fertility-surveys/runner.R
+++ b/benchmarks/fertility-surveys/runner.R
@@ -1,0 +1,214 @@
+fertility_usage <- function() {
+    paste(
+        "usage: run.R [--inventory-only] [--program=a,b] [--release=113,118]",
+        "[--id=F0001,F0002] [--shard-index=N --shard-count=N] [--max-files=N]",
+        "[--timeout-seconds=N] [--retry]"
+    )
+}
+
+fertility_parse_positive_integer <- function(value, option) {
+    if (!grepl("^[1-9][0-9]*$", value)) stop(option, " must be a positive integer")
+    number <- as.double(value)
+    if (!is.finite(number) || number > .Machine$integer.max) stop(option, " is too large")
+    as.integer(number)
+}
+
+fertility_parse_arguments <- function(arguments) {
+    options <- list(
+        inventory_only = FALSE, programs = character(), releases = integer(),
+        ids = character(), shard_index = 1L, shard_count = 1L,
+        max_files = Inf, timeout_seconds = 600L, retry = FALSE
+    )
+    seen_shard_index <- seen_shard_count <- FALSE
+    for (argument in arguments) {
+        if (identical(argument, "--inventory-only")) options$inventory_only <- TRUE
+        else if (identical(argument, "--retry")) options$retry <- TRUE
+        else if (startsWith(argument, "--program=")) {
+            options$programs <- unique(strsplit(tolower(sub("^[^=]+=", "", argument)),
+                                                ",", fixed = TRUE)[[1L]])
+        } else if (startsWith(argument, "--release=")) {
+            values <- strsplit(sub("^[^=]+=", "", argument), ",", fixed = TRUE)[[1L]]
+            if (any(!grepl("^[0-9]+$", values))) stop("--release values must be integers")
+            options$releases <- unique(as.integer(values))
+        } else if (startsWith(argument, "--id=")) {
+            options$ids <- unique(strsplit(sub("^[^=]+=", "", argument),
+                                           ",", fixed = TRUE)[[1L]])
+            if (any(!grepl("^F[0-9]{4}$", options$ids))) stop("invalid --id value")
+        } else if (startsWith(argument, "--shard-index=")) {
+            options$shard_index <- fertility_parse_positive_integer(
+                sub("^[^=]+=", "", argument), "--shard-index"
+            )
+            seen_shard_index <- TRUE
+        } else if (startsWith(argument, "--shard-count=")) {
+            options$shard_count <- fertility_parse_positive_integer(
+                sub("^[^=]+=", "", argument), "--shard-count"
+            )
+            seen_shard_count <- TRUE
+        } else if (startsWith(argument, "--max-files=")) {
+            options$max_files <- fertility_parse_positive_integer(
+                sub("^[^=]+=", "", argument), "--max-files"
+            )
+        } else if (startsWith(argument, "--timeout-seconds=")) {
+            options$timeout_seconds <- fertility_parse_positive_integer(
+                sub("^[^=]+=", "", argument), "--timeout-seconds"
+            )
+        } else stop(fertility_usage())
+    }
+    if (xor(seen_shard_index, seen_shard_count)) {
+        stop("--shard-index and --shard-count must be supplied together")
+    }
+    if (options$shard_index > options$shard_count) {
+        stop("--shard-index must not exceed --shard-count")
+    }
+    options
+}
+
+fertility_filter_inventory <- function(inventory, options) {
+    selected <- inventory
+    if (length(options$programs)) {
+        if (length(setdiff(options$programs, unique(inventory$program)))) {
+            stop("unknown --program value")
+        }
+        selected <- selected[selected$program %in% options$programs, , drop = FALSE]
+    }
+    if (length(options$releases)) {
+        if (length(setdiff(options$releases, unique(inventory$release)))) {
+            stop("unknown --release value")
+        }
+        selected <- selected[selected$release %in% options$releases, , drop = FALSE]
+    }
+    if (length(options$ids)) {
+        if (length(setdiff(options$ids, inventory$id))) stop("unknown --id value")
+        selected <- selected[selected$id %in% options$ids, , drop = FALSE]
+    }
+    positions <- match(selected$id, inventory$id)
+    selected <- selected[((positions - 1L) %% options$shard_count) + 1L ==
+                             options$shard_index, , drop = FALSE]
+    if (is.finite(options$max_files) && nrow(selected) > options$max_files) {
+        selected <- selected[seq_len(options$max_files), , drop = FALSE]
+    }
+    selected
+}
+
+fertility_capture_input <- function(item) {
+    info <- file.info(item$path)
+    if (!nrow(info) || is.na(info$size[[1L]])) {
+        size <- NA_character_
+        modified <- NA_character_
+    } else {
+        size <- as.character(info$size[[1L]])
+        modified <- format(info$mtime[[1L]], "%Y-%m-%dT%H:%M:%OS6Z", tz = "UTC")
+    }
+    actual <- tryCatch(suppressWarnings(fertility_file_sha512(item$path)),
+                       error = function(error) NA_character_)
+    hash_status <- if (is.na(actual)) "error" else "ok"
+    identity <- fertility_stable_id(list(
+        id = item$id, release = as.integer(item$release),
+        expected_sha512 = item$expected_sha512, hash_status = hash_status,
+        actual_sha512 = if (is.na(actual)) "" else actual,
+        size = size, modified = modified
+    ))
+    list(input_id = identity, hash_status = hash_status,
+         actual_sha512 = actual, size = size, modified = modified)
+}
+
+fertility_checkpoint_valid <- function(checkpoint, item, framework_id,
+                                       input = NULL, timeout_seconds = NULL) {
+    valid <- is.list(checkpoint) &&
+        identical(checkpoint$schema_version, fertility_schema_version) &&
+        identical(checkpoint$framework_id, framework_id) &&
+        identical(checkpoint$id, item$id) &&
+        identical(checkpoint$expected_sha512, item$expected_sha512) &&
+        identical(as.integer(checkpoint$release), as.integer(item$release)) &&
+        !is.null(checkpoint$input_id) && !is.null(checkpoint$timeout_seconds)
+    if (valid && !is.null(timeout_seconds)) {
+        valid <- identical(as.integer(checkpoint$timeout_seconds),
+                           as.integer(timeout_seconds))
+    }
+    if (!valid || is.null(input)) return(valid)
+    identical(checkpoint$input_id, input$input_id)
+}
+
+fertility_checkpoint_input_current <- function(checkpoint, item) {
+    fertility_checkpoint_valid(
+        checkpoint, item, checkpoint$framework_id, fertility_capture_input(item),
+        checkpoint$timeout_seconds
+    )
+}
+
+fertility_base_result <- function(item, framework_id, timeout_seconds, input,
+                                  classification, elapsed_seconds = NA_real_) {
+    list(
+        schema_version = fertility_schema_version,
+        framework_id = framework_id, input_id = input$input_id,
+        id = item$id, program = item$program, level = item$level,
+        release = as.integer(item$release), expected_sha512 = item$expected_sha512,
+        timeout_seconds = timeout_seconds, classification = classification,
+        component = NA_integer_, rows = NA_real_, columns = NA_integer_,
+        actual_sha512 = input$actual_sha512, elapsed_seconds = elapsed_seconds
+    )
+}
+
+fertility_process_item <- function(item, checkpoint_path, framework_id,
+                                   timeout_seconds, retry, execute) {
+    input_before <- fertility_capture_input(item)
+    checkpoint <- if (file.exists(checkpoint_path)) tryCatch(
+        readRDS(checkpoint_path), error = function(error) NULL
+    ) else NULL
+    if (!is.null(checkpoint) &&
+        fertility_checkpoint_valid(
+            checkpoint, item, framework_id, input_before, timeout_seconds
+        ) &&
+        (!retry || !fertility_should_retry(checkpoint))) {
+        return(list(result = checkpoint, resumed = TRUE))
+    }
+    if (identical(input_before$hash_status, "error")) {
+        result <- fertility_base_result(
+            item, framework_id, timeout_seconds, input_before, "input-hash-error"
+        )
+    } else if (nzchar(item$expected_sha512) &&
+               !identical(input_before$actual_sha512,
+                          tolower(item$expected_sha512))) {
+        result <- fertility_base_result(
+            item, framework_id, timeout_seconds, input_before,
+            "input-signature-mismatch"
+        )
+    } else {
+        result <- execute(item, input_before)
+        input_after <- fertility_capture_input(item)
+        if (!identical(input_after$input_id, input_before$input_id)) {
+            result <- fertility_base_result(
+                item, framework_id, timeout_seconds, input_after,
+                "input-changed-during-subprocess"
+            )
+        } else {
+            result$input_id <- input_before$input_id
+            result$actual_sha512 <- input_before$actual_sha512
+        }
+    }
+    fertility_atomic_save_rds(result, checkpoint_path)
+    list(result = result, resumed = FALSE)
+}
+
+fertility_should_retry <- function(checkpoint) {
+    !(checkpoint$classification %in% c("match", "unsupported-release"))
+}
+
+fertility_result_frame <- function(checkpoints) {
+    fields <- c("framework_id", "id", "program", "level", "release",
+                "classification", "component", "rows", "columns",
+                "elapsed_seconds")
+    rows <- lapply(checkpoints, function(value) {
+        as.data.frame(value[fields], stringsAsFactors = FALSE, optional = TRUE)
+    })
+    result <- do.call(rbind, rows)
+    rownames(result) <- NULL
+    result
+}
+
+fertility_publish_results <- function(checkpoints, build_provenance_id, path) {
+    results <- fertility_result_frame(checkpoints)
+    results$build_provenance_id <- build_provenance_id
+    fertility_atomic_write_table(results, path)
+    results
+}

--- a/benchmarks/fertility-surveys/runner.R
+++ b/benchmarks/fertility-surveys/runner.R
@@ -316,8 +316,12 @@ fertility_manifest_id <- function(
     manifest, fields = names(manifest), schema_version = fertility_schema_version
 ) {
     if (!identical(names(manifest), fields)) stop("manifest schema is not canonical")
-    rows <- if (!nrow(manifest)) character() else apply(
-        manifest, 1L, function(row) paste(as.character(row), collapse = "\037")
+    text <- lapply(manifest, as.character)
+    rows <- if (!nrow(manifest)) character() else vapply(
+        seq_len(nrow(manifest)), function(index) {
+            paste(vapply(text, function(column) column[[index]], character(1L)),
+                  collapse = "\037")
+        }, character(1L)
     )
     fertility_stable_id(list(
         schema_version = as.integer(schema_version),
@@ -716,7 +720,7 @@ fertility_process_item <- function(item, checkpoint_path, framework_id,
 }
 
 fertility_should_retry <- function(checkpoint) {
-    !(checkpoint$classification %in% c("match", "unsupported-release"))
+    !(checkpoint$classification %in% c("match", "expected-unsupported-111"))
 }
 
 fertility_run_provenance_fields <- function() c(

--- a/benchmarks/fertility-surveys/runner.R
+++ b/benchmarks/fertility-surveys/runner.R
@@ -98,7 +98,7 @@ fertility_parse_arguments <- function(arguments) {
     options
 }
 
-fertility_filter_inventory <- function(inventory, options) {
+fertility_filter_inventory_base <- function(inventory, options) {
     selected <- inventory
     if (length(options$programs)) {
         if (length(setdiff(options$programs, unique(inventory$program)))) {
@@ -116,13 +116,150 @@ fertility_filter_inventory <- function(inventory, options) {
         if (length(setdiff(options$ids, inventory$id))) stop("unknown --id value")
         selected <- selected[selected$id %in% options$ids, , drop = FALSE]
     }
-    positions <- match(selected$id, inventory$id)
-    selected <- selected[((positions - 1L) %% options$shard_count) + 1L ==
-                             options$shard_index, , drop = FALSE]
+    selected
+}
+
+fertility_shard_index <- function(ids, inventory_ids, shard_count) {
+    positions <- match(ids, inventory_ids)
+    if (anyNA(positions)) stop("selection contains an unknown inventory ID")
+    ((positions - 1L) %% as.integer(shard_count)) + 1L
+}
+
+fertility_filter_inventory <- function(inventory, options) {
+    selected <- fertility_filter_inventory_base(inventory, options)
+    owners <- fertility_shard_index(selected$id, inventory$id, options$shard_count)
+    selected <- selected[owners == options$shard_index, , drop = FALSE]
     if (is.finite(options$max_files) && nrow(selected) > options$max_files) {
         selected <- selected[seq_len(options$max_files), , drop = FALSE]
     }
     selected
+}
+
+fertility_family_selection <- function(inventory, options) {
+    eligible <- fertility_filter_inventory_base(inventory, options)
+    pieces <- lapply(seq_len(options$shard_count), function(index) {
+        current <- eligible[fertility_shard_index(
+            eligible$id, inventory$id, options$shard_count
+        ) == index, , drop = FALSE]
+        if (is.finite(options$max_files) && nrow(current) > options$max_files) {
+            current <- current[seq_len(options$max_files), , drop = FALSE]
+        }
+        current
+    })
+    if (!length(pieces)) return(eligible[FALSE, , drop = FALSE])
+    result <- do.call(rbind, pieces)
+    result[order(match(result$id, inventory$id)), , drop = FALSE]
+}
+
+fertility_inventory_id <- function(inventory) {
+    fertility_stable_id(list(
+        ids = paste(inventory$id, collapse = ","),
+        programs = paste(inventory$program, collapse = ","),
+        levels = paste(inventory$level, collapse = ","),
+        releases = paste(inventory$release, collapse = ","),
+        signatures = paste(inventory$expected_sha512, collapse = ",")
+    ))
+}
+
+fertility_manifest_id <- function(manifest, fields = names(manifest)) {
+    if (!identical(names(manifest), fields)) stop("manifest schema is not canonical")
+    rows <- if (!nrow(manifest)) character() else apply(
+        manifest, 1L, function(row) paste(as.character(row), collapse = "\037")
+    )
+    fertility_stable_id(list(
+        schema_version = fertility_schema_version,
+        fields = paste(fields, collapse = ","),
+        rows = paste(rows, collapse = "\036")
+    ))
+}
+
+fertility_inventory_manifest <- function(inventory) {
+    manifest <- fertility_public_inventory(inventory)
+    manifest$release <- as.integer(manifest$release)
+    rownames(manifest) <- NULL
+    manifest
+}
+
+fertility_family_manifest <- function(inventory, options) {
+    family <- fertility_family_selection(inventory, options)
+    manifest <- fertility_public_inventory(family)
+    manifest$release <- as.integer(manifest$release)
+    manifest$shard_index <- fertility_shard_index(
+        manifest$id, inventory$id, options$shard_count
+    )
+    rownames(manifest) <- NULL
+    manifest
+}
+
+fertility_filter_spec <- function(options) {
+    list(
+        program_filter = paste(sort(options$programs), collapse = ","),
+        release_filter = paste(sort(options$releases), collapse = ","),
+        id_filter = paste(sort(options$ids), collapse = ","),
+        max_files = as.character(options$max_files)
+    )
+}
+
+fertility_options_from_filter_spec <- function(provenance) {
+    split_filter <- function(value, mode = "character") {
+        if (!nzchar(value)) return(if (mode == "integer") integer() else character())
+        pieces <- strsplit(value, ",", fixed = TRUE)[[1L]]
+        if (mode == "integer") {
+            if (any(!grepl("^[0-9]+$", pieces))) stop("invalid release filter provenance")
+            return(as.integer(pieces))
+        }
+        pieces
+    }
+    max_value <- provenance$max_files[[1L]]
+    max_files <- if (identical(max_value, "Inf")) Inf else {
+        if (!grepl("^[1-9][0-9]*$", max_value)) stop("invalid max-files provenance")
+        as.integer(max_value)
+    }
+    programs <- split_filter(provenance$program_filter[[1L]])
+    releases <- split_filter(provenance$release_filter[[1L]], "integer")
+    ids <- split_filter(provenance$id_filter[[1L]])
+    if (any(!programs %in% fertility_programs) ||
+        any(!grepl("^F[0-9]{4}$", ids)) || anyDuplicated(programs) ||
+        anyDuplicated(releases) || anyDuplicated(ids) ||
+        !identical(programs, sort(programs)) ||
+        !identical(releases, sort(releases)) || !identical(ids, sort(ids))) {
+        stop("filter provenance is not canonical")
+    }
+    shard_value <- provenance$shard_count[[1L]]
+    if (!grepl("^[1-9][0-9]*$", shard_value)) stop("invalid shard-count provenance")
+    shard_count <- suppressWarnings(as.integer(shard_value))
+    if (is.na(shard_count)) stop("invalid shard-count provenance")
+    list(
+        programs = programs, releases = releases, ids = ids,
+        shard_index = 1L, shard_count = shard_count, max_files = max_files
+    )
+}
+
+fertility_family_id_from_manifest <- function(
+    manifest, framework_id, config_id, build_provenance_id, inventory_id,
+    shard_count, max_files
+) {
+    fertility_stable_id(list(
+        framework_id = framework_id, config_id = config_id,
+        build_provenance_id = build_provenance_id,
+        inventory_id = inventory_id,
+        family_manifest_id = fertility_manifest_id(manifest),
+        shard_count = as.integer(shard_count), max_files = as.character(max_files)
+    ))
+}
+
+fertility_selection_family_id <- function(inventory, options, framework_id,
+                                          config_id, build_provenance_id) {
+    fertility_family_id_from_manifest(
+        fertility_family_manifest(inventory, options), framework_id, config_id,
+        build_provenance_id, fertility_inventory_id(inventory),
+        options$shard_count, options$max_files
+    )
+}
+
+fertility_full_default_family <- function(options) {
+    !length(options$programs) && !length(options$releases) &&
+        !length(options$ids) && !is.finite(options$max_files)
 }
 
 fertility_capture_input <- function(item) {
@@ -199,8 +336,11 @@ fertility_base_result <- function(item, framework_id, timeout_seconds, input,
         id = item$id, program = item$program, level = item$level,
         release = as.integer(item$release), expected_sha512 = item$expected_sha512,
         timeout_seconds = timeout_seconds, classification = classification,
-        component = NA_integer_, rows = NA_real_, columns = NA_integer_,
-        actual_sha512 = input$actual_sha512, elapsed_seconds = elapsed_seconds
+        component = NA_integer_, secondary_categories = "", mismatch_count = 0L,
+        mismatch_categories = "", mismatch_signatures = "", rows = NA_real_,
+        columns = NA_integer_, tiles_expected = 0L, tiles_completed = 0L,
+        complete = FALSE, actual_sha512 = input$actual_sha512,
+        elapsed_seconds = elapsed_seconds
     )
 }
 
@@ -219,14 +359,14 @@ fertility_process_item <- function(item, checkpoint_path, framework_id,
     }
     if (identical(input_before$hash_status, "error")) {
         result <- fertility_base_result(
-            item, framework_id, timeout_seconds, input_before, "input-hash-error"
+            item, framework_id, timeout_seconds, input_before, "inventory-hash-error"
         )
     } else if (nzchar(item$expected_sha512) &&
                !identical(input_before$actual_sha512,
                           tolower(item$expected_sha512))) {
         result <- fertility_base_result(
             item, framework_id, timeout_seconds, input_before,
-            "input-signature-mismatch"
+            "inventory-hash-error"
         )
     } else {
         result <- execute(item, input_before)
@@ -249,29 +389,525 @@ fertility_should_retry <- function(checkpoint) {
     !(checkpoint$classification %in% c("match", "unsupported-release"))
 }
 
-fertility_result_frame <- function(checkpoints) {
+fertility_run_provenance_fields <- function() c(
+    "schema_version", "selection_id", "family_id", "family_manifest_id",
+    "framework_id", "config_id", "build_provenance_id", "inventory_id",
+    "report_schema_id", "selected_files", "expected_family_files",
+    "full_default_family", "program_filter", "release_filter", "id_filter",
+    "max_files", "shard_index", "shard_count", "timeout_seconds",
+    "chunk_rows", "column_batch", "memory_mib", "cell_budget",
+    "max_tiles_per_batch", "beyond_end_windows", "retry", "created_at_utc"
+)
+
+fertility_result_fields <- function(include_build = TRUE) {
     fields <- c(
         "framework_id", "id", "program", "level", "release", "classification",
         "secondary_categories", "mismatch_count", "mismatch_categories",
         "mismatch_signatures", "rows", "columns", "tiles_expected",
         "tiles_completed", "complete", "elapsed_seconds"
     )
-    rows <- lapply(checkpoints, function(value) {
-        row <- setNames(lapply(fields, function(field) {
-            if (is.null(value[[field]])) NA else value[[field]]
-        }), fields)
-        as.data.frame(row, stringsAsFactors = FALSE, optional = TRUE)
-    })
-    result <- do.call(rbind, rows)
+    if (include_build) c(fields, "build_provenance_id") else fields
+}
+
+fertility_report_schema_id <- function() {
+    fertility_stable_id(list(
+        schema_version = fertility_schema_version,
+        fields = paste(fertility_result_fields(), collapse = ","),
+        contract = paste(
+            "hash,id,enum,manifest-release,enum,fixed-categories,count,",
+            "fixed-counts,fixed-category-pair-hashed-counts-v2,",
+            "optional-number,optional-count,count,",
+            "count,boolean,optional-number,hash", sep = ""
+        )
+    ))
+}
+
+fertility_result_frame <- function(checkpoints) {
+    fields <- fertility_result_fields(include_build = FALSE)
+    character_fields <- c(
+        "framework_id", "id", "program", "level", "classification",
+        "secondary_categories", "mismatch_categories", "mismatch_signatures"
+    )
+    integer_fields <- c(
+        "release", "mismatch_count", "columns", "tiles_expected", "tiles_completed"
+    )
+    numeric_fields <- c("rows", "elapsed_seconds")
+    coerce_field <- function(value, field) {
+        if (is.null(value) || length(value) != 1L) value <- NA
+        if (field %in% character_fields) return(as.character(value))
+        if (field %in% integer_fields) return(as.integer(value))
+        if (field %in% numeric_fields) return(as.double(value))
+        if (identical(field, "complete")) return(as.logical(value))
+        stop("unknown public result field")
+    }
+    columns <- setNames(lapply(fields, function(field) {
+        if (!length(checkpoints)) return(coerce_field(NULL, field)[FALSE])
+        vapply(checkpoints, function(value) coerce_field(value[[field]], field),
+               coerce_field(NULL, field))
+    }), fields)
+    result <- as.data.frame(columns, stringsAsFactors = FALSE, optional = TRUE)
     rownames(result) <- NULL
     result
 }
 
+fertility_classifications <- function() c(
+    "pass", "expected-unsupported-111", "inventory-hash-error",
+    "direct-vs-rust-mismatch", "dtaparser-only-error", "haven-only-error",
+    "shared-reader-error", "metadata-mismatch", "value-mismatch", "tag-mismatch",
+    "date-mismatch", "encoding-mismatch", "row-termination-mismatch",
+    "known-intentional-divergence", "timeout", "memory-limit", "crash", "unresolved"
+)
+
+fertility_mismatch_categories <- function() c(
+    "metadata-mismatch", "value-mismatch", "tag-mismatch", "date-mismatch",
+    "encoding-mismatch", "row-termination-mismatch", "direct-vs-rust-mismatch",
+    "known-intentional-divergence", "unresolved"
+)
+
+fertility_validate_public_results <- function(results) {
+    if (!is.data.frame(results) ||
+        !identical(names(results), fertility_result_fields())) {
+        stop("result report schema is not the exact public schema")
+    }
+    if (any(vapply(results, function(value) {
+        is.factor(value) || is.list(value) || !is.atomic(value) || !is.null(dim(value))
+    }, logical(1)))) stop("result report contains an invalid column type")
+    character_fields <- c(
+        "framework_id", "id", "program", "level", "classification",
+        "secondary_categories", "mismatch_categories", "mismatch_signatures",
+        "build_provenance_id"
+    )
+    numeric_fields <- c(
+        "release", "mismatch_count", "rows", "columns", "tiles_expected",
+        "tiles_completed", "elapsed_seconds"
+    )
+    if (any(vapply(character_fields, function(field) {
+        !is.character(results[[field]])
+    }, logical(1))) || any(vapply(numeric_fields, function(field) {
+        !(is.character(results[[field]]) || is.integer(results[[field]]) ||
+          is.double(results[[field]]))
+    }, logical(1))) || !(is.character(results$complete) || is.logical(results$complete))) {
+        stop("result report contains an invalid column type")
+    }
+    if (!nrow(results)) return(invisible(TRUE))
+    values <- lapply(results, function(value) {
+        value <- as.character(value)
+        value[is.na(value)] <- ""
+        value
+    })
+    if (any(!grepl("^[0-9a-f]{64}$", values$framework_id)) ||
+        any(!grepl("^[0-9a-f]{64}$", values$build_provenance_id)) ||
+        any(!grepl("^F[0-9]{4}$", values$id)) ||
+        any(!values$program %in% fertility_programs) ||
+        any(!values$level %in% fertility_levels) ||
+        any(!grepl("^[1-9][0-9]*$", values$release)) ||
+        any(!values$classification %in% fertility_classifications()) ||
+        any(!values$complete %in% c("TRUE", "FALSE"))) {
+        stop("result report contains an invalid scalar")
+    }
+    integer_required <- c("mismatch_count", "tiles_expected", "tiles_completed")
+    integer_optional <- "columns"
+    number_optional <- c("rows", "elapsed_seconds")
+    if (any(vapply(integer_required, function(field) {
+        any(!grepl("^(0|[1-9][0-9]*)$", values[[field]]))
+    }, logical(1))) || any(vapply(integer_optional, function(field) {
+        any(nzchar(values[[field]]) &
+            !grepl("^(0|[1-9][0-9]*)$", values[[field]]))
+    }, logical(1))) || any(vapply(number_optional, function(field) {
+        any(nzchar(values[[field]]) &
+            !grepl("^[0-9]+([.][0-9]+)?([eE][+-]?[0-9]+)?$", values[[field]]))
+    }, logical(1)))) stop("result report contains an invalid numeric scalar")
+    if (any(as.double(values$tiles_completed) > as.double(values$tiles_expected))) {
+        stop("result report contains inconsistent tile accounting")
+    }
+    allowed_secondary <- unique(c(
+        fertility_classifications(), fertility_mismatch_categories(),
+        "direct-reader-error", "rust-reader-error", "haven-reader-error",
+        "metadata-reader-error", "hash-read-error", "signature-mismatch",
+        "input-changed", "tile-ceiling-reached",
+        "structural-metadata-unavailable"
+    ))
+    secondary_ok <- vapply(values$secondary_categories, function(value) {
+        if (!nzchar(value)) return(TRUE)
+        pieces <- strsplit(value, ",", fixed = TRUE)[[1L]]
+        all(pieces %in% allowed_secondary) && !anyDuplicated(pieces) &&
+            identical(pieces, sort(pieces))
+    }, logical(1))
+    parse_count_map <- function(value, key_pattern, allowed_keys = NULL) {
+        if (!nzchar(value)) return(list(keys = character(), counts = integer()))
+        pieces <- strsplit(value, ",", fixed = TRUE)[[1L]]
+        if (any(!grepl(paste0("^", key_pattern, "=[1-9][0-9]*$"), pieces))) {
+            return(NULL)
+        }
+        keys <- sub("=[0-9]+$", "", pieces)
+        counts <- suppressWarnings(as.integer(sub("^.*=", "", pieces)))
+        if (anyNA(counts) || anyDuplicated(keys) ||
+            (!is.null(allowed_keys) && any(!keys %in% allowed_keys)) ||
+            !identical(order(-counts, keys), seq_along(keys))) return(NULL)
+        list(keys = keys, counts = counts)
+    }
+    categories <- lapply(values$mismatch_categories, parse_count_map,
+                         key_pattern = "[a-z0-9-]+",
+                         allowed_keys = fertility_mismatch_categories())
+    signatures <- lapply(values$mismatch_signatures, parse_count_map,
+                         key_pattern = "[0-9a-f]{64}")
+    aggregate_ok <- vapply(seq_len(nrow(results)), function(index) {
+        if (is.null(categories[[index]]) || is.null(signatures[[index]])) return(FALSE)
+        expected <- as.integer(values$mismatch_count[[index]])
+        category_total <- sum(categories[[index]]$counts)
+        signature_total <- sum(signatures[[index]]$counts)
+        identical(category_total, expected) && identical(signature_total, expected) &&
+            identical(expected == 0L,
+                      !nzchar(values$mismatch_categories[[index]])) &&
+            identical(expected == 0L,
+                      !nzchar(values$mismatch_signatures[[index]]))
+    }, logical(1))
+    if (!all(secondary_ok) || !all(aggregate_ok)) {
+        stop("result report contains non-public mismatch detail or inconsistent counts")
+    }
+    invisible(TRUE)
+}
+
+fertility_classification_summary <- function(results) {
+    if (!nrow(results)) {
+        return(data.frame(classification = character(), files = integer(),
+                          stringsAsFactors = FALSE))
+    }
+    summary <- as.data.frame(table(classification = results$classification),
+                             stringsAsFactors = FALSE)
+    names(summary)[[2L]] <- "files"
+    summary
+}
+
 fertility_publish_results <- function(checkpoints, build_provenance_id, path) {
     results <- fertility_result_frame(checkpoints)
-    results$build_provenance_id <- build_provenance_id
+    results$build_provenance_id <- rep(build_provenance_id, nrow(results))
+    fertility_validate_public_results(results)
     fertility_atomic_write_table(results, path)
     results
+}
+
+fertility_manifest_character <- function(manifest, fields) {
+    if (!is.data.frame(manifest) || !identical(names(manifest), fields)) {
+        stop("manifest schema is not canonical")
+    }
+    result <- as.data.frame(lapply(manifest, as.character), stringsAsFactors = FALSE,
+                            optional = TRUE)
+    names(result) <- fields
+    rownames(result) <- NULL
+    result
+}
+
+fertility_validate_shard_bundles <- function(bundles, family_id,
+                                               canonical_inventory) {
+    if (!length(bundles)) stop("no current shard reports found for family ID")
+    required <- fertility_run_provenance_fields()
+    if (any(vapply(bundles, function(bundle) {
+        !is.list(bundle) || !is.data.frame(bundle$provenance) ||
+            nrow(bundle$provenance) != 1L ||
+            !identical(names(bundle$provenance), required) ||
+            !is.data.frame(bundle$results) || !is.data.frame(bundle$family_manifest)
+    }, logical(1)))) stop("shard report provenance schema is invalid")
+    provenance <- do.call(rbind, lapply(bundles, `[[`, "provenance"))
+    hash_fields <- c(
+        "selection_id", "family_id", "family_manifest_id", "framework_id",
+        "config_id", "build_provenance_id", "inventory_id", "report_schema_id"
+    )
+    if (any(provenance$schema_version != as.character(fertility_schema_version)) ||
+        any(vapply(hash_fields, function(field) {
+            any(!grepl("^[0-9a-f]{64}$", provenance[[field]]))
+        }, logical(1))) || any(!provenance$retry %in% c("TRUE", "FALSE")) ||
+        any(!grepl("^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$",
+                   provenance$created_at_utc))) {
+        stop("shard report provenance contains an invalid scalar")
+    }
+    if (any(provenance$family_id != family_id)) stop("shard report family ID disagrees")
+    stable_fields <- c(
+        "schema_version", "family_id", "family_manifest_id", "framework_id",
+        "config_id", "build_provenance_id", "inventory_id", "report_schema_id",
+        "expected_family_files", "full_default_family", "program_filter",
+        "release_filter", "id_filter", "max_files", "shard_count",
+        "timeout_seconds", "chunk_rows", "column_batch", "memory_mib",
+        "cell_budget", "max_tiles_per_batch", "beyond_end_windows"
+    )
+    for (field in stable_fields) {
+        if (length(unique(provenance[[field]])) != 1L) {
+            stop("shard reports do not share identical framework/config/build/inventory")
+        }
+    }
+    if (!identical(provenance$report_schema_id[[1L]], fertility_report_schema_id())) {
+        stop("shard report schema identity is invalid")
+    }
+    boolean <- provenance$full_default_family[[1L]]
+    if (!boolean %in% c("TRUE", "FALSE")) stop("invalid full-default provenance")
+    full_default <- identical(boolean, "TRUE")
+    integer_field <- function(field, positive = FALSE) {
+        text <- provenance[[field]]
+        pattern <- if (positive) "^[1-9][0-9]*$" else "^(0|[1-9][0-9]*)$"
+        values <- suppressWarnings(as.integer(text))
+        if (any(!grepl(pattern, text)) || anyNA(values)) {
+            stop("invalid shard report accounting")
+        }
+        values
+    }
+    shard_count <- integer_field("shard_count", positive = TRUE)[[1L]]
+    shard_indexes <- integer_field("shard_index", positive = TRUE)
+    for (field in c("selected_files", "expected_family_files")) integer_field(field)
+    for (field in c(
+        "timeout_seconds", "chunk_rows", "column_batch", "memory_mib",
+        "cell_budget", "max_tiles_per_batch", "beyond_end_windows"
+    )) integer_field(field, positive = TRUE)
+    if (shard_count < 1L || length(shard_indexes) != shard_count ||
+        !identical(sort(shard_indexes), seq_len(shard_count))) {
+        stop("shard reports do not contain every shard index exactly once")
+    }
+    ordering <- order(shard_indexes)
+    bundles <- bundles[ordering]
+    provenance <- provenance[ordering, , drop = FALSE]
+    shard_indexes <- shard_indexes[ordering]
+    canonical <- fertility_validate_canonical_inventory(canonical_inventory)
+    options <- fertility_options_from_filter_spec(provenance[1L, , drop = FALSE])
+    if (!identical(full_default, fertility_full_default_family(options))) {
+        stop("full-default provenance disagrees with filter provenance")
+    }
+    expected_family <- fertility_family_manifest(canonical, options)
+    expected_family <- fertility_manifest_character(
+        expected_family, c("id", "program", "level", "release", "shard_index")
+    )
+    manifests <- lapply(bundles, function(bundle) fertility_manifest_character(
+        bundle$family_manifest,
+        c("id", "program", "level", "release", "shard_index")
+    ))
+    for (manifest in manifests) {
+        if (!identical(manifest, expected_family) ||
+            !identical(fertility_manifest_id(manifest),
+                       provenance$family_manifest_id[[1L]])) {
+            stop("shard family manifest is not canonical")
+        }
+    }
+    expected_family_id <- fertility_family_id_from_manifest(
+        expected_family, provenance$framework_id[[1L]],
+        provenance$config_id[[1L]], provenance$build_provenance_id[[1L]],
+        provenance$inventory_id[[1L]], shard_count, provenance$max_files[[1L]]
+    )
+    if (!identical(family_id, expected_family_id)) {
+        stop("family ID is not bound to the canonical manifest")
+    }
+    expected_files <- integer_field("expected_family_files")[[1L]]
+    if (nrow(expected_family) != expected_files) {
+        stop("family manifest count disagrees with provenance")
+    }
+    selected_files <- integer_field("selected_files")
+    if (anyDuplicated(provenance$selection_id)) stop("duplicate shard selection report")
+    for (index in seq_along(bundles)) {
+        results <- fertility_manifest_character(
+            bundles[[index]]$results, fertility_result_fields()
+        )
+        fertility_validate_public_results(results)
+        expected <- expected_family[
+            expected_family$shard_index == as.character(shard_indexes[[index]]),
+            c("id", "program", "level", "release"), drop = FALSE
+        ]
+        rownames(expected) <- NULL
+        if (nrow(results) != selected_files[[index]] || nrow(results) != nrow(expected)) {
+            stop("shard result count disagrees with canonical selection")
+        }
+        if (!identical(results[c("id", "program", "level", "release")], expected)) {
+            stop("shard results do not match canonical family membership")
+        }
+        if (nrow(results) && (
+            any(results$framework_id != provenance$framework_id[[index]]) ||
+            any(results$build_provenance_id !=
+                provenance$build_provenance_id[[index]])
+        )) stop("shard result provenance disagrees with its bundle")
+        expected_selection_id <- fertility_stable_id(list(
+            family_id = family_id, shard_index = shard_indexes[[index]],
+            selected_ids = paste(expected$id, collapse = ",")
+        ))
+        if (!identical(provenance$selection_id[[index]], expected_selection_id)) {
+            stop("shard selection identity disagrees with canonical membership")
+        }
+        bundles[[index]]$results <- results
+    }
+    results <- do.call(rbind, lapply(bundles, `[[`, "results"))
+    results <- results[order(match(results$id, expected_family$id)), , drop = FALSE]
+    rownames(results) <- NULL
+    if (anyDuplicated(results$id) || nrow(results) != expected_files ||
+        !identical(results[c("id", "program", "level", "release")],
+                   expected_family[c("id", "program", "level", "release")])) {
+        stop("shard reports do not provide exact family accounting")
+    }
+    if (full_default) {
+        if (!identical(results$id, sprintf("F%04d", seq_len(fertility_expected_rows)))) {
+            stop("full corpus IDs are not exactly F0001 through F1004")
+        }
+        release_counts <- table(factor(
+            as.integer(results$release), levels = as.integer(names(fertility_expected_releases))
+        ))
+        if (!identical(as.integer(release_counts),
+                       as.integer(fertility_expected_releases))) {
+            stop("full corpus release counts are invalid")
+        }
+        unsupported <- results$release == "111"
+        if (!all(results$classification[unsupported] == "expected-unsupported-111")) {
+            stop("release 111 classifications are invalid")
+        }
+        supported <- !unsupported
+        hash_errors <- results$classification[supported] == "inventory-hash-error"
+        if (sum(hash_errors) != 5L || sum(!hash_errors) != 869L ||
+            any(results$classification[supported] == "expected-unsupported-111")) {
+            stop("supported corpus executable accounting is invalid")
+        }
+    }
+    list(results = results, provenance = provenance, shard_count = shard_count,
+         full_default = full_default, family_manifest = expected_family)
+}
+
+fertility_framework_id <- function(provenance_id, datasigs_path) {
+    datasigs_sha256 <- tolower(as.character(openssl::sha256(file(datasigs_path))))
+    fertility_stable_id(list(
+        schema_version = fertility_schema_version,
+        provenance_id = provenance_id,
+        datasigs_sha256 = datasigs_sha256,
+        comparator_tolerance = "1e-7"
+    ))
+}
+
+fertility_validate_canonical_inventory <- function(manifest, exact = FALSE) {
+    values <- fertility_manifest_character(
+        manifest, c("id", "program", "level", "release")
+    )
+    if (any(!grepl("^F[0-9]{4}$", values$id)) || anyDuplicated(values$id) ||
+        any(!values$program %in% fertility_programs) ||
+        any(!values$level %in% fertility_levels) ||
+        any(!grepl("^[1-9][0-9]*$", values$release))) {
+        stop("canonical inventory manifest is invalid")
+    }
+    if (exact) {
+        if (!identical(values$id, sprintf("F%04d", seq_len(fertility_expected_rows)))) {
+            stop("canonical inventory IDs are not exactly F0001 through F1004")
+        }
+        release_counts <- table(factor(
+            as.integer(values$release),
+            levels = as.integer(names(fertility_expected_releases))
+        ))
+        if (any(!(as.integer(values$release) %in%
+                  as.integer(names(fertility_expected_releases)))) ||
+            !identical(as.integer(release_counts),
+                       as.integer(fertility_expected_releases))) {
+            stop("canonical inventory release counts are invalid")
+        }
+    }
+    values
+}
+
+fertility_framework_inventory <- function(snapshot_root, inventory = NULL,
+                                          framework_id = NULL) {
+    manifest_path <- file.path(snapshot_root, "inventory-manifest.tsv")
+    provenance_path <- file.path(snapshot_root, "inventory-manifest-provenance.tsv")
+    if (!file.exists(manifest_path) || !file.exists(provenance_path)) {
+        stop("canonical inventory manifest is absent")
+    }
+    manifest <- read.delim(manifest_path, colClasses = "character",
+                           check.names = FALSE)
+    manifest <- fertility_validate_canonical_inventory(manifest, exact = TRUE)
+    provenance <- read.delim(provenance_path, colClasses = "character",
+                             check.names = FALSE)
+    fields <- c("schema_version", "framework_id", "inventory_id",
+                "inventory_manifest_id", "report_schema_id", "files")
+    if (nrow(provenance) != 1L || !identical(names(provenance), fields) ||
+        !identical(provenance$schema_version[[1L]],
+                   as.character(fertility_schema_version)) ||
+        any(!grepl("^[0-9a-f]{64}$", unlist(provenance[c(
+            "framework_id", "inventory_id", "inventory_manifest_id",
+            "report_schema_id"
+        )], use.names = FALSE))) ||
+        !identical(provenance$inventory_manifest_id[[1L]],
+                   fertility_manifest_id(manifest)) ||
+        !identical(provenance$report_schema_id[[1L]], fertility_report_schema_id()) ||
+        !identical(provenance$files[[1L]], as.character(nrow(manifest)))) {
+        stop("canonical inventory manifest provenance is invalid")
+    }
+    if (!is.null(framework_id) &&
+        !identical(provenance$framework_id[[1L]], framework_id)) {
+        stop("canonical inventory manifest has a foreign framework")
+    }
+    if (!is.null(inventory)) {
+        expected <- fertility_manifest_character(
+            fertility_inventory_manifest(inventory), names(manifest)
+        )
+        if (!identical(manifest, expected) ||
+            !identical(provenance$inventory_id[[1L]], fertility_inventory_id(inventory))) {
+            stop("canonical inventory manifest does not match the live inventory")
+        }
+    }
+    list(manifest = manifest, provenance = provenance)
+}
+
+fertility_prepare_framework_snapshot <- function(script_dir, raw_root, framework_id,
+                                                 inventory) {
+    snapshot_root <- file.path(raw_root, "framework", framework_id)
+    dir.create(snapshot_root, recursive = TRUE, showWarnings = FALSE, mode = "0700")
+    Sys.chmod(c(file.path(raw_root, "framework"), snapshot_root), mode = "0700")
+    for (name in c("common.R", "worker.R", "compare.R", "runtime.R")) {
+        source_path <- file.path(script_dir, name)
+        snapshot_path <- file.path(snapshot_root, name)
+        if (!file.exists(snapshot_path)) {
+            temporary <- tempfile(paste0(name, "."), tmpdir = snapshot_root)
+            if (!file.copy(source_path, temporary, overwrite = TRUE)) {
+                stop("could not snapshot corpus framework")
+            }
+            Sys.chmod(temporary, mode = "0600")
+            if (!file.rename(temporary, snapshot_path)) {
+                unlink(temporary)
+                if (!file.exists(snapshot_path)) {
+                    stop("could not publish corpus framework snapshot")
+                }
+            }
+        }
+        if (!identical(unname(tools::sha256sum(source_path)),
+                       unname(tools::sha256sum(snapshot_path)))) {
+            stop("corpus framework snapshot does not match its provenance")
+        }
+    }
+    manifest <- fertility_inventory_manifest(inventory)
+    manifest_provenance <- data.frame(
+        schema_version = fertility_schema_version,
+        framework_id = framework_id,
+        inventory_id = fertility_inventory_id(inventory),
+        inventory_manifest_id = fertility_manifest_id(manifest),
+        report_schema_id = fertility_report_schema_id(),
+        files = nrow(manifest), stringsAsFactors = FALSE, check.names = FALSE
+    )
+    manifest_path <- file.path(snapshot_root, "inventory-manifest.tsv")
+    provenance_path <- file.path(snapshot_root, "inventory-manifest-provenance.tsv")
+    if (!file.exists(manifest_path)) fertility_atomic_write_table(manifest, manifest_path)
+    if (!file.exists(provenance_path)) {
+        fertility_atomic_write_table(manifest_provenance, provenance_path)
+    }
+    invisible(fertility_framework_inventory(
+        snapshot_root, inventory = inventory, framework_id = framework_id
+    ))
+    snapshot_root
+}
+
+fertility_verify_framework_snapshot <- function(script_dir, raw_root, framework_id,
+                                                inventory = NULL) {
+    snapshot_root <- file.path(raw_root, "framework", framework_id)
+    if (!dir.exists(snapshot_root)) stop("corpus framework snapshot is absent")
+    for (name in c("common.R", "worker.R", "compare.R", "runtime.R")) {
+        source_path <- file.path(script_dir, name)
+        snapshot_path <- file.path(snapshot_root, name)
+        if (!file.exists(snapshot_path) ||
+            !identical(unname(tools::sha256sum(source_path)),
+                       unname(tools::sha256sum(snapshot_path)))) {
+            stop("corpus framework snapshot does not match its provenance")
+        }
+    }
+    invisible(fertility_framework_inventory(
+        snapshot_root, inventory = inventory, framework_id = framework_id
+    ))
+    snapshot_root
 }
 
 fertility_tile_configuration <- function(options) {
@@ -281,7 +917,8 @@ fertility_tile_configuration <- function(options) {
         max_tiles_per_batch = options$max_tiles_per_batch,
         beyond_end_windows = options$beyond_end_windows,
         timeout_seconds = options$timeout_seconds, object_overhead_bytes = 64L,
-        readers_per_tile = 3L
+        readers_per_tile = 3L, strl_sample_count = 16L,
+        strl_safety_factor = 8, strl_fallback_rows = 64L
     )
     c(fields, list(config_id = fertility_stable_id(fields)))
 }
@@ -299,17 +936,59 @@ fertility_adaptive_rows <- function(column_bytes, configuration) {
     as.integer(max(1, min(configuration$chunk_rows, by_memory, by_cells)))
 }
 
+fertility_strl_sample_offsets <- function(total_rows, sample_count) {
+    if (!is.finite(total_rows) || total_rows < 0) stop("invalid structural row count")
+    sample_count <- as.integer(sample_count)
+    if (sample_count < 1L) stop("strL sample count must be positive")
+    if (total_rows == 0) return(0)
+    count <- min(as.double(sample_count), total_rows)
+    unique(floor(seq(0, total_rows - 1, length.out = count)))
+}
+
+fertility_strl_rows <- function(payload_bytes_per_row, column_count, configuration) {
+    payload <- as.double(payload_bytes_per_row)
+    if (length(payload) != 1L || is.na(payload) || payload < 0) {
+        return(as.integer(min(configuration$chunk_rows,
+                              configuration$strl_fallback_rows)))
+    }
+    readers <- as.double(configuration$readers_per_tile)
+    overhead <- readers * as.double(configuration$object_overhead_bytes) *
+        max(1, as.double(column_count))
+    estimated <- max(1, payload + overhead)
+    memory_bytes <- as.double(configuration$memory_mib) * 1024^2
+    by_memory <- floor(memory_bytes /
+                       (as.double(configuration$strl_safety_factor) * estimated))
+    by_cells <- floor(as.double(configuration$cell_budget) /
+                      (readers * max(1, as.double(column_count))))
+    as.integer(max(1, min(configuration$chunk_rows, by_memory, by_cells)))
+}
+
 fertility_metadata_tile <- function() {
     list(tile_id = "metadata", type = "metadata", batch = 0L, skip = 0L,
          n_max = 0L, column_names = character(), column_hash = "all")
 }
 
+fertility_sizing_tile <- function(batch, column_names, total_rows,
+                                  sample_count) {
+    offsets <- fertility_strl_sample_offsets(total_rows, sample_count)
+    list(
+        tile_id = sprintf("b%05d-sizing", as.integer(batch)),
+        type = "sizing", batch = as.integer(batch), skip = 0, n_max = 1L,
+        column_names = column_names, sample_offsets = as.double(offsets),
+        column_hash = fertility_stable_id(list(
+            batch = as.integer(batch), type = "sizing",
+            names = paste(column_names, collapse = "\037"),
+            sample_offsets = paste(format(offsets, scientific = FALSE), collapse = ",")
+        ))
+    )
+}
+
 fertility_value_tile <- function(batch, skip, n_max, column_names,
                                  type = "value", probe = 0L) {
     list(
-        tile_id = sprintf("b%05d-%s%02d-r%015.0f", as.integer(batch),
+        tile_id = sprintf("b%05d-%s%02d-r%015.0f-n%010d", as.integer(batch),
                           if (identical(type, "value")) "v" else "p",
-                          as.integer(probe), as.double(skip)),
+                          as.integer(probe), as.double(skip), as.integer(n_max)),
         type = type, batch = as.integer(batch), skip = as.double(skip),
         n_max = as.integer(n_max), column_names = column_names,
         column_hash = fertility_stable_id(list(
@@ -369,6 +1048,30 @@ fertility_plan_offsets <- function(total_rows, rows_per_tile, max_tiles) {
     if (needed > max_tiles) return(list(offsets = numeric(), ceiling = TRUE))
     list(offsets = if (total_rows == 0) 0 else
              seq(0, total_rows - 1, by = rows_per_tile), ceiling = FALSE)
+}
+
+fertility_process_adaptive_range <- function(batch, skip, n_max, column_names,
+                                             process, split_budget) {
+    tile <- fertility_value_tile(batch, skip, n_max, column_names)
+    result <- process(tile)
+    if (identical(result$classification, "memory-limit") && n_max > 1L &&
+        split_budget$remaining >= 2L) {
+        # The failed parent was already executed; splitting launches two more
+        # subprocess tiles, so consume two execution credits.
+        split_budget$remaining <- split_budget$remaining - 2L
+        left <- as.integer(floor(n_max / 2L))
+        right <- as.integer(n_max - left)
+        return(c(
+            fertility_process_adaptive_range(
+                batch, skip, left, column_names, process, split_budget
+            ),
+            fertility_process_adaptive_range(
+                batch, as.double(skip) + left, right, column_names,
+                process, split_budget
+            )
+        ))
+    }
+    list(result)
 }
 
 fertility_memory_error <- function(error) {
@@ -431,19 +1134,26 @@ fertility_mismatch_summary <- function(tiles) {
     if (!length(mismatches)) return(list(count = 0L, categories = "", signatures = ""))
     mismatches <- do.call(rbind, mismatches)
     if (!nrow(mismatches)) return(list(count = 0L, categories = "", signatures = ""))
-    keys <- paste(mismatches$category, mismatches$detail,
-                  ifelse(is.na(mismatches$component), "", mismatches$component),
-                  if ("pair" %in% names(mismatches)) mismatches$pair else "",
-                  sep = ":")
-    counts <- sort(table(keys), decreasing = TRUE)
+    # Public signatures intentionally contain only fixed public categories and
+    # fixed reader-pair IDs. Private details and column ordinals remain solely in
+    # the private RDS checkpoints and cannot be dictionary-recovered from reports.
+    pair <- if ("pair" %in% names(mismatches)) mismatches$pair else ""
+    pair[is.na(pair)] <- ""
+    keys <- paste(mismatches$category, pair, sep = ":")
+    counts <- table(keys)
+    signature_hashes <- vapply(names(counts), function(key) {
+        fertility_stable_id(list(signature = key))
+    }, character(1))
+    signature_order <- order(-as.integer(counts), signature_hashes)
     categories <- sort(table(mismatches$category), decreasing = TRUE)
     list(
         count = as.integer(sum(counts)),
         categories = paste(names(categories), as.integer(categories), sep = "=",
                            collapse = ","),
-        signatures = paste(vapply(names(counts), function(key) {
-            fertility_stable_id(list(signature = key))
-        }, character(1)), as.integer(counts), sep = "=", collapse = ",")
+        signatures = paste(
+            signature_hashes[signature_order], as.integer(counts)[signature_order],
+            sep = "=", collapse = ","
+        )
     )
 }
 

--- a/benchmarks/fertility-surveys/runner.R
+++ b/benchmarks/fertility-surveys/runner.R
@@ -720,7 +720,10 @@ fertility_process_item <- function(item, checkpoint_path, framework_id,
 }
 
 fertility_should_retry <- function(checkpoint) {
-    !(checkpoint$classification %in% c("match", "expected-unsupported-111"))
+    checkpoint$classification %in% c(
+        "timeout", "crash", "dtaparser-only-error", "haven-only-error",
+        "shared-reader-error", "memory-limit", "unresolved"
+    )
 }
 
 fertility_run_provenance_fields <- function() c(

--- a/benchmarks/fertility-surveys/runner.R
+++ b/benchmarks/fertility-surveys/runner.R
@@ -445,7 +445,11 @@ fertility_validate_full_output_results <- function(results) {
         tiles_completed[supported] == tiles_expected[supported]
     supported_pass_complete <- values$classification[supported] != "pass" |
         values$complete[supported] == "TRUE"
+    unsupported_tiles_zero <- !is.na(tiles_expected[unsupported]) &
+        tiles_expected[unsupported] == 0L & !is.na(tiles_completed[unsupported]) &
+        tiles_completed[unsupported] == 0L
     if (any(values$complete[unsupported] != "TRUE") ||
+        any(!unsupported_tiles_zero) ||
         any(!supported_terminal) || any(!supported_tiles_complete) ||
         any(!supported_pass_complete)) {
         stop("full output family executable accounting is invalid")

--- a/benchmarks/fertility-surveys/runner.R
+++ b/benchmarks/fertility-surveys/runner.R
@@ -454,21 +454,29 @@ fertility_validate_full_output_results <- function(results) {
 }
 
 fertility_capture_input <- function(item, acceptance = NULL) {
-    info <- file.info(item$path)
-    if (!nrow(info) || is.na(info$size[[1L]])) {
+    captured <- tryCatch(
+        suppressWarnings(fertility_nofollow_file_capture(item$path)),
+        error = function(error) NULL
+    )
+    if (is.null(captured)) {
+        device <- inode <- mode <- ""
         size <- NA_character_
         modified <- NA_character_
+        actual <- NA_character_
     } else {
-        size <- as.character(info$size[[1L]])
-        modified <- format(info$mtime[[1L]], "%Y-%m-%dT%H:%M:%OS6Z", tz = "UTC")
+        device <- captured$device
+        inode <- captured$inode
+        mode <- captured$mode
+        size <- captured$size
+        modified <- fertility_descriptor_timestamp(captured$modified_seconds)
+        actual <- captured$sha512
     }
-    actual <- tryCatch(suppressWarnings(fertility_file_sha512(item$path)),
-                       error = function(error) NA_character_)
     hash_status <- if (is.na(actual)) "error" else "ok"
     identity_fields <- list(
         id = item$id, release = as.integer(item$release),
         expected_sha512 = item$expected_sha512, hash_status = hash_status,
         actual_sha512 = if (is.na(actual)) "" else actual,
+        device = device, inode = inode, mode = mode,
         size = size, modified = modified
     )
     accepted_sha512 <- ""

--- a/benchmarks/fertility-surveys/runner.R
+++ b/benchmarks/fertility-surveys/runner.R
@@ -2724,7 +2724,8 @@ fertility_tile_secondary <- function(
 }
 
 fertility_aggregate_classification <- function(
-    tiles, complete, allow_legacy_empty_reader_artifact = FALSE
+    tiles, complete, execution_complete = complete,
+    allow_legacy_empty_reader_artifact = FALSE
 ) {
     classes <- vapply(tiles, `[[`, character(1), "classification")
     secondary <- unique(fertility_tile_secondary(
@@ -2734,11 +2735,11 @@ fertility_aggregate_classification <- function(
     if (any(classes == "timeout")) return("timeout")
     if (any(classes == "memory-limit")) return("memory-limit")
     if (any(classes == "crash")) return("crash")
+    if (!execution_complete || any(classes == "unresolved")) return("unresolved")
     for (classification in c("shared-reader-error", "dtaparser-only-error",
                              "haven-only-error")) {
         if (classification %in% classes) return(classification)
     }
-    if (any(classes == "unresolved")) return("unresolved")
     if ("row-termination-mismatch" %in% c(classes, secondary)) {
         return("row-termination-mismatch")
     }
@@ -2753,8 +2754,117 @@ fertility_aggregate_classification <- function(
     if (!complete) "unresolved" else "pass"
 }
 
+fertility_validate_tile_execution <- function(
+    tiles, batches, total_rows, configuration, tiles_expected = length(tiles)
+) {
+    scalar_number <- function(value) {
+        length(value) == 1L && is.numeric(value) && !is.na(value) &&
+            is.finite(value)
+    }
+    valid_type <- function(tile) {
+        is.list(tile) && is.character(tile$tile_type) &&
+            length(tile$tile_type) == 1L && !is.na(tile$tile_type) &&
+            tile$tile_type %in% c("metadata", "value", "terminal")
+    }
+    if (!is.list(tiles) || !length(tiles) || !all(vapply(
+            tiles, valid_type, logical(1)
+        )) || !identical(tiles[[1L]]$tile_type, "metadata") ||
+        !scalar_number(tiles_expected) || tiles_expected < 1 ||
+        tiles_expected != as.integer(tiles_expected) ||
+        !identical(as.integer(length(tiles)), as.integer(tiles_expected)) ||
+        !scalar_number(total_rows) || total_rows < 0 ||
+        total_rows != floor(total_rows) || !is.list(batches) ||
+        !length(batches) || !all(vapply(batches, is.character, logical(1))) ||
+        is.null(configuration$beyond_end_windows) ||
+        !scalar_number(configuration$beyond_end_windows) ||
+        configuration$beyond_end_windows < 0 ||
+        configuration$beyond_end_windows !=
+            as.integer(configuration$beyond_end_windows)) return(FALSE)
+    terminal_tiles <- tiles[vapply(
+        tiles, function(tile) identical(tile$tile_type, "terminal"), logical(1)
+    )]
+    expected_probes <- as.integer(configuration$beyond_end_windows)
+    if (length(terminal_tiles) != expected_probes) return(FALSE)
+    if (length(terminal_tiles) && !all(vapply(terminal_tiles, function(tile) {
+        scalar_number(tile$batch) && scalar_number(tile$skip) &&
+            scalar_number(tile$n_max)
+    }, logical(1)))) return(FALSE)
+    terminal_tiles <- terminal_tiles[order(vapply(
+        terminal_tiles, `[[`, numeric(1), "skip"
+    ))]
+    expected_terminal_skips <- as.double(total_rows) +
+        seq.int(0, expected_probes - 1L)
+    for (probe in seq_len(expected_probes)) {
+        tile <- terminal_tiles[[probe]]
+        if (!identical(as.integer(tile$batch), 1L) ||
+            !identical(as.double(tile$skip), expected_terminal_skips[[probe]]) ||
+            !identical(as.integer(tile$n_max), 1L)) return(FALSE)
+    }
+    value_tiles <- tiles[vapply(
+        tiles, function(tile) identical(tile$tile_type, "value"), logical(1)
+    )]
+    if (!length(value_tiles) || !all(vapply(value_tiles, function(tile) {
+        scalar_number(tile$batch) && tile$batch == as.integer(tile$batch) &&
+            tile$batch >= 1L && tile$batch <= length(batches) &&
+            scalar_number(tile$skip) && tile$skip >= 0 &&
+            tile$skip == floor(tile$skip) &&
+            scalar_number(tile$n_max) && tile$n_max >= 1L &&
+            tile$n_max == as.integer(tile$n_max) &&
+            is.character(tile$framework_id) &&
+            length(tile$framework_id) == 1L && !is.na(tile$framework_id) &&
+            is.character(tile$classification) &&
+            length(tile$classification) == 1L && !is.na(tile$classification)
+    }, logical(1)))) return(FALSE)
+    if (!identical(
+        sort(unique(vapply(value_tiles, function(tile) {
+            as.integer(tile$batch)
+        }, integer(1)))), seq_along(batches)
+    )) return(FALSE)
+    reader_errors <- c(
+        "shared-reader-error", "dtaparser-only-error", "haven-only-error"
+    )
+    for (batch in seq_along(batches)) {
+        current <- value_tiles[vapply(
+            value_tiles, function(tile) identical(as.integer(tile$batch), batch),
+            logical(1)
+        )]
+        current <- current[order(vapply(current, `[[`, numeric(1), "skip"))]
+        expected_skip <- 0
+        expected_count <- length(batches[[batch]])
+        for (tile in current) {
+            expected_hash <- fertility_projection_hash(
+                batches[[batch]], tile$framework_id
+            )
+            planned <- identical(as.integer(tile$projection_expected_count),
+                                 as.integer(expected_count)) &&
+                is.character(tile$projection_expected_hash) &&
+                length(tile$projection_expected_hash) == 1L &&
+                !is.na(tile$projection_expected_hash) &&
+                identical(tile$projection_expected_hash, expected_hash) &&
+                identical(as.double(tile$skip), as.double(expected_skip))
+            if (!isTRUE(planned)) return(FALSE)
+            expected_rows <- min(
+                as.integer(tile$n_max), as.double(total_rows) - expected_skip
+            )
+            observed_rows <- suppressWarnings(as.double(tile$rows))
+            observed_valid <- length(observed_rows) == 1L &&
+                !is.na(observed_rows) && is.finite(observed_rows) &&
+                identical(observed_rows, as.double(expected_rows))
+            if (!observed_valid && !tile$classification %in% reader_errors) {
+                return(FALSE)
+            }
+            expected_skip <- expected_skip + expected_rows
+        }
+        if (!identical(as.double(expected_skip), as.double(total_rows))) return(FALSE)
+    }
+    TRUE
+}
+
 fertility_validate_tile_completeness <- function(tiles, batches, total_rows,
                                                  configuration) {
+    if (!fertility_validate_tile_execution(
+        tiles, batches, total_rows, configuration, length(tiles)
+    )) return(FALSE)
     if (!length(tiles) || !identical(tiles[[1L]]$tile_type, "metadata")) return(FALSE)
     if (is.na(total_rows) || !length(batches) ||
         is.null(configuration$beyond_end_windows)) return(FALSE)
@@ -2846,9 +2956,12 @@ fertility_file_result_valid <- function(result, item, framework_id,
 
 fertility_tiled_result <- function(
     item, framework_id, configuration, input, tiles, batches, total_rows,
-    allow_legacy_empty_reader_artifact = FALSE
+    tiles_expected = length(tiles), allow_legacy_empty_reader_artifact = FALSE
 ) {
-    complete <- fertility_validate_tile_completeness(
+    execution_complete <- fertility_validate_tile_execution(
+        tiles, batches, total_rows, configuration, tiles_expected
+    )
+    complete <- execution_complete && fertility_validate_tile_completeness(
         tiles, batches, total_rows, configuration
     )
     mismatch <- fertility_mismatch_summary(tiles)
@@ -2865,14 +2978,16 @@ fertility_tiled_result <- function(
         release = as.integer(item$release), expected_sha512 = item$expected_sha512,
         timeout_seconds = configuration$timeout_seconds,
         classification = fertility_aggregate_classification(
-            tiles, complete, allow_legacy_empty_reader_artifact
+            tiles, complete, execution_complete,
+            allow_legacy_empty_reader_artifact
         ),
         secondary_categories = paste(secondary, collapse = ","),
         mismatch_count = mismatch$count, mismatch_categories = mismatch$categories,
         mismatch_signatures = mismatch$signatures,
         rows = as.double(total_rows), columns = length(unlist(batches)),
-        tiles_expected = length(tiles), tiles_completed = length(tiles),
-        complete = complete, actual_sha512 = input$actual_sha512,
+        tiles_expected = as.integer(tiles_expected),
+        tiles_completed = length(tiles), complete = complete,
+        actual_sha512 = input$actual_sha512,
         elapsed_seconds = sum(vapply(tiles, function(tile) tile$elapsed_seconds,
                                      numeric(1)), na.rm = TRUE)
     ), fertility_result_acceptance_fields(input))

--- a/benchmarks/fertility-surveys/runner.R
+++ b/benchmarks/fertility-surveys/runner.R
@@ -1632,10 +1632,16 @@ fertility_validate_assessment_families <- function(full, accepted) {
 }
 
 fertility_framework_id <- function(provenance_id, datasigs_path,
-                                   acceptance = NULL) {
+                                   acceptance = NULL,
+                                   schema_version = fertility_schema_version) {
+    if (!is.numeric(schema_version) || length(schema_version) != 1L ||
+        is.na(schema_version) || schema_version != as.integer(schema_version) ||
+        !as.integer(schema_version) %in% c(
+            fertility_schema_version, fertility_legacy_corpus_schema_version
+        )) stop("framework corpus schema version is invalid")
     datasigs_sha256 <- tolower(as.character(openssl::sha256(file(datasigs_path))))
     fields <- list(
-        schema_version = fertility_schema_version,
+        schema_version = as.integer(schema_version),
         provenance_id = provenance_id,
         datasigs_sha256 = datasigs_sha256,
         comparator_tolerance = "1e-7"

--- a/benchmarks/fertility-surveys/runner.R
+++ b/benchmarks/fertility-surveys/runner.R
@@ -459,7 +459,7 @@ fertility_capture_input <- function(item, acceptance = NULL) {
         error = function(error) NULL
     )
     if (is.null(captured)) {
-        device <- inode <- mode <- changed_ns <- ""
+        device <- inode <- mode <- modified_ns <- changed_ns <- ""
         size <- NA_character_
         modified <- NA_character_
         actual <- NA_character_
@@ -467,6 +467,7 @@ fertility_capture_input <- function(item, acceptance = NULL) {
         device <- captured$device
         inode <- captured$inode
         mode <- captured$mode
+        modified_ns <- captured$modified_ns
         changed_ns <- captured$changed_ns
         size <- captured$size
         modified <- fertility_descriptor_timestamp(captured$modified_seconds)
@@ -477,8 +478,8 @@ fertility_capture_input <- function(item, acceptance = NULL) {
         id = item$id, release = as.integer(item$release),
         expected_sha512 = item$expected_sha512, hash_status = hash_status,
         actual_sha512 = if (is.na(actual)) "" else actual,
-        device = device, inode = inode, mode = mode, changed_ns = changed_ns,
-        size = size, modified = modified
+        device = device, inode = inode, mode = mode, modified_ns = modified_ns,
+        changed_ns = changed_ns, size = size, modified = modified
     )
     accepted_sha512 <- ""
     manifest_hash_status <- if (identical(hash_status, "error")) "hash-read-error" else
@@ -503,7 +504,9 @@ fertility_capture_input <- function(item, acceptance = NULL) {
     identity <- fertility_stable_id(identity_fields)
     list(
         input_id = identity, hash_status = hash_status, actual_sha512 = actual,
-        size = size, modified = modified, accepted_sha512 = accepted_sha512,
+        device = device, inode = inode, mode = mode, size = size,
+        modified_ns = modified_ns, changed_ns = changed_ns, modified = modified,
+        accepted_sha512 = accepted_sha512,
         manifest_hash_status = manifest_hash_status,
         local_evidence_status = local_evidence_status,
         acceptance_authority = if (is.null(acceptance)) "" else acceptance$authority,

--- a/benchmarks/fertility-surveys/runner.R
+++ b/benchmarks/fertility-surveys/runner.R
@@ -380,9 +380,67 @@ fertility_selection_family_id <- function(
     )
 }
 
-fertility_full_default_family <- function(options) {
-    !length(options$programs) && !length(options$releases) &&
+fertility_full_output_family <- function(options) {
+    identical(options$programs, "output") && !length(options$releases) &&
         !length(options$ids) && !is.finite(options$max_files)
+}
+
+fertility_full_default_family <- function(options) {
+    (!length(options$programs) || fertility_full_output_family(options)) &&
+        !length(options$releases) && !length(options$ids) &&
+        !is.finite(options$max_files)
+}
+
+fertility_output_expected_releases <- c(
+    `111` = 130L, `113` = 486L, `114` = 24L, `115` = 5L, `118` = 581L
+)
+fertility_output_expected_levels <- c(survey = 1218L, aggregate = 8L)
+
+fertility_output_terminal_classifications <- function() c(
+    "pass", "direct-vs-rust-mismatch", "dtaparser-only-error",
+    "haven-only-error", "shared-reader-error", "metadata-mismatch",
+    "value-mismatch", "tag-mismatch", "date-mismatch", "encoding-mismatch",
+    "row-termination-mismatch"
+)
+
+fertility_validate_full_output_results <- function(results) {
+    values <- fertility_manifest_character(results, fertility_result_fields())
+    releases <- suppressWarnings(as.integer(values$release))
+    release_counts <- table(factor(
+        releases, levels = as.integer(names(fertility_output_expected_releases))
+    ))
+    level_counts <- table(factor(
+        values$level, levels = names(fertility_output_expected_levels)
+    ))
+    unsupported <- releases == 111L
+    supported <- !unsupported
+    if (nrow(values) != fertility_output_expected_files ||
+        !identical(values$id,
+                   sprintf("F%04d", seq_len(fertility_output_expected_files))) ||
+        any(values$program != "output")) {
+        stop("full output family membership is invalid")
+    }
+    if (anyNA(releases) ||
+        any(!(releases %in% as.integer(names(fertility_output_expected_releases)))) ||
+        !identical(as.integer(release_counts),
+                   as.integer(fertility_output_expected_releases))) {
+        stop("full output family release counts are invalid")
+    }
+    if (any(!(values$level %in% names(fertility_output_expected_levels))) ||
+        !identical(as.integer(level_counts),
+                   as.integer(fertility_output_expected_levels))) {
+        stop("full output family level counts are invalid")
+    }
+    if (!all(values$classification[unsupported] == "expected-unsupported-111") ||
+        any(values$classification[supported] == "expected-unsupported-111")) {
+        stop("full output family unsupported-release classifications are invalid")
+    }
+    if (any(values$complete != "TRUE") ||
+        any(!(values$classification[supported] %in%
+              fertility_output_terminal_classifications()))) {
+        stop("full output family executable accounting is invalid")
+    }
+    invisible(TRUE)
 }
 
 fertility_capture_input <- function(item, acceptance = NULL) {
@@ -811,9 +869,17 @@ fertility_classification_summary <- function(results) {
     summary
 }
 
+fertility_publication_frame <- function(value) {
+    result <- fertility_character_frame(value)
+    for (field in names(result)) result[[field]][is.na(result[[field]])] <- ""
+    result
+}
+
 fertility_publish_results <- function(checkpoints, build_provenance_id, path) {
     results <- fertility_result_frame(checkpoints)
     results$build_provenance_id <- rep(build_provenance_id, nrow(results))
+    fertility_validate_public_results(results)
+    results <- fertility_publication_frame(results)
     fertility_validate_public_results(results)
     fertility_atomic_write_table(results, path)
     results
@@ -1018,8 +1084,11 @@ fertility_validate_merged_bundle <- function(bundle, family_id,
         stop("merged evidence family identity is invalid")
     }
     full_default <- identical(provenance$full_default_family[[1L]], "TRUE")
-    if (full_default && !identical(results$id,
-                                   sprintf("F%04d", seq_len(fertility_expected_rows)))) {
+    if (full_default && identical(provenance$program_filter[[1L]], "output")) {
+        fertility_validate_full_output_results(results)
+    } else if (full_default && !identical(
+        results$id, sprintf("F%04d", seq_len(fertility_expected_rows))
+    )) {
         stop("merged full family membership is invalid")
     }
     if (accepted && (full_default || provenance$shard_count[[1L]] != "1" ||
@@ -1459,7 +1528,9 @@ fertility_validate_shard_bundles <- function(bundles, family_id,
             stop("accepted-current-hash family is not the exact executable five-ID family")
         }
     }
-    if (full_default) {
+    if (full_default && fertility_full_output_family(options)) {
+        fertility_validate_full_output_results(results)
+    } else if (full_default) {
         if (!identical(results$id, sprintf("F%04d", seq_len(fertility_expected_rows)))) {
             stop("full corpus IDs are not exactly F0001 through F1004")
         }

--- a/benchmarks/fertility-surveys/runner.R
+++ b/benchmarks/fertility-surveys/runner.R
@@ -1084,7 +1084,9 @@ fertility_validate_merged_bundle <- function(bundle, family_id,
         stop("merged evidence family identity is invalid")
     }
     full_default <- identical(provenance$full_default_family[[1L]], "TRUE")
-    if (full_default && identical(provenance$program_filter[[1L]], "output")) {
+    full_output <- full_default && nrow(results) > 0L &&
+        all(results$program == "output")
+    if (full_output) {
         fertility_validate_full_output_results(results)
     } else if (full_default && !identical(
         results$id, sprintf("F%04d", seq_len(fertility_expected_rows))

--- a/benchmarks/fertility-surveys/runner.R
+++ b/benchmarks/fertility-surveys/runner.R
@@ -2794,9 +2794,25 @@ fertility_validate_tile_execution <- function(
     ))]
     expected_terminal_skips <- as.double(total_rows) +
         seq.int(0, expected_probes - 1L)
+    expected_terminal_count <- length(batches[[1L]])
     for (probe in seq_len(expected_probes)) {
         tile <- terminal_tiles[[probe]]
-        if (!identical(as.integer(tile$batch), 1L) ||
+        framework_valid <- is.character(tile$framework_id) &&
+            length(tile$framework_id) == 1L && !is.na(tile$framework_id)
+        expected_hash <- if (framework_valid) {
+            fertility_projection_hash(batches[[1L]], tile$framework_id)
+        } else NA_character_
+        projection_planned <- scalar_number(tile$projection_expected_count) &&
+            tile$projection_expected_count ==
+                as.integer(tile$projection_expected_count) &&
+            identical(as.integer(tile$projection_expected_count),
+                      as.integer(expected_terminal_count)) &&
+            is.character(tile$projection_expected_hash) &&
+            length(tile$projection_expected_hash) == 1L &&
+            !is.na(tile$projection_expected_hash) &&
+            identical(tile$projection_expected_hash, expected_hash)
+        if (!framework_valid || !projection_planned ||
+            !identical(as.integer(tile$batch), 1L) ||
             !identical(as.double(tile$skip), expected_terminal_skips[[probe]]) ||
             !identical(as.integer(tile$n_max), 1L)) return(FALSE)
     }

--- a/benchmarks/fertility-surveys/runtime.R
+++ b/benchmarks/fertility-surveys/runtime.R
@@ -1,3 +1,45 @@
+fertility_runtime_path_is_symlink <- function(path) {
+    link <- Sys.readlink(path)
+    !is.na(link) & nzchar(link)
+}
+
+fertility_runtime_assert_file <- function(path, parent = dirname(path),
+                                          label = "runtime file") {
+    path <- path.expand(path)
+    parent <- path.expand(parent)
+    if (!identical(dirname(path), parent) || !dir.exists(parent) ||
+        fertility_runtime_path_is_symlink(parent) ||
+        fertility_runtime_path_is_symlink(path) || !file.exists(path) ||
+        dir.exists(path)) stop(label, " must be a direct non-symlink file")
+    if (!identical(normalizePath(parent, winslash = "/", mustWork = TRUE), parent) ||
+        !identical(normalizePath(path, winslash = "/", mustWork = TRUE), path)) {
+        stop(label, " must be canonical")
+    }
+    path
+}
+
+fertility_secure_directory <- function(path, label = "runtime directory") {
+    lexical <- path.expand(path)
+    if (!startsWith(lexical, "/")) stop(label, " must be absolute")
+    pieces <- strsplit(sub("^/", "", lexical), "/", fixed = TRUE)[[1L]]
+    current <- "/"
+    for (piece in pieces[nzchar(pieces)]) {
+        child <- file.path(current, piece)
+        if (fertility_runtime_path_is_symlink(child)) stop(label, " must not traverse symlinks")
+        if (!dir.exists(child) &&
+            !dir.create(child, showWarnings = FALSE, mode = "0700")) {
+            stop("could not create ", label)
+        }
+        if (fertility_runtime_path_is_symlink(current) || fertility_runtime_path_is_symlink(child) ||
+            !identical(
+                dirname(normalizePath(child, winslash = "/", mustWork = TRUE)),
+                normalizePath(current, winslash = "/", mustWork = TRUE)
+            )) stop(label, " escaped its lexical parent")
+        current <- child
+    }
+    lexical
+}
+
 fertility_host <- function() {
     value <- unname(Sys.info()[["nodename"]])
     if (is.null(value) || is.na(value) || !nzchar(value)) "unknown-host" else value
@@ -55,8 +97,14 @@ fertility_random_identity <- function(pid = Sys.getpid()) {
 }
 
 fertility_touch_heartbeat <- function(path, identity) {
-    dir.create(dirname(path), recursive = TRUE, showWarnings = FALSE, mode = "0700")
-    temporary <- tempfile("heartbeat.", tmpdir = dirname(path))
+    parent <- fertility_secure_directory(dirname(path), "heartbeat parent")
+    if (fertility_runtime_path_is_symlink(path) || dir.exists(path)) {
+        stop("owner heartbeat must not be a symlink or directory")
+    }
+    if (file.exists(path)) fertility_runtime_assert_file(
+        path, parent, "owner heartbeat"
+    )
+    temporary <- tempfile("heartbeat.", tmpdir = parent)
     on.exit(unlink(temporary), add = TRUE)
     writeLines(identity, temporary, useBytes = TRUE)
     Sys.chmod(temporary, mode = "0600")
@@ -82,7 +130,14 @@ fertility_owner <- function(heartbeat, pid = Sys.getpid(), start = NULL,
 }
 
 fertility_write_owner <- function(directory, owner) {
+    directory <- fertility_secure_directory(directory, "owner directory")
     path <- file.path(directory, "owner.tsv")
+    if (fertility_runtime_path_is_symlink(path) || dir.exists(path)) {
+        stop("ownership record must not be a symlink or directory")
+    }
+    if (file.exists(path)) fertility_runtime_assert_file(
+        path, directory, "ownership record"
+    )
     temporary <- tempfile("owner.", tmpdir = directory)
     on.exit(unlink(temporary), add = TRUE)
     fields <- c("token", "pid", "host", "start", "heartbeat", "created")
@@ -94,8 +149,16 @@ fertility_write_owner <- function(directory, owner) {
 }
 
 fertility_read_owner <- function(directory) {
+    directory <- path.expand(directory)
+    if (fertility_runtime_path_is_symlink(directory)) {
+        stop("owner directory must not be a symlink")
+    }
     path <- file.path(directory, "owner.tsv")
+    if (fertility_runtime_path_is_symlink(path)) {
+        stop("ownership record must not be a symlink")
+    }
     if (!file.exists(path)) return(NULL)
+    path <- fertility_runtime_assert_file(path, directory, "ownership record")
     lines <- tryCatch(readLines(path, warn = FALSE), error = function(error) character())
     pieces <- strsplit(lines, "\t", fixed = TRUE)
     fields <- c("token", "pid", "host", "start", "heartbeat", "created")
@@ -125,11 +188,17 @@ fertility_owner_alive <- function(owner, heartbeat_grace = 3,
     # If the owner is remote or OS process-generation metadata is temporarily
     # unavailable, a recent matching heartbeat can preserve ownership but can
     # never prove staleness.
+    if (fertility_runtime_path_is_symlink(owner$heartbeat)) {
+        stop("owner heartbeat must not be a symlink")
+    }
     if (!file.exists(owner$heartbeat)) return(NA)
-    identity <- tryCatch(readLines(owner$heartbeat, warn = FALSE, n = 1L),
+    heartbeat <- fertility_runtime_assert_file(
+        owner$heartbeat, dirname(owner$heartbeat), "owner heartbeat"
+    )
+    identity <- tryCatch(readLines(heartbeat, warn = FALSE, n = 1L),
                          error = function(error) character())
     if (length(identity) != 1L || !identical(identity[[1L]], owner$start)) return(NA)
-    info <- file.info(owner$heartbeat)
+    info <- file.info(heartbeat)
     if (!nrow(info) || is.na(info$mtime[[1L]])) return(NA)
     age <- as.numeric(difftime(Sys.time(), info$mtime[[1L]], units = "secs"))
     if (is.finite(age) && age <= heartbeat_grace) TRUE else NA
@@ -151,8 +220,8 @@ fertility_local_owner <- function(directory) {
 fertility_acquire_lock <- function(path, owner = NULL, initialization_grace = 5,
                                    remote_stale_after = 7 * 24 * 3600,
                                    owner_status = fertility_owner_alive) {
-    parent <- dirname(path)
-    dir.create(parent, recursive = TRUE, showWarnings = FALSE, mode = "0700")
+    parent <- fertility_secure_directory(dirname(path), "lock parent")
+    if (fertility_runtime_path_is_symlink(path)) stop("lock path must not be a symlink")
     for (attempt in seq_len(3L)) {
         if (dir.create(path, showWarnings = FALSE, mode = "0700")) {
             if (is.null(owner)) owner <- fertility_local_owner(path)
@@ -302,7 +371,7 @@ fertility_hold_owner <- function(state, parent_pid) {
         error = function(error) NA_character_
     )
     if (is.na(parent_start)) stop("could not identify orchestrator process generation")
-    dir.create(state, recursive = TRUE, showWarnings = FALSE, mode = "0700")
+    state <- fertility_secure_directory(state, "owner state directory")
     heartbeat <- file.path(state, "heartbeat")
     owner <- fertility_owner(heartbeat, pid = parent_pid, start = parent_start)
     fertility_touch_heartbeat(heartbeat, owner$start)

--- a/benchmarks/fertility-surveys/runtime.R
+++ b/benchmarks/fertility-surveys/runtime.R
@@ -1,0 +1,296 @@
+fertility_host <- function() {
+    value <- unname(Sys.info()[["nodename"]])
+    if (is.null(value) || is.na(value) || !nzchar(value)) "unknown-host" else value
+}
+
+fertility_process_observation <- function(
+    pid,
+    signal_probe = function(pid) tools::pskill(pid, signal = 0L),
+    handle_probe = ps::ps_handle,
+    running_probe = ps::ps_is_running,
+    start_probe = ps::ps_create_time
+) {
+    pid <- as.integer(pid)
+    signal_alive <- tryCatch({
+        value <- signal_probe(pid)
+        if (isTRUE(value)) TRUE else NA
+    }, no_such_process = function(error) FALSE,
+       error = function(error) NA)
+    handle <- tryCatch(handle_probe(pid),
+                       no_such_process = function(error) structure(
+                           list(), class = "fertility_missing_process"
+                       ),
+                       error = function(error) NULL)
+    if (inherits(handle, "fertility_missing_process")) {
+        return(list(alive = FALSE, start = NA_character_))
+    }
+    if (!is.null(handle)) {
+        running <- tryCatch(running_probe(handle),
+                            no_such_process = function(error) FALSE,
+                            error = function(error) NA)
+        if (isFALSE(running)) return(list(alive = FALSE, start = NA_character_))
+        if (isTRUE(running)) {
+            start <- tryCatch(
+                sprintf("%.6f", as.numeric(start_probe(handle))),
+                no_such_process = function(error) NA_character_,
+                error = function(error) NA_character_
+            )
+            return(list(alive = TRUE, start = start))
+        }
+    }
+    list(alive = signal_alive, start = NA_character_)
+}
+
+fertility_pid_alive <- function(pid) {
+    fertility_process_observation(pid)$alive
+}
+
+fertility_process_start <- function(pid) {
+    fertility_process_observation(pid)$start
+}
+
+fertility_random_identity <- function(pid = Sys.getpid()) {
+    paste(pid, as.integer(Sys.time()), sample.int(.Machine$integer.max, 1L),
+          sep = "-")
+}
+
+fertility_touch_heartbeat <- function(path, identity) {
+    dir.create(dirname(path), recursive = TRUE, showWarnings = FALSE, mode = "0700")
+    temporary <- tempfile("heartbeat.", tmpdir = dirname(path))
+    on.exit(unlink(temporary), add = TRUE)
+    writeLines(identity, temporary, useBytes = TRUE)
+    Sys.chmod(temporary, mode = "0600")
+    if (!file.rename(temporary, path)) stop("could not update owner heartbeat")
+    invisible(path)
+}
+
+fertility_owner <- function(heartbeat, pid = Sys.getpid(), start = NULL,
+                            token = NULL) {
+    pid <- as.integer(pid)
+    if (length(pid) != 1L || is.na(pid) || pid < 1L ||
+        !isTRUE(fertility_pid_alive(pid))) {
+        stop("owner process is not alive")
+    }
+    if (is.null(start)) start <- fertility_process_start(pid)
+    if (length(start) != 1L || is.na(start) || !nzchar(start)) {
+        stop("could not identify owner process generation")
+    }
+    if (is.null(token)) token <- fertility_random_identity(pid)
+    list(token = token, pid = pid, host = fertility_host(), start = start,
+         heartbeat = normalizePath(heartbeat, winslash = "/", mustWork = FALSE),
+         created = as.numeric(Sys.time()))
+}
+
+fertility_write_owner <- function(directory, owner) {
+    path <- file.path(directory, "owner.tsv")
+    temporary <- tempfile("owner.", tmpdir = directory)
+    on.exit(unlink(temporary), add = TRUE)
+    fields <- c("token", "pid", "host", "start", "heartbeat", "created")
+    values <- vapply(fields, function(name) as.character(owner[[name]]), character(1))
+    writeLines(paste(names(values), values, sep = "\t"), temporary, useBytes = TRUE)
+    Sys.chmod(temporary, mode = "0600")
+    if (!file.rename(temporary, path)) stop("could not publish ownership record")
+    invisible(path)
+}
+
+fertility_read_owner <- function(directory) {
+    path <- file.path(directory, "owner.tsv")
+    if (!file.exists(path)) return(NULL)
+    lines <- tryCatch(readLines(path, warn = FALSE), error = function(error) character())
+    pieces <- strsplit(lines, "\t", fixed = TRUE)
+    fields <- c("token", "pid", "host", "start", "heartbeat", "created")
+    if (length(pieces) != length(fields) || any(lengths(pieces) != 2L)) return(NULL)
+    values <- setNames(vapply(pieces, `[[`, character(1), 2L),
+                       vapply(pieces, `[[`, character(1), 1L))
+    if (!identical(names(values), fields) ||
+        !grepl("^[1-9][0-9]*$", values[["pid"]]) ||
+        is.na(suppressWarnings(as.numeric(values[["created"]])))) return(NULL)
+    list(token = values[["token"]], pid = as.integer(values[["pid"]]),
+         host = values[["host"]], start = values[["start"]],
+         heartbeat = values[["heartbeat"]],
+         created = as.numeric(values[["created"]]))
+}
+
+fertility_owner_alive <- function(owner, heartbeat_grace = 3,
+                                    process_probe = fertility_process_observation) {
+    if (is.null(owner) || !identical(owner$host, fertility_host())) return(NA)
+    observation <- process_probe(owner$pid)
+    if (isFALSE(observation$alive)) return(FALSE)
+    if (isTRUE(observation$alive) && !is.na(observation$start)) {
+        return(identical(observation$start, owner$start))
+    }
+
+    # If OS process-generation metadata is temporarily unavailable, a recent
+    # matching heartbeat can preserve ownership but can never prove staleness.
+    if (!file.exists(owner$heartbeat)) return(NA)
+    identity <- tryCatch(readLines(owner$heartbeat, warn = FALSE, n = 1L),
+                         error = function(error) character())
+    if (length(identity) != 1L || !identical(identity[[1L]], owner$start)) return(NA)
+    info <- file.info(owner$heartbeat)
+    if (!nrow(info) || is.na(info$mtime[[1L]])) return(NA)
+    age <- as.numeric(difftime(Sys.time(), info$mtime[[1L]], units = "secs"))
+    if (is.finite(age) && age <= heartbeat_grace) TRUE else NA
+}
+
+fertility_directory_age <- function(path) {
+    info <- file.info(path)
+    if (!nrow(info) || is.na(info$mtime[[1L]])) return(Inf)
+    as.numeric(difftime(Sys.time(), info$mtime[[1L]], units = "secs"))
+}
+
+fertility_local_owner <- function(directory) {
+    heartbeat <- file.path(directory, "heartbeat")
+    owner <- fertility_owner(heartbeat)
+    fertility_touch_heartbeat(heartbeat, owner$start)
+    owner
+}
+
+fertility_acquire_lock <- function(path, owner = NULL, initialization_grace = 5,
+                                   remote_stale_after = 7 * 24 * 3600,
+                                   owner_status = fertility_owner_alive) {
+    parent <- dirname(path)
+    dir.create(parent, recursive = TRUE, showWarnings = FALSE, mode = "0700")
+    for (attempt in seq_len(3L)) {
+        if (dir.create(path, showWarnings = FALSE, mode = "0700")) {
+            if (is.null(owner)) owner <- fertility_local_owner(path)
+            if (!isTRUE(fertility_owner_alive(owner))) {
+                unlink(path, recursive = TRUE)
+                stop("orchestrator owner is not alive")
+            }
+            complete <- FALSE
+            on.exit(if (!complete) unlink(path, recursive = TRUE), add = TRUE)
+            fertility_write_owner(path, owner)
+            complete <- TRUE
+            return(owner$token)
+        }
+        recorded <- fertility_read_owner(path)
+        age <- fertility_directory_age(path)
+        alive <- owner_status(recorded)
+        stale <- if (is.null(recorded)) {
+            age >= initialization_grace
+        } else if (isTRUE(alive)) {
+            FALSE
+        } else if (isFALSE(alive)) {
+            TRUE
+        } else {
+            age >= remote_stale_after
+        }
+        if (!stale) stop("another fertility corpus build or run is active")
+        stale_path <- paste0(path, ".stale.", Sys.getpid(), ".", attempt)
+        if (!file.rename(path, stale_path)) next
+        moved_owner <- fertility_read_owner(stale_path)
+        same_generation <- if (is.null(recorded)) is.null(moved_owner) else
+            !is.null(moved_owner) && identical(moved_owner$token, recorded$token)
+        if (!same_generation) {
+            if (!file.exists(path)) file.rename(stale_path, path)
+            stop("lock ownership changed during stale-lock reclamation")
+        }
+        unlink(stale_path, recursive = TRUE)
+    }
+    stop("could not acquire fertility corpus run lock")
+}
+
+fertility_release_lock <- function(path, token) {
+    owner <- fertility_read_owner(path)
+    if (is.null(owner) || !identical(owner$token, token)) return(FALSE)
+    released <- paste0(path, ".released.", Sys.getpid())
+    if (!file.rename(path, released)) return(FALSE)
+    moved <- fertility_read_owner(released)
+    if (is.null(moved) || !identical(moved$token, token)) {
+        if (!file.exists(path)) file.rename(released, path)
+        return(FALSE)
+    }
+    unlink(released, recursive = TRUE)
+    TRUE
+}
+
+fertility_write_temp_owner <- function(path, owner = NULL) {
+    if (is.null(owner)) owner <- fertility_local_owner(path)
+    if (!isTRUE(fertility_owner_alive(owner))) stop("orchestrator owner is not alive")
+    fertility_write_owner(path, owner)
+}
+
+fertility_clean_stale_tempdirs <- function(temp_root, current,
+                                           ownerless_grace = 3600,
+                                           remote_stale_after = 7 * 24 * 3600,
+                                           owner_status = fertility_owner_alive) {
+    paths <- list.dirs(temp_root, recursive = FALSE, full.names = TRUE)
+    paths <- paths[grepl("^run[.]", basename(paths)) & paths != current]
+    removed <- character()
+    for (path in paths) {
+        owner <- fertility_read_owner(path)
+        alive <- owner_status(owner)
+        stale <- if (is.null(owner)) {
+            fertility_directory_age(path) >= ownerless_grace
+        } else if (isFALSE(alive)) {
+            TRUE
+        } else if (is.na(alive)) {
+            fertility_directory_age(path) >= remote_stale_after
+        } else FALSE
+        if (stale) {
+            claimed <- paste0(path, ".stale.", Sys.getpid())
+            if (file.rename(path, claimed)) {
+                unlink(claimed, recursive = TRUE)
+                removed <- c(removed, path)
+            }
+        }
+    }
+    invisible(removed)
+}
+
+fertility_hold_owner <- function(state, parent_pid) {
+    parent_handle <- tryCatch(ps::ps_handle(as.integer(parent_pid)),
+                              error = function(error) NULL)
+    if (is.null(parent_handle) || !isTRUE(ps::ps_is_running(parent_handle))) {
+        stop("could not identify orchestrator process generation")
+    }
+    parent_start <- tryCatch(
+        sprintf("%.6f", as.numeric(ps::ps_create_time(parent_handle))),
+        error = function(error) NA_character_
+    )
+    if (is.na(parent_start)) stop("could not identify orchestrator process generation")
+    dir.create(state, recursive = TRUE, showWarnings = FALSE, mode = "0700")
+    heartbeat <- file.path(state, "heartbeat")
+    owner <- fertility_owner(heartbeat, pid = parent_pid, start = parent_start)
+    fertility_touch_heartbeat(heartbeat, owner$start)
+    fertility_write_owner(state, owner)
+    while (isTRUE(tryCatch(ps::ps_is_running(parent_handle),
+                           error = function(error) FALSE))) {
+        fertility_touch_heartbeat(heartbeat, owner$start)
+        Sys.sleep(0.5)
+    }
+    invisible(NULL)
+}
+
+fertility_assert_tempdir <- function(raw_root) {
+    root <- normalizePath(raw_root, winslash = "/", mustWork = TRUE)
+    temporary <- normalizePath(tempdir(), winslash = "/", mustWork = TRUE)
+    if (!startsWith(temporary, paste0(root, "/"))) {
+        stop("R temporary directory must remain beneath target/fertility-surveys/raw")
+    }
+    temporary
+}
+
+if (sys.nframe() == 0L) {
+    arguments <- commandArgs(trailingOnly = TRUE)
+    if (length(arguments) < 2L) stop("runtime.R requires an action and path")
+    action <- arguments[[1L]]
+    path <- arguments[[2L]]
+    if (identical(action, "hold-owner")) {
+        if (length(arguments) != 3L) stop("hold-owner requires parent PID")
+        fertility_hold_owner(path, as.integer(arguments[[3L]]))
+    } else if (identical(action, "acquire-lock")) {
+        if (length(arguments) != 3L) stop("acquire-lock requires owner state")
+        owner <- fertility_read_owner(arguments[[3L]])
+        cat(fertility_acquire_lock(path, owner))
+    } else if (identical(action, "release-lock")) {
+        if (length(arguments) != 3L || !fertility_release_lock(path, arguments[[3L]]))
+            quit(status = 1L)
+    } else if (identical(action, "write-temp-owner")) {
+        if (length(arguments) != 3L) stop("write-temp-owner requires owner state")
+        fertility_write_temp_owner(path, fertility_read_owner(arguments[[3L]]))
+    } else if (identical(action, "clean-temp")) {
+        if (length(arguments) != 3L) stop("clean-temp requires current temp path")
+        fertility_clean_stale_tempdirs(path, arguments[[3L]])
+    } else stop("unknown runtime.R action")
+}

--- a/benchmarks/fertility-surveys/runtime.R
+++ b/benchmarks/fertility-surveys/runtime.R
@@ -113,15 +113,18 @@ fertility_read_owner <- function(directory) {
 
 fertility_owner_alive <- function(owner, heartbeat_grace = 3,
                                     process_probe = fertility_process_observation) {
-    if (is.null(owner) || !identical(owner$host, fertility_host())) return(NA)
-    observation <- process_probe(owner$pid)
-    if (isFALSE(observation$alive)) return(FALSE)
-    if (isTRUE(observation$alive) && !is.na(observation$start)) {
-        return(identical(observation$start, owner$start))
+    if (is.null(owner)) return(NA)
+    if (identical(owner$host, fertility_host())) {
+        observation <- process_probe(owner$pid)
+        if (isFALSE(observation$alive)) return(FALSE)
+        if (isTRUE(observation$alive) && !is.na(observation$start)) {
+            return(identical(observation$start, owner$start))
+        }
     }
 
-    # If OS process-generation metadata is temporarily unavailable, a recent
-    # matching heartbeat can preserve ownership but can never prove staleness.
+    # If the owner is remote or OS process-generation metadata is temporarily
+    # unavailable, a recent matching heartbeat can preserve ownership but can
+    # never prove staleness.
     if (!file.exists(owner$heartbeat)) return(NA)
     identity <- tryCatch(readLines(owner$heartbeat, warn = FALSE, n = 1L),
                          error = function(error) character())
@@ -190,6 +193,18 @@ fertility_acquire_lock <- function(path, owner = NULL, initialization_grace = 5,
     stop("could not acquire fertility corpus run lock")
 }
 
+fertility_acquire_lock_wait <- function(path, owner, timeout = 1800,
+                                        poll_seconds = 0.1) {
+    deadline <- Sys.time() + timeout
+    repeat {
+        result <- tryCatch(fertility_acquire_lock(path, owner), error = identity)
+        if (!inherits(result, "error")) return(result)
+        if (!grepl("another fertility corpus", conditionMessage(result)) ||
+            Sys.time() >= deadline) stop(result)
+        Sys.sleep(poll_seconds)
+    }
+}
+
 fertility_release_lock <- function(path, token) {
     owner <- fertility_read_owner(path)
     if (is.null(owner) || !identical(owner$token, token)) return(FALSE)
@@ -202,6 +217,44 @@ fertility_release_lock <- function(path, token) {
     }
     unlink(released, recursive = TRUE)
     TRUE
+}
+
+fertility_lock_component <- function(value, label = "lock component") {
+    value <- as.character(value)
+    if (length(value) != 1L || is.na(value) ||
+        !grepl("^[A-Za-z0-9._-]+$", value)) {
+        stop(label, " is not safe for a lock path")
+    }
+    value
+}
+
+fertility_acquire_lock_set <- function(paths, owner) {
+    paths <- sort(unique(normalizePath(paths, winslash = "/", mustWork = FALSE)))
+    acquired <- character()
+    tokens <- character()
+    on.exit({
+        if (length(acquired)) {
+            for (index in rev(seq_along(acquired))) {
+                fertility_release_lock(acquired[[index]], tokens[[index]])
+            }
+        }
+    }, add = TRUE)
+    for (path in paths) {
+        token <- fertility_acquire_lock(path, owner)
+        acquired <- c(acquired, path)
+        tokens <- c(tokens, token)
+    }
+    result <- setNames(tokens, acquired)
+    acquired <- character()
+    result
+}
+
+fertility_release_lock_set <- function(tokens) {
+    if (!length(tokens)) return(TRUE)
+    results <- vapply(rev(seq_along(tokens)), function(index) {
+        fertility_release_lock(names(tokens)[[index]], tokens[[index]])
+    }, logical(1))
+    all(results)
 }
 
 fertility_write_temp_owner <- function(path, owner = NULL) {
@@ -283,6 +336,10 @@ if (sys.nframe() == 0L) {
         if (length(arguments) != 3L) stop("acquire-lock requires owner state")
         owner <- fertility_read_owner(arguments[[3L]])
         cat(fertility_acquire_lock(path, owner))
+    } else if (identical(action, "acquire-lock-wait")) {
+        if (length(arguments) != 3L) stop("acquire-lock-wait requires owner state")
+        owner <- fertility_read_owner(arguments[[3L]])
+        cat(fertility_acquire_lock_wait(path, owner))
     } else if (identical(action, "release-lock")) {
         if (length(arguments) != 3L || !fertility_release_lock(path, arguments[[3L]]))
             quit(status = 1L)

--- a/benchmarks/fertility-surveys/test-benchmark-helpers.sh
+++ b/benchmarks/fertility-surveys/test-benchmark-helpers.sh
@@ -69,6 +69,28 @@ run_benchmark_rejection() {
     fi
 }
 
+run_environment_rejection() {
+    run_environment_rejection_name=$1
+    run_environment_rejection_message=$2
+    run_environment_rejection_ci=$3
+    run_environment_rejection_opt_in=$4
+    set +e
+    CI=$run_environment_rejection_ci \
+        GITHUB_ACTIONS= GITHUB_RUN_ID= GITHUB_WORKFLOW= \
+        DTAPARSER_FERTILITY_CORPUS=$run_environment_rejection_opt_in \
+        /bin/sh "$benchmark_script" --inventory-only \
+        >"$test_root/$run_environment_rejection_name.out" 2>&1
+    run_environment_rejection_status=$?
+    set -e
+    if [ "$run_environment_rejection_status" -ne 2 ] ||
+       ! grep -q -- "$run_environment_rejection_message" \
+           "$test_root/$run_environment_rejection_name.out"; then
+        printf '%s\n' "$run_environment_rejection_name: unexpected rejection" >&2
+        command cat "$test_root/$run_environment_rejection_name.out" >&2
+        exit 1
+    fi
+}
+
 canonical_root="$test_root/canonical"
 canonical_builds="$canonical_root/builds"
 mkdir -p "$canonical_builds"
@@ -107,6 +129,10 @@ printf '%s\n' 'canonical' > "$nondirect_parent_root/builds/CURRENT"
 run_assert_direct_file 2 nondirect-parent \
     "$nondirect_parent_root/direct/../builds" \
     "$nondirect_parent_root/direct/../builds/CURRENT"
+
+run_environment_rejection ci-refusal 'refused in CI' \
+    true I_UNDERSTAND_THIS_READS_PROPRIETARY_DATA
+run_environment_rejection opt-in-refusal 'manual opt-in required' '' ''
 
 run_benchmark_rejection missing-roots 'requires explicit --cache-root and --manifest' \
     --inventory-only

--- a/benchmarks/fertility-surveys/test-benchmark-helpers.sh
+++ b/benchmarks/fertility-surveys/test-benchmark-helpers.sh
@@ -49,6 +49,26 @@ run_assert_direct_file() {
     fi
 }
 
+run_benchmark_rejection() {
+    run_benchmark_rejection_name=$1
+    run_benchmark_rejection_message=$2
+    shift 2
+    set +e
+    CI= GITHUB_ACTIONS= GITHUB_RUN_ID= GITHUB_WORKFLOW= \
+        DTAPARSER_FERTILITY_CORPUS=I_UNDERSTAND_THIS_READS_PROPRIETARY_DATA \
+        /bin/sh "$benchmark_script" "$@" \
+        >"$test_root/$run_benchmark_rejection_name.out" 2>&1
+    run_benchmark_rejection_status=$?
+    set -e
+    if [ "$run_benchmark_rejection_status" -ne 2 ] ||
+       ! grep -q -- "$run_benchmark_rejection_message" \
+           "$test_root/$run_benchmark_rejection_name.out"; then
+        printf '%s\n' "$run_benchmark_rejection_name: unexpected rejection" >&2
+        command cat "$test_root/$run_benchmark_rejection_name.out" >&2
+        exit 1
+    fi
+}
+
 canonical_root="$test_root/canonical"
 canonical_builds="$canonical_root/builds"
 mkdir -p "$canonical_builds"
@@ -87,3 +107,18 @@ printf '%s\n' 'canonical' > "$nondirect_parent_root/builds/CURRENT"
 run_assert_direct_file 2 nondirect-parent \
     "$nondirect_parent_root/direct/../builds" \
     "$nondirect_parent_root/direct/../builds/CURRENT"
+
+run_benchmark_rejection missing-roots 'requires explicit --cache-root and --manifest' \
+    --inventory-only
+run_benchmark_rejection nonabsolute-root 'must be explicit absolute paths' \
+    --cache-root=relative --manifest="$test_root/manifest.csv" --inventory-only
+run_benchmark_rejection noncanonical-root 'must be canonical paths' \
+    --cache-root="$test_root/direct/../cache" \
+    --manifest="$test_root/manifest.csv" --inventory-only
+run_benchmark_rejection duplicate-root 'requires explicit --cache-root and --manifest' \
+    --cache-root="$test_root/cache" --cache-root="$test_root/cache" \
+    --manifest="$test_root/manifest.csv" --inventory-only
+run_benchmark_rejection wrong-output-mode \
+    '--output-root must be supplied once without raw root arguments' \
+    --output-root="$test_root/output" --cache-root="$test_root/cache" \
+    --manifest="$test_root/manifest.csv" --inventory-only

--- a/benchmarks/fertility-surveys/test-benchmark-helpers.sh
+++ b/benchmarks/fertility-surveys/test-benchmark-helpers.sh
@@ -1,0 +1,89 @@
+#!/bin/sh
+set -eu
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd -P)
+benchmark_script="$script_dir/benchmark.sh"
+test_root=$(mktemp -d "${TMPDIR:-/tmp}/fertility-benchmark-helpers.XXXXXX")
+test_root=$(CDPATH= cd -- "$test_root" && pwd -P)
+trap 'rm -rf "$test_root"' EXIT HUP INT TERM
+helper_definitions="$test_root/helpers.sh"
+
+extract_function() {
+    extract_function_name=$1
+    awk -v signature="$extract_function_name() {" '
+        $0 == signature { copying = 1 }
+        copying { print }
+        copying && $0 == "}" { exit }
+    ' "$benchmark_script"
+}
+
+{
+    extract_function assert_direct_directory
+    extract_function assert_direct_file
+} > "$helper_definitions"
+
+if ! grep -q '^assert_direct_directory() {$' "$helper_definitions" ||
+   ! grep -q '^assert_direct_file() {$' "$helper_definitions"; then
+    printf '%s\n' 'could not extract benchmark path helper definitions' >&2
+    exit 1
+fi
+
+run_assert_direct_file() {
+    run_assert_direct_file_expected=$1
+    run_assert_direct_file_name=$2
+    run_assert_direct_file_parent=$3
+    run_assert_direct_file_child=$4
+    set +e
+    /bin/sh -c '. "$1"; assert_direct_file "$2" "$3" "build CURRENT"' sh \
+        "$helper_definitions" \
+        "$run_assert_direct_file_parent" \
+        "$run_assert_direct_file_child" \
+        >"$test_root/$run_assert_direct_file_name.out" 2>&1
+    run_assert_direct_file_status=$?
+    set -e
+    if [ "$run_assert_direct_file_status" -ne "$run_assert_direct_file_expected" ]; then
+        printf '%s\n' \
+            "$run_assert_direct_file_name: expected exit $run_assert_direct_file_expected, got $run_assert_direct_file_status" >&2
+        command cat "$test_root/$run_assert_direct_file_name.out" >&2
+        exit 1
+    fi
+}
+
+canonical_root="$test_root/canonical"
+canonical_builds="$canonical_root/builds"
+mkdir -p "$canonical_builds"
+printf '%s\n' 'canonical' > "$canonical_builds/CURRENT"
+run_assert_direct_file 0 canonical \
+    "$canonical_builds" "$canonical_builds/CURRENT"
+
+symlink_root="$test_root/symlink-current"
+mkdir -p "$symlink_root/builds"
+printf '%s\n' 'outside' > "$symlink_root/outside"
+ln -s "$symlink_root/outside" "$symlink_root/builds/CURRENT"
+run_assert_direct_file 2 symlink-current \
+    "$symlink_root/builds" "$symlink_root/builds/CURRENT"
+
+directory_root="$test_root/directory-current"
+mkdir -p "$directory_root/builds/CURRENT"
+run_assert_direct_file 2 directory-current \
+    "$directory_root/builds" "$directory_root/builds/CURRENT"
+
+nonregular_root="$test_root/nonregular-current"
+mkdir -p "$nonregular_root/builds"
+mkfifo "$nonregular_root/builds/CURRENT"
+run_assert_direct_file 2 nonregular-current \
+    "$nonregular_root/builds" "$nonregular_root/builds/CURRENT"
+
+symlinked_parent_root="$test_root/symlinked-parent"
+mkdir -p "$symlinked_parent_root/real-builds"
+printf '%s\n' 'canonical' > "$symlinked_parent_root/real-builds/CURRENT"
+ln -s "$symlinked_parent_root/real-builds" "$symlinked_parent_root/builds"
+run_assert_direct_file 2 symlinked-parent \
+    "$symlinked_parent_root/builds" "$symlinked_parent_root/builds/CURRENT"
+
+nondirect_parent_root="$test_root/nondirect-parent"
+mkdir -p "$nondirect_parent_root/direct" "$nondirect_parent_root/builds"
+printf '%s\n' 'canonical' > "$nondirect_parent_root/builds/CURRENT"
+run_assert_direct_file 2 nondirect-parent \
+    "$nondirect_parent_root/direct/../builds" \
+    "$nondirect_parent_root/direct/../builds/CURRENT"

--- a/benchmarks/fertility-surveys/test-framework.R
+++ b/benchmarks/fertility-surveys/test-framework.R
@@ -1175,6 +1175,102 @@ full_bad_supported_class[[1L]]$results$classification[[additional_supported]] <-
 expect_error(fertility_validate_shard_bundles(
     full_bad_supported_class, full_fixture$id, full_canonical
 ), "executable accounting")
+
+output_releases <- rep(
+    as.integer(names(fertility_output_expected_releases)),
+    as.integer(fertility_output_expected_releases)
+)
+output_levels <- rep(
+    names(fertility_output_expected_levels),
+    as.integer(fertility_output_expected_levels)
+)
+output_canonical <- data.frame(
+    id = sprintf("F%04d", seq_len(fertility_output_expected_files)),
+    program = "output", level = output_levels, release = output_releases,
+    stringsAsFactors = FALSE
+)
+output_options <- fertility_parse_arguments(c(
+    "--program=output", "--shard-index=1", "--shard-count=8"
+))
+stopifnot(fertility_full_output_family(output_options),
+          fertility_full_default_family(output_options),
+          !fertility_full_default_family(fertility_parse_arguments(c(
+              "--program=output", "--release=118"
+          ))))
+output_classes <- rep("pass", fertility_output_expected_files)
+output_classes[output_releases == 111L] <- "expected-unsupported-111"
+output_fixture <- make_bundle_family(
+    output_canonical, output_options, output_classes,
+    inventory_id = paste(rep("a", 64L), collapse = "")
+)
+output_validated <- fertility_validate_shard_bundles(
+    output_fixture$bundles, output_fixture$id, output_canonical
+)
+stopifnot(output_validated$full_default,
+          nrow(output_validated$results) == fertility_output_expected_files)
+output_bad_unsupported <- output_fixture$bundles
+output_bad_unsupported[[1L]]$results$classification[[1L]] <- "pass"
+expect_error(fertility_validate_shard_bundles(
+    output_bad_unsupported, output_fixture$id, output_canonical
+), "unsupported-release classifications")
+output_bad_terminal <- output_fixture$bundles
+supported_bundle <- which(vapply(output_bad_terminal, function(bundle) {
+    "F0131" %in% bundle$results$id
+}, logical(1)))[[1L]]
+supported_row <- match("F0131", output_bad_terminal[[supported_bundle]]$results$id)
+output_bad_terminal[[supported_bundle]]$results$classification[[supported_row]] <-
+    "timeout"
+expect_error(fertility_validate_shard_bundles(
+    output_bad_terminal, output_fixture$id, output_canonical
+), "executable accounting")
+output_bad_complete <- output_fixture$bundles
+output_bad_complete[[supported_bundle]]$results$complete[[supported_row]] <- "FALSE"
+expect_error(fertility_validate_shard_bundles(
+    output_bad_complete, output_fixture$id, output_canonical
+), "executable accounting")
+output_bad_release_canonical <- output_canonical
+output_bad_release_canonical$release[[131L]] <- 118L
+output_bad_release_fixture <- make_bundle_family(
+    output_bad_release_canonical, output_options, output_classes,
+    inventory_id = paste(rep("b", 64L), collapse = "")
+)
+expect_error(fertility_validate_shard_bundles(
+    output_bad_release_fixture$bundles, output_bad_release_fixture$id,
+    output_bad_release_canonical
+), "release counts")
+output_bad_level_canonical <- output_canonical
+output_bad_level_canonical$level[[9L]] <- "aggregate"
+output_bad_level_fixture <- make_bundle_family(
+    output_bad_level_canonical, output_options, output_classes,
+    inventory_id = paste(rep("c", 64L), collapse = "")
+)
+expect_error(fertility_validate_shard_bundles(
+    output_bad_level_fixture$bundles, output_bad_level_fixture$id,
+    output_bad_level_canonical
+), "level counts")
+
+publication_na <- make_public_results(output_canonical[1L, , drop = FALSE],
+                                      "expected-unsupported-111")
+publication_na$rows <- NA_character_
+publication_na$columns <- NA_character_
+publication_na$elapsed_seconds <- NA_character_
+publication_na <- fertility_publication_frame(publication_na)
+stopifnot(!anyNA(publication_na), publication_na$rows[[1L]] == "",
+          publication_na$columns[[1L]] == "",
+          publication_na$elapsed_seconds[[1L]] == "")
+publication_na_root <- file.path(root, "publication-na")
+dir.create(publication_na_root)
+fertility_atomic_write_table(
+    publication_na, file.path(publication_na_root, "results.tsv")
+)
+stopifnot(identical(
+    fertility_validate_exact_table_bundle(
+        publication_na_root, c(results = "results.tsv"),
+        list(results = publication_na), "NA publication regression"
+    )$results,
+    fertility_character_frame(publication_na)
+))
+
 stopifnot(nrow(fertility_validate_canonical_inventory(
     full_canonical, exact = TRUE
 )) == fertility_expected_rows)

--- a/benchmarks/fertility-surveys/test-framework.R
+++ b/benchmarks/fertility-surveys/test-framework.R
@@ -3081,6 +3081,46 @@ stopifnot(
         reader_error_tiles, complete = FALSE, execution_complete = TRUE
     ) == "haven-only-error"
 )
+terminal_reader_error_tiles <- traversed_tiles
+terminal_reader_error <- length(terminal_reader_error_tiles)
+terminal_reader_error_tiles[[terminal_reader_error]]$classification <-
+    "haven-only-error"
+terminal_reader_error_tiles[[terminal_reader_error]]$projection_ok[["haven"]] <- FALSE
+terminal_reader_error_tiles[[terminal_reader_error]]$projection_counts[["haven"]] <-
+    NA_integer_
+terminal_reader_error_tiles[[terminal_reader_error]]$projection_hashes[["haven"]] <-
+    NA_character_
+stopifnot(
+    fertility_validate_tile_execution(
+        terminal_reader_error_tiles, synthetic_batches, 3, tile_configuration,
+        length(terminal_reader_error_tiles)
+    ),
+    !fertility_validate_tile_completeness(
+        terminal_reader_error_tiles, synthetic_batches, 3, tile_configuration
+    ),
+    fertility_aggregate_classification(
+        terminal_reader_error_tiles, complete = FALSE, execution_complete = TRUE
+    ) == "haven-only-error"
+)
+malformed_terminal_plans <- list(
+    { value <- terminal_reader_error_tiles; value[[terminal_reader_error]]$framework_id <- NULL; value },
+    { value <- terminal_reader_error_tiles; value[[terminal_reader_error]]$projection_expected_count <- NULL; value },
+    { value <- terminal_reader_error_tiles; value[[terminal_reader_error]]$projection_expected_count <- 2L; value },
+    { value <- terminal_reader_error_tiles; value[[terminal_reader_error]]$projection_expected_hash <- NULL; value },
+    { value <- terminal_reader_error_tiles; value[[terminal_reader_error]]$projection_expected_hash <- paste(rep("0", 64L), collapse = ""); value }
+)
+for (malformed_terminal_plan in malformed_terminal_plans) {
+    stopifnot(
+        !fertility_validate_tile_execution(
+            malformed_terminal_plan, synthetic_batches, 3, tile_configuration,
+            length(malformed_terminal_plan)
+        ),
+        fertility_aggregate_classification(
+            malformed_terminal_plan, complete = FALSE,
+            execution_complete = FALSE
+        ) == "unresolved"
+    )
+}
 reader_planning_failure <- c(reader_error_tiles, list(list(
     tile_type = "planning", classification = "unresolved",
     secondary = "tile-ceiling-reached", mismatches = empty_mismatches

--- a/benchmarks/fertility-surveys/test-framework.R
+++ b/benchmarks/fertility-surveys/test-framework.R
@@ -2104,7 +2104,9 @@ merge_live_inventory <- full_canonical
 merge_live_inventory$expected_sha512 <- rep(
     paste(rep("a", 128L), collapse = ""), nrow(merge_live_inventory)
 )
-make_merged_bundle <- function(validated, family_id) {
+make_merged_bundle <- function(
+    validated, family_id, canonical_inventory = merge_live_inventory
+) {
     provenance <- validated$provenance
     family_input_attestation_id <- fertility_family_input_attestation_id(provenance)
     evidence_family_id <- fertility_evidence_family_id(
@@ -2129,7 +2131,7 @@ make_merged_bundle <- function(validated, family_id) {
         framework_id = provenance$framework_id[[1L]],
         config_id = provenance$config_id[[1L]],
         build_provenance_id = provenance$build_provenance_id[[1L]],
-        inventory_id = fertility_inventory_id(merge_live_inventory),
+        inventory_id = fertility_inventory_id(canonical_inventory),
         family_manifest_id = provenance$family_manifest_id[[1L]],
         report_schema_id = provenance$report_schema_id[[1L]],
         results_id = fertility_merged_results_id(validated$results),
@@ -2161,6 +2163,52 @@ accepted_assessment <- fertility_validate_merged_bundle(
 stopifnot(
     grepl("^[0-9a-f]{64}$", full_assessment$merge_id),
     grepl("^[0-9a-f]{64}$", accepted_assessment$merge_id)
+)
+production_framework_inventory <- fertility_framework_inventory(
+    publication_snapshot, inventory = publication_inventory,
+    framework_id = publication_framework_id
+)
+stopifnot(
+    !"expected_sha512" %in% names(production_framework_inventory$manifest),
+    identical(
+        production_framework_inventory$provenance$inventory_id[[1L]],
+        fertility_inventory_id(publication_inventory)
+    )
+)
+production_merged_bundle <- make_merged_bundle(
+    accepted_family_validated, accepted_family_fixture$id, publication_inventory
+)
+stopifnot(grepl("^[0-9a-f]{64}$", fertility_validate_merged_bundle(
+    production_merged_bundle, accepted_family_fixture$id, publication_inventory
+)$merge_id))
+wrong_live_signature <- publication_inventory
+wrong_live_signature$expected_sha512[[1L]] <- paste(rep("b", 128L), collapse = "")
+expect_error(fertility_framework_inventory(
+    publication_snapshot, inventory = wrong_live_signature,
+    framework_id = publication_framework_id
+), "does not match the live inventory")
+expect_error(fertility_validate_merged_bundle(
+    production_merged_bundle, accepted_family_fixture$id, wrong_live_signature
+), "does not match canonical inventory authority")
+wrong_live_inventory_id <- production_merged_bundle
+wrong_live_inventory_id$provenance$inventory_id <- paste(rep("b", 64L), collapse = "")
+expect_error(fertility_validate_merged_bundle(
+    wrong_live_inventory_id, accepted_family_fixture$id, publication_inventory
+), "does not match canonical inventory authority")
+merge_source <- paste(
+    readLines(file.path(script_dir, "merge.R"), warn = FALSE), collapse = "\n"
+)
+stopifnot(
+    grepl("inventory = live_inventory", merge_source, fixed = TRUE),
+    grepl("inventory = current_live_inventory", merge_source, fixed = TRUE),
+    grepl(
+        "fertility_validate_merged_bundle(loaded, family_id, canonical_inventory)",
+        merge_source, fixed = TRUE
+    ),
+    !grepl(
+        "fertility_validate_merged_bundle(\n        loaded, family_id, framework_inventory$manifest",
+        merge_source, fixed = TRUE
+    )
 )
 tampered_merged_results <- accepted_merged_bundle
 tampered_merged_results$results$classification[[1L]] <- "timeout"

--- a/benchmarks/fertility-surveys/test-framework.R
+++ b/benchmarks/fertility-surveys/test-framework.R
@@ -103,7 +103,7 @@ local({
         fifo <- file.path(fixture, "nonregular.dta")
         stopifnot(system2(mkfifo, shQuote(fifo)) == 0L)
         expect_error(
-            fertility_output_entries(fertility_output_root), "must be a regular file"
+            fertility_output_entries(fertility_output_root), "attest regular files"
         )
         unlink(fifo)
     }

--- a/benchmarks/fertility-surveys/test-framework.R
+++ b/benchmarks/fertility-surveys/test-framework.R
@@ -7,6 +7,7 @@ source(file.path(script_dir, "runner.R"))
 source(file.path(script_dir, "worker.R"))
 source(file.path(script_dir, "runtime.R"))
 source(file.path(script_dir, "provenance.R"))
+fertility_output_root <- NULL
 
 expect_error <- function(expression, pattern) {
     error <- tryCatch({ force(expression); NULL }, error = identity)
@@ -845,13 +846,18 @@ stopifnot(file.copy(
     file.path(script_dir, "benchmark.sh"), file.path(shell_script_dir, "benchmark.sh")
 ), file.symlink(confinement_outside, file.path(shell_raw, "tmp")))
 run_shell_confinement <- function(arguments = "--inventory-only") {
+    source_arguments <- c(
+        paste0("--cache-root=", file.path(root, "unused-cache")),
+        paste0("--manifest=", file.path(root, "unused-manifest.csv"))
+    )
     suppressWarnings(system2(
     "/usr/bin/env",
     c(
         "-u", "CI", "-u", "GITHUB_ACTIONS", "-u", "GITHUB_RUN_ID",
         "-u", "GITHUB_WORKFLOW",
         paste0("DTAPARSER_FERTILITY_CORPUS=", fertility_opt_in_value),
-        "sh", file.path(shell_script_dir, "benchmark.sh"), arguments
+        "sh", file.path(shell_script_dir, "benchmark.sh"),
+        source_arguments, arguments
     ),
     stdout = TRUE, stderr = TRUE
     ))
@@ -1002,8 +1008,7 @@ for (i in seq_along(paths)) write_release(paths[[i]], releases[[i]])
 datasigs <- file.path(root, "datasigs.csv")
 write.csv(rows, datasigs, row.names = FALSE, quote = FALSE)
 inventory <- fertility_build_inventory(
-    list(cache = cache, datasigs = datasigs), assert_counts = FALSE,
-    enforce_required_paths = FALSE
+    list(cache = cache, datasigs = datasigs), assert_counts = FALSE
 )
 stopifnot(
     identical(inventory$id, sprintf("F%04d", 1:5)),
@@ -1017,8 +1022,7 @@ stopifnot(
 primary_second <- file.path(cache, "DHS/Original_Data/BB,2001/bh.dta")
 write_release(primary_second, 113L)
 precedence_inventory <- fertility_build_inventory(
-    list(cache = cache, datasigs = datasigs), assert_counts = FALSE,
-    enforce_required_paths = FALSE
+    list(cache = cache, datasigs = datasigs), assert_counts = FALSE
 )
 stopifnot(precedence_inventory$path[[2L]] ==
           normalizePath(primary_second, winslash = "/"))
@@ -1026,10 +1030,74 @@ drifted_rows <- rows
 drifted_rows$level[[1L]] <- "survey"
 write.csv(drifted_rows, datasigs, row.names = FALSE, quote = FALSE)
 expect_error(fertility_build_inventory(
-    list(cache = cache, datasigs = datasigs), assert_counts = FALSE,
-    enforce_required_paths = FALSE
+    list(cache = cache, datasigs = datasigs), assert_counts = FALSE
 ), "unknown cache level")
 write.csv(rows, datasigs, row.names = FALSE, quote = FALSE)
+
+raw_source_arguments <- c(
+    paste0("--cache-root=", normalizePath(cache, winslash = "/")),
+    paste0("--manifest=", normalizePath(datasigs, winslash = "/"))
+)
+raw_source_options <- fertility_validate_source_arguments(
+    fertility_parse_arguments(raw_source_arguments)
+)
+stopifnot(
+    identical(raw_source_options$cache_root, normalizePath(cache, winslash = "/")),
+    identical(raw_source_options$manifest, normalizePath(datasigs, winslash = "/")),
+    identical(
+        fertility_tile_configuration(raw_source_options)$config_id,
+        fertility_tile_configuration(fertility_parse_arguments(character()))$config_id
+    )
+)
+expect_error(fertility_validate_source_arguments(
+    fertility_parse_arguments(character())
+), "requires explicit --cache-root and --manifest")
+expect_error(fertility_validate_source_arguments(
+    fertility_parse_arguments(raw_source_arguments[[1L]])
+), "requires explicit --cache-root and --manifest")
+expect_error(fertility_parse_arguments("--cache-root=relative"), "must be absolute")
+expect_error(fertility_parse_arguments("--manifest=relative"), "must be absolute")
+expect_error(fertility_validate_source_arguments(fertility_parse_arguments(c(
+    paste0("--cache-root=", cache, "/../", basename(cache)),
+    raw_source_arguments[[2L]]
+))), "must be canonical")
+expect_error(fertility_parse_arguments(c(
+    raw_source_arguments, raw_source_arguments[[1L]]
+)), "only once")
+wrong_mode_options <- fertility_parse_arguments(raw_source_arguments)
+wrong_mode_options$output_root <- "/private/generated-output"
+expect_error(fertility_validate_source_arguments(wrong_mode_options),
+             "invalid with --output-root")
+
+missing_root_entry_points <- list(
+    run.R = character(), prepare.R = character(),
+    merge.R = paste0("--family-id=", paste(rep("a", 64L), collapse = "")),
+    assessment.R = c(
+        paste0("--assessment-family-id=", paste(rep("a", 64L), collapse = "")),
+        paste0("--accepted-family-id=", paste(rep("b", 64L), collapse = ""))
+    ),
+    republish.R = c(
+        paste0("--republish-framework=", paste(rep("a", 64L), collapse = "")),
+        "--shard-count=8"
+    ),
+    accepted.R = "--capture-accepted-current-hashes"
+)
+for (entry_name in names(missing_root_entry_points)) {
+    output <- suppressWarnings(system2(
+        file.path(R.home("bin"), "Rscript"),
+        c("--vanilla", file.path(script_dir, entry_name),
+          missing_root_entry_points[[entry_name]]),
+        stdout = TRUE, stderr = TRUE,
+        env = c(
+            "CI=", "GITHUB_ACTIONS=", "GITHUB_RUN_ID=", "GITHUB_WORKFLOW=",
+            paste0("DTAPARSER_FERTILITY_CORPUS=", fertility_opt_in_value)
+        )
+    ))
+    stopifnot(
+        !is.null(attr(output, "status", exact = TRUE)),
+        any(grepl("cache-root|manifest|explicit raw roots", output))
+    )
+}
 
 options <- fertility_parse_arguments(c(
     "--program=dhs,mics", "--release=113,114", "--shard-index=1",

--- a/benchmarks/fertility-surveys/test-framework.R
+++ b/benchmarks/fertility-surveys/test-framework.R
@@ -29,8 +29,10 @@ local({
     outside <- file.path(root, "output-inventory-outside")
     dir.create(file.path(fixture, "nested"), recursive = TRUE)
     dir.create(outside)
-    writeBin(as.raw(1:3), file.path(fixture, "regular.dta"))
-    writeBin(as.raw(4:6), file.path(fixture, "nested", "upper.DTA"))
+    writeBin(c(as.raw(113L), as.raw(rep(0L, 40L))),
+             file.path(fixture, "regular.dta"))
+    writeBin(charToRaw("<stata_dta><header><release>118</release></header>"),
+             file.path(fixture, "nested", "upper.DTA"))
     writeLines("ignored", file.path(fixture, "notes.txt"))
     writeLines("outside", file.path(outside, "outside.txt"))
     stopifnot(file.symlink(
@@ -103,10 +105,90 @@ local({
         fifo <- file.path(fixture, "nonregular.dta")
         stopifnot(system2(mkfifo, shQuote(fifo)) == 0L)
         expect_error(
-            fertility_output_entries(fertility_output_root), "attest regular files"
+            fertility_output_entries(fertility_output_root), "attest.*regular files"
         )
         unlink(fifo)
     }
+
+    # A DTA swapped to an external symlink immediately before hashing/release
+    # cannot be opened, even when the original path is restored before a later
+    # traversal could observe the substitution.
+    descriptor_target <- file.path(fixture, "regular.dta")
+    descriptor_saved <- file.path(fixture, "regular.dta.saved")
+    external_dta <- file.path(outside, "external.dta")
+    writeBin(c(as.raw(113L), as.raw(rep(255L, 40L))), external_dta)
+    external_before <- unname(tools::sha256sum(external_dta))
+    restorer <- NULL
+    options(dtaparser.fertility.output_inventory_test_hook = function(
+        boundary, context
+    ) {
+        if (identical(boundary, "before-descriptor-content-read")) {
+            stopifnot(
+                file.rename(descriptor_target, descriptor_saved),
+                file.symlink(external_dta, descriptor_target)
+            )
+            restorer <<- callr::r_bg(function(path, saved) {
+                Sys.sleep(0.5)
+                unlink(path)
+                if (!file.rename(saved, path)) stop("could not restore descriptor fixture")
+                TRUE
+            }, args = list(descriptor_target, descriptor_saved),
+            supervise = TRUE, user_profile = FALSE, system_profile = FALSE)
+        }
+    })
+    expect_error(
+        fertility_output_descriptor_manifest(fertility_output_root, TRUE),
+        "descriptor-bound regular files"
+    )
+    stopifnot(!is.null(restorer))
+    restorer$wait(timeout = 5000L)
+    stopifnot(
+        identical(restorer$get_result(), TRUE),
+        !fertility_path_is_symlink(descriptor_target),
+        file.exists(descriptor_target),
+        !file.exists(descriptor_saved),
+        identical(unname(tools::sha256sum(external_dta)), external_before)
+    )
+    options(dtaparser.fertility.output_inventory_test_hook = NULL)
+
+    descriptor_capture <- fertility_nofollow_file_capture(
+        descriptor_target, include_release = TRUE
+    )
+    stopifnot(
+        identical(descriptor_capture$release, 113L),
+        identical(descriptor_capture$sha512,
+                  fertility_file_sha512(descriptor_target))
+    )
+    restorer <- NULL
+    options(dtaparser.fertility.output_inventory_test_hook = function(
+        boundary, context
+    ) {
+        if (identical(boundary, "before-descriptor-file-read")) {
+            stopifnot(
+                file.rename(descriptor_target, descriptor_saved),
+                file.symlink(external_dta, descriptor_target)
+            )
+            restorer <<- callr::r_bg(function(path, saved) {
+                Sys.sleep(0.5)
+                unlink(path)
+                if (!file.rename(saved, path)) stop("could not restore capture fixture")
+                TRUE
+            }, args = list(descriptor_target, descriptor_saved),
+            supervise = TRUE, user_profile = FALSE, system_profile = FALSE)
+        }
+    })
+    expect_error(
+        fertility_nofollow_file_capture(descriptor_target, include_release = TRUE),
+        "descriptor-bound file capture failed"
+    )
+    stopifnot(!is.null(restorer))
+    restorer$wait(timeout = 5000L)
+    stopifnot(
+        identical(restorer$get_result(), TRUE),
+        !fertility_path_is_symlink(descriptor_target),
+        identical(unname(tools::sha256sum(external_dta)), external_before)
+    )
+    options(dtaparser.fertility.output_inventory_test_hook = NULL)
 })
 
 # Output confinement rejects symlinked roots, publication descendants, CURRENT

--- a/benchmarks/fertility-surveys/test-framework.R
+++ b/benchmarks/fertility-surveys/test-framework.R
@@ -1203,6 +1203,12 @@ output_fixture <- make_bundle_family(
     output_canonical, output_options, output_classes,
     inventory_id = paste(rep("a", 64L), collapse = "")
 )
+output_fixture$bundles <- lapply(output_fixture$bundles, function(bundle) {
+    supported_rows <- bundle$results$release != "111"
+    bundle$results$tiles_expected[supported_rows] <- "1"
+    bundle$results$tiles_completed[supported_rows] <- "1"
+    bundle
+})
 output_validated <- fertility_validate_shard_bundles(
     output_fixture$bundles, output_fixture$id, output_canonical
 )
@@ -1241,6 +1247,20 @@ output_bad_terminal[[supported_bundle]]$results$classification[[supported_row]] 
     "timeout"
 expect_error(fertility_validate_shard_bundles(
     output_bad_terminal, output_fixture$id, output_canonical
+), "executable accounting")
+output_terminal_reader_error <- output_fixture$bundles
+output_terminal_reader_error[[supported_bundle]]$results$classification[[supported_row]] <-
+    "haven-only-error"
+output_terminal_reader_error[[supported_bundle]]$results$complete[[supported_row]] <-
+    "FALSE"
+stopifnot(nrow(fertility_validate_shard_bundles(
+    output_terminal_reader_error, output_fixture$id, output_canonical
+)$results) == fertility_output_expected_files)
+output_bad_tile_accounting <- output_terminal_reader_error
+output_bad_tile_accounting[[supported_bundle]]$results$tiles_completed[[supported_row]] <-
+    "0"
+expect_error(fertility_validate_shard_bundles(
+    output_bad_tile_accounting, output_fixture$id, output_canonical
 ), "executable accounting")
 output_bad_complete <- output_fixture$bundles
 output_bad_complete[[supported_bundle]]$results$complete[[supported_row]] <- "FALSE"

--- a/benchmarks/fertility-surveys/test-framework.R
+++ b/benchmarks/fertility-surveys/test-framework.R
@@ -5085,7 +5085,14 @@ fertility_write_owner(stale_temp, list(
 fertility_clean_stale_tempdirs(temp_root, current_temp)
 stopifnot(dir.exists(current_temp), !file.exists(stale_temp))
 
-# Runtime dependencies are bound to canonical paths and installed trees.
+# Runtime dependencies and source artifacts are bound to canonical identities.
+valid_source_sha256 <- paste(rep("a", 64L), collapse = "")
+stopifnot(identical(
+    fertility_source_tarball_sha256(toupper(valid_source_sha256)),
+    valid_source_sha256
+))
+expect_error(fertility_source_tarball_sha256(NA_character_), "SHA-256 is invalid")
+expect_error(fertility_source_tarball_sha256("invalid"), "SHA-256 is invalid")
 dependency <- fertility_dependency_provenance("rlang")
 moved <- dependency
 moved$rlang_path <- paste0(moved$rlang_path, "-moved")

--- a/benchmarks/fertility-surveys/test-framework.R
+++ b/benchmarks/fertility-surveys/test-framework.R
@@ -232,6 +232,55 @@ local({
         identical(unname(tools::sha256sum(external_dta)), external_before)
     )
 
+    # Replacing an ancestor above the configured output root after lexical
+    # validation cannot redirect descriptor traversal into another tree.
+    ancestor_parent <- file.path(root, "output-ancestor")
+    ancestor_saved <- paste0(ancestor_parent, ".saved")
+    ancestor_output <- file.path(ancestor_parent, "output")
+    external_ancestor <- file.path(root, "external-output-ancestor")
+    dir.create(ancestor_output, recursive = TRUE)
+    dir.create(file.path(external_ancestor, "output"), recursive = TRUE)
+    writeBin(c(as.raw(113L), as.raw(rep(3L, 40L))),
+             file.path(ancestor_output, "original.dta"))
+    writeBin(c(as.raw(118L), as.raw(rep(4L, 40L))),
+             file.path(external_ancestor, "output", "replacement.dta"))
+    assign("fertility_output_root", normalizePath(
+        ancestor_output, winslash = "/", mustWork = TRUE
+    ), envir = .GlobalEnv)
+    restorer <- NULL
+    options(dtaparser.fertility.output_inventory_test_hook = function(
+        boundary, context
+    ) {
+        if (identical(boundary, "before-descriptor-content-read")) {
+            stopifnot(
+                file.rename(ancestor_parent, ancestor_saved),
+                file.symlink(external_ancestor, ancestor_parent)
+            )
+            restorer <<- callr::r_bg(function(path, saved) {
+                Sys.sleep(0.5)
+                unlink(path)
+                if (!file.rename(saved, path)) stop("could not restore output ancestor")
+                TRUE
+            }, args = list(ancestor_parent, ancestor_saved), supervise = TRUE,
+            user_profile = FALSE, system_profile = FALSE)
+        }
+    })
+    expect_error(
+        fertility_output_descriptor_manifest(fertility_output_root, TRUE),
+        "descriptor-bound regular files"
+    )
+    stopifnot(!is.null(restorer))
+    restorer$wait(timeout = 5000L)
+    stopifnot(
+        identical(restorer$get_result(), TRUE),
+        !fertility_path_is_symlink(ancestor_parent),
+        file.exists(file.path(ancestor_output, "original.dta"))
+    )
+    assign("fertility_output_root", normalizePath(
+        fixture, winslash = "/", mustWork = TRUE
+    ), envir = .GlobalEnv)
+    options(dtaparser.fertility.output_inventory_test_hook = NULL)
+
     capture_parent <- file.path(fixture, "capture-parent")
     capture_parent_saved <- paste0(capture_parent, ".saved")
     external_parent <- file.path(outside, "capture-parent")
@@ -270,6 +319,67 @@ local({
         !fertility_path_is_symlink(capture_parent)
     )
     options(dtaparser.fertility.output_inventory_test_hook = NULL)
+})
+
+# A worker connection is accepted only for the captured inode, survives source
+# parent substitution, resets its shared file offset between independent reads,
+# and closes deterministically after both successful and failed workers.
+local({
+    bound_parent <- file.path(root, "bound-worker-parent")
+    bound_saved <- paste0(bound_parent, ".saved")
+    dir.create(bound_parent)
+    bound_path <- file.path(bound_parent, "input.dta")
+    original <- as.raw(seq_len(64L))
+    replacement <- as.raw(rep(255L, length(original)))
+    writeBin(original, bound_path)
+    bound_item <- list(
+        id = "FBOUND", release = 113L, expected_sha512 = "",
+        path = normalizePath(bound_path, winslash = "/", mustWork = TRUE)
+    )
+    bound_input <- fertility_capture_input(bound_item)
+    connection <- fertility_open_bound_input_connection(bound_item$path, bound_input)
+    stopifnot(file.rename(bound_parent, bound_saved), dir.create(bound_parent))
+    writeBin(replacement, bound_path)
+    observed <- callr::r(
+        function(common_script) {
+            source(common_script, local = environment())
+            lapply(seq_len(3L), function(index) {
+                fertility_reset_bound_input("/dev/fd/3")
+                readBin("/dev/fd/3", "raw", n = 64L)
+            })
+        },
+        args = list(file.path(script_dir, "common.R")),
+        connections = list(connection), poll_connection = FALSE,
+        user_profile = FALSE, system_profile = FALSE
+    )
+    stopifnot(all(vapply(observed, identical, logical(1), original)))
+    fertility_close_bound_input_connection(connection)
+    stopifnot(identical(processx::conn_get_fileno(connection), -1L))
+    unlink(bound_parent, recursive = TRUE)
+    stopifnot(file.rename(bound_saved, bound_parent))
+
+    # Opening after substitution must reject the stale captured identity.
+    stale_input <- fertility_capture_input(bound_item)
+    stopifnot(file.rename(bound_parent, bound_saved), dir.create(bound_parent))
+    writeBin(replacement, bound_path)
+    expect_error(
+        fertility_open_bound_input_connection(bound_path, stale_input),
+        "does not match captured identity"
+    )
+    unlink(bound_parent, recursive = TRUE)
+    stopifnot(file.rename(bound_saved, bound_parent))
+
+    failure_connection <- fertility_open_bound_input_connection(
+        bound_item$path, fertility_capture_input(bound_item)
+    )
+    failure <- tryCatch(callr::r(
+        function() stop("synthetic worker failure"),
+        connections = list(failure_connection), poll_connection = FALSE,
+        user_profile = FALSE, system_profile = FALSE
+    ), error = identity)
+    stopifnot(inherits(failure, "error"))
+    fertility_close_bound_input_connection(failure_connection)
+    stopifnot(identical(processx::conn_get_fileno(failure_connection), -1L))
 })
 
 # Output confinement rejects symlinked roots, publication descendants, CURRENT
@@ -4182,6 +4292,34 @@ if (dir.exists(file.path(checkout_library, "dtaparser"))) {
                 skip = 0L, n_max = 1L, .name_repair = "minimal"
             )
         )
+    )
+    fd_input <- fertility_capture_input(bounded_item)
+    fd_connection <- fertility_open_bound_input_connection(bounded_path, fd_input)
+    fd_values <- callr::r(
+        function(common_script, runtime_script, worker_script, tile, input) {
+            source(common_script, local = environment())
+            source(runtime_script, local = environment())
+            path <- fertility_materialize_bound_input(
+                "/dev/fd/3", input, dirname(tempdir())
+            )
+            on.exit(unlink(path), add = TRUE)
+            source(worker_script, local = environment())
+            lapply(c("direct", "rust", "haven"), function(reader) {
+                fertility_tile_read(reader, path, tile)
+            })
+        },
+        args = list(file.path(script_dir, "common.R"),
+                    file.path(script_dir, "runtime.R"),
+                    file.path(script_dir, "worker.R"), default_tile, fd_input),
+        libpath = .libPaths(), connections = list(fd_connection),
+        poll_connection = FALSE, user_profile = FALSE, system_profile = FALSE
+    )
+    fertility_close_bound_input_connection(fd_connection)
+    stopifnot(
+        identical(processx::conn_get_fileno(fd_connection), -1L),
+        identical(fd_values[[1L]], fd_values[[2L]]),
+        identical(fd_values[[1L]], fd_values[[3L]]),
+        identical(as.character(fd_values[[1L]]$text), "encoding_probe_ascii")
     )
     encoding_item <- bounded_item
     encoding_item$id <- "F9903"

--- a/benchmarks/fertility-surveys/test-framework.R
+++ b/benchmarks/fertility-surveys/test-framework.R
@@ -132,9 +132,21 @@ make_bundle_family <- function(
             family_id = family_id, shard_index = index,
             selected_ids = paste(expected$id, collapse = ",")
         ))
+        input_attestation_id <- fertility_stable_id(list(
+            synthetic_shard = index, ids = paste(expected$id, collapse = ",")
+        ))
+        evidence_selection_id <- fertility_evidence_selection_id(
+            selection_id, input_attestation_id, "fresh-execution",
+            fertility_schema_version, fertility_report_schema_id()
+        )
         provenance <- data.frame(
             schema_version = as.character(fertility_schema_version),
-            selection_id = selection_id, family_id = family_id,
+            report_schema_version = as.character(fertility_report_schema_version),
+            evidence_origin = "fresh-execution",
+            source_corpus_schema_version = as.character(fertility_schema_version),
+            replayed_at_utc = "", selection_id = selection_id,
+            evidence_selection_id = evidence_selection_id,
+            input_attestation_id = input_attestation_id, family_id = family_id,
             family_manifest_id = manifest_id, framework_id = test_framework_id,
             config_id = test_config_id, build_provenance_id = test_build_id,
             inventory_id = inventory_id, report_schema_id = fertility_report_schema_id(),
@@ -168,6 +180,60 @@ validated_merge <- fertility_validate_shard_bundles(
 )
 stopifnot(identical(validated_merge$results$id, c("F0001", "F0002")),
           validated_merge$shard_count == 2L)
+false_origin <- merge_bundles
+false_origin[[1L]]$provenance$evidence_origin <- "historical-schema-10-replay"
+expect_error(fertility_validate_shard_bundles(
+    false_origin, merge_fixture$id, canonical_inventory
+), "false claim|identical framework/config/build/inventory")
+historical_non_eight <- merge_bundles
+historical_config <- fertility_tile_configuration(fertility_parse_arguments(c(
+    "--shard-index=1", "--shard-count=8", "--timeout-seconds=600",
+    "--chunk-rows=50000", "--column-batch=32", "--memory-mib=1024",
+    "--cell-budget=10000000", "--max-tiles-per-batch=100000",
+    "--beyond-end-windows=1"
+)))
+historical_family_id <- fertility_family_id_from_manifest(
+    merge_fixture$manifest, test_framework_id, historical_config$config_id,
+    test_build_id, historical_non_eight[[1L]]$provenance$inventory_id[[1L]],
+    2L, Inf, fertility_report_schema_id(), "historical-schema-10-replay",
+    fertility_legacy_corpus_schema_version
+)
+for (index in seq_along(historical_non_eight)) {
+    provenance <- historical_non_eight[[index]]$provenance
+    selected_ids <- historical_non_eight[[index]]$results$id
+    selection_id <- fertility_stable_id(list(
+        family_id = historical_family_id, shard_index = index,
+        selected_ids = paste(selected_ids, collapse = ",")
+    ))
+    provenance$evidence_origin <- "historical-schema-10-replay"
+    provenance$source_corpus_schema_version <-
+        as.character(fertility_legacy_corpus_schema_version)
+    provenance$replayed_at_utc <- "2026-01-01T00:00:00Z"
+    provenance$family_id <- historical_family_id
+    provenance$config_id <- historical_config$config_id
+    provenance$selection_id <- selection_id
+    provenance$evidence_selection_id <- fertility_evidence_selection_id(
+        selection_id, provenance$input_attestation_id[[1L]],
+        provenance$evidence_origin[[1L]],
+        fertility_legacy_corpus_schema_version, fertility_report_schema_id()
+    )
+    provenance$timeout_seconds <- "600"
+    provenance$chunk_rows <- "50000"
+    provenance$column_batch <- "32"
+    provenance$memory_mib <- "1024"
+    provenance$cell_budget <- "10000000"
+    provenance$max_tiles_per_batch <- "100000"
+    provenance$beyond_end_windows <- "1"
+    historical_non_eight[[index]]$provenance <- provenance
+}
+expect_error(fertility_validate_shard_bundles(
+    historical_non_eight, historical_family_id, canonical_inventory
+), "exact eight-shard run")
+false_attestation <- merge_bundles
+false_attestation[[1L]]$provenance$input_attestation_id <- paste(rep("f", 64L), collapse = "")
+expect_error(fertility_validate_shard_bundles(
+    false_attestation, merge_fixture$id, canonical_inventory
+), "evidence selection identity")
 expect_error(fertility_validate_shard_bundles(
     merge_bundles[1L], merge_fixture$id, canonical_inventory
 ), "every shard index")
@@ -248,21 +314,29 @@ privacy_provenance[[1L]]$provenance$path <- "/private/source"
 expect_error(fertility_validate_shard_bundles(
     privacy_provenance, merge_fixture$id, canonical_inventory
 ), "provenance schema")
-prior_report_schema_id <- fertility_stable_id(list(
-    schema_version = 9L,
-    fields = paste(fertility_result_fields(), collapse = ","),
-    contract = paste(
-        "hash,id,enum,manifest-release,enum,fixed-categories,count,",
-        "fixed-counts,hashed-counts,optional-number,optional-count,count,",
-        "count,boolean,optional-number,hash", sep = ""
-    )
-))
-stopifnot(!identical(prior_report_schema_id, fertility_report_schema_id()))
+prior_report_schema_id <- fertility_report_schema_id(
+    fertility_legacy_report_schema_version
+)
+stopifnot(
+    !identical(prior_report_schema_id, fertility_report_schema_id()),
+    fertility_report_schema_version != fertility_schema_version
+)
 wrong_report_schema <- merge_bundles
 wrong_report_schema[[1L]]$provenance$report_schema_id <- prior_report_schema_id
 expect_error(fertility_validate_shard_bundles(
     wrong_report_schema, merge_fixture$id, canonical_inventory
 ), "identical framework/config/build/inventory|schema identity")
+wrong_report_version <- merge_bundles
+wrong_report_version[[1L]]$provenance$report_schema_version <-
+    as.character(fertility_legacy_report_schema_version)
+expect_error(fertility_validate_shard_bundles(
+    wrong_report_version, merge_fixture$id, canonical_inventory
+), "invalid scalar|identical framework/config/build/inventory")
+missing_report_version <- merge_bundles
+missing_report_version[[1L]]$provenance$report_schema_version <- NULL
+expect_error(fertility_validate_shard_bundles(
+    missing_report_version, merge_fixture$id, canonical_inventory
+), "provenance schema")
 substituted_manifest <- merge_bundles
 substituted_manifest[[1L]]$family_manifest$id[[1L]] <- "F0003"
 expect_error(fertility_validate_shard_bundles(
@@ -381,6 +455,107 @@ full_canonical_bad_release$release[[131L]] <- 114L
 expect_error(fertility_validate_canonical_inventory(
     full_canonical_bad_release, exact = TRUE
 ), "release counts")
+legacy_snapshot <- file.path(root, "legacy-framework-snapshot")
+dir.create(legacy_snapshot)
+fertility_atomic_write_table(
+    full_canonical, file.path(legacy_snapshot, "inventory-manifest.tsv")
+)
+legacy_inventory_provenance <- data.frame(
+    schema_version = fertility_schema_version, framework_id = test_framework_id,
+    inventory_id = paste(rep("e", 64L), collapse = ""),
+    inventory_manifest_id = fertility_manifest_id(full_canonical),
+    report_schema_id = fertility_report_schema_id(
+        fertility_legacy_report_schema_version
+    ), files = nrow(full_canonical), stringsAsFactors = FALSE, check.names = FALSE
+)
+fertility_atomic_write_table(
+    legacy_inventory_provenance,
+    file.path(legacy_snapshot, "inventory-manifest-provenance.tsv")
+)
+stopifnot(nrow(fertility_framework_inventory(
+    legacy_snapshot, framework_id = test_framework_id,
+    report_schema_version = fertility_legacy_report_schema_version
+)$manifest) == fertility_expected_rows)
+expect_error(fertility_framework_inventory(
+    legacy_snapshot, framework_id = test_framework_id
+), "provenance is invalid")
+stale_legacy_provenance <- legacy_inventory_provenance
+stale_legacy_provenance$report_schema_id <- fertility_report_schema_id()
+fertility_atomic_write_table(
+    stale_legacy_provenance,
+    file.path(legacy_snapshot, "inventory-manifest-provenance.tsv")
+)
+expect_error(fertility_framework_inventory(
+    legacy_snapshot, framework_id = test_framework_id,
+    report_schema_version = fertility_legacy_report_schema_version
+), "provenance is invalid")
+fertility_atomic_write_table(
+    legacy_inventory_provenance,
+    file.path(legacy_snapshot, "inventory-manifest-provenance.tsv")
+)
+current_snapshot <- file.path(root, "current-framework-snapshot")
+dir.create(current_snapshot)
+fertility_atomic_write_table(
+    full_canonical, file.path(current_snapshot, "inventory-manifest.tsv")
+)
+current_inventory_provenance <- data.frame(
+    schema_version = fertility_schema_version,
+    report_schema_version = fertility_report_schema_version,
+    framework_id = test_framework_id,
+    inventory_id = paste(rep("e", 64L), collapse = ""),
+    inventory_manifest_id = fertility_manifest_id(full_canonical),
+    report_schema_id = fertility_report_schema_id(), files = nrow(full_canonical),
+    stringsAsFactors = FALSE, check.names = FALSE
+)
+fertility_atomic_write_table(
+    current_inventory_provenance,
+    file.path(current_snapshot, "inventory-manifest-provenance.tsv")
+)
+stopifnot(nrow(fertility_framework_inventory(
+    current_snapshot, framework_id = test_framework_id
+)$manifest) == fertility_expected_rows)
+fresh_snapshot_provenance <- data.frame(
+    evidence_origin = "fresh-execution",
+    source_corpus_schema_version = as.character(fertility_schema_version),
+    stringsAsFactors = FALSE
+)
+historical_snapshot_provenance <- data.frame(
+    evidence_origin = "historical-schema-10-replay",
+    source_corpus_schema_version =
+        as.character(fertility_legacy_corpus_schema_version),
+    stringsAsFactors = FALSE
+)
+stopifnot(
+    identical(
+        fertility_snapshot_report_schema_version(fresh_snapshot_provenance),
+        fertility_report_schema_version
+    ),
+    identical(
+        fertility_snapshot_report_schema_version(historical_snapshot_provenance),
+        fertility_legacy_report_schema_version
+    ),
+    nrow(fertility_framework_inventory(
+        legacy_snapshot, framework_id = test_framework_id,
+        report_schema_version = fertility_snapshot_report_schema_version(
+            historical_snapshot_provenance
+        )
+    )$manifest) == fertility_expected_rows,
+    nrow(fertility_framework_inventory(
+        current_snapshot, framework_id = test_framework_id,
+        report_schema_version = fertility_snapshot_report_schema_version(
+            fresh_snapshot_provenance
+        )
+    )$manifest) == fertility_expected_rows
+)
+mixed_snapshot_provenance <- rbind(
+    fresh_snapshot_provenance, historical_snapshot_provenance
+)
+expect_error(fertility_snapshot_report_schema_version(
+    mixed_snapshot_provenance
+), "mixed evidence origins")
+expect_error(fertility_snapshot_report_schema_version(data.frame(
+    source_corpus_schema_version = as.character(fertility_schema_version)
+)), "unavailable")
 preflight_item <- list(expected_sha512 = paste(rep("a", 128L), collapse = ""))
 preflight_match <- list(hash_status = "ok", actual_sha512 = preflight_item$expected_sha512)
 preflight_mismatch <- list(hash_status = "ok",
@@ -494,6 +669,15 @@ equal_count_public$mismatch_categories <- equal_count_summary$categories
 equal_count_public$mismatch_signatures <- equal_count_summary$signatures
 equal_count_public$secondary_categories <- "value-mismatch"
 stopifnot(isTRUE(fertility_validate_public_results(equal_count_public)))
+tied_categories <- fertility_mismatch_summary(list(list(mismatches = data.frame(
+    category = c("value-mismatch", "metadata-mismatch"),
+    detail = c("private-b", "private-a"), component = c(2L, 1L),
+    pair = c("direct-haven", "direct-rust"), stringsAsFactors = FALSE
+))))
+stopifnot(identical(
+    tied_categories$categories,
+    "metadata-mismatch=1,value-mismatch=1"
+))
 private_attribute <- pair_frames$haven
 attr(private_attribute$value, "private_source_attribute") <- "different"
 private_pair_result <- fertility_compare_available_pairs(
@@ -719,6 +903,275 @@ stopifnot(fertility_validate_tile_completeness(
           ),
           fertility_aggregate_classification(traversed_tiles, TRUE) ==
               "value-mismatch")
+reader_flags <- setNames(rep(FALSE, 3L), c("direct", "rust", "haven"))
+stopifnot(!length(fertility_reader_error_categories(reader_flags)))
+reader_flags[["rust"]] <- TRUE
+stopifnot(identical(fertility_reader_error_categories(reader_flags),
+                    "rust-reader-error"))
+legacy_tiles <- traversed_tiles
+legacy_tiles <- lapply(legacy_tiles, function(tile) {
+    tile$secondary <- c(tile$secondary, "-reader-error")
+    tile
+})
+similar_artifact_tiles <- legacy_tiles
+similar_artifact_tiles[[1L]]$secondary <- "-reader-errors"
+expect_error(fertility_tile_secondary(
+    similar_artifact_tiles, allow_legacy_empty_reader_artifact = TRUE
+), "non-canonical reader-error")
+expect_error(fertility_tiled_result(
+    list(id = "F0001", program = "dhs", level = "women", release = 118L,
+         expected_sha512 = ""),
+    test_framework_id, tile_configuration,
+    list(input_id = paste(rep("e", 64L), collapse = ""),
+         actual_sha512 = paste(rep("f", 128L), collapse = "")),
+    legacy_tiles, synthetic_batches, 3
+), "legacy empty-reader artifact")
+legacy_result <- fertility_tiled_result(
+    list(id = "F0001", program = "dhs", level = "women", release = 118L,
+         expected_sha512 = ""),
+    test_framework_id, tile_configuration,
+    list(input_id = paste(rep("e", 64L), collapse = ""),
+         actual_sha512 = paste(rep("f", 128L), collapse = "")),
+    legacy_tiles, synthetic_batches, 3,
+    allow_legacy_empty_reader_artifact = TRUE
+)
+stopifnot(!grepl("-reader-error", legacy_result$secondary_categories, fixed = TRUE))
+legacy_public <- fertility_result_frame(list(legacy_result))
+legacy_public$build_provenance_id <- test_build_id
+stopifnot(isTRUE(fertility_validate_public_results(legacy_public)))
+recorded_item <- list(
+    id = "F0001", program = "dhs", level = "women", release = 118L
+)
+stopifnot(fertility_recorded_result_valid(
+    legacy_result, recorded_item, test_framework_id, tile_configuration
+))
+foreign_schema_result <- legacy_result
+foreign_schema_result$schema_version <- fertility_schema_version + 1L
+stopifnot(
+    !fertility_recorded_result_valid(
+        foreign_schema_result, recorded_item, test_framework_id, tile_configuration
+    ),
+    fertility_recorded_result_valid(
+        foreign_schema_result, recorded_item, test_framework_id, tile_configuration,
+        corpus_schema_version = fertility_schema_version + 1L
+    )
+)
+stale_recorded_result <- legacy_result
+stale_recorded_result$schema_version <- fertility_schema_version - 1L
+stopifnot(!fertility_recorded_result_valid(
+    stale_recorded_result, recorded_item, test_framework_id, tile_configuration
+))
+private_recorded_result <- legacy_result
+private_recorded_result$private_path <- "/private/source"
+stopifnot(!fertility_recorded_result_valid(
+    private_recorded_result, recorded_item, test_framework_id, tile_configuration
+))
+attested_result <- legacy_result
+attested_result$expected_sha512 <- paste(rep("a", 128L), collapse = "")
+attested_result$actual_sha512 <- attested_result$expected_sha512
+attested_result$classification <- "pass"
+attested_result$secondary_categories <- ""
+stopifnot(isTRUE(fertility_validate_recorded_input_attestation(attested_result)))
+signature_failure <- attested_result
+signature_failure$actual_sha512 <- paste(rep("b", 128L), collapse = "")
+signature_failure$classification <- "inventory-hash-error"
+signature_failure$secondary_categories <- "signature-mismatch"
+stopifnot(isTRUE(fertility_validate_recorded_input_attestation(signature_failure)))
+hash_read_failure <- attested_result
+hash_read_failure$actual_sha512 <- NA_character_
+hash_read_failure$classification <- "inventory-hash-error"
+hash_read_failure$secondary_categories <- "hash-read-error"
+stopifnot(isTRUE(fertility_validate_recorded_input_attestation(hash_read_failure)))
+input_changed_failure <- attested_result
+input_changed_failure$classification <- "inventory-hash-error"
+input_changed_failure$secondary_categories <- "input-changed"
+stopifnot(isTRUE(fertility_validate_recorded_input_attestation(
+    input_changed_failure
+)))
+for (corpus_schema_version in c(
+    fertility_schema_version, fertility_legacy_corpus_schema_version
+)) {
+    for (attestation in list(
+        attested_result, signature_failure, hash_read_failure,
+        input_changed_failure
+    )) {
+        attestation$schema_version <- as.integer(corpus_schema_version)
+        stopifnot(
+            fertility_recorded_result_valid(
+                attestation, recorded_item, test_framework_id, tile_configuration,
+                corpus_schema_version = corpus_schema_version
+            ),
+            isTRUE(fertility_validate_recorded_input_attestation(attestation))
+        )
+    }
+}
+unsupported_attested <- attested_result
+unsupported_attested$classification <- "expected-unsupported-111"
+stopifnot(isTRUE(fertility_validate_recorded_input_attestation(unsupported_attested)))
+invalid_attestations <- list(
+    { value <- signature_failure; value$expected_sha512 <- ""; value },
+    { value <- signature_failure; value$actual_sha512 <- value$expected_sha512; value },
+    { value <- attested_result; value$actual_sha512 <- paste(rep("b", 128L), collapse = ""); value },
+    { value <- attested_result; value$actual_sha512 <- NA_character_; value },
+    { value <- attested_result; value$classification <- "inventory-hash-error"; value },
+    { value <- unsupported_attested; value$actual_sha512 <- paste(rep("b", 128L), collapse = ""); value },
+    { value <- attested_result; value$secondary_categories <- "signature-mismatch"; value },
+    { value <- hash_read_failure; value$actual_sha512 <- attested_result$actual_sha512; value },
+    { value <- input_changed_failure; value$actual_sha512 <- NA_character_; value },
+    { value <- input_changed_failure; value$input_id <- "invalid"; value },
+    { value <- input_changed_failure; value$secondary_categories <-
+        "input-changed,signature-mismatch"; value }
+)
+for (corpus_schema_version in c(
+    fertility_schema_version, fertility_legacy_corpus_schema_version
+)) {
+    for (invalid_attestation in invalid_attestations) {
+        invalid_attestation$schema_version <- as.integer(corpus_schema_version)
+        expect_error(
+            fertility_validate_recorded_input_attestation(invalid_attestation),
+            "preflight attestation is inconsistent"
+        )
+    }
+}
+empty_expected_attestation <- attested_result
+empty_expected_attestation$id <- "F0002"
+empty_expected_attestation$expected_sha512 <- ""
+input_attestation_id <- fertility_input_attestation_id(list(
+    attested_result, empty_expected_attestation
+))
+changed_empty_attestation <- empty_expected_attestation
+changed_empty_attestation$actual_sha512 <- paste(rep("c", 128L), collapse = "")
+stopifnot(
+    grepl("^[0-9a-f]{64}$", input_attestation_id),
+    !identical(input_attestation_id, fertility_input_attestation_id(list(
+        attested_result, changed_empty_attestation
+    )))
+)
+expect_error(fertility_input_attestation_id(list(
+    empty_expected_attestation, attested_result
+)), "canonical case order")
+stage_state <- new.env(parent = emptyenv())
+stage_state$paths <- setNames(logical(), character())
+stage_error <- tryCatch(fertility_prepare_report_stages(
+    list(1L, 2L),
+    create_stage = function(item) {
+        path <- paste0("stage", item)
+        stage_state$paths[[path]] <- TRUE
+        list(stage = path)
+    },
+    write_stage = function(stage, item) item != 2L,
+    remove_path = function(path) {
+        stage_state$paths[[path]] <- FALSE
+        TRUE
+    },
+    path_exists = function(path) isTRUE(stage_state$paths[[path]])
+), error = identity)
+stopifnot(inherits(stage_error, "error"),
+          !any(unlist(as.list(stage_state$paths), use.names = FALSE)))
+transaction_stages <- list(
+    list(parent = "p1", stage = "s1", published = "p1/n1", old_current = "old1"),
+    list(parent = "p2", stage = "s2", published = "p2/n2", old_current = NA_character_)
+)
+run_transaction_fixture <- function(fail_rename = 0L, fail_pointer = 0L,
+                                    fail_rollback = FALSE) {
+    state <- new.env(parent = emptyenv())
+    state$paths <- c(s1 = TRUE, s2 = TRUE, `p1/n1` = FALSE, `p2/n2` = FALSE)
+    state$pointers <- c(p1 = "old1", p2 = NA_character_)
+    state$rename_calls <- state$pointer_calls <- 0L
+    rename_path <- function(from, to) {
+        state$rename_calls <- state$rename_calls + 1L
+        if (state$rename_calls == fail_rename) return(FALSE)
+        state$paths[[from]] <- FALSE
+        state$paths[[to]] <- TRUE
+        TRUE
+    }
+    write_pointer <- function(parent, value) {
+        state$pointer_calls <- state$pointer_calls + 1L
+        if (state$pointer_calls == fail_pointer ||
+            (fail_rollback && state$pointer_calls > fail_pointer)) return(FALSE)
+        state$pointers[[parent]] <- value
+        TRUE
+    }
+    remove_path <- function(path) {
+        if (fail_rollback && startsWith(path, "p")) return(FALSE)
+        if (endsWith(path, "CURRENT")) {
+            state$pointers[[dirname(path)]] <- NA_character_
+        } else state$paths[[path]] <- FALSE
+        TRUE
+    }
+    expression <- function() fertility_publish_pointer_transaction(
+        transaction_stages, rename_path, write_pointer, remove_path,
+        pointer_state = function(parent) state$pointers[[parent]],
+        path_exists = function(path) isTRUE(state$paths[[path]])
+    )
+    list(state = state, expression = expression)
+}
+transaction_success <- run_transaction_fixture()
+stopifnot(isTRUE(transaction_success$expression()))
+rename_failure <- run_transaction_fixture(fail_rename = 2L)
+expect_error(rename_failure$expression(), "atomically publish every report bundle")
+stopifnot(!isTRUE(rename_failure$state$paths[["p1/n1"]]))
+pointer_failure <- run_transaction_fixture(fail_pointer = 2L)
+expect_error(pointer_failure$expression(), "republished shard pointer")
+stopifnot(identical(pointer_failure$state$pointers[["p1"]], "old1"),
+          is.na(pointer_failure$state$pointers[["p2"]]),
+          !isTRUE(pointer_failure$state$paths[["p1/n1"]]),
+          !isTRUE(pointer_failure$state$paths[["p2/n2"]]))
+rollback_failure <- run_transaction_fixture(fail_pointer = 2L, fail_rollback = TRUE)
+expect_error(rollback_failure$expression(), "rollback did not restore")
+recorded_tile_spec <- fertility_value_tile(1L, 0, 2L, "a")
+recorded_tile_fixture <- c(make_tile_result(1L, 0, 2L), list(
+    schema_version = fertility_schema_version, config_id = tile_configuration$config_id,
+    input_id = paste(rep("d", 64L), collapse = ""), id = "F0001",
+    tile_id = recorded_tile_spec$tile_id, tile_type = recorded_tile_spec$type,
+    column_hash = recorded_tile_spec$column_hash,
+    timeout_seconds = tile_configuration$timeout_seconds,
+    reader_rows = setNames(rep(2L, 3L), c("direct", "rust", "haven")),
+    columns = 1L, column_names = character(), storage = character(),
+    structural_rows = NA_real_, column_bytes = numeric(), strl = logical()
+))
+recorded_tile_fixture <- recorded_tile_fixture[!duplicated(names(recorded_tile_fixture),
+                                                           fromLast = TRUE)]
+stopifnot(isTRUE(fertility_validate_recorded_tile(recorded_tile_fixture)))
+current_artifact_tile <- recorded_tile_fixture
+current_artifact_tile$secondary <- "-reader-error"
+expect_error(fertility_validate_recorded_tile(current_artifact_tile),
+             "malformed or non-canonical")
+expect_error(fertility_validate_recorded_tile(
+    current_artifact_tile, allow_legacy_empty_reader_artifact = TRUE
+), "malformed or non-canonical")
+legacy_artifact_tile <- current_artifact_tile
+legacy_artifact_tile$schema_version <- fertility_legacy_corpus_schema_version
+expect_error(fertility_validate_recorded_tile(
+    legacy_artifact_tile,
+    corpus_schema_version = fertility_legacy_corpus_schema_version
+), "malformed or non-canonical")
+stopifnot(isTRUE(fertility_validate_recorded_tile(
+    legacy_artifact_tile,
+    corpus_schema_version = fertility_legacy_corpus_schema_version,
+    allow_legacy_empty_reader_artifact = TRUE
+)))
+similar_legacy_artifact_tile <- legacy_artifact_tile
+similar_legacy_artifact_tile$secondary <- "-reader-errors"
+expect_error(fertility_validate_recorded_tile(
+    similar_legacy_artifact_tile,
+    corpus_schema_version = fertility_legacy_corpus_schema_version,
+    allow_legacy_empty_reader_artifact = TRUE
+), "malformed or non-canonical")
+foreign_schema_tile <- recorded_tile_fixture
+foreign_schema_tile$schema_version <- fertility_schema_version + 1L
+expect_error(fertility_validate_recorded_tile(foreign_schema_tile),
+             "schema is invalid")
+stopifnot(isTRUE(fertility_validate_recorded_tile(
+    foreign_schema_tile, corpus_schema_version = fertility_schema_version + 1L
+)))
+private_tile <- recorded_tile_fixture
+private_tile$secondary <- "/private/source"
+expect_error(fertility_validate_recorded_tile(private_tile),
+             "malformed or non-canonical")
+malformed_tile <- recorded_tile_fixture
+malformed_tile$unexpected <- "stale"
+expect_error(fertility_validate_recorded_tile(malformed_tile), "schema is invalid")
 missing_terminal <- traversed_tiles[-length(traversed_tiles)]
 duplicate_terminal <- c(traversed_tiles, list(make_terminal_result()))
 wrong_terminal_skip <- traversed_tiles
@@ -853,6 +1306,19 @@ retried_tile <- fertility_process_tile(
 )
 stopifnot(!first_tile$resumed, resumed_tile$resumed, !retried_tile$resumed,
           tile_counter$n == 2L)
+foreign_tile_checkpoint <- first_tile$result
+foreign_tile_checkpoint$schema_version <- fertility_schema_version + 1L
+stopifnot(
+    !fertility_tile_checkpoint_valid(
+        foreign_tile_checkpoint, tile_item, tile, "framework", tile_config$config_id,
+        tile_input$input_id, tile_config$timeout_seconds
+    ),
+    fertility_tile_checkpoint_valid(
+        foreign_tile_checkpoint, tile_item, tile, "framework", tile_config$config_id,
+        tile_input$input_id, tile_config$timeout_seconds,
+        corpus_schema_version = fertility_schema_version + 1L
+    )
+)
 sizing_tile <- fertility_sizing_tile(1L, "long", 10000000,
                                      tile_config$strl_sample_count)
 sizing_checkpoint <- file.path(root, "sizing-checkpoint.rds")
@@ -1074,6 +1540,13 @@ if (dir.exists(file.path(checkout_library, "dtaparser"))) {
 }
 worker_source <- paste(readLines(file.path(script_dir, "worker.R")), collapse = "\n")
 stopifnot(!grepl("read_dta\\(item\\$path\\)", worker_source))
+republish_source <- paste(readLines(file.path(script_dir, "republish.R")), collapse = "\n")
+stopifnot(
+    !grepl("fertility_capture_input", republish_source, fixed = TRUE),
+    !grepl("read_dta", republish_source, fixed = TRUE),
+    !grepl("item$path", republish_source, fixed = TRUE),
+    grepl("options$shard_count != 8L", republish_source, fixed = TRUE)
+)
 
 # Timeout checkpoints retain the parent hash, publish, resume without retry, and
 # execute again only when retry is requested.

--- a/benchmarks/fertility-surveys/test-framework.R
+++ b/benchmarks/fertility-surveys/test-framework.R
@@ -1616,6 +1616,70 @@ if (dir.exists(file.path(checkout_library, "dtaparser"))) {
     stopifnot(metadata_worker$rows == 5L,
               metadata_worker$columns == ncol(bounded_data),
               identical(metadata_worker$column_names, names(bounded_data)))
+    structural_failure_message <- "private synthetic structural parser failure"
+    structural_failure_worker <- (function() {
+        worker_environment <- environment(fertility_worker_tile)
+        had_binding <- exists(
+            "fertility_structural_metadata", envir = worker_environment,
+            inherits = FALSE
+        )
+        original <- get(
+            "fertility_structural_metadata", envir = worker_environment,
+            inherits = TRUE
+        )
+        assign(
+            "fertility_structural_metadata",
+            function(path) stop(structural_failure_message),
+            envir = worker_environment
+        )
+        on.exit({
+            if (had_binding) {
+                assign(
+                    "fertility_structural_metadata", original,
+                    envir = worker_environment
+                )
+            } else {
+                rm("fertility_structural_metadata", envir = worker_environment)
+            }
+        }, add = TRUE)
+        fertility_worker_tile(
+            bounded_item, fertility_metadata_tile(),
+            file.path(script_dir, "compare.R"), dirname(installed_dtaparser),
+            installed_dtaparser, "framework", 10L
+        )
+    })()
+    structural_planning_failure <- list(
+        classification = "unresolved",
+        secondary = "structural-metadata-unavailable",
+        mismatches = fertility_mismatch_record(
+            "unresolved", "structural-metadata-unavailable"
+        )
+    )
+    structural_failure_tiles <- list(
+        structural_failure_worker, structural_planning_failure
+    )
+    stopifnot(
+        structural_failure_worker$classification == "pass",
+        all(structural_failure_worker$reader_rows[c("direct", "rust")] ==
+            nrow(bounded_data)),
+        is.na(structural_failure_worker$reader_rows[["haven"]]),
+        !any(grepl("reader-error", structural_failure_worker$secondary, fixed = TRUE)),
+        is.na(structural_failure_worker$structural_rows),
+        !length(structural_failure_worker$column_bytes),
+        !length(structural_failure_worker$strl),
+        fertility_aggregate_classification(
+            structural_failure_tiles, complete = FALSE
+        ) == "unresolved",
+        identical(
+            fertility_tile_secondary(structural_failure_tiles),
+            "structural-metadata-unavailable"
+        ),
+        !any(grepl(
+            structural_failure_message,
+            as.character(unlist(structural_failure_tiles, use.names = FALSE)),
+            fixed = TRUE
+        ))
+    )
     bounded_tile <- fertility_value_tile(1L, 1L, 2L, c("number", "day"))
     bounded_worker <- fertility_worker_tile(
         bounded_item, bounded_tile, file.path(script_dir, "compare.R"),
@@ -1677,13 +1741,33 @@ if (dir.exists(file.path(checkout_library, "dtaparser"))) {
         encoding_item, fertility_metadata_tile(), file.path(script_dir, "compare.R"),
         dirname(installed_dtaparser), installed_dtaparser, "framework", 10L
     )
-    encoding_terminal <- fertility_worker_tile(
-        encoding_item, fertility_value_tile(
-            1L, nrow(bounded_data), 1L,
-            encoding_metadata$column_names[[4L]], type = "terminal", probe = 1L
-        ), file.path(script_dir, "compare.R"), dirname(installed_dtaparser),
-        installed_dtaparser, "framework", 10L
-    )
+    encoding_terminal_probe <- (function() {
+        worker_environment <- environment(fertility_worker_tile)
+        original <- get(
+            "fertility_tile_read", envir = worker_environment, inherits = TRUE
+        )
+        calls <- list()
+        assign("fertility_tile_read", function(reader, path, tile, encoding = NULL) {
+            if (identical(tile$type, "terminal")) {
+                calls[[length(calls) + 1L]] <<- list(
+                    reader = reader, encoding = encoding
+                )
+            }
+            original(reader, path, tile, encoding = encoding)
+        }, envir = worker_environment)
+        on.exit(assign(
+            "fertility_tile_read", original, envir = worker_environment
+        ), add = TRUE)
+        result <- fertility_worker_tile(
+            encoding_item, fertility_value_tile(
+                1L, nrow(bounded_data), 1L,
+                encoding_metadata$column_names[[4L]], type = "terminal", probe = 1L
+            ), file.path(script_dir, "compare.R"), dirname(installed_dtaparser),
+            installed_dtaparser, "framework", 10L
+        )
+        list(result = result, calls = calls)
+    })()
+    encoding_terminal <- encoding_terminal_probe$result
     encoding_sizing <- fertility_worker_tile(
         encoding_item, fertility_sizing_tile(1L, "text", 1, 1L),
         file.path(script_dir, "compare.R"), dirname(installed_dtaparser),
@@ -1702,6 +1786,14 @@ if (dir.exists(file.path(checkout_library, "dtaparser"))) {
         ),
         encoding_terminal$classification == "pass",
         all(encoding_terminal$reader_rows == 0L),
+        identical(
+            vapply(encoding_terminal_probe$calls, `[[`, character(1), "reader"),
+            c("direct", "rust", "haven")
+        ),
+        length(encoding_terminal_probe$calls) == 3L,
+        all(vapply(encoding_terminal_probe$calls, function(call) {
+            identical(call$encoding, encoding_item$encoding_override)
+        }, logical(1))),
         encoding_sizing$classification == "pass",
         encoding_sizing$samples_completed == 1L
     )

--- a/benchmarks/fertility-surveys/test-framework.R
+++ b/benchmarks/fertility-surveys/test-framework.R
@@ -321,6 +321,53 @@ local({
     options(dtaparser.fertility.output_inventory_test_hook = NULL)
 })
 
+# Descriptor hardening versions the persistent output authority and preserves a
+# schema-1 artifact as explicitly superseded before recapturing schema 2.
+local({
+    fixture <- file.path(root, "output-inventory-migration")
+    raw_root <- file.path(root, "output-inventory-migration-raw")
+    dir.create(fixture)
+    dir.create(raw_root)
+    writeBin(c(as.raw(113L), as.raw(rep(0L, 40L))),
+             file.path(fixture, "one.dta"))
+    writeBin(charToRaw("<stata_dta><header><release>118</release></header>"),
+             file.path(fixture, "two.DTA"))
+    old <- list(
+        root = fertility_output_root,
+        files = fertility_output_expected_files,
+        bytes = fertility_output_expected_bytes,
+        largest = fertility_output_expected_largest
+    )
+    on.exit({
+        assign("fertility_output_root", old$root, envir = .GlobalEnv)
+        assign("fertility_output_expected_files", old$files, envir = .GlobalEnv)
+        assign("fertility_output_expected_bytes", old$bytes, envir = .GlobalEnv)
+        assign("fertility_output_expected_largest", old$largest,
+               envir = .GlobalEnv)
+    }, add = TRUE)
+    assign("fertility_output_root", normalizePath(fixture, winslash = "/"),
+           envir = .GlobalEnv)
+    sizes <- file.info(list.files(fixture, full.names = TRUE))$size
+    assign("fertility_output_expected_files", 2L, envir = .GlobalEnv)
+    assign("fertility_output_expected_bytes", sum(sizes), envir = .GlobalEnv)
+    assign("fertility_output_expected_largest", max(sizes), envir = .GlobalEnv)
+    inventory_path <- fertility_output_inventory_path(raw_root)
+    fertility_atomic_save_rds(list(
+        schema_version = 1L, manifest = data.frame()
+    ), inventory_path)
+    migrated <- fertility_build_output_inventory(fertility_output_root, raw_root)
+    frozen <- readRDS(inventory_path)
+    stopifnot(
+        nrow(migrated) == 2L,
+        identical(frozen$schema_version,
+                  fertility_output_inventory_schema_version),
+        file.exists(file.path(dirname(inventory_path), "inventory-schema1.rds")),
+        identical(readRDS(file.path(
+            dirname(inventory_path), "inventory-schema1.rds"
+        ))$schema_version, 1L)
+    )
+})
+
 # A worker connection is accepted only for the captured inode, survives source
 # parent substitution, resets its shared file offset between independent reads,
 # and closes deterministically after both successful and failed workers.
@@ -1610,6 +1657,12 @@ output_bad_unsupported[[1L]]$results$classification[[1L]] <- "pass"
 expect_error(fertility_validate_shard_bundles(
     output_bad_unsupported, output_fixture$id, output_canonical
 ), "unsupported-release classifications")
+output_bad_unsupported_tiles <- output_fixture$bundles
+output_bad_unsupported_tiles[[1L]]$results$tiles_expected[[1L]] <- "1"
+output_bad_unsupported_tiles[[1L]]$results$tiles_completed[[1L]] <- "1"
+expect_error(fertility_validate_shard_bundles(
+    output_bad_unsupported_tiles, output_fixture$id, output_canonical
+), "executable accounting")
 output_bad_terminal <- output_fixture$bundles
 output_bad_terminal[[supported_bundle]]$results$classification[[supported_row]] <-
     "timeout"

--- a/benchmarks/fertility-surveys/test-framework.R
+++ b/benchmarks/fertility-surveys/test-framework.R
@@ -2295,7 +2295,18 @@ stopifnot(
     !identical(
         fertility_framework_id(test_build_id, datasigs),
         fertility_framework_id(test_build_id, datasigs, acceptance)
+    ),
+    !identical(
+        fertility_framework_id(test_build_id, datasigs),
+        fertility_framework_id(
+            test_build_id, datasigs,
+            schema_version = fertility_legacy_corpus_schema_version
+        )
     )
+)
+expect_error(
+    fertility_framework_id(test_build_id, datasigs, schema_version = 9L),
+    "schema version is invalid"
 )
 accepted_item <- as.list(acceptance_inventory[1L, , drop = FALSE])
 accepted_input <- fertility_capture_input(accepted_item, acceptance)

--- a/benchmarks/fertility-surveys/test-framework.R
+++ b/benchmarks/fertility-surveys/test-framework.R
@@ -975,6 +975,14 @@ precedence_inventory <- fertility_build_inventory(
 )
 stopifnot(precedence_inventory$path[[2L]] ==
           normalizePath(primary_second, winslash = "/"))
+drifted_rows <- rows
+drifted_rows$level[[1L]] <- "survey"
+write.csv(drifted_rows, datasigs, row.names = FALSE, quote = FALSE)
+expect_error(fertility_build_inventory(
+    list(cache = cache, datasigs = datasigs), assert_counts = FALSE,
+    enforce_required_paths = FALSE
+), "unknown cache level")
+write.csv(rows, datasigs, row.names = FALSE, quote = FALSE)
 
 options <- fertility_parse_arguments(c(
     "--program=dhs,mics", "--release=113,114", "--shard-index=1",

--- a/benchmarks/fertility-surveys/test-framework.R
+++ b/benchmarks/fertility-surveys/test-framework.R
@@ -76,6 +76,311 @@ expect_error(fertility_parse_arguments("--beyond-end-windows=9"), "must not exce
 expect_error(fertility_filter_inventory(
     inventory, fertility_parse_arguments("--id=F9999")
 ), "unknown --id")
+shard_options <- fertility_parse_arguments(c("--shard-index=1", "--shard-count=2"))
+shard_one <- fertility_filter_inventory(inventory, shard_options)
+shard_options$shard_index <- 2L
+shard_two <- fertility_filter_inventory(inventory, shard_options)
+stopifnot(!length(intersect(shard_one$id, shard_two$id)),
+          identical(sort(c(shard_one$id, shard_two$id)), sort(inventory$id)),
+          nrow(fertility_family_selection(inventory, shard_options)) == nrow(inventory))
+family_a <- fertility_parse_arguments(c("--program=dhs,mics", "--shard-index=1",
+                                        "--shard-count=2"))
+family_b <- fertility_parse_arguments(c("--program=mics,dhs", "--shard-index=2",
+                                        "--shard-count=2"))
+stopifnot(identical(
+    fertility_selection_family_id(inventory, family_a, "framework", "config", "build"),
+    fertility_selection_family_id(inventory, family_b, "framework", "config", "build")
+))
+
+test_framework_id <- paste(rep("a", 64L), collapse = "")
+test_build_id <- paste(rep("b", 64L), collapse = "")
+test_config_id <- paste(rep("c", 64L), collapse = "")
+make_public_results <- function(expected, classifications = "pass") {
+    count <- nrow(expected)
+    if (length(classifications) == 1L) classifications <- rep(classifications, count)
+    data.frame(
+        framework_id = rep(test_framework_id, count), id = expected$id,
+        program = expected$program, level = expected$level,
+        release = as.character(expected$release), classification = classifications,
+        secondary_categories = rep("", count), mismatch_count = rep("0", count),
+        mismatch_categories = rep("", count), mismatch_signatures = rep("", count),
+        rows = rep("", count), columns = rep("", count),
+        tiles_expected = rep("0", count), tiles_completed = rep("0", count),
+        complete = rep("TRUE", count), elapsed_seconds = rep("", count),
+        build_provenance_id = rep(test_build_id, count),
+        stringsAsFactors = FALSE, check.names = FALSE
+    )
+}
+make_bundle_family <- function(
+    canonical, family_options, classifications = NULL,
+    inventory_id = paste(rep("d", 64L), collapse = "")
+) {
+    manifest <- fertility_family_manifest(canonical, family_options)
+    manifest_id <- fertility_manifest_id(manifest)
+    family_id <- fertility_family_id_from_manifest(
+        manifest, test_framework_id, test_config_id, test_build_id, inventory_id,
+        family_options$shard_count, family_options$max_files
+    )
+    spec <- fertility_filter_spec(family_options)
+    bundles <- lapply(seq_len(family_options$shard_count), function(index) {
+        expected <- manifest[manifest$shard_index == index,
+                             c("id", "program", "level", "release"), drop = FALSE]
+        classes <- if (is.null(classifications)) "pass" else
+            classifications[match(expected$id, manifest$id)]
+        results <- make_public_results(expected, classes)
+        selection_id <- fertility_stable_id(list(
+            family_id = family_id, shard_index = index,
+            selected_ids = paste(expected$id, collapse = ",")
+        ))
+        provenance <- data.frame(
+            schema_version = as.character(fertility_schema_version),
+            selection_id = selection_id, family_id = family_id,
+            family_manifest_id = manifest_id, framework_id = test_framework_id,
+            config_id = test_config_id, build_provenance_id = test_build_id,
+            inventory_id = inventory_id, report_schema_id = fertility_report_schema_id(),
+            selected_files = as.character(nrow(expected)),
+            expected_family_files = as.character(nrow(manifest)),
+            full_default_family = if (fertility_full_default_family(family_options))
+                "TRUE" else "FALSE",
+            program_filter = spec$program_filter, release_filter = spec$release_filter,
+            id_filter = spec$id_filter, max_files = spec$max_files,
+            shard_index = as.character(index),
+            shard_count = as.character(family_options$shard_count),
+            timeout_seconds = "600", chunk_rows = "10000", column_batch = "16",
+            memory_mib = "256", cell_budget = "1000000",
+            max_tiles_per_batch = "100000", beyond_end_windows = "1",
+            retry = "FALSE", created_at_utc = "2026-01-01T00:00:00Z",
+            stringsAsFactors = FALSE, check.names = FALSE
+        )
+        list(provenance = provenance, results = results,
+             family_manifest = manifest)
+    })
+    list(id = family_id, bundles = bundles, manifest = manifest)
+}
+canonical_inventory <- fertility_inventory_manifest(inventory)
+merge_options <- fertility_parse_arguments(c(
+    "--id=F0001,F0002", "--shard-index=1", "--shard-count=2"
+))
+merge_fixture <- make_bundle_family(canonical_inventory, merge_options)
+merge_bundles <- merge_fixture$bundles
+validated_merge <- fertility_validate_shard_bundles(
+    merge_bundles, merge_fixture$id, canonical_inventory
+)
+stopifnot(identical(validated_merge$results$id, c("F0001", "F0002")),
+          validated_merge$shard_count == 2L)
+expect_error(fertility_validate_shard_bundles(
+    merge_bundles[1L], merge_fixture$id, canonical_inventory
+), "every shard index")
+substitution <- merge_bundles
+substitution[[1L]]$results$id <- "F0003"
+expect_error(fertility_validate_shard_bundles(
+    substitution, merge_fixture$id, canonical_inventory
+), "canonical family membership")
+foreign_config <- merge_bundles
+foreign_config[[2L]]$provenance$config_id <- paste(rep("d", 64L), collapse = "")
+expect_error(fertility_validate_shard_bundles(
+    foreign_config, merge_fixture$id, canonical_inventory
+), "identical framework/config/build/inventory")
+wrong_filter <- merge_bundles
+wrong_filter[[2L]]$provenance$id_filter <- "F0001"
+expect_error(fertility_validate_shard_bundles(
+    wrong_filter, merge_fixture$id, canonical_inventory
+), "identical framework/config/build/inventory")
+wrong_release <- merge_bundles
+wrong_release[[2L]]$results$release <- "118"
+expect_error(fertility_validate_shard_bundles(
+    wrong_release, merge_fixture$id, canonical_inventory
+), "canonical family membership")
+wrong_classification <- merge_bundles
+wrong_classification[[1L]]$results$classification <- "private-reader-message"
+expect_error(fertility_validate_shard_bundles(
+    wrong_classification, merge_fixture$id, canonical_inventory
+), "invalid scalar")
+privacy_path <- merge_bundles
+privacy_path[[1L]]$results$path <- "/private/source"
+expect_error(fertility_validate_shard_bundles(
+    privacy_path, merge_fixture$id, canonical_inventory
+), "exact public schema|manifest schema")
+privacy_reader <- merge_bundles
+privacy_reader[[1L]]$results$reader_error <- "private error"
+expect_error(fertility_validate_shard_bundles(
+    privacy_reader, merge_fixture$id, canonical_inventory
+), "exact public schema|manifest schema")
+privacy_allowed_field <- merge_bundles
+privacy_allowed_field[[1L]]$results$secondary_categories <-
+    "reader failed at /private/source"
+expect_error(fertility_validate_shard_bundles(
+    privacy_allowed_field, merge_fixture$id, canonical_inventory
+), "non-public mismatch detail")
+private_program <- merge_bundles
+private_program[[1L]]$results$program <- "private_identifier"
+expect_error(fertility_validate_shard_bundles(
+    private_program, merge_fixture$id, canonical_inventory
+), "invalid scalar")
+inconsistent_mismatch <- merge_bundles
+inconsistent_mismatch[[1L]]$results$mismatch_categories <- "value-mismatch=1"
+expect_error(fertility_validate_shard_bundles(
+    inconsistent_mismatch, merge_fixture$id, canonical_inventory
+), "inconsistent counts")
+duplicate_mismatch <- merge_bundles
+duplicate_mismatch[[1L]]$results$mismatch_count <- "2"
+duplicate_mismatch[[1L]]$results$mismatch_categories <-
+    "value-mismatch=1,value-mismatch=1"
+duplicate_mismatch[[1L]]$results$mismatch_signatures <- paste0(
+    paste(rep("a", 64L), collapse = ""), "=2"
+)
+expect_error(fertility_validate_shard_bundles(
+    duplicate_mismatch, merge_fixture$id, canonical_inventory
+), "inconsistent counts")
+noncanonical_mismatch <- merge_bundles
+noncanonical_mismatch[[1L]]$results$mismatch_count <- "3"
+noncanonical_mismatch[[1L]]$results$mismatch_categories <-
+    "value-mismatch=1,metadata-mismatch=2"
+noncanonical_mismatch[[1L]]$results$mismatch_signatures <- paste0(
+    paste(rep("a", 64L), collapse = ""), "=1,",
+    paste(rep("b", 64L), collapse = ""), "=2"
+)
+expect_error(fertility_validate_shard_bundles(
+    noncanonical_mismatch, merge_fixture$id, canonical_inventory
+), "inconsistent counts")
+privacy_provenance <- merge_bundles
+privacy_provenance[[1L]]$provenance$path <- "/private/source"
+expect_error(fertility_validate_shard_bundles(
+    privacy_provenance, merge_fixture$id, canonical_inventory
+), "provenance schema")
+prior_report_schema_id <- fertility_stable_id(list(
+    schema_version = 9L,
+    fields = paste(fertility_result_fields(), collapse = ","),
+    contract = paste(
+        "hash,id,enum,manifest-release,enum,fixed-categories,count,",
+        "fixed-counts,hashed-counts,optional-number,optional-count,count,",
+        "count,boolean,optional-number,hash", sep = ""
+    )
+))
+stopifnot(!identical(prior_report_schema_id, fertility_report_schema_id()))
+wrong_report_schema <- merge_bundles
+wrong_report_schema[[1L]]$provenance$report_schema_id <- prior_report_schema_id
+expect_error(fertility_validate_shard_bundles(
+    wrong_report_schema, merge_fixture$id, canonical_inventory
+), "identical framework/config/build/inventory|schema identity")
+substituted_manifest <- merge_bundles
+substituted_manifest[[1L]]$family_manifest$id[[1L]] <- "F0003"
+expect_error(fertility_validate_shard_bundles(
+    substituted_manifest, merge_fixture$id, canonical_inventory
+), "family manifest")
+reordered_manifest <- merge_bundles
+reordered_manifest[[1L]]$family_manifest <-
+    reordered_manifest[[1L]]$family_manifest[2:1, , drop = FALSE]
+expect_error(fertility_validate_shard_bundles(
+    reordered_manifest, merge_fixture$id, canonical_inventory
+), "family manifest")
+wrong_manifest_owner <- merge_bundles
+wrong_manifest_owner[[1L]]$family_manifest$shard_index[[1L]] <- 2L
+expect_error(fertility_validate_shard_bundles(
+    wrong_manifest_owner, merge_fixture$id, canonical_inventory
+), "family manifest")
+wrong_manifest_program <- merge_bundles
+wrong_manifest_program[[1L]]$family_manifest$program[[1L]] <- "mics"
+expect_error(fertility_validate_shard_bundles(
+    wrong_manifest_program, merge_fixture$id, canonical_inventory
+), "family manifest")
+wrong_manifest_level <- merge_bundles
+wrong_manifest_level[[1L]]$family_manifest$level[[1L]] <- "births"
+expect_error(fertility_validate_shard_bundles(
+    wrong_manifest_level, merge_fixture$id, canonical_inventory
+), "family manifest")
+wrong_manifest_release <- merge_bundles
+wrong_manifest_release[[1L]]$family_manifest$release[[1L]] <- 118L
+expect_error(fertility_validate_shard_bundles(
+    wrong_manifest_release, merge_fixture$id, canonical_inventory
+), "family manifest")
+empty_options <- fertility_parse_arguments(c(
+    "--id=F0001", "--shard-index=1", "--shard-count=2"
+))
+empty_fixture <- make_bundle_family(canonical_inventory, empty_options)
+stopifnot(nrow(fertility_validate_shard_bundles(
+    empty_fixture$bundles, empty_fixture$id, canonical_inventory
+)$results) == 1L)
+
+full_releases <- rep(as.integer(names(fertility_expected_releases)),
+                     as.integer(fertility_expected_releases))
+full_canonical <- data.frame(
+    id = sprintf("F%04d", seq_len(fertility_expected_rows)),
+    program = "dhs", level = "women", release = full_releases,
+    stringsAsFactors = FALSE
+)
+full_options <- fertility_parse_arguments(character())
+full_classes <- rep("pass", fertility_expected_rows)
+full_classes[full_releases == 111L] <- "expected-unsupported-111"
+supported_positions <- which(full_releases != 111L)
+full_classes[supported_positions[seq_len(5L)]] <- "inventory-hash-error"
+full_fixture <- make_bundle_family(
+    full_canonical, full_options, full_classes,
+    inventory_id = paste(rep("e", 64L), collapse = "")
+)
+full_validated <- fertility_validate_shard_bundles(
+    full_fixture$bundles, full_fixture$id, full_canonical
+)
+stopifnot(nrow(full_validated$results) == 1004L,
+          sum(full_validated$results$classification == "inventory-hash-error") == 5L)
+full_missing <- full_fixture$bundles
+full_missing[[1L]]$results <- full_missing[[1L]]$results[-1004L, , drop = FALSE]
+expect_error(fertility_validate_shard_bundles(
+    full_missing, full_fixture$id, full_canonical
+), "count|accounting")
+full_bad_release <- full_fixture$bundles
+full_bad_release[[1L]]$results$release[[131L]] <- "114"
+expect_error(fertility_validate_shard_bundles(
+    full_bad_release, full_fixture$id, full_canonical
+), "canonical family membership")
+full_bad_unsupported <- full_fixture$bundles
+full_bad_unsupported[[1L]]$results$classification[[1L]] <- "pass"
+expect_error(fertility_validate_shard_bundles(
+    full_bad_unsupported, full_fixture$id, full_canonical
+), "release 111 classifications")
+full_bad_hash_count <- full_fixture$bundles
+full_bad_hash_count[[1L]]$results$classification[[supported_positions[[6L]]]] <-
+    "inventory-hash-error"
+expect_error(fertility_validate_shard_bundles(
+    full_bad_hash_count, full_fixture$id, full_canonical
+), "executable accounting")
+full_too_few_hashes <- full_fixture$bundles
+full_too_few_hashes[[1L]]$results$classification[[supported_positions[[5L]]]] <- "pass"
+expect_error(fertility_validate_shard_bundles(
+    full_too_few_hashes, full_fixture$id, full_canonical
+), "executable accounting")
+full_bad_supported_class <- full_fixture$bundles
+full_bad_supported_class[[1L]]$results$classification[[supported_positions[[6L]]]] <-
+    "expected-unsupported-111"
+expect_error(fertility_validate_shard_bundles(
+    full_bad_supported_class, full_fixture$id, full_canonical
+), "executable accounting")
+stopifnot(nrow(fertility_validate_canonical_inventory(
+    full_canonical, exact = TRUE
+)) == fertility_expected_rows)
+expect_error(fertility_validate_canonical_inventory(
+    full_canonical[-1L, , drop = FALSE], exact = TRUE
+), "exactly F0001 through F1004")
+full_extra <- rbind(full_canonical, transform(
+    full_canonical[1004L, , drop = FALSE], id = "F1005"
+))
+expect_error(fertility_validate_canonical_inventory(
+    full_extra, exact = TRUE
+), "exactly F0001 through F1004")
+full_reordered <- full_canonical[c(2L, 1L, 3:nrow(full_canonical)), , drop = FALSE]
+expect_error(fertility_validate_canonical_inventory(
+    full_reordered, exact = TRUE
+), "exactly F0001 through F1004")
+full_duplicate <- full_canonical
+full_duplicate$id[[2L]] <- full_duplicate$id[[1L]]
+expect_error(fertility_validate_canonical_inventory(
+    full_duplicate, exact = TRUE
+), "manifest is invalid")
+full_canonical_bad_release <- full_canonical
+full_canonical_bad_release$release[[131L]] <- 114L
+expect_error(fertility_validate_canonical_inventory(
+    full_canonical_bad_release, exact = TRUE
+), "release counts")
 preflight_item <- list(expected_sha512 = paste(rep("a", 128L), collapse = ""))
 preflight_match <- list(hash_status = "ok", actual_sha512 = preflight_item$expected_sha512)
 preflight_mismatch <- list(hash_status = "ok",
@@ -180,6 +485,15 @@ pair_result <- fertility_compare_available_pairs(
 )
 stopifnot(identical(sort(unique(pair_result$mismatches$pair)),
                     c("direct-haven", "direct-rust", "rust-haven")))
+equal_count_summary <- fertility_mismatch_summary(list(list(
+    mismatches = pair_result$mismatches
+)))
+equal_count_public <- make_public_results(canonical_inventory[1L, , drop = FALSE])
+equal_count_public$mismatch_count <- as.character(equal_count_summary$count)
+equal_count_public$mismatch_categories <- equal_count_summary$categories
+equal_count_public$mismatch_signatures <- equal_count_summary$signatures
+equal_count_public$secondary_categories <- "value-mismatch"
+stopifnot(isTRUE(fertility_validate_public_results(equal_count_public)))
 private_attribute <- pair_frames$haven
 attr(private_attribute$value, "private_source_attribute") <- "different"
 private_pair_result <- fertility_compare_available_pairs(
@@ -190,6 +504,17 @@ private_pair_result <- fertility_compare_available_pairs(
 stopifnot(any(grepl("private_source_attribute",
                    private_pair_result$mismatches$detail)),
           !any(grepl("private_source_attribute", private_pair_result$secondary)))
+private_summary <- fertility_mismatch_summary(list(list(
+    mismatches = private_pair_result$mismatches
+)))
+renamed_private <- private_pair_result$mismatches
+renamed_private$detail <- sub(
+    "private_source_attribute", "another_private_attribute", renamed_private$detail,
+    fixed = TRUE
+)
+renamed_private$component <- renamed_private$component + 100L
+renamed_summary <- fertility_mismatch_summary(list(list(mismatches = renamed_private)))
+stopifnot(identical(private_summary$signatures, renamed_summary$signatures))
 date_expected <- actual
 date_expected$day[[1L]] <- date_expected$day[[1L]] + 1
 stopifnot("date-mismatch" %in%
@@ -214,6 +539,9 @@ stopifnot(identical(fertility_adaptive_rows(8, tile_configuration), 100L),
           identical(fertility_adaptive_rows(rep(8, 8), tile_configuration), 12L),
           identical(fertility_adaptive_rows(2045, tile_configuration), 100L),
           identical(fertility_adaptive_rows(Inf, tile_configuration), 1L),
+          identical(fertility_strl_sample_offsets(0, 16L), 0),
+          identical(fertility_strl_sample_offsets(5, 3L), c(0, 2, 4)),
+          identical(fertility_strl_rows(12, 1L, tile_configuration), 100L),
           identical(
               fertility_column_batches(c("a", "wide", "long", "b"), 8L,
                                         c(8, 2045, Inf, 8)),
@@ -223,6 +551,64 @@ finite_plan <- fertility_plan_offsets(5, 2L, 3L)
 stopifnot(!finite_plan$ceiling, identical(finite_plan$offsets, c(0, 2, 4)))
 stopifnot(fertility_plan_offsets(7, 2L, 3L)$ceiling,
           fertility_plan_offsets(Inf, 2L, 3L)$ceiling)
+large_strl_configuration <- tile_configuration
+large_strl_configuration$chunk_rows <- 10000L
+large_strl_configuration$cell_budget <- 1000000L
+small_payload_rows <- fertility_strl_rows(24, 1L, large_strl_configuration)
+small_payload_plan <- fertility_plan_offsets(10000000, small_payload_rows, 2000L)
+stopifnot(small_payload_rows == 10000L, !small_payload_plan$ceiling,
+          length(small_payload_plan$offsets) == 1000L)
+
+# A rare large payload missed by sampling is still memory-safe: a memory-limited
+# range is split deterministically until the exceptional row is isolated, with no
+# gaps, overlaps, or skipped rows.
+adaptive_execute <- function(tile) {
+    contains_rare <- tile$skip <= 13 && tile$skip + tile$n_max > 13
+    memory <- contains_rare && tile$n_max > 1L
+    list(
+        tile_type = "value", batch = tile$batch, skip = tile$skip,
+        n_max = tile$n_max, rows = if (memory) NA_integer_ else tile$n_max,
+        classification = if (memory) "memory-limit" else "pass"
+    )
+}
+run_adaptive_fixture <- function() {
+    budget <- new.env(parent = emptyenv())
+    budget$remaining <- 20L
+    fertility_process_adaptive_range(
+        1L, 0, 20L, "long", adaptive_execute, budget
+    )
+}
+adaptive_leaves <- run_adaptive_fixture()
+adaptive_again <- run_adaptive_fixture()
+leaf_skip <- vapply(adaptive_leaves, `[[`, numeric(1), "skip")
+leaf_n <- vapply(adaptive_leaves, `[[`, integer(1), "n_max")
+stopifnot(
+    identical(leaf_skip, vapply(adaptive_again, `[[`, numeric(1), "skip")),
+    identical(leaf_n, vapply(adaptive_again, `[[`, integer(1), "n_max")),
+    all(vapply(adaptive_leaves, `[[`, character(1), "classification") == "pass"),
+    identical(leaf_skip, cumsum(c(0, head(leaf_n, -1L)))),
+    sum(leaf_n) == 20L, any(leaf_skip == 13 & leaf_n == 1L)
+)
+limited_budget <- new.env(parent = emptyenv())
+limited_budget$remaining <- 0L
+limited_leaf <- fertility_process_adaptive_range(
+    1L, 0, 20L, "long", adaptive_execute, limited_budget
+)
+stopifnot(length(limited_leaf) == 1L,
+          limited_leaf[[1L]]$classification == "memory-limit")
+execution_counter <- new.env(parent = emptyenv())
+execution_counter$n <- 0L
+counted_execute <- function(tile) {
+    execution_counter$n <- execution_counter$n + 1L
+    adaptive_execute(tile)
+}
+execution_ceiling <- 7L
+execution_budget <- new.env(parent = emptyenv())
+execution_budget$remaining <- execution_ceiling - 1L
+invisible(fertility_process_adaptive_range(
+    1L, 0, 20L, "long", counted_execute, execution_budget
+))
+stopifnot(execution_counter$n <= execution_ceiling)
 stopifnot(fertility_memory_error(simpleError("vector memory exhausted")),
           !fertility_memory_error(simpleError("reader failed")))
 
@@ -467,6 +853,72 @@ retried_tile <- fertility_process_tile(
 )
 stopifnot(!first_tile$resumed, resumed_tile$resumed, !retried_tile$resumed,
           tile_counter$n == 2L)
+sizing_tile <- fertility_sizing_tile(1L, "long", 10000000,
+                                     tile_config$strl_sample_count)
+sizing_checkpoint <- file.path(root, "sizing-checkpoint.rds")
+sizing_counter <- new.env(parent = emptyenv())
+sizing_counter$n <- 0L
+sizing_execute <- function(item, tile, input) {
+    sizing_counter$n <- sizing_counter$n + 1L
+    list(
+        schema_version = fertility_schema_version, framework_id = "framework",
+        id = item$id, tile_id = tile$tile_id, tile_type = tile$type,
+        batch = tile$batch, skip = tile$skip, n_max = tile$n_max,
+        classification = "pass", secondary = character(),
+        mismatches = fertility_bind_mismatches(list()), rows = 16L,
+        payload_bytes_per_row = 24, chosen_rows = 10000L,
+        elapsed_seconds = 0
+    )
+}
+first_sizing <- fertility_process_tile(
+    tile_item, sizing_tile, sizing_checkpoint, "framework", tile_config,
+    tile_input, FALSE, sizing_execute
+)
+resumed_sizing <- fertility_process_tile(
+    tile_item, sizing_tile, sizing_checkpoint, "framework", tile_config,
+    tile_input, FALSE, sizing_execute
+)
+stopifnot(!first_sizing$resumed, resumed_sizing$resumed,
+          sizing_counter$n == 1L,
+          resumed_sizing$result$chosen_rows == 10000L,
+          identical(resumed_sizing$result$column_hash, sizing_tile$column_hash))
+adaptive_checkpoint_root <- file.path(root, "adaptive-checkpoints")
+dir.create(adaptive_checkpoint_root)
+adaptive_counter <- new.env(parent = emptyenv())
+adaptive_counter$n <- 0L
+adaptive_checkpoint_execute <- function(item, tile, input) {
+    adaptive_counter$n <- adaptive_counter$n + 1L
+    contains_rare <- tile$skip <= 13 && tile$skip + tile$n_max > 13
+    memory <- contains_rare && tile$n_max > 1L
+    list(
+        schema_version = fertility_schema_version, framework_id = "framework",
+        id = item$id, tile_id = tile$tile_id, tile_type = tile$type,
+        batch = tile$batch, skip = tile$skip, n_max = tile$n_max,
+        classification = if (memory) "memory-limit" else "pass",
+        secondary = character(), mismatches = fertility_bind_mismatches(list()),
+        rows = if (memory) NA_integer_ else tile$n_max, elapsed_seconds = 0
+    )
+}
+run_checkpointed_adaptation <- function() {
+    budget <- new.env(parent = emptyenv())
+    budget$remaining <- 20L
+    process <- function(tile) fertility_process_tile(
+        tile_item, tile,
+        file.path(adaptive_checkpoint_root, paste0(tile$tile_id, ".rds")),
+        "framework", tile_config, tile_input, FALSE,
+        adaptive_checkpoint_execute
+    )$result
+    fertility_process_adaptive_range(1L, 0, 20L, "long", process, budget)
+}
+checkpointed_first <- run_checkpointed_adaptation()
+first_execution_count <- adaptive_counter$n
+checkpointed_resumed <- run_checkpointed_adaptation()
+stopifnot(first_execution_count > 1L,
+          adaptive_counter$n == first_execution_count,
+          identical(vapply(checkpointed_first, `[[`, numeric(1), "skip"),
+                    vapply(checkpointed_resumed, `[[`, numeric(1), "skip")),
+          identical(vapply(checkpointed_first, `[[`, integer(1), "n_max"),
+                    vapply(checkpointed_resumed, `[[`, integer(1), "n_max")))
 
 supported_item <- as.list(inventory[2L, , drop = FALSE])
 supported_item$path <- normalizePath(primary_second, winslash = "/")
@@ -505,6 +957,12 @@ bounded_data <- tibble::tibble(
     day = as.Date("2020-01-01") + 0:4
 )
 haven::write_dta(bounded_data, bounded_path)
+rare_strl_path <- file.path(root, "rare-strl.dta")
+haven::write_dta(data.frame(
+    long_string = c(rep("x", 999L), strrep("z", 100000L))
+), rare_strl_path, version = 14)
+rare_structure <- fertility_structural_metadata(rare_strl_path)
+stopifnot(rare_structure$rows == 1000, identical(rare_structure$strl, TRUE))
 bounded_item <- list(
     id = "F9900", program = "dhs", level = "women", release = 118L,
     path = normalizePath(bounded_path, winslash = "/"), expected_sha512 = ""
@@ -513,8 +971,16 @@ haven_zero_column <- tryCatch(
     haven::read_dta(bounded_path, col_select = character()), error = identity
 )
 stopifnot(inherits(haven_zero_column, "error"))
-checkout_library <- file.path(script_dir, "..", "..", "target",
-                              "fertility-surveys", "raw", "library")
+checkout_raw <- file.path(script_dir, "..", "..", "target",
+                          "fertility-surveys", "raw")
+checkout_library <- file.path(checkout_raw, "library")
+build_pointer <- file.path(checkout_raw, "builds", "CURRENT")
+if (file.exists(build_pointer)) {
+    build_id <- readLines(build_pointer, warn = FALSE, n = 1L)
+    if (length(build_id) == 1L && grepl("^[0-9a-f]{64}$", build_id)) {
+        checkout_library <- file.path(checkout_raw, "builds", build_id, "library")
+    }
+}
 if (dir.exists(file.path(checkout_library, "dtaparser"))) {
     old_paths <- .libPaths()
     .libPaths(c(checkout_library, old_paths))
@@ -540,6 +1006,33 @@ if (dir.exists(file.path(checkout_library, "dtaparser"))) {
                   bounded_worker[c("projection_hashes", "projection_expected_hash")],
                   use.names = FALSE
               )))
+    wide_item <- bounded_item
+    wide_item$id <- "F9901"
+    wide_item$path <- normalizePath(wide_path, winslash = "/")
+    sizing_worker <- fertility_worker_tile(
+        wide_item, fertility_sizing_tile(1L, "long_string", 3, 16L),
+        file.path(script_dir, "compare.R"), dirname(installed_dtaparser),
+        installed_dtaparser, "framework", 10L
+    )
+    stopifnot(sizing_worker$classification == "pass",
+              sizing_worker$samples_requested == 3L,
+              sizing_worker$samples_completed == 3L,
+              sizing_worker$payload_bytes_per_row >= 9000,
+              !any(c("long_string", strrep("y", 10)) %in%
+                   unlist(sizing_worker, use.names = FALSE)))
+    rare_item <- wide_item
+    rare_item$id <- "F9902"
+    rare_item$path <- normalizePath(rare_strl_path, winslash = "/")
+    rare_sizing <- fertility_worker_tile(
+        rare_item, fertility_sizing_tile(1L, "long_string", 1000, 16L),
+        file.path(script_dir, "compare.R"), dirname(installed_dtaparser),
+        installed_dtaparser, "framework", 10L
+    )
+    stopifnot(rare_sizing$classification == "pass",
+              rare_sizing$samples_completed == 16L,
+              rare_sizing$payload_bytes_per_row >= 300000,
+              !any(c("long_string", strrep("z", 10)) %in%
+                   unlist(rare_sizing, use.names = FALSE)))
     # The isolated callr worker must install comparator functions in the worker's
     # lexical environment, not only in the transient fertility_worker_tile frame.
     isolated_worker <- callr::r(
@@ -602,30 +1095,32 @@ timeout_execute <- function(item, input) {
     )
     stopifnot(inherits(error, "callr_timeout_error"))
     fertility_base_result(
-        item, "framework", timeout_counter$seconds, input, "timeout"
+        item, test_framework_id, timeout_counter$seconds, input, "timeout"
     )
 }
 first_timeout <- fertility_process_item(
-    timeout_item, timeout_checkpoint, "framework", 1L, FALSE, timeout_execute
+    timeout_item, timeout_checkpoint, test_framework_id, 1L, FALSE, timeout_execute
 )
 stopifnot(!first_timeout$resumed, first_timeout$result$classification == "timeout",
           nzchar(first_timeout$result$input_id), timeout_counter$n == 1L)
 timeout_report <- file.path(root, "timeout-results.tsv")
-invisible(fertility_publish_results(list(first_timeout$result), "build", timeout_report))
+invisible(fertility_publish_results(
+    list(first_timeout$result), test_build_id, timeout_report
+))
 stopifnot(file.exists(timeout_report),
           read.delim(timeout_report)$classification[[1L]] == "timeout")
 resumed_timeout <- fertility_process_item(
-    timeout_item, timeout_checkpoint, "framework", 1L, FALSE, timeout_execute
+    timeout_item, timeout_checkpoint, test_framework_id, 1L, FALSE, timeout_execute
 )
 stopifnot(resumed_timeout$resumed, timeout_counter$n == 1L)
 timeout_counter$seconds <- 2L
 changed_timeout <- fertility_process_item(
-    timeout_item, timeout_checkpoint, "framework", 2L, FALSE, timeout_execute
+    timeout_item, timeout_checkpoint, test_framework_id, 2L, FALSE, timeout_execute
 )
 stopifnot(!changed_timeout$resumed, timeout_counter$n == 2L,
           changed_timeout$result$timeout_seconds == 2L)
 retried_timeout <- fertility_process_item(
-    timeout_item, timeout_checkpoint, "framework", 2L, TRUE, timeout_execute
+    timeout_item, timeout_checkpoint, test_framework_id, 2L, TRUE, timeout_execute
 )
 stopifnot(!retried_timeout$resumed, timeout_counter$n == 3L)
 
@@ -635,15 +1130,25 @@ hash_error_item$path <- file.path(root, "missing-input.dta")
 hash_error_checkpoint <- file.path(root, "hash-error-checkpoint.rds")
 never_execute <- function(item, input) stop("hash errors must not launch a child")
 hash_error <- fertility_process_item(
-    hash_error_item, hash_error_checkpoint, "framework", 1L, FALSE, never_execute
+    hash_error_item, hash_error_checkpoint, test_framework_id, 1L, FALSE, never_execute
 )
-stopifnot(hash_error$result$classification == "input-hash-error",
+stopifnot(hash_error$result$classification == "inventory-hash-error",
           nzchar(hash_error$result$input_id),
           fertility_process_item(hash_error_item, hash_error_checkpoint,
-                                 "framework", 1L, FALSE, never_execute)$resumed)
+                                 test_framework_id, 1L, FALSE, never_execute)$resumed)
 invisible(fertility_publish_results(
-    list(hash_error$result), "build", file.path(root, "hash-error-results.tsv")
+    list(hash_error$result), test_build_id,
+    file.path(root, "hash-error-results.tsv")
 ))
+empty_results_path <- file.path(root, "empty-shard-results.tsv")
+empty_results <- fertility_publish_results(list(), test_build_id, empty_results_path)
+empty_roundtrip <- read.delim(empty_results_path, colClasses = "character",
+                              check.names = FALSE)
+stopifnot(nrow(empty_results) == 0L, nrow(empty_roundtrip) == 0L,
+          "build_provenance_id" %in% names(empty_roundtrip),
+          identical(names(fertility_classification_summary(empty_results)),
+                    c("classification", "files")),
+          nrow(fertility_classification_summary(empty_results)) == 0L)
 
 # Ownership follows a long-lived orchestrator rather than the short-lived R
 # helper that writes metadata. Live owners block reclamation; dead owners do not.
@@ -675,6 +1180,20 @@ unlink(c(stale_heartbeat_lock, stale_heartbeat_temp_root), recursive = TRUE)
 # Permission-denied/unavailable probes are indeterminate, never dead. With no
 # recent heartbeat they follow the conservative stale-age policy rather than
 # permitting immediate lock or temp reclamation.
+remote_owner <- stale_heartbeat_owner
+remote_owner$host <- "synthetic-remote-host"
+fertility_touch_heartbeat(remote_owner$heartbeat, remote_owner$start)
+stopifnot(isTRUE(fertility_owner_alive(remote_owner)))
+remote_lock <- file.path(root, "remote-live.lock")
+dir.create(remote_lock, mode = "0700")
+fertility_write_owner(remote_lock, remote_owner)
+Sys.setFileTime(remote_lock, Sys.time() - 8 * 24 * 3600)
+expect_error(fertility_acquire_lock(
+    remote_lock, initialization_grace = 0, remote_stale_after = 0
+), "another fertility corpus")
+unlink(remote_lock, recursive = TRUE)
+Sys.setFileTime(remote_owner$heartbeat, Sys.time() - 60)
+
 denied_probe <- function(pid) list(alive = NA, start = NA_character_)
 denied_status <- function(owner) fertility_owner_alive(
     owner, process_probe = denied_probe
@@ -728,6 +1247,68 @@ live_owner <- fertility_read_owner(owner_state)
 stopifnot(!is.null(live_owner), identical(live_owner$pid, Sys.getpid()),
           identical(live_owner$start, fertility_process_start(Sys.getpid())),
           isTRUE(fertility_owner_alive(live_owner)))
+
+# Two independent shard processes can hold disjoint deterministic case selections
+# concurrently, while a third overlapping selection is rejected.
+concurrent_root <- file.path(root, "concurrent-shards")
+dir.create(concurrent_root, recursive = TRUE, mode = "0700")
+launch_shard <- function(name, case_id) {
+    ready <- file.path(concurrent_root, paste0(name, ".ready"))
+    release <- file.path(concurrent_root, paste0(name, ".release"))
+    process <- callr::r_bg(
+        function(runtime_script, owner_state, lock_root, name, case_id,
+                 ready, release) {
+            source(runtime_script, local = environment())
+            owner <- fertility_read_owner(owner_state)
+            paths <- c(file.path(lock_root, "selections", name),
+                       file.path(lock_root, "cases", case_id))
+            tokens <- fertility_acquire_lock_set(paths, owner)
+            on.exit(fertility_release_lock_set(tokens), add = TRUE)
+            file.create(ready)
+            deadline <- Sys.time() + 10
+            while (!file.exists(release) && Sys.time() < deadline) Sys.sleep(0.02)
+            if (!file.exists(release)) stop("concurrent shard release timed out")
+            TRUE
+        },
+        args = list(file.path(script_dir, "runtime.R"), owner_state,
+                    concurrent_root, name, case_id, ready, release),
+        user_profile = FALSE, system_profile = FALSE, stdout = "|", stderr = "|"
+    )
+    list(process = process, ready = ready, release = release)
+}
+concurrent_one <- launch_shard("selection-one", "F0001")
+concurrent_two <- launch_shard("selection-two", "F0002")
+on.exit({
+    if (concurrent_one$process$is_alive()) concurrent_one$process$kill_tree()
+    if (concurrent_two$process$is_alive()) concurrent_two$process$kill_tree()
+}, add = TRUE)
+for (attempt in seq_len(500L)) {
+    if (file.exists(concurrent_one$ready) && file.exists(concurrent_two$ready)) break
+    if (!concurrent_one$process$is_alive() || !concurrent_two$process$is_alive()) {
+        stop("concurrent shard process exited before acquiring disjoint locks")
+    }
+    Sys.sleep(0.02)
+}
+stopifnot(file.exists(concurrent_one$ready), file.exists(concurrent_two$ready))
+overlap_error <- tryCatch(callr::r(
+    function(runtime_script, owner_state, path) {
+        source(runtime_script, local = environment())
+        fertility_acquire_lock_set(path, fertility_read_owner(owner_state))
+    },
+    args = list(file.path(script_dir, "runtime.R"), owner_state,
+                file.path(concurrent_root, "cases", "F0001")),
+    user_profile = FALSE, system_profile = FALSE, spinner = FALSE
+), error = identity)
+stopifnot(inherits(overlap_error, "error"),
+          grepl("another fertility corpus", conditionMessage(overlap_error)))
+file.create(concurrent_one$release, concurrent_two$release)
+concurrent_one$process$wait(timeout = 5000)
+concurrent_two$process$wait(timeout = 5000)
+stopifnot(isTRUE(concurrent_one$process$get_result()),
+          isTRUE(concurrent_two$process$get_result()),
+          !file.exists(file.path(concurrent_root, "cases", "F0001")),
+          !file.exists(file.path(concurrent_root, "cases", "F0002")))
+
 live_lock <- file.path(root, "live-owner.lock")
 dir.create(live_lock, mode = "0700")
 fertility_write_owner(live_lock, live_owner)
@@ -845,9 +1426,9 @@ cat("\nsynthetic modification\n", file = file.path(copy_package, "DESCRIPTION"),
     append = TRUE)
 modified_digest <- fertility_directory_digest(copy_package)
 modified <- dependency
-modified$rlang_installed_md5 <- modified_digest
+modified$rlang_installed_sha256 <- modified_digest
 stopifnot(!identical(original_digest, modified_digest),
-          "rlang_installed_md5" %in%
+          "rlang_installed_sha256" %in%
               fertility_provenance_mismatches(dependency, modified))
 
 # Start a real parent R process with TMPDIR configured before startup. That

--- a/benchmarks/fertility-surveys/test-framework.R
+++ b/benchmarks/fertility-surveys/test-framework.R
@@ -985,26 +985,65 @@ stopifnot(isTRUE(fertility_validate_recorded_input_attestation(hash_read_failure
 input_changed_failure <- attested_result
 input_changed_failure$classification <- "inventory-hash-error"
 input_changed_failure$secondary_categories <- "input-changed"
-stopifnot(isTRUE(fertility_validate_recorded_input_attestation(
-    input_changed_failure
-)))
+stopifnot(
+    isTRUE(fertility_validate_recorded_input_attestation(
+        input_changed_failure
+    )),
+    identical(fertility_changed_input_reason(list(
+        input_id = input_changed_failure$input_id,
+        hash_status = "ok",
+        actual_sha512 = input_changed_failure$actual_sha512
+    )), "input-changed"),
+    identical(fertility_changed_input_reason(list(
+        input_id = input_changed_failure$input_id,
+        hash_status = "error", actual_sha512 = NA_character_
+    )), "hash-read-error")
+)
+expect_error(fertility_changed_input_reason(list(
+    input_id = input_changed_failure$input_id,
+    hash_status = "error", actual_sha512 = input_changed_failure$actual_sha512
+)), "inconsistent")
+for (attestation in list(
+    attested_result, signature_failure, hash_read_failure, input_changed_failure
+)) {
+    fresh_attestation <- attestation
+    fresh_attestation$schema_version <- fertility_schema_version
+    replay_attestation <- attestation
+    replay_attestation$schema_version <- fertility_legacy_corpus_schema_version
+    stopifnot(
+        fertility_recorded_result_valid(
+            fresh_attestation, recorded_item, test_framework_id, tile_configuration
+        ),
+        isTRUE(fertility_validate_recorded_input_attestation(fresh_attestation)),
+        fertility_recorded_result_valid(
+            replay_attestation, recorded_item, test_framework_id, tile_configuration,
+            corpus_schema_version = fertility_legacy_corpus_schema_version
+        ),
+        isTRUE(fertility_validate_recorded_input_attestation(replay_attestation))
+    )
+}
+input_changed_recorded <- input_changed_failure
+input_changed_recorded$complete <- FALSE
+input_changed_recorded$mismatch_count <- 0L
+input_changed_recorded$mismatch_categories <- ""
+input_changed_recorded$mismatch_signatures <- ""
 for (corpus_schema_version in c(
     fertility_schema_version, fertility_legacy_corpus_schema_version
 )) {
-    for (attestation in list(
-        attested_result, signature_failure, hash_read_failure,
-        input_changed_failure
-    )) {
-        attestation$schema_version <- as.integer(corpus_schema_version)
-        stopifnot(
-            fertility_recorded_result_valid(
-                attestation, recorded_item, test_framework_id, tile_configuration,
-                corpus_schema_version = corpus_schema_version
-            ),
-            isTRUE(fertility_validate_recorded_input_attestation(attestation))
-        )
-    }
+    input_changed_recorded$schema_version <- as.integer(corpus_schema_version)
+    stopifnot(isTRUE(fertility_validate_recorded_input_result(
+        input_changed_recorded, 3L
+    )))
 }
+expect_error(fertility_validate_recorded_input_result(
+    signature_failure, 1L
+), "input-validation result is inconsistent")
+expect_error(fertility_validate_recorded_input_result(
+    hash_read_failure, 1L
+), "input-validation result is inconsistent")
+expect_error(fertility_validate_recorded_input_result(
+    input_changed_failure, 1L
+), "input-validation result is inconsistent")
 unsupported_attested <- attested_result
 unsupported_attested$classification <- "expected-unsupported-111"
 stopifnot(isTRUE(fertility_validate_recorded_input_attestation(unsupported_attested)))
@@ -1017,6 +1056,9 @@ invalid_attestations <- list(
     { value <- unsupported_attested; value$actual_sha512 <- paste(rep("b", 128L), collapse = ""); value },
     { value <- attested_result; value$secondary_categories <- "signature-mismatch"; value },
     { value <- hash_read_failure; value$actual_sha512 <- attested_result$actual_sha512; value },
+    { value <- attested_result; value$input_id <- "invalid"; value },
+    { value <- signature_failure; value$input_id <- "invalid"; value },
+    { value <- hash_read_failure; value$input_id <- "invalid"; value },
     { value <- input_changed_failure; value$actual_sha512 <- NA_character_; value },
     { value <- input_changed_failure; value$input_id <- "invalid"; value },
     { value <- input_changed_failure; value$secondary_categories <-
@@ -1032,6 +1074,16 @@ for (corpus_schema_version in c(
             "preflight attestation is inconsistent"
         )
     }
+}
+for (malformed_actual in list(NULL, NA, NA_real_)) {
+    malformed_hash_read <- hash_read_failure
+    malformed_hash_read$actual_sha512 <- malformed_actual
+    stopifnot(!fertility_recorded_result_valid(
+        malformed_hash_read, recorded_item, test_framework_id, tile_configuration
+    ))
+    expect_error(fertility_validate_recorded_input_attestation(
+        malformed_hash_read
+    ), "preflight attestation is inconsistent")
 }
 empty_expected_attestation <- attested_result
 empty_expected_attestation$id <- "F0002"
@@ -1606,9 +1658,61 @@ hash_error <- fertility_process_item(
     hash_error_item, hash_error_checkpoint, test_framework_id, 1L, FALSE, never_execute
 )
 stopifnot(hash_error$result$classification == "inventory-hash-error",
+          hash_error$result$secondary_categories == "hash-read-error",
+          isTRUE(fertility_validate_recorded_input_attestation(hash_error$result)),
           nzchar(hash_error$result$input_id),
           fertility_process_item(hash_error_item, hash_error_checkpoint,
                                  test_framework_id, 1L, FALSE, never_execute)$resumed)
+signature_error_item <- timeout_item
+signature_error_item$id <- "F9003"
+signature_error_item$expected_sha512 <- paste(rep("a", 128L), collapse = "")
+signature_error <- fertility_process_item(
+    signature_error_item, file.path(root, "signature-error-checkpoint.rds"),
+    test_framework_id, 1L, FALSE, never_execute
+)
+stopifnot(
+    signature_error$result$classification == "inventory-hash-error",
+    signature_error$result$secondary_categories == "signature-mismatch",
+    isTRUE(fertility_validate_recorded_input_attestation(signature_error$result))
+)
+changed_input_path <- file.path(root, "changed-input.dta")
+write_release(changed_input_path, 118L)
+changed_input_item <- timeout_item
+changed_input_item$id <- "F9004"
+changed_input_item$path <- normalizePath(changed_input_path, winslash = "/")
+change_during_execute <- function(item, input) {
+    write("changed", file = item$path, append = TRUE)
+    fertility_base_result(item, test_framework_id, 1L, input, "pass")
+}
+changed_input <- fertility_process_item(
+    changed_input_item, file.path(root, "changed-input-checkpoint.rds"),
+    test_framework_id, 1L, FALSE, change_during_execute
+)
+stopifnot(
+    changed_input$result$classification == "inventory-hash-error",
+    changed_input$result$secondary_categories == "input-changed",
+    isTRUE(fertility_validate_recorded_input_attestation(changed_input$result))
+)
+removed_input_path <- file.path(root, "removed-input.dta")
+write_release(removed_input_path, 118L)
+removed_input_item <- timeout_item
+removed_input_item$id <- "F9005"
+removed_input_item$path <- normalizePath(removed_input_path, winslash = "/")
+remove_during_execute <- function(item, input) {
+    unlink(item$path)
+    fertility_base_result(item, test_framework_id, 1L, input, "pass")
+}
+removed_input <- fertility_process_item(
+    removed_input_item, file.path(root, "removed-input-checkpoint.rds"),
+    test_framework_id, 1L, FALSE, remove_during_execute
+)
+stopifnot(
+    removed_input$result$classification == "inventory-hash-error",
+    removed_input$result$secondary_categories == "hash-read-error",
+    is.character(removed_input$result$actual_sha512),
+    is.na(removed_input$result$actual_sha512),
+    isTRUE(fertility_validate_recorded_input_attestation(removed_input$result))
+)
 invisible(fertility_publish_results(
     list(hash_error$result), test_build_id,
     file.path(root, "hash-error-results.tsv")

--- a/benchmarks/fertility-surveys/test-framework.R
+++ b/benchmarks/fertility-surveys/test-framework.R
@@ -159,6 +159,20 @@ local({
         identical(descriptor_capture$sha512,
                   fertility_file_sha512(descriptor_target))
     )
+    ambiguous_release <- file.path(fixture, "ambiguous-release.dta")
+    writeBin(charToRaw(paste0(
+        "<stata_dta><header><release>118</release>",
+        "<release>117</release></header>"
+    )), ambiguous_release)
+    expect_error(
+        fertility_nofollow_file_capture(ambiguous_release, include_release = TRUE),
+        "descriptor-bound file capture failed"
+    )
+    expect_error(
+        fertility_output_descriptor_manifest(fertility_output_root, TRUE),
+        "descriptor-bound regular files"
+    )
+    unlink(ambiguous_release)
     restorer <- NULL
     options(dtaparser.fertility.output_inventory_test_hook = function(
         boundary, context
@@ -1511,9 +1525,12 @@ fertility_atomic_write_table(
     full_canonical, file.path(legacy_snapshot, "inventory-manifest.tsv")
 )
 legacy_inventory_provenance <- data.frame(
-    schema_version = fertility_schema_version, framework_id = test_framework_id,
+    schema_version = fertility_legacy_corpus_schema_version,
+    framework_id = test_framework_id,
     inventory_id = paste(rep("e", 64L), collapse = ""),
-    inventory_manifest_id = fertility_manifest_id(full_canonical),
+    inventory_manifest_id = fertility_manifest_id(
+        full_canonical, schema_version = fertility_legacy_corpus_schema_version
+    ),
     report_schema_id = fertility_report_schema_id(
         fertility_legacy_report_schema_version
     ), files = nrow(full_canonical), stringsAsFactors = FALSE, check.names = FALSE

--- a/benchmarks/fertility-surveys/test-framework.R
+++ b/benchmarks/fertility-surveys/test-framework.R
@@ -4085,7 +4085,7 @@ checkpoint <- list(
     input_id = item_input$input_id,
     id = inventory$id[[1L]], expected_sha512 = inventory$expected_sha512[[1L]],
     release = inventory$release[[1L]], timeout_seconds = 1L,
-    classification = "match"
+    classification = "pass"
 )
 stopifnot(fertility_checkpoint_valid(
               checkpoint, item, "framework", item_input, 1L
@@ -4094,6 +4094,8 @@ stopifnot(fertility_checkpoint_valid(
               checkpoint, item, "framework", item_input, 2L
           ),
           !fertility_should_retry(checkpoint))
+checkpoint$classification <- "metadata-mismatch"
+stopifnot(!fertility_should_retry(checkpoint))
 checkpoint$classification <- "expected-unsupported-111"
 stopifnot(!fertility_should_retry(checkpoint))
 checkpoint$classification <- "timeout"

--- a/benchmarks/fertility-surveys/test-framework.R
+++ b/benchmarks/fertility-surveys/test-framework.R
@@ -777,6 +777,118 @@ validated_merge <- fertility_validate_shard_bundles(
 )
 stopifnot(identical(validated_merge$results$id, c("F0001", "F0002")),
           validated_merge$shard_count == 2L)
+current_family_files <- c(
+    provenance = "run-provenance.tsv", results = "results.tsv",
+    family_manifest = "family-manifest.tsv"
+)
+write_current_report <- function(name, bundle, run_name = "bundle") {
+    parent <- file.path(root, name)
+    run <- file.path(parent, run_name)
+    dir.create(run, recursive = TRUE)
+    fertility_atomic_write_table(
+        bundle$provenance, file.path(run, current_family_files[["provenance"]])
+    )
+    fertility_atomic_write_table(
+        bundle$results, file.path(run, current_family_files[["results"]])
+    )
+    fertility_atomic_write_table(
+        bundle$family_manifest,
+        file.path(run, current_family_files[["family_manifest"]])
+    )
+    writeLines(run_name, file.path(parent, "CURRENT"))
+    parent
+}
+load_current_report <- function(parent, family_id) {
+    current <- fertility_current_bundle_for_family(
+        parent, family_id, current_family_files, "synthetic report shard"
+    )
+    if (is.null(current)) return(NULL)
+    lapply(current$paths, function(path) read.delim(
+        path, colClasses = "character", check.names = FALSE
+    ))
+}
+valid_report_parents <- lapply(seq_along(merge_bundles), function(index) {
+    write_current_report(paste0("merge-valid-", index), merge_bundles[[index]])
+})
+loaded_valid_reports <- lapply(
+    valid_report_parents, load_current_report, family_id = merge_fixture$id
+)
+valid_current_merge <- fertility_validate_shard_bundles(
+    loaded_valid_reports, merge_fixture$id, canonical_inventory
+)
+stopifnot(
+    identical(valid_current_merge$results$id, c("F0001", "F0002")),
+    valid_current_merge$shard_count == 2L
+)
+stale_report_parent <- file.path(root, "merge-stale-bundle")
+dir.create(stale_report_parent)
+writeLines("removed-bundle", file.path(stale_report_parent, "CURRENT"))
+stopifnot(is.null(load_current_report(stale_report_parent, merge_fixture$id)))
+unrelated_bundle <- merge_bundles[[1L]]
+unrelated_bundle$provenance$family_id <- paste(rep("0", 64L), collapse = "")
+unrelated_missing_parent <- write_current_report(
+    "merge-unrelated-missing-file", unrelated_bundle
+)
+unlink(file.path(unrelated_missing_parent, "bundle", "results.tsv"))
+stopifnot(is.null(load_current_report(
+    unrelated_missing_parent, merge_fixture$id
+)))
+matching_missing_parent <- write_current_report(
+    "merge-matching-missing-file", merge_bundles[[1L]]
+)
+unlink(file.path(matching_missing_parent, "bundle", "results.tsv"))
+expect_error(load_current_report(
+    matching_missing_parent, merge_fixture$id
+), "No such file|results must be an existing regular file")
+matching_tampered_parent <- write_current_report(
+    "merge-matching-tampered-file", merge_bundles[[1L]]
+)
+tampered_results_path <- file.path(
+    matching_tampered_parent, "bundle", "results.tsv"
+)
+tampered_results <- read.delim(
+    tampered_results_path, colClasses = "character", check.names = FALSE
+)
+tampered_results$id[[1L]] <- "F9999"
+fertility_atomic_write_table(tampered_results, tampered_results_path)
+expect_error(fertility_validate_shard_bundles(
+    list(
+        load_current_report(matching_tampered_parent, merge_fixture$id),
+        loaded_valid_reports[[2L]]
+    ),
+    merge_fixture$id, canonical_inventory
+), "shard results do not match canonical family membership")
+escape_report_parent <- write_current_report(
+    "merge-current-escape", unrelated_bundle
+)
+writeLines("../bundle", file.path(escape_report_parent, "CURRENT"))
+expect_error(load_current_report(
+    escape_report_parent, merge_fixture$id
+), "CURRENT pointer is invalid")
+symlink_report_parent <- file.path(root, "merge-bundle-symlink")
+dir.create(symlink_report_parent)
+writeLines("bundle", file.path(symlink_report_parent, "CURRENT"))
+stopifnot(file.symlink(
+    file.path(valid_report_parents[[1L]], "bundle"),
+    file.path(symlink_report_parent, "bundle")
+))
+expect_error(load_current_report(
+    symlink_report_parent, merge_fixture$id
+), "bundle must not be a symlink")
+provenance_symlink_parent <- write_current_report(
+    "merge-provenance-symlink", unrelated_bundle
+)
+provenance_path <- file.path(
+    provenance_symlink_parent, "bundle", "run-provenance.tsv"
+)
+unlink(provenance_path)
+stopifnot(file.symlink(
+    file.path(valid_report_parents[[1L]], "bundle", "run-provenance.tsv"),
+    provenance_path
+))
+expect_error(load_current_report(
+    provenance_symlink_parent, merge_fixture$id
+), "provenance must not be a symlink")
 legacy_provenance_bundles <- merge_bundles
 for (index in seq_along(legacy_provenance_bundles)) {
     legacy_provenance_bundles[[index]]$provenance[c(

--- a/benchmarks/fertility-surveys/test-framework.R
+++ b/benchmarks/fertility-surveys/test-framework.R
@@ -1212,7 +1212,18 @@ supported_bundle <- which(vapply(output_fixture$bundles, function(bundle) {
     "F0131" %in% bundle$results$id
 }, logical(1)))[[1L]]
 supported_row <- match("F0131", output_fixture$bundles[[supported_bundle]]$results$id)
-for (classification in fertility_output_terminal_classifications()) {
+expected_output_terminal_classifications <- c(
+    "pass", "direct-vs-rust-mismatch", "dtaparser-only-error",
+    "haven-only-error", "shared-reader-error", "metadata-mismatch",
+    "value-mismatch", "tag-mismatch", "date-mismatch",
+    "encoding-mismatch", "row-termination-mismatch",
+    "known-intentional-divergence"
+)
+stopifnot(identical(
+    fertility_output_terminal_classifications(),
+    expected_output_terminal_classifications
+))
+for (classification in expected_output_terminal_classifications) {
     output_allowed <- output_fixture$bundles
     output_allowed[[supported_bundle]]$results$classification[[supported_row]] <-
         classification
@@ -2264,9 +2275,21 @@ full_assessment <- fertility_validate_merged_bundle(
 accepted_assessment <- fertility_validate_merged_bundle(
     accepted_merged_bundle, accepted_family_fixture$id, merge_live_inventory
 )
+output_merge_live_inventory <- output_canonical
+output_merge_live_inventory$expected_sha512 <- rep(
+    paste(rep("b", 128L), collapse = ""), nrow(output_merge_live_inventory)
+)
+output_merged_bundle <- make_merged_bundle(
+    output_validated, output_fixture$id, output_merge_live_inventory
+)
+output_assessment <- fertility_validate_merged_bundle(
+    output_merged_bundle, output_fixture$id, output_merge_live_inventory
+)
 stopifnot(
     grepl("^[0-9a-f]{64}$", full_assessment$merge_id),
-    grepl("^[0-9a-f]{64}$", accepted_assessment$merge_id)
+    grepl("^[0-9a-f]{64}$", accepted_assessment$merge_id),
+    grepl("^[0-9a-f]{64}$", output_assessment$merge_id),
+    nrow(output_assessment$results) == fertility_output_expected_files
 )
 production_framework_inventory <- fertility_framework_inventory(
     publication_snapshot, inventory = publication_inventory,

--- a/benchmarks/fertility-surveys/test-framework.R
+++ b/benchmarks/fertility-surveys/test-framework.R
@@ -1208,16 +1208,24 @@ output_validated <- fertility_validate_shard_bundles(
 )
 stopifnot(output_validated$full_default,
           nrow(output_validated$results) == fertility_output_expected_files)
+supported_bundle <- which(vapply(output_fixture$bundles, function(bundle) {
+    "F0131" %in% bundle$results$id
+}, logical(1)))[[1L]]
+supported_row <- match("F0131", output_fixture$bundles[[supported_bundle]]$results$id)
+for (classification in fertility_output_terminal_classifications()) {
+    output_allowed <- output_fixture$bundles
+    output_allowed[[supported_bundle]]$results$classification[[supported_row]] <-
+        classification
+    stopifnot(nrow(fertility_validate_shard_bundles(
+        output_allowed, output_fixture$id, output_canonical
+    )$results) == fertility_output_expected_files)
+}
 output_bad_unsupported <- output_fixture$bundles
 output_bad_unsupported[[1L]]$results$classification[[1L]] <- "pass"
 expect_error(fertility_validate_shard_bundles(
     output_bad_unsupported, output_fixture$id, output_canonical
 ), "unsupported-release classifications")
 output_bad_terminal <- output_fixture$bundles
-supported_bundle <- which(vapply(output_bad_terminal, function(bundle) {
-    "F0131" %in% bundle$results$id
-}, logical(1)))[[1L]]
-supported_row <- match("F0131", output_bad_terminal[[supported_bundle]]$results$id)
 output_bad_terminal[[supported_bundle]]$results$classification[[supported_row]] <-
     "timeout"
 expect_error(fertility_validate_shard_bundles(

--- a/benchmarks/fertility-surveys/test-framework.R
+++ b/benchmarks/fertility-surveys/test-framework.R
@@ -1,0 +1,503 @@
+script_argument <- grep("^--file=", commandArgs(trailingOnly = FALSE), value = TRUE)[[1L]]
+script_dir <- dirname(normalizePath(sub("^--file=", "", script_argument), winslash = "/"))
+source(file.path(script_dir, "common.R"))
+source(file.path(script_dir, "compare.R"))
+source(file.path(script_dir, "runner.R"))
+source(file.path(script_dir, "worker.R"))
+source(file.path(script_dir, "runtime.R"))
+source(file.path(script_dir, "provenance.R"))
+
+expect_error <- function(expression, pattern) {
+    error <- tryCatch({ force(expression); NULL }, error = identity)
+    stopifnot(inherits(error, "error"), grepl(pattern, conditionMessage(error)))
+}
+
+root <- tempfile("fertility-framework-")
+dir.create(root)
+on.exit(unlink(root, recursive = TRUE), add = TRUE)
+cache <- file.path(root, "cache")
+dir.create(cache)
+write_release <- function(path, release) {
+    dir.create(dirname(path), recursive = TRUE, showWarnings = FALSE)
+    bytes <- if (release >= 117L) {
+        charToRaw(sprintf("<stata_dta><header><release>%03d</release></header>", release))
+    } else c(as.raw(release), as.raw(rep(0L, 40L)))
+    writeBin(bytes, path)
+}
+rows <- data.frame(
+    program = c("dhs", "dhs", "mics", "wfs", "enadid"),
+    survey = c("AA_2000", "BB_2001", "CC_2002", "WFTEST", "EE_2003"),
+    level = c("women", "births", "women", "women", "births"),
+    datasig = "", sha512 = "", stringsAsFactors = FALSE
+)
+paths <- c(
+    file.path(cache, "DHS/Original_Data/AA,2000/wm.dta"),
+    file.path(cache, "DHS/Original_Data_Provenance_Unknown/BB,2001/bh.dta"),
+    file.path(cache, "MICS/Data/Original Data/CC,2002/wm.dta"),
+    file.path(cache, "WFS/Data/WFTEST.dta"),
+    file.path(cache, "ENADID/Data/Original Data/EE,2003/bh.dta")
+)
+releases <- c(111L, 113L, 114L, 117L, 118L)
+for (i in seq_along(paths)) write_release(paths[[i]], releases[[i]])
+datasigs <- file.path(root, "datasigs.csv")
+write.csv(rows, datasigs, row.names = FALSE, quote = FALSE)
+inventory <- fertility_build_inventory(
+    list(cache = cache, datasigs = datasigs), assert_counts = FALSE,
+    enforce_required_paths = FALSE
+)
+stopifnot(
+    identical(inventory$id, sprintf("F%04d", 1:5)),
+    identical(inventory$release, releases),
+    identical(inventory$path, normalizePath(paths, winslash = "/")),
+    identical(names(fertility_public_inventory(inventory)),
+              c("id", "program", "level", "release")),
+    !any(c("path", "survey", "expected_sha512") %in%
+         names(fertility_public_inventory(inventory)))
+)
+primary_second <- file.path(cache, "DHS/Original_Data/BB,2001/bh.dta")
+write_release(primary_second, 113L)
+precedence_inventory <- fertility_build_inventory(
+    list(cache = cache, datasigs = datasigs), assert_counts = FALSE,
+    enforce_required_paths = FALSE
+)
+stopifnot(precedence_inventory$path[[2L]] ==
+          normalizePath(primary_second, winslash = "/"))
+
+options <- fertility_parse_arguments(c(
+    "--program=dhs,mics", "--release=113,114", "--shard-index=1",
+    "--shard-count=2", "--max-files=1", "--timeout-seconds=9", "--retry"
+))
+selected <- fertility_filter_inventory(inventory, options)
+stopifnot(nrow(selected) == 1L, selected$id[[1L]] == "F0003",
+          options$timeout_seconds == 9L, options$retry)
+expect_error(fertility_parse_arguments("--shard-count=2"), "supplied together")
+expect_error(fertility_parse_arguments("--timeout-seconds=0"), "positive integer")
+expect_error(fertility_filter_inventory(
+    inventory, fertility_parse_arguments("--id=F9999")
+), "unknown --id")
+
+actual <- tibble::tibble(
+    number = c(1, 2 + 5e-8, haven::tagged_na("a")),
+    text = c("a", NA, "c"),
+    day = as.Date(c("2020-01-01", NA, "2020-01-03"))
+)
+attr(actual, "label") <- "synthetic"
+attr(actual$number, "label") <- "number"
+expected <- actual
+stopifnot(fertility_compare_internal(actual, actual)$ok)
+stopifnot(fertility_compare_haven(actual, expected)$ok)
+expected$number[[2L]] <- expected$number[[2L]] + 4e-8
+stopifnot(fertility_compare_haven(actual, expected)$ok)
+large_actual <- tibble::tibble(value = c(1e15, 2))
+large_expected <- tibble::tibble(value = c(1e15 + 1, 2))
+stopifnot(fertility_compare_haven(large_actual, large_expected)$classification ==
+          "value-mismatch")
+outlier_actual <- tibble::tibble(value = rep(0, 10000L))
+outlier_expected <- outlier_actual
+outlier_expected$value[[9876L]] <- 2e-7
+stopifnot(fertility_compare_haven(outlier_actual, outlier_expected)$classification ==
+          "value-mismatch")
+expected$number[[2L]] <- 3
+stopifnot(fertility_compare_haven(actual, expected)$classification == "value-mismatch")
+expected <- actual
+expected$number[[3L]] <- haven::tagged_na("b")
+stopifnot(fertility_compare_haven(actual, expected)$classification ==
+          "tagged-missing-mismatch")
+expected <- actual
+expected$number[[2L]] <- NaN
+actual_missing <- actual
+actual_missing$number[[2L]] <- NA_real_
+stopifnot(fertility_compare_haven(actual_missing, expected)$classification ==
+          "missing-kind-mismatch")
+expected <- actual
+attr(expected$text, "label") <- "different"
+stopifnot(fertility_compare_haven(actual, expected)$classification ==
+          "attribute-mismatch")
+changed <- actual
+changed$text[[1L]] <- "different"
+stopifnot(fertility_compare_internal(actual, changed)$classification ==
+          "internal-collector-mismatch")
+
+item <- as.list(inventory[1L, , drop = FALSE])
+item_input <- fertility_capture_input(item)
+checkpoint <- list(
+    schema_version = fertility_schema_version, framework_id = "framework",
+    input_id = item_input$input_id,
+    id = inventory$id[[1L]], expected_sha512 = inventory$expected_sha512[[1L]],
+    release = inventory$release[[1L]], timeout_seconds = 1L,
+    classification = "match"
+)
+stopifnot(fertility_checkpoint_valid(
+              checkpoint, item, "framework", item_input, 1L
+          ),
+          !fertility_checkpoint_valid(
+              checkpoint, item, "framework", item_input, 2L
+          ),
+          !fertility_should_retry(checkpoint))
+checkpoint$classification <- "timeout"
+stopifnot(fertility_should_retry(checkpoint))
+checkpoint$expected_sha512 <- "changed"
+stopifnot(!fertility_checkpoint_valid(checkpoint, item, "framework"))
+checkpoint_path <- file.path(root, "checkpoint.rds")
+fertility_atomic_save_rds(checkpoint, checkpoint_path)
+stopifnot(identical(readRDS(checkpoint_path), checkpoint))
+supported_item <- as.list(inventory[2L, , drop = FALSE])
+supported_item$path <- normalizePath(primary_second, winslash = "/")
+supported_input <- fertility_capture_input(supported_item)
+supported_checkpoint <- list(
+    schema_version = fertility_schema_version, framework_id = "framework",
+    input_id = supported_input$input_id,
+    id = supported_item$id, expected_sha512 = "", release = supported_item$release,
+    timeout_seconds = 1L, actual_sha512 = supported_input$actual_sha512,
+    classification = "match"
+)
+stopifnot(fertility_checkpoint_input_current(supported_checkpoint, supported_item))
+writeBin(as.raw(1L), supported_item$path, useBytes = TRUE)
+stopifnot(!fertility_checkpoint_input_current(supported_checkpoint, supported_item))
+
+unsupported_item <- as.list(inventory[1L, , drop = FALSE])
+unsupported <- fertility_worker(
+    unsupported_item, file.path(script_dir, "compare.R"),
+    root, root, "framework", 1L, fertility_file_sha512(unsupported_item$path)
+)
+stopifnot(unsupported$classification == "unsupported-release")
+hash_item <- as.list(inventory[2L, , drop = FALSE])
+hash_item$expected_sha512 <- paste(rep("0", 128L), collapse = "")
+hash_failure <- fertility_worker(
+    hash_item, file.path(script_dir, "compare.R"), root, root, "framework", 1L,
+    fertility_file_sha512(hash_item$path)
+)
+stopifnot(hash_failure$classification == "input-signature-mismatch")
+
+# Timeout checkpoints retain the parent hash, publish, resume without retry, and
+# execute again only when retry is requested.
+timeout_path <- file.path(root, "timeout-input.dta")
+write_release(timeout_path, 118L)
+timeout_item <- list(
+    id = "F9001", program = "dhs", level = "women", release = 118L,
+    path = normalizePath(timeout_path, winslash = "/"), expected_sha512 = ""
+)
+timeout_checkpoint <- file.path(root, "timeout-checkpoint.rds")
+timeout_counter <- new.env(parent = emptyenv())
+timeout_counter$n <- 0L
+timeout_counter$seconds <- 1L
+timeout_execute <- function(item, input) {
+    timeout_counter$n <- timeout_counter$n + 1L
+    error <- tryCatch(
+        callr::r(function() Sys.sleep(2), timeout = 0.1, spinner = FALSE),
+        error = identity
+    )
+    stopifnot(inherits(error, "callr_timeout_error"))
+    fertility_base_result(
+        item, "framework", timeout_counter$seconds, input, "timeout"
+    )
+}
+first_timeout <- fertility_process_item(
+    timeout_item, timeout_checkpoint, "framework", 1L, FALSE, timeout_execute
+)
+stopifnot(!first_timeout$resumed, first_timeout$result$classification == "timeout",
+          nzchar(first_timeout$result$input_id), timeout_counter$n == 1L)
+timeout_report <- file.path(root, "timeout-results.tsv")
+invisible(fertility_publish_results(list(first_timeout$result), "build", timeout_report))
+stopifnot(file.exists(timeout_report),
+          read.delim(timeout_report)$classification[[1L]] == "timeout")
+resumed_timeout <- fertility_process_item(
+    timeout_item, timeout_checkpoint, "framework", 1L, FALSE, timeout_execute
+)
+stopifnot(resumed_timeout$resumed, timeout_counter$n == 1L)
+timeout_counter$seconds <- 2L
+changed_timeout <- fertility_process_item(
+    timeout_item, timeout_checkpoint, "framework", 2L, FALSE, timeout_execute
+)
+stopifnot(!changed_timeout$resumed, timeout_counter$n == 2L,
+          changed_timeout$result$timeout_seconds == 2L)
+retried_timeout <- fertility_process_item(
+    timeout_item, timeout_checkpoint, "framework", 2L, TRUE, timeout_execute
+)
+stopifnot(!retried_timeout$resumed, timeout_counter$n == 3L)
+
+hash_error_item <- timeout_item
+hash_error_item$id <- "F9002"
+hash_error_item$path <- file.path(root, "missing-input.dta")
+hash_error_checkpoint <- file.path(root, "hash-error-checkpoint.rds")
+never_execute <- function(item, input) stop("hash errors must not launch a child")
+hash_error <- fertility_process_item(
+    hash_error_item, hash_error_checkpoint, "framework", 1L, FALSE, never_execute
+)
+stopifnot(hash_error$result$classification == "input-hash-error",
+          nzchar(hash_error$result$input_id),
+          fertility_process_item(hash_error_item, hash_error_checkpoint,
+                                 "framework", 1L, FALSE, never_execute)$resumed)
+invisible(fertility_publish_results(
+    list(hash_error$result), "build", file.path(root, "hash-error-results.tsv")
+))
+
+# Ownership follows a long-lived orchestrator rather than the short-lived R
+# helper that writes metadata. Live owners block reclamation; dead owners do not.
+stopifnot(!fertility_pid_alive(.Machine$integer.max))
+
+# A matching OS process generation remains authoritative even if its supplemental
+# heartbeat is old.
+stale_heartbeat_state <- file.path(root, "stale-heartbeat-owner")
+dir.create(stale_heartbeat_state, mode = "0700")
+stale_heartbeat <- file.path(stale_heartbeat_state, "heartbeat")
+stale_heartbeat_owner <- fertility_owner(stale_heartbeat)
+fertility_touch_heartbeat(stale_heartbeat, stale_heartbeat_owner$start)
+Sys.setFileTime(stale_heartbeat, Sys.time() - 60)
+stopifnot(isTRUE(fertility_owner_alive(stale_heartbeat_owner)))
+stale_heartbeat_lock <- file.path(root, "stale-heartbeat.lock")
+dir.create(stale_heartbeat_lock, mode = "0700")
+fertility_write_owner(stale_heartbeat_lock, stale_heartbeat_owner)
+expect_error(fertility_acquire_lock(
+    stale_heartbeat_lock, initialization_grace = 0
+), "another fertility corpus")
+stale_heartbeat_temp_root <- file.path(root, "stale-heartbeat-temp")
+stale_heartbeat_temp <- file.path(stale_heartbeat_temp_root, "run.live")
+dir.create(stale_heartbeat_temp, recursive = TRUE, mode = "0700")
+fertility_write_temp_owner(stale_heartbeat_temp, stale_heartbeat_owner)
+fertility_clean_stale_tempdirs(stale_heartbeat_temp_root, current = "")
+stopifnot(dir.exists(stale_heartbeat_temp))
+unlink(c(stale_heartbeat_lock, stale_heartbeat_temp_root), recursive = TRUE)
+
+# Permission-denied/unavailable probes are indeterminate, never dead. With no
+# recent heartbeat they follow the conservative stale-age policy rather than
+# permitting immediate lock or temp reclamation.
+denied_probe <- function(pid) list(alive = NA, start = NA_character_)
+denied_status <- function(owner) fertility_owner_alive(
+    owner, process_probe = denied_probe
+)
+stopifnot(is.na(denied_status(stale_heartbeat_owner)))
+denied_lock <- file.path(root, "denied-probes.lock")
+dir.create(denied_lock, mode = "0700")
+fertility_write_owner(denied_lock, stale_heartbeat_owner)
+expect_error(fertility_acquire_lock(
+    denied_lock, initialization_grace = 0, owner_status = denied_status
+), "another fertility corpus")
+denied_temp_root <- file.path(root, "denied-probes-temp")
+denied_temp <- file.path(denied_temp_root, "run.indeterminate")
+dir.create(denied_temp, recursive = TRUE, mode = "0700")
+fertility_write_owner(denied_temp, stale_heartbeat_owner)
+fertility_clean_stale_tempdirs(
+    denied_temp_root, current = "", owner_status = denied_status
+)
+stopifnot(dir.exists(denied_temp))
+unlink(c(denied_lock, denied_temp_root), recursive = TRUE)
+
+# A confirmed live PID with a different start generation is definitive PID reuse
+# and can be reclaimed immediately.
+mismatch_status <- function(owner) fertility_owner_alive(
+    owner,
+    process_probe = function(pid) list(alive = TRUE, start = "different-generation")
+)
+stopifnot(isFALSE(mismatch_status(stale_heartbeat_owner)))
+mismatch_lock <- file.path(root, "pid-reuse.lock")
+dir.create(mismatch_lock, mode = "0700")
+fertility_write_owner(mismatch_lock, stale_heartbeat_owner)
+mismatch_token <- fertility_acquire_lock(
+    mismatch_lock, initialization_grace = 0, owner_status = mismatch_status
+)
+stopifnot(fertility_release_lock(mismatch_lock, mismatch_token))
+
+owner_state <- file.path(root, "live-owner-state")
+owner_process <- processx::process$new(
+    file.path(R.home("bin"), "Rscript"),
+    c("--vanilla", file.path(script_dir, "runtime.R"), "hold-owner",
+      owner_state, as.character(Sys.getpid())),
+    cleanup_tree = TRUE, stdout = "|", stderr = "|"
+)
+on.exit(if (owner_process$is_alive()) owner_process$kill_tree(), add = TRUE)
+for (attempt in seq_len(100L)) {
+    if (file.exists(file.path(owner_state, "owner.tsv"))) break
+    if (!owner_process$is_alive()) stop("owner helper exited during initialization")
+    Sys.sleep(0.02)
+}
+live_owner <- fertility_read_owner(owner_state)
+stopifnot(!is.null(live_owner), identical(live_owner$pid, Sys.getpid()),
+          identical(live_owner$start, fertility_process_start(Sys.getpid())),
+          isTRUE(fertility_owner_alive(live_owner)))
+live_lock <- file.path(root, "live-owner.lock")
+dir.create(live_lock, mode = "0700")
+fertility_write_owner(live_lock, live_owner)
+expect_error(fertility_acquire_lock(
+    live_lock, initialization_grace = 0
+), "another fertility corpus")
+live_temp_root <- file.path(root, "live-owner-temp")
+live_temp <- file.path(live_temp_root, "run.live")
+dir.create(live_temp, recursive = TRUE, mode = "0700")
+fertility_write_temp_owner(live_temp, live_owner)
+fertility_clean_stale_tempdirs(live_temp_root, current = "")
+stopifnot(dir.exists(live_temp))
+invisible(owner_process$kill_tree())
+owner_process$wait(timeout = 5000)
+stopifnot(isTRUE(fertility_owner_alive(live_owner)))
+expect_error(fertility_acquire_lock(
+    live_lock, initialization_grace = 0
+), "another fertility corpus")
+fertility_clean_stale_tempdirs(live_temp_root, current = "")
+stopifnot(dir.exists(live_temp))
+unlink(c(live_lock, live_temp_root), recursive = TRUE)
+
+# The owner helper monitors the orchestrator's exact process generation. Killing
+# only that parent makes the helper exit and releases both kinds of stale state.
+monitored_parent <- processx::process$new(
+    "/bin/sleep", "30", cleanup_tree = TRUE, stdout = "|", stderr = "|"
+)
+on.exit(if (monitored_parent$is_alive()) monitored_parent$kill_tree(), add = TRUE)
+monitored_state <- file.path(root, "monitored-owner-state")
+monitored_helper <- processx::process$new(
+    file.path(R.home("bin"), "Rscript"),
+    c("--vanilla", file.path(script_dir, "runtime.R"), "hold-owner",
+      monitored_state, as.character(monitored_parent$get_pid())),
+    cleanup_tree = TRUE, stdout = "|", stderr = "|"
+)
+on.exit(if (monitored_helper$is_alive()) monitored_helper$kill_tree(), add = TRUE)
+for (attempt in seq_len(100L)) {
+    if (file.exists(file.path(monitored_state, "owner.tsv"))) break
+    if (!monitored_helper$is_alive()) stop("monitored owner helper exited early")
+    Sys.sleep(0.02)
+}
+monitored_owner <- fertility_read_owner(monitored_state)
+stopifnot(!is.null(monitored_owner),
+          identical(monitored_owner$pid, monitored_parent$get_pid()),
+          identical(monitored_owner$start,
+                    fertility_process_start(monitored_parent$get_pid())),
+          isTRUE(fertility_owner_alive(monitored_owner)))
+monitored_lock <- file.path(root, "monitored-owner.lock")
+dir.create(monitored_lock, mode = "0700")
+fertility_write_owner(monitored_lock, monitored_owner)
+monitored_temp_root <- file.path(root, "monitored-owner-temp")
+monitored_temp <- file.path(monitored_temp_root, "run.live")
+dir.create(monitored_temp, recursive = TRUE, mode = "0700")
+fertility_write_temp_owner(monitored_temp, monitored_owner)
+# Helper death alone cannot release ownership while its published parent
+# generation is still alive.
+invisible(monitored_helper$kill_tree())
+monitored_helper$wait(timeout = 5000)
+stopifnot(isTRUE(fertility_owner_alive(monitored_owner)))
+expect_error(fertility_acquire_lock(
+    monitored_lock, initialization_grace = 0
+), "another fertility corpus")
+fertility_clean_stale_tempdirs(monitored_temp_root, current = "")
+stopifnot(dir.exists(monitored_temp))
+# Once that exact parent dies, recovery succeeds even though the heartbeat helper
+# was already gone.
+invisible(monitored_parent$kill())
+monitored_parent$wait(timeout = 5000)
+stopifnot(!isTRUE(fertility_owner_alive(monitored_owner)))
+monitored_token <- fertility_acquire_lock(monitored_lock, initialization_grace = 0)
+stopifnot(fertility_release_lock(monitored_lock, monitored_token))
+fertility_clean_stale_tempdirs(monitored_temp_root, current = "")
+stopifnot(!file.exists(monitored_temp))
+
+# Stale and ownerless locks are reclaimed, while release remains token-owned.
+lock_path <- file.path(root, "run.lock")
+dir.create(lock_path, mode = "0700")
+fertility_write_owner(lock_path, list(
+    token = "dead", pid = .Machine$integer.max, host = fertility_host(),
+    start = "not-a-process", heartbeat = file.path(root, "missing-heartbeat"),
+    created = 0
+))
+lock_token <- fertility_acquire_lock(lock_path)
+stopifnot(nzchar(lock_token), fertility_release_lock(lock_path, lock_token),
+          !file.exists(lock_path))
+dir.create(lock_path, mode = "0700")
+Sys.setFileTime(lock_path, Sys.time() - 10)
+lock_token <- fertility_acquire_lock(lock_path, initialization_grace = 0)
+stopifnot(fertility_release_lock(lock_path, lock_token))
+temp_root <- file.path(root, "stale-temp")
+current_temp <- file.path(temp_root, "run.current")
+stale_temp <- file.path(temp_root, "run.stale")
+dir.create(current_temp, recursive = TRUE, mode = "0700")
+dir.create(stale_temp, mode = "0700")
+fertility_write_owner(stale_temp, list(
+    token = "dead-temp", pid = .Machine$integer.max, host = fertility_host(),
+    start = "not-a-process", heartbeat = file.path(root, "missing-heartbeat"),
+    created = 0
+))
+fertility_clean_stale_tempdirs(temp_root, current_temp)
+stopifnot(dir.exists(current_temp), !file.exists(stale_temp))
+
+# Runtime dependencies are bound to canonical paths and installed trees.
+dependency <- fertility_dependency_provenance("rlang")
+moved <- dependency
+moved$rlang_path <- paste0(moved$rlang_path, "-moved")
+stopifnot("rlang_path" %in% fertility_provenance_mismatches(dependency, moved))
+source_package <- dependency$rlang_path[[1L]]
+copy_parent <- file.path(root, "dependency-copy")
+dir.create(copy_parent)
+stopifnot(file.copy(source_package, copy_parent, recursive = TRUE))
+copy_package <- file.path(copy_parent, basename(source_package))
+original_digest <- fertility_directory_digest(copy_package)
+cat("\nsynthetic modification\n", file = file.path(copy_package, "DESCRIPTION"),
+    append = TRUE)
+modified_digest <- fertility_directory_digest(copy_package)
+modified <- dependency
+modified$rlang_installed_md5 <- modified_digest
+stopifnot(!identical(original_digest, modified_digest),
+          "rlang_installed_md5" %in%
+              fertility_provenance_mismatches(dependency, modified))
+
+# Start a real parent R process with TMPDIR configured before startup. That
+# parent launches callr, and both its tempdir and callr's live serialization and
+# control artifacts must remain beneath the private raw root.
+private_raw <- file.path(root, "target", "fertility-surveys", "raw")
+private_tmp <- file.path(private_raw, "tmp", "run.synthetic")
+dir.create(private_tmp, recursive = TRUE, mode = "0700")
+temp_lifecycle <- callr::r(
+    function(runtime_script, raw_root, configured_tmp) {
+        source(runtime_script, local = environment())
+        parent_temp <- fertility_assert_tempdir(raw_root)
+        before <- list.files(parent_temp, recursive = TRUE, all.files = TRUE,
+                             full.names = TRUE, no.. = TRUE)
+        child <- callr::r_bg(
+            function(runtime_script, raw_root) {
+                source(runtime_script, local = environment())
+                value <- fertility_assert_tempdir(raw_root)
+                Sys.sleep(0.5)
+                value
+            },
+            args = list(runtime_script, raw_root),
+            env = c(TMPDIR = configured_tmp, R_ENVIRON_USER = "/dev/null",
+                    R_PROFILE_USER = "/dev/null"),
+            user_profile = FALSE, system_profile = FALSE,
+            stdout = "|", stderr = "|"
+        )
+        Sys.sleep(0.1)
+        during <- list.files(parent_temp, recursive = TRUE, all.files = TRUE,
+                             full.names = TRUE, no.. = TRUE)
+        control <- setdiff(during, before)
+        child$wait(timeout = 5000)
+        child_temp <- child$get_result()
+        list(parent = parent_temp, child = child_temp, control = control)
+    },
+    args = list(file.path(script_dir, "runtime.R"), private_raw, private_tmp),
+    env = c(TMPDIR = private_tmp, R_ENVIRON_USER = "/dev/null",
+            R_PROFILE_USER = "/dev/null"),
+    user_profile = FALSE, system_profile = FALSE, spinner = FALSE
+)
+private_prefix <- paste0(normalizePath(private_raw, winslash = "/"), "/")
+all_temp_paths <- c(temp_lifecycle$parent, temp_lifecycle$child,
+                    temp_lifecycle$control)
+stopifnot(length(temp_lifecycle$control) > 0L,
+          all(startsWith(normalizePath(
+              all_temp_paths, winslash = "/", mustWork = FALSE
+          ), private_prefix)))
+
+environment_names <- c("DTAPARSER_FERTILITY_CORPUS", "CI", "GITHUB_ACTIONS",
+                       "GITHUB_RUN_ID", "GITHUB_WORKFLOW")
+old_environment <- Sys.getenv(environment_names, unset = NA_character_)
+on.exit({
+    for (i in seq_along(environment_names)) {
+        if (is.na(old_environment[[i]])) Sys.unsetenv(environment_names[[i]])
+        else do.call(Sys.setenv, setNames(list(old_environment[[i]]), environment_names[[i]]))
+    }
+}, add = TRUE)
+Sys.setenv(DTAPARSER_FERTILITY_CORPUS = fertility_opt_in_value, CI = "true")
+expect_error(fertility_assert_manual_run(), "refused in CI")
+Sys.unsetenv(c("CI", "GITHUB_ACTIONS", "GITHUB_RUN_ID", "GITHUB_WORKFLOW"))
+Sys.setenv(DTAPARSER_FERTILITY_CORPUS = "")
+expect_error(fertility_assert_manual_run(), "manual opt-in")
+Sys.setenv(DTAPARSER_FERTILITY_CORPUS = fertility_opt_in_value)
+stopifnot(is.null(fertility_assert_manual_run()))
+
+message("fertility framework synthetic tests passed")

--- a/benchmarks/fertility-surveys/test-framework.R
+++ b/benchmarks/fertility-surveys/test-framework.R
@@ -1872,8 +1872,10 @@ fertility_atomic_write_table(data.frame(
     stringsAsFactors = FALSE, check.names = FALSE
 ), file.path(publication_snapshot, "acceptance-provenance.tsv"))
 publication_provenance <- data.frame(
+    schema_version = fertility_schema_version,
+    report_schema_version = fertility_report_schema_version,
     evidence_origin = "fresh-execution",
-    source_corpus_schema_version = as.character(fertility_schema_version),
+    source_corpus_schema_version = fertility_schema_version,
     framework_id = publication_framework_id,
     build_provenance_id = test_build_id,
     inventory_id = publication_inventory_id,
@@ -1889,6 +1891,65 @@ stopifnot(identical(
     )$acceptance$artifact_sha256,
     acceptance_reloaded$artifact_sha256
 ))
+publication_provenance_path <- file.path(
+    root, "accepted-publication-provenance.tsv"
+)
+fertility_atomic_write_table(publication_provenance, publication_provenance_path)
+publication_provenance_tsv <- read.delim(
+    publication_provenance_path, colClasses = "character", check.names = FALSE
+)
+stopifnot(
+    all(vapply(publication_provenance_tsv[c(
+        "schema_version", "report_schema_version",
+        "source_corpus_schema_version"
+    )], is.character, logical(1))),
+    identical(
+        fertility_revalidate_accepted_publication(
+            acceptance_raw, publication_provenance_tsv, publication_inventory,
+            datasigs
+        )$acceptance$artifact_sha256,
+        acceptance_reloaded$artifact_sha256
+    )
+)
+publication_schema_fields <- c(
+    schema_version = fertility_schema_version,
+    report_schema_version = fertility_report_schema_version,
+    source_corpus_schema_version = fertility_schema_version
+)
+for (field in names(publication_schema_fields)) {
+    wrong_publication_schema <- publication_provenance
+    wrong_publication_schema[[field]] <-
+        as.character(publication_schema_fields[[field]] + 1L)
+    expect_error(fertility_revalidate_accepted_publication(
+        acceptance_raw, wrong_publication_schema, publication_inventory, datasigs
+    ), "framework provenance is invalid")
+}
+malformed_publication_schema <- publication_provenance
+malformed_publication_schema$source_corpus_schema_version <-
+    paste0(fertility_schema_version, ".0")
+expect_error(fertility_revalidate_accepted_publication(
+    acceptance_raw, malformed_publication_schema, publication_inventory, datasigs
+), "framework provenance is invalid")
+missing_publication_schema <- publication_provenance
+missing_publication_schema$report_schema_version <- NULL
+expect_error(fertility_revalidate_accepted_publication(
+    acceptance_raw, missing_publication_schema, publication_inventory, datasigs
+), "framework provenance is invalid")
+nonatomic_publication_schema <- publication_provenance
+nonatomic_publication_schema$schema_version <- I(list(fertility_schema_version))
+expect_error(fertility_revalidate_accepted_publication(
+    acceptance_raw, nonatomic_publication_schema, publication_inventory, datasigs
+), "framework provenance is invalid")
+mixed_publication_schema <- rbind(publication_provenance, publication_provenance)
+mixed_publication_schema$source_corpus_schema_version[[2L]] <-
+    fertility_schema_version + 1L
+expect_error(fertility_revalidate_accepted_publication(
+    acceptance_raw, mixed_publication_schema, publication_inventory, datasigs
+), "framework provenance is invalid")
+empty_publication_provenance <- publication_provenance[FALSE, , drop = FALSE]
+expect_error(fertility_revalidate_accepted_publication(
+    acceptance_raw, empty_publication_provenance, publication_inventory, datasigs
+), "framework provenance is invalid")
 foreign_publication_framework <- publication_provenance
 foreign_publication_framework$framework_id <- test_framework_id
 expect_error(fertility_revalidate_accepted_publication(

--- a/benchmarks/fertility-surveys/test-framework.R
+++ b/benchmarks/fertility-surveys/test-framework.R
@@ -22,6 +22,93 @@ dir.create(root)
 root <- normalizePath(root, winslash = "/", mustWork = TRUE)
 on.exit(unlink(root, recursive = TRUE), add = TRUE)
 
+# The output walk includes only regular case-insensitive DTA files and fails
+# closed when a potentially relevant entry cannot be safely inventoried.
+local({
+    fixture <- file.path(root, "output-inventory")
+    outside <- file.path(root, "output-inventory-outside")
+    dir.create(file.path(fixture, "nested"), recursive = TRUE)
+    dir.create(outside)
+    writeBin(as.raw(1:3), file.path(fixture, "regular.dta"))
+    writeBin(as.raw(4:6), file.path(fixture, "nested", "upper.DTA"))
+    writeLines("ignored", file.path(fixture, "notes.txt"))
+    writeLines("outside", file.path(outside, "outside.txt"))
+    stopifnot(file.symlink(
+        file.path(outside, "outside.txt"), file.path(fixture, "ignored-link.txt")
+    ))
+    old_root <- fertility_output_root
+    old_hook <- getOption("dtaparser.fertility.output_inventory_test_hook")
+    on.exit({
+        assign("fertility_output_root", old_root, envir = .GlobalEnv)
+        options(dtaparser.fertility.output_inventory_test_hook = old_hook)
+    }, add = TRUE)
+    assign(
+        "fertility_output_root",
+        normalizePath(fixture, winslash = "/", mustWork = TRUE),
+        envir = .GlobalEnv
+    )
+    expected <- sort(c(
+        file.path(fertility_output_root, "regular.dta"),
+        file.path(fertility_output_root, "nested", "upper.DTA")
+    ), method = "radix")
+    stopifnot(identical(fertility_output_entries(fertility_output_root), expected))
+
+    dta_link <- file.path(fixture, "linked.dta")
+    stopifnot(file.symlink(file.path(outside, "outside.txt"), dta_link))
+    expect_error(
+        fertility_output_entries(fertility_output_root), "refuses DTA symlinks"
+    )
+    unlink(dta_link)
+
+    directory_link <- file.path(fixture, "linked-directory")
+    stopifnot(file.symlink(outside, directory_link))
+    expect_error(
+        fertility_output_entries(fertility_output_root), "symlinked directories"
+    )
+    unlink(directory_link)
+
+    unavailable <- file.path(fixture, "unavailable.dta")
+    writeBin(as.raw(7:9), unavailable)
+    options(dtaparser.fertility.output_inventory_test_hook = function(
+        boundary, context
+    ) {
+        if (identical(boundary, "before-entry-info") &&
+            identical(context$entry, unavailable)) unlink(unavailable)
+    })
+    expect_error(
+        fertility_output_entries(fertility_output_root), "metadata is unavailable"
+    )
+    options(dtaparser.fertility.output_inventory_test_hook = NULL)
+
+    raced <- file.path(fixture, "raced.dta")
+    writeBin(as.raw(10:12), raced)
+    options(dtaparser.fertility.output_inventory_test_hook = function(
+        boundary, context
+    ) {
+        if (identical(boundary, "after-entry-info") &&
+            identical(context$entry, raced)) {
+            unlink(raced)
+            stopifnot(file.symlink(file.path(outside, "outside.txt"), raced))
+        }
+    })
+    expect_error(
+        fertility_output_entries(fertility_output_root),
+        "changed to a symlink|must not be a symlink"
+    )
+    options(dtaparser.fertility.output_inventory_test_hook = NULL)
+    unlink(raced)
+
+    mkfifo <- Sys.which("mkfifo")
+    if (nzchar(mkfifo)) {
+        fifo <- file.path(fixture, "nonregular.dta")
+        stopifnot(system2(mkfifo, shQuote(fifo)) == 0L)
+        expect_error(
+            fertility_output_entries(fertility_output_root), "must be a regular file"
+        )
+        unlink(fifo)
+    }
+})
+
 # Output confinement rejects symlinked roots, publication descendants, CURRENT
 # pointers, selected bundles, and consumed files before any private publication.
 confinement_checkout <- file.path(root, "confinement-checkout")
@@ -2967,11 +3054,79 @@ traversed_tiles <- list(
     make_tile_result(2L, 2, 1L),
     make_terminal_result()
 )
-stopifnot(fertility_validate_tile_completeness(
-              traversed_tiles, synthetic_batches, 3, tile_configuration
-          ),
-          fertility_aggregate_classification(traversed_tiles, TRUE) ==
-              "value-mismatch")
+stopifnot(
+    fertility_validate_tile_execution(
+        traversed_tiles, synthetic_batches, 3, tile_configuration,
+        length(traversed_tiles)
+    ),
+    fertility_validate_tile_completeness(
+        traversed_tiles, synthetic_batches, 3, tile_configuration
+    ),
+    fertility_aggregate_classification(traversed_tiles, TRUE) == "value-mismatch"
+)
+reader_error_tiles <- traversed_tiles
+reader_error_tiles[[2L]]$classification <- "haven-only-error"
+reader_error_tiles[[2L]]$projection_ok[["haven"]] <- FALSE
+reader_error_tiles[[2L]]$projection_counts[["haven"]] <- NA_integer_
+reader_error_tiles[[2L]]$projection_hashes[["haven"]] <- NA_character_
+stopifnot(
+    fertility_validate_tile_execution(
+        reader_error_tiles, synthetic_batches, 3, tile_configuration,
+        length(reader_error_tiles)
+    ),
+    !fertility_validate_tile_completeness(
+        reader_error_tiles, synthetic_batches, 3, tile_configuration
+    ),
+    fertility_aggregate_classification(
+        reader_error_tiles, complete = FALSE, execution_complete = TRUE
+    ) == "haven-only-error"
+)
+reader_planning_failure <- c(reader_error_tiles, list(list(
+    tile_type = "planning", classification = "unresolved",
+    secondary = "tile-ceiling-reached", mismatches = empty_mismatches
+)))
+reader_missing_value <- reader_error_tiles[-3L]
+reader_missing_terminal <- reader_error_tiles[-length(reader_error_tiles)]
+for (incomplete_tiles in list(
+    reader_planning_failure, reader_missing_value, reader_missing_terminal
+)) {
+    stopifnot(
+        !fertility_validate_tile_execution(
+            incomplete_tiles, synthetic_batches, 3, tile_configuration,
+            length(incomplete_tiles)
+        ),
+        fertility_aggregate_classification(
+            incomplete_tiles, complete = FALSE, execution_complete = FALSE
+        ) == "unresolved"
+    )
+}
+execution_item <- list(
+    id = "F0001", program = "dhs", level = "women", release = 118L,
+    expected_sha512 = ""
+)
+execution_input <- list(
+    input_id = paste(rep("e", 64L), collapse = ""),
+    actual_sha512 = paste(rep("f", 128L), collapse = "")
+)
+complete_reader_error_result <- fertility_tiled_result(
+    execution_item, test_framework_id, tile_configuration, execution_input,
+    reader_error_tiles, synthetic_batches, 3,
+    tiles_expected = length(reader_error_tiles)
+)
+incomplete_reader_error_result <- fertility_tiled_result(
+    execution_item, test_framework_id, tile_configuration, execution_input,
+    reader_missing_terminal, synthetic_batches, 3,
+    tiles_expected = length(reader_error_tiles)
+)
+stopifnot(
+    complete_reader_error_result$classification == "haven-only-error",
+    !complete_reader_error_result$complete,
+    complete_reader_error_result$tiles_expected ==
+        complete_reader_error_result$tiles_completed,
+    incomplete_reader_error_result$classification == "unresolved",
+    incomplete_reader_error_result$tiles_expected ==
+        incomplete_reader_error_result$tiles_completed + 1L
+)
 reader_flags <- setNames(rep(FALSE, 3L), c("direct", "rust", "haven"))
 stopifnot(!length(fertility_reader_error_categories(reader_flags)))
 reader_flags[["rust"]] <- TRUE
@@ -3353,8 +3508,39 @@ zero_column_tiles <- list(
     retarget_projection(make_tile_result(1L, 2, 1L), character()),
     retarget_projection(make_terminal_result(), character())
 )
-stopifnot(fertility_validate_tile_completeness(
-    zero_column_tiles, zero_batches, 3, tile_configuration
+stopifnot(
+    fertility_validate_tile_execution(
+        zero_column_tiles, zero_batches, 3, tile_configuration,
+        length(zero_column_tiles)
+    ),
+    fertility_validate_tile_completeness(
+        zero_column_tiles, zero_batches, 3, tile_configuration
+    )
+)
+zero_row_tiles <- list(
+    metadata_result,
+    make_tile_result(1L, 0, 0L),
+    make_tile_result(2L, 0, 0L),
+    make_terminal_result(skip = 0)
+)
+stopifnot(
+    fertility_validate_tile_execution(
+        zero_row_tiles, synthetic_batches, 0, tile_configuration,
+        length(zero_row_tiles)
+    ),
+    fertility_validate_tile_completeness(
+        zero_row_tiles, synthetic_batches, 0, tile_configuration
+    ),
+    !fertility_validate_tile_execution(
+        c(zero_row_tiles, list(list())), synthetic_batches, 0,
+        tile_configuration, length(zero_row_tiles) + 1L
+    )
+)
+reader_error_without_observed_rows <- reader_error_tiles
+reader_error_without_observed_rows[[2L]]$rows <- NA_integer_
+stopifnot(fertility_validate_tile_execution(
+    reader_error_without_observed_rows, synthetic_batches, 3,
+    tile_configuration, length(reader_error_without_observed_rows)
 ))
 shared_empty <- fertility_projection_attestation(
     list(direct = data.frame(), rust = data.frame(), haven = data.frame()),

--- a/benchmarks/fertility-surveys/test-framework.R
+++ b/benchmarks/fertility-surveys/test-framework.R
@@ -1,6 +1,7 @@
 script_argument <- grep("^--file=", commandArgs(trailingOnly = FALSE), value = TRUE)[[1L]]
 script_dir <- dirname(normalizePath(sub("^--file=", "", script_argument), winslash = "/"))
 source(file.path(script_dir, "common.R"))
+source(file.path(script_dir, "accepted.R"))
 source(file.path(script_dir, "compare.R"))
 source(file.path(script_dir, "runner.R"))
 source(file.path(script_dir, "worker.R"))
@@ -9,12 +10,564 @@ source(file.path(script_dir, "provenance.R"))
 
 expect_error <- function(expression, pattern) {
     error <- tryCatch({ force(expression); NULL }, error = identity)
-    stopifnot(inherits(error, "error"), grepl(pattern, conditionMessage(error)))
+    if (!inherits(error, "error")) stop("expected error matching: ", pattern)
+    if (!grepl(pattern, conditionMessage(error))) {
+        stop("expected error matching '", pattern, "', got: ", conditionMessage(error))
+    }
+    invisible(error)
 }
 
 root <- tempfile("fertility-framework-")
 dir.create(root)
+root <- normalizePath(root, winslash = "/", mustWork = TRUE)
 on.exit(unlink(root, recursive = TRUE), add = TRUE)
+
+# Output confinement rejects symlinked roots, publication descendants, CURRENT
+# pointers, selected bundles, and consumed files before any private publication.
+confinement_checkout <- file.path(root, "confinement-checkout")
+dir.create(confinement_checkout)
+confinement_raw <- file.path(
+    confinement_checkout, "target", "fertility-surveys", "raw"
+)
+stopifnot(identical(
+    fertility_assert_checkout_raw_root(
+        confinement_raw, confinement_checkout, create = TRUE
+    ),
+    confinement_raw
+))
+confinement_outside <- file.path(root, "confinement-outside")
+dir.create(confinement_outside, mode = "0755")
+outside_mode <- file.info(confinement_outside)$mode[[1L]]
+raw_symlink_checkout <- file.path(root, "raw-symlink-checkout")
+dir.create(file.path(raw_symlink_checkout, "target", "fertility-surveys"),
+           recursive = TRUE)
+stopifnot(file.symlink(
+    confinement_outside,
+    file.path(raw_symlink_checkout, "target", "fertility-surveys", "raw")
+))
+expect_error(fertility_assert_checkout_raw_root(
+    file.path(raw_symlink_checkout, "target", "fertility-surveys", "raw"),
+    raw_symlink_checkout
+), "must not be symlinks")
+for (name in c(
+    "tmp", "reports", "merged", "assessments", "checkpoints", "framework",
+    ".locks", "builds", "accepted-current-hashes"
+)) {
+    path <- file.path(confinement_raw, name)
+    stopifnot(file.symlink(confinement_outside, path))
+    expect_error(fertility_assert_direct_child(
+        path, confinement_raw, paste(name, "test path")
+    ), "symlink")
+    unlink(path)
+}
+destination_parent <- file.path(root, "destination-confinement")
+dir.create(destination_parent)
+for (with_content in c(FALSE, TRUE)) {
+    destination <- file.path(
+        destination_parent, paste0("existing-", as.integer(with_content))
+    )
+    dir.create(destination)
+    sentinel <- file.path(destination, "sentinel")
+    if (with_content) writeLines("untouched", sentinel)
+    before <- list.files(destination, all.files = TRUE, no.. = TRUE)
+    expect_error(fertility_assert_new_destination(
+        destination, destination_parent, "publication destination"
+    ), "already exists")
+    stopifnot(identical(
+        list.files(destination, all.files = TRUE, no.. = TRUE), before
+    ))
+    if (with_content) stopifnot(identical(readLines(sentinel), "untouched"))
+}
+atomic_parent <- file.path(root, "atomic-publication")
+dir.create(atomic_parent)
+atomic_source <- file.path(atomic_parent, "source")
+atomic_destination <- file.path(atomic_parent, "destination")
+dir.create(atomic_source)
+writeLines("source", file.path(atomic_source, "value"))
+fertility_atomic_rename_noreplace(
+    atomic_source, atomic_destination, "synthetic atomic publication"
+)
+stopifnot(
+    !dir.exists(atomic_source),
+    identical(readLines(file.path(atomic_destination, "value")), "source")
+)
+atomic_competitor <- file.path(atomic_parent, "competitor")
+atomic_race_destination <- file.path(atomic_parent, "race-destination")
+dir.create(atomic_competitor)
+writeLines("competitor", file.path(atomic_competitor, "value"))
+old_atomic_hook <- getOption("dtaparser.fertility.publication_test_hook")
+options(dtaparser.fertility.publication_test_hook = function(boundary, context) {
+    if (identical(boundary, "atomic-noreplace-before-operation")) {
+        dir.create(context$to)
+        writeLines("winner", file.path(context$to, "value"))
+    }
+})
+expect_error(fertility_atomic_rename_noreplace(
+    atomic_competitor, atomic_race_destination,
+    "synthetic atomic race publication"
+), "destination already exists")
+options(dtaparser.fertility.publication_test_hook = old_atomic_hook)
+stopifnot(
+    identical(readLines(file.path(atomic_competitor, "value")), "competitor"),
+    identical(readLines(file.path(atomic_race_destination, "value")), "winner")
+)
+revalidation_fixture <- file.path(root, "publication-revalidation")
+dir.create(revalidation_fixture)
+framework_source_fixture <- file.path(revalidation_fixture, "framework.tsv")
+checkpoint_source_fixture <- file.path(revalidation_fixture, "checkpoint.rds")
+writeLines("framework-v1", framework_source_fixture)
+saveRDS("checkpoint-v1", checkpoint_source_fixture)
+source_attestation <- fertility_attest_existing_files(
+    c(framework_source_fixture, checkpoint_source_fixture),
+    "publication source"
+)
+old_publication_hook <- getOption(
+    "dtaparser.fertility.publication_test_hook"
+)
+options(dtaparser.fertility.publication_test_hook = function(boundary, context) {
+    if (identical(boundary, "synthetic-before-current")) {
+        writeLines("framework-v2", framework_source_fixture)
+    }
+})
+fertility_publication_test_hook("synthetic-before-current")
+expect_error(fertility_revalidate_existing_files(
+    source_attestation, "publication source"
+), "identity changed")
+writeLines("framework-v1", framework_source_fixture)
+options(dtaparser.fertility.publication_test_hook = function(boundary, context) {
+    if (identical(boundary, "synthetic-before-current")) {
+        saveRDS("checkpoint-v2", checkpoint_source_fixture)
+    }
+})
+fertility_publication_test_hook("synthetic-before-current")
+expect_error(fertility_revalidate_existing_files(
+    source_attestation, "publication source"
+), "identity changed")
+saveRDS("checkpoint-v1", checkpoint_source_fixture)
+options(dtaparser.fertility.publication_test_hook = old_publication_hook)
+stopifnot(isTRUE(fertility_revalidate_existing_files(
+    source_attestation, "publication source"
+)))
+for (boundary in c("staged", "renamed")) {
+    exact_bundle <- file.path(root, paste0("exact-report-", boundary))
+    dir.create(exact_bundle)
+    exact_results <- data.frame(
+        id = "F0001", classification = "pass",
+        stringsAsFactors = FALSE, check.names = FALSE
+    )
+    exact_summary <- data.frame(
+        classification = "pass", files = 1L,
+        stringsAsFactors = FALSE, check.names = FALSE
+    )
+    fertility_atomic_write_table(
+        exact_results, file.path(exact_bundle, "results.tsv")
+    )
+    fertility_atomic_write_table(
+        exact_summary, file.path(exact_bundle, "summary.tsv")
+    )
+    stopifnot(length(fertility_validate_exact_table_bundle(
+        exact_bundle, c(results = "results.tsv", summary = "summary.tsv"),
+        list(results = exact_results, summary = exact_summary),
+        paste(boundary, "report bundle")
+    )) == 2L)
+    changed_results <- exact_results
+    changed_results$classification <- "metadata-mismatch"
+    fertility_atomic_write_table(
+        changed_results, file.path(exact_bundle, "results.tsv")
+    )
+    expect_error(fertility_validate_exact_table_bundle(
+        exact_bundle, c(results = "results.tsv", summary = "summary.tsv"),
+        list(results = exact_results, summary = exact_summary),
+        paste(boundary, "report bundle")
+    ), "exact contents changed")
+
+    assessment_bundle <- file.path(root, paste0("exact-assessment-", boundary))
+    dir.create(assessment_bundle)
+    expected_assessment <- data.frame(
+        assessment_id = paste(rep("a", 64L), collapse = ""),
+        manifest_gate = TRUE, stringsAsFactors = FALSE, check.names = FALSE
+    )
+    fertility_atomic_write_table(
+        expected_assessment, file.path(assessment_bundle, "assessment.tsv")
+    )
+    changed_assessment <- expected_assessment
+    changed_assessment$manifest_gate <- FALSE
+    fertility_atomic_write_table(
+        changed_assessment, file.path(assessment_bundle, "assessment.tsv")
+    )
+    expect_error(fertility_validate_exact_table_bundle(
+        assessment_bundle, c(assessment = "assessment.tsv"),
+        list(assessment = expected_assessment),
+        paste(boundary, "assessment bundle")
+    ), "exact contents changed")
+}
+for (bundle_kind in c("run", "merge", "assessment")) {
+    for (boundary in c("staged", "renamed")) {
+        for (mutation in c("extra-file", "hidden-file", "nested-directory")) {
+            shape_bundle <- file.path(
+                root, paste("exact-shape", bundle_kind, boundary, mutation, sep = "-")
+            )
+            dir.create(shape_bundle)
+            expected_name <- if (identical(bundle_kind, "assessment")) {
+                "assessment.tsv"
+            } else "results.tsv"
+            expected_table <- data.frame(
+                value = "canonical", stringsAsFactors = FALSE,
+                check.names = FALSE
+            )
+            fertility_atomic_write_table(
+                expected_table, file.path(shape_bundle, expected_name)
+            )
+            if (identical(mutation, "extra-file")) {
+                writeLines("extra", file.path(shape_bundle, "extra.tsv"))
+            } else if (identical(mutation, "hidden-file")) {
+                writeLines("hidden", file.path(shape_bundle, ".hidden"))
+            } else {
+                dir.create(file.path(shape_bundle, "nested"))
+                writeLines("nested", file.path(shape_bundle, "nested", "value"))
+            }
+            expect_error(fertility_validate_exact_table_bundle(
+                shape_bundle, setNames(expected_name, "table"),
+                list(table = expected_table),
+                paste(boundary, bundle_kind, "publication bundle")
+            ), "exact file set changed")
+        }
+    }
+}
+build_id_fixture <- paste(rep("c", 64L), collapse = "")
+builds_fixture <- file.path(confinement_raw, "builds")
+generation_fixture <- file.path(builds_fixture, build_id_fixture)
+library_fixture <- file.path(generation_fixture, "library")
+package_fixture <- file.path(library_fixture, "dtaparser")
+dir.create(package_fixture, recursive = TRUE)
+writeLines("synthetic", file.path(generation_fixture, "build-provenance.tsv"))
+writeLines(build_id_fixture, file.path(builds_fixture, "CURRENT"))
+stopifnot(identical(
+    fertility_resolve_build_bundle(
+        confinement_raw, build_id_fixture, require_current = TRUE
+    )$package,
+    package_fixture
+))
+build_external <- file.path(root, "build-descendant-external")
+dir.create(file.path(build_external, "library", "dtaparser"), recursive = TRUE)
+writeLines("external", file.path(build_external, "CURRENT"))
+writeLines("external", file.path(build_external, "build-provenance.tsv"))
+build_external_before <- as.list(file.info(c(
+    build_external, file.path(build_external, "CURRENT"),
+    file.path(build_external, "build-provenance.tsv")
+))[, c("size", "mode")])
+for (case in list(
+    list(path = file.path(builds_fixture, "CURRENT"),
+         target = file.path(build_external, "CURRENT")),
+    list(path = generation_fixture, target = build_external),
+    list(path = library_fixture, target = file.path(build_external, "library")),
+    list(path = file.path(generation_fixture, "build-provenance.tsv"),
+         target = file.path(build_external, "build-provenance.tsv")),
+    list(path = package_fixture,
+         target = file.path(build_external, "library", "dtaparser"))
+)) {
+    saved <- paste0(case$path, ".saved")
+    stopifnot(file.rename(case$path, saved), file.symlink(case$target, case$path))
+    expect_error(fertility_resolve_build_bundle(
+        confinement_raw, build_id_fixture, require_current = TRUE
+    ), "symlink")
+    unlink(case$path)
+    stopifnot(file.rename(saved, case$path))
+}
+stopifnot(identical(as.list(file.info(c(
+    build_external, file.path(build_external, "CURRENT"),
+    file.path(build_external, "build-provenance.tsv")
+))[, c("size", "mode")]), build_external_before))
+package_nested <- file.path(package_fixture, "R")
+dir.create(package_nested)
+package_file <- file.path(package_nested, "dtaparser")
+writeLines("equal-content", package_file)
+package_attestation <- fertility_attest_regular_tree(
+    package_fixture, "synthetic installed package"
+)
+external_package_file <- file.path(root, "external-package-file")
+writeLines("equal-content", external_package_file)
+stopifnot(file.rename(package_file, paste0(package_file, ".saved")))
+stopifnot(file.symlink(external_package_file, package_file))
+expect_error(fertility_attest_regular_tree(
+    package_fixture, "synthetic installed package"
+), "symlinks")
+unlink(package_file)
+stopifnot(file.rename(paste0(package_file, ".saved"), package_file))
+external_package_directory <- file.path(root, "external-package-directory")
+dir.create(external_package_directory)
+writeLines("equal-content", file.path(external_package_directory, "dtaparser"))
+stopifnot(file.rename(package_nested, paste0(package_nested, ".saved")))
+stopifnot(file.symlink(external_package_directory, package_nested))
+expect_error(fertility_attest_regular_tree(
+    package_fixture, "synthetic installed package"
+), "symlinks")
+unlink(package_nested)
+stopifnot(file.rename(paste0(package_nested, ".saved"), package_nested))
+stopifnot(isTRUE(fertility_revalidate_regular_tree(
+    package_attestation, "synthetic installed package"
+)))
+unlink(builds_fixture, recursive = TRUE)
+checkpoint_framework_id <- paste(rep("e", 64L), collapse = "")
+checkpoint_config_id <- paste(rep("f", 64L), collapse = "")
+checkpoint_case_id <- "F0001"
+checkpoint_case <- file.path(
+    confinement_raw, "checkpoints", checkpoint_framework_id,
+    checkpoint_config_id, checkpoint_case_id
+)
+dir.create(file.path(checkpoint_case, "tiles"), recursive = TRUE)
+saveRDS("result", file.path(checkpoint_case, "result.rds"))
+saveRDS("tile", file.path(checkpoint_case, "tiles", "metadata.rds"))
+checkpoint_paths <- fertility_resolve_checkpoint_case(
+    confinement_raw, checkpoint_framework_id, checkpoint_config_id,
+    checkpoint_case_id
+)
+stopifnot(length(fertility_checkpoint_tile_files(checkpoint_paths)) == 1L)
+checkpoint_external <- file.path(root, "checkpoint-descendant-external")
+dir.create(file.path(checkpoint_external, "tiles"), recursive = TRUE)
+saveRDS("external-result", file.path(checkpoint_external, "result.rds"))
+saveRDS("external-tile", file.path(checkpoint_external, "tiles", "metadata.rds"))
+checkpoint_external_before <- unname(tools::sha256sum(c(
+    file.path(checkpoint_external, "result.rds"),
+    file.path(checkpoint_external, "tiles", "metadata.rds")
+)))
+checkpoint_framework <- file.path(
+    confinement_raw, "checkpoints", checkpoint_framework_id
+)
+checkpoint_configuration <- file.path(
+    checkpoint_framework, checkpoint_config_id
+)
+for (case in list(
+    list(path = checkpoint_framework, target = checkpoint_external),
+    list(path = checkpoint_configuration, target = checkpoint_external),
+    list(path = checkpoint_case, target = checkpoint_external),
+    list(path = file.path(checkpoint_case, "result.rds"),
+         target = file.path(checkpoint_external, "result.rds")),
+    list(path = file.path(checkpoint_case, "tiles"),
+         target = file.path(checkpoint_external, "tiles"))
+)) {
+    saved <- paste0(case$path, ".saved")
+    stopifnot(file.rename(case$path, saved), file.symlink(case$target, case$path))
+    expect_error(fertility_resolve_checkpoint_case(
+        confinement_raw, checkpoint_framework_id, checkpoint_config_id,
+        checkpoint_case_id
+    ), "symlink")
+    unlink(case$path)
+    stopifnot(file.rename(saved, case$path))
+}
+tile_path <- file.path(checkpoint_case, "tiles", "metadata.rds")
+tile_saved <- file.path(root, "checkpoint-metadata.saved")
+stopifnot(file.rename(tile_path, tile_saved), file.symlink(
+    file.path(checkpoint_external, "tiles", "metadata.rds"), tile_path
+))
+expect_error(fertility_checkpoint_tile_files(
+    fertility_resolve_checkpoint_case(
+        confinement_raw, checkpoint_framework_id, checkpoint_config_id,
+        checkpoint_case_id
+    )
+), "symlink")
+unlink(tile_path)
+stopifnot(file.rename(tile_saved, tile_path))
+stopifnot(identical(unname(tools::sha256sum(c(
+    file.path(checkpoint_external, "result.rds"),
+    file.path(checkpoint_external, "tiles", "metadata.rds")
+))), checkpoint_external_before))
+unlink(file.path(confinement_raw, "checkpoints"), recursive = TRUE)
+owner_fixture <- file.path(root, "owner-confinement")
+dir.create(owner_fixture)
+owner_external <- file.path(root, "owner-external.tsv")
+writeLines("external-owner", owner_external)
+stopifnot(file.symlink(owner_external, file.path(owner_fixture, "owner.tsv")))
+expect_error(fertility_read_owner(owner_fixture), "symlink")
+unlink(file.path(owner_fixture, "owner.tsv"))
+heartbeat_external <- file.path(root, "heartbeat-external")
+writeLines("generation", heartbeat_external)
+heartbeat_link <- file.path(owner_fixture, "heartbeat")
+stopifnot(file.symlink(heartbeat_external, heartbeat_link))
+expect_error(fertility_owner_alive(list(
+    token = "token", pid = 1L, host = "foreign-host", start = "generation",
+    heartbeat = heartbeat_link, created = as.numeric(Sys.time())
+)), "symlink")
+stopifnot(identical(readLines(owner_external), "external-owner"),
+          identical(readLines(heartbeat_external), "generation"))
+benchmark_lines <- readLines(file.path(script_dir, "benchmark.sh"), warn = FALSE)
+atomic_function_start <- grep(
+    "^atomic_move_noreplace\\(\\) \\{$", benchmark_lines
+)[[1L]]
+atomic_function_end <- which(
+    seq_along(benchmark_lines) > atomic_function_start & benchmark_lines == "}"
+)[[1L]]
+shell_atomic_root <- file.path(root, "shell-atomic-publication")
+dir.create(shell_atomic_root)
+shell_atomic_source <- file.path(shell_atomic_root, "source")
+shell_atomic_competitor <- file.path(shell_atomic_root, "competitor")
+shell_atomic_destination <- file.path(shell_atomic_root, "destination")
+dir.create(shell_atomic_source)
+dir.create(shell_atomic_competitor)
+writeLines("source", file.path(shell_atomic_source, "value"))
+writeLines("competitor", file.path(shell_atomic_competitor, "value"))
+shell_atomic_script <- file.path(root, "shell-atomic-test.sh")
+writeLines(c(
+    "#!/bin/sh", "set -eu",
+    benchmark_lines[atomic_function_start:atomic_function_end],
+    paste(
+        "atomic_move_noreplace", shQuote(shell_atomic_source),
+        shQuote(shell_atomic_destination), shQuote("synthetic shell publication")
+    ),
+    paste(
+        "atomic_move_noreplace", shQuote(shell_atomic_competitor),
+        shQuote(shell_atomic_destination), shQuote("synthetic shell race")
+    )
+), shell_atomic_script)
+shell_atomic_result <- suppressWarnings(system2(
+    "sh", shell_atomic_script, stdout = TRUE, stderr = TRUE
+))
+stopifnot(
+    identical(attr(shell_atomic_result, "status"), 2L),
+    any(grepl("destination already exists", shell_atomic_result, fixed = TRUE)),
+    !dir.exists(shell_atomic_source),
+    identical(readLines(file.path(shell_atomic_destination, "value")), "source"),
+    identical(readLines(file.path(shell_atomic_competitor, "value")), "competitor")
+)
+shell_checkout <- file.path(root, "shell-confinement-checkout")
+shell_script_dir <- file.path(shell_checkout, "benchmarks", "fertility-surveys")
+shell_raw <- file.path(shell_checkout, "target", "fertility-surveys", "raw")
+dir.create(shell_script_dir, recursive = TRUE)
+dir.create(shell_raw, recursive = TRUE)
+stopifnot(file.copy(
+    file.path(script_dir, "benchmark.sh"), file.path(shell_script_dir, "benchmark.sh")
+), file.symlink(confinement_outside, file.path(shell_raw, "tmp")))
+run_shell_confinement <- function(arguments = "--inventory-only") {
+    suppressWarnings(system2(
+    "/usr/bin/env",
+    c(
+        "-u", "CI", "-u", "GITHUB_ACTIONS", "-u", "GITHUB_RUN_ID",
+        "-u", "GITHUB_WORKFLOW",
+        paste0("DTAPARSER_FERTILITY_CORPUS=", fertility_opt_in_value),
+        "sh", file.path(shell_script_dir, "benchmark.sh"), arguments
+    ),
+    stdout = TRUE, stderr = TRUE
+    ))
+}
+assert_shell_confinement <- function(result) stopifnot(
+    !is.null(attr(result, "status")),
+    any(grepl("symlink", result)),
+    identical(file.info(confinement_outside)$mode[[1L]], outside_mode),
+    !length(list.files(confinement_outside, all.files = TRUE, no.. = TRUE))
+)
+assert_shell_confinement(run_shell_confinement())
+unlink(file.path(shell_raw, "tmp"))
+unlink(shell_raw, recursive = TRUE)
+stopifnot(file.symlink(confinement_outside, shell_raw))
+assert_shell_confinement(run_shell_confinement())
+unlink(shell_raw)
+dir.create(file.path(shell_raw, "tmp"), recursive = TRUE)
+stopifnot(
+    file.copy(file.path(script_dir, "runtime.R"),
+              file.path(shell_script_dir, "runtime.R")),
+    file.symlink(confinement_outside, file.path(shell_raw, "builds"))
+)
+assert_shell_confinement(run_shell_confinement(character()))
+unlink(file.path(shell_raw, "builds"))
+shell_build_id <- paste(rep("d", 64L), collapse = "")
+shell_builds <- file.path(shell_raw, "builds")
+shell_generation <- file.path(shell_builds, shell_build_id)
+shell_library <- file.path(shell_generation, "library")
+shell_package <- file.path(shell_library, "dtaparser")
+dir.create(shell_package, recursive = TRUE)
+writeLines(shell_build_id, file.path(shell_builds, "CURRENT"))
+writeLines("synthetic", file.path(shell_generation, "build-provenance.tsv"))
+shell_external <- file.path(root, "shell-build-external")
+dir.create(file.path(shell_external, "library", "dtaparser"), recursive = TRUE)
+writeLines(shell_build_id, file.path(shell_external, "CURRENT"))
+writeLines("external", file.path(shell_external, "build-provenance.tsv"))
+shell_external_mode <- file.info(shell_external)$mode[[1L]]
+for (case in list(
+    list(path = file.path(shell_builds, "CURRENT"),
+         target = file.path(shell_external, "CURRENT")),
+    list(path = shell_generation, target = shell_external),
+    list(path = shell_library, target = file.path(shell_external, "library")),
+    list(path = file.path(shell_generation, "build-provenance.tsv"),
+         target = file.path(shell_external, "build-provenance.tsv")),
+    list(path = shell_package,
+         target = file.path(shell_external, "library", "dtaparser"))
+)) {
+    saved <- paste0(case$path, ".saved")
+    stopifnot(file.rename(case$path, saved), file.symlink(case$target, case$path))
+    result <- run_shell_confinement(character())
+    stopifnot(
+        !is.null(attr(result, "status")), any(grepl("symlink", result)),
+        identical(file.info(shell_external)$mode[[1L]], shell_external_mode),
+        identical(readLines(file.path(shell_external, "build-provenance.tsv")),
+                  "external")
+    )
+    unlink(case$path)
+    stopifnot(file.rename(saved, case$path))
+}
+reports_root <- file.path(confinement_raw, "reports")
+selection_parent <- file.path(reports_root, "selection")
+bundle_dir <- file.path(selection_parent, "bundle")
+dir.create(bundle_dir, recursive = TRUE)
+for (name in c(
+    "run-provenance.tsv", "results.tsv", "summary.tsv",
+    "family-manifest.tsv", "input-attestation.tsv"
+)) {
+    writeLines("synthetic", file.path(bundle_dir, name))
+}
+writeLines("bundle", file.path(selection_parent, "CURRENT"))
+current_files <- c(
+    provenance = "run-provenance.tsv", results = "results.tsv",
+    summary = "summary.tsv", family_manifest = "family-manifest.tsv",
+    input_attestation = "input-attestation.tsv"
+)
+stopifnot(identical(
+    fertility_current_bundle_paths(
+        selection_parent, current_files, "synthetic report"
+    )$bundle,
+    bundle_dir
+))
+current_path <- file.path(selection_parent, "CURRENT")
+current_saved <- paste0(current_path, ".saved")
+stopifnot(file.rename(current_path, current_saved),
+          file.symlink(current_saved, current_path))
+expect_error(fertility_current_bundle_paths(
+    selection_parent, current_files, "synthetic report"
+), "CURRENT pointer must not be a symlink")
+unlink(current_path)
+stopifnot(file.rename(current_saved, current_path))
+bundle_saved <- paste0(bundle_dir, ".saved")
+stopifnot(file.rename(bundle_dir, bundle_saved),
+          file.symlink(bundle_saved, bundle_dir))
+expect_error(fertility_current_bundle_paths(
+    selection_parent, current_files, "synthetic report"
+), "bundle must not be a symlink")
+unlink(bundle_dir)
+stopifnot(file.rename(bundle_saved, bundle_dir))
+for (field in names(current_files)) {
+    consumed_path <- file.path(bundle_dir, current_files[[field]])
+    consumed_saved <- paste0(consumed_path, ".saved")
+    stopifnot(file.rename(consumed_path, consumed_saved),
+              file.symlink(consumed_saved, consumed_path))
+    expect_error(fertility_current_bundle_paths(
+        selection_parent, current_files, "synthetic report"
+    ), paste0(field, " must not be a symlink"))
+    unlink(consumed_path)
+    stopifnot(file.rename(consumed_saved, consumed_path))
+}
+second_bundle <- file.path(selection_parent, "bundle-two")
+dir.create(second_bundle)
+stopifnot(all(file.copy(
+    file.path(bundle_dir, unname(current_files)), second_bundle
+)))
+writeLines("bundle-two", current_path)
+expect_error(fertility_revalidate_current_bundle(
+    selection_parent, "bundle", current_files, "source report shard"
+), "CURRENT changed")
+writeLines("bundle", current_path)
+stopifnot(identical(fertility_revalidate_current_bundle(
+    selection_parent, "bundle", current_files, "source report shard"
+)$run_name, "bundle"))
+
 cache <- file.path(root, "cache")
 dir.create(cache)
 write_release <- function(path, release) {
@@ -141,11 +694,13 @@ make_public_results <- function(expected, classifications = "pass") {
 }
 make_bundle_family <- function(
     canonical, family_options, classifications = NULL,
-    inventory_id = paste(rep("d", 64L), collapse = "")
+    inventory_id = paste(rep("d", 64L), collapse = ""), acceptance = NULL
 ) {
     manifest <- fertility_family_manifest(canonical, family_options)
     manifest_id <- fertility_manifest_id(manifest)
-    family_config_id <- fertility_tile_configuration(family_options)$config_id
+    family_config_id <- fertility_tile_configuration(
+        family_options, acceptance
+    )$config_id
     family_id <- fertility_family_id_from_manifest(
         manifest, test_framework_id, family_config_id, test_build_id, inventory_id,
         family_options$shard_count, family_options$max_files
@@ -164,16 +719,25 @@ make_bundle_family <- function(
         input_attestation_id <- fertility_stable_id(list(
             synthetic_shard = index, ids = paste(expected$id, collapse = ",")
         ))
+        acceptance_authority <- if (is.null(acceptance)) "" else
+            acceptance$authority
+        acceptance_commitment_id <- if (is.null(acceptance)) "" else
+            acceptance$commitment_id
         evidence_selection_id <- fertility_evidence_selection_id(
             selection_id, input_attestation_id, "fresh-execution",
-            fertility_schema_version, fertility_report_schema_id()
+            fertility_schema_version, fertility_report_schema_id(),
+            acceptance_authority, acceptance_commitment_id
         )
         provenance <- data.frame(
             schema_version = as.character(fertility_schema_version),
             report_schema_version = as.character(fertility_report_schema_version),
             evidence_origin = "fresh-execution",
             source_corpus_schema_version = as.character(fertility_schema_version),
-            replayed_at_utc = "", selection_id = selection_id,
+            replayed_at_utc = "", acceptance_authority = acceptance_authority,
+            acceptance_commitment_id = acceptance_commitment_id,
+            acceptance_artifact_sha256 = if (is.null(acceptance)) "" else
+                acceptance$artifact_sha256,
+            selection_id = selection_id,
             evidence_selection_id = evidence_selection_id,
             input_attestation_id = input_attestation_id, family_id = family_id,
             family_manifest_id = manifest_id, framework_id = test_framework_id,
@@ -213,6 +777,16 @@ validated_merge <- fertility_validate_shard_bundles(
 )
 stopifnot(identical(validated_merge$results$id, c("F0001", "F0002")),
           validated_merge$shard_count == 2L)
+legacy_provenance_bundles <- merge_bundles
+for (index in seq_along(legacy_provenance_bundles)) {
+    legacy_provenance_bundles[[index]]$provenance[c(
+        "acceptance_authority", "acceptance_commitment_id",
+        "acceptance_artifact_sha256"
+    )] <- NULL
+}
+stopifnot(is.list(fertility_validate_shard_bundles(
+    legacy_provenance_bundles, merge_fixture$id, canonical_inventory
+)))
 override_merge_options <- fertility_parse_arguments(c(
     "--id=F0001,F0002", "--shard-index=1", "--shard-count=2",
     "--encoding-override=F0001:ISO-8859-1"
@@ -435,11 +1009,18 @@ full_options <- fertility_parse_arguments(character())
 full_classes <- rep("pass", fertility_expected_rows)
 full_classes[full_releases == 111L] <- "expected-unsupported-111"
 supported_positions <- which(full_releases != 111L)
-full_classes[supported_positions[seq_len(5L)]] <- "inventory-hash-error"
+full_classes[match(fertility_accepted_ids(), full_canonical$id)] <-
+    "inventory-hash-error"
 full_fixture <- make_bundle_family(
     full_canonical, full_options, full_classes,
     inventory_id = paste(rep("e", 64L), collapse = "")
 )
+for (index in seq_along(full_fixture$bundles)) {
+    hash_rows <- full_fixture$bundles[[index]]$results$classification ==
+        "inventory-hash-error"
+    full_fixture$bundles[[index]]$results$secondary_categories[hash_rows] <-
+        "signature-mismatch"
+}
 full_validated <- fertility_validate_shard_bundles(
     full_fixture$bundles, full_fixture$id, full_canonical
 )
@@ -461,18 +1042,23 @@ expect_error(fertility_validate_shard_bundles(
     full_bad_unsupported, full_fixture$id, full_canonical
 ), "release 111 classifications")
 full_bad_hash_count <- full_fixture$bundles
-full_bad_hash_count[[1L]]$results$classification[[supported_positions[[6L]]]] <-
+additional_supported <- supported_positions[
+    !full_canonical$id[supported_positions] %in% fertility_accepted_ids()
+][[1L]]
+full_bad_hash_count[[1L]]$results$classification[[additional_supported]] <-
     "inventory-hash-error"
 expect_error(fertility_validate_shard_bundles(
     full_bad_hash_count, full_fixture$id, full_canonical
 ), "executable accounting")
 full_too_few_hashes <- full_fixture$bundles
-full_too_few_hashes[[1L]]$results$classification[[supported_positions[[5L]]]] <- "pass"
+full_too_few_hashes[[1L]]$results$classification[[
+    match(fertility_accepted_ids()[[1L]], full_canonical$id)
+]] <- "pass"
 expect_error(fertility_validate_shard_bundles(
     full_too_few_hashes, full_fixture$id, full_canonical
 ), "executable accounting")
 full_bad_supported_class <- full_fixture$bundles
-full_bad_supported_class[[1L]]$results$classification[[supported_positions[[6L]]]] <-
+full_bad_supported_class[[1L]]$results$classification[[additional_supported]] <-
     "expected-unsupported-111"
 expect_error(fertility_validate_shard_bundles(
     full_bad_supported_class, full_fixture$id, full_canonical
@@ -562,6 +1148,71 @@ fertility_atomic_write_table(
 stopifnot(nrow(fertility_framework_inventory(
     current_snapshot, framework_id = test_framework_id
 )$manifest) == fertility_expected_rows)
+framework_acceptance_path <- file.path(
+    current_snapshot, "acceptance-provenance.tsv"
+)
+fertility_atomic_write_table(data.frame(
+    authority = fertility_acceptance_authority(),
+    commitment_id = paste(rep("a", 64L), collapse = ""),
+    artifact_sha256 = paste(rep("b", 64L), collapse = ""),
+    stringsAsFactors = FALSE, check.names = FALSE
+), framework_acceptance_path)
+stopifnot(!is.null(fertility_framework_inventory(
+    current_snapshot, framework_id = test_framework_id
+)$acceptance_provenance))
+for (name in c(
+    "inventory-manifest.tsv", "inventory-manifest-provenance.tsv",
+    "acceptance-provenance.tsv"
+)) {
+    path <- file.path(current_snapshot, name)
+    saved <- paste0(path, ".saved")
+    stopifnot(file.rename(path, saved), file.symlink(saved, path))
+    expect_error(fertility_framework_inventory(
+        current_snapshot, framework_id = test_framework_id
+    ), "symlink")
+    unlink(path)
+    stopifnot(file.rename(saved, path))
+}
+current_snapshot_saved <- paste0(current_snapshot, ".saved")
+stopifnot(file.rename(current_snapshot, current_snapshot_saved),
+          file.symlink(current_snapshot_saved, current_snapshot))
+expect_error(fertility_framework_inventory(
+    current_snapshot, framework_id = test_framework_id
+), "symlink")
+unlink(current_snapshot)
+stopifnot(file.rename(current_snapshot_saved, current_snapshot))
+framework_confinement_root <- file.path(confinement_raw, "framework")
+framework_confinement_snapshot <- file.path(
+    framework_confinement_root, test_framework_id
+)
+dir.create(framework_confinement_snapshot, recursive = TRUE)
+for (name in c("common.R", "accepted.R", "worker.R", "compare.R", "runtime.R")) {
+    stopifnot(file.copy(
+        file.path(script_dir, name), file.path(framework_confinement_snapshot, name)
+    ))
+}
+fertility_atomic_write_table(
+    full_canonical,
+    file.path(framework_confinement_snapshot, "inventory-manifest.tsv")
+)
+fertility_atomic_write_table(
+    current_inventory_provenance,
+    file.path(framework_confinement_snapshot,
+              "inventory-manifest-provenance.tsv")
+)
+stopifnot(identical(fertility_verify_framework_snapshot(
+    script_dir, confinement_raw, test_framework_id
+), framework_confinement_snapshot))
+for (name in c("common.R", "accepted.R", "worker.R", "compare.R", "runtime.R")) {
+    path <- file.path(framework_confinement_snapshot, name)
+    saved <- file.path(root, paste0("framework-", name, ".saved"))
+    stopifnot(file.rename(path, saved), file.symlink(saved, path))
+    expect_error(fertility_verify_framework_snapshot(
+        script_dir, confinement_raw, test_framework_id
+    ), "symlink")
+    unlink(path)
+    stopifnot(file.rename(saved, path))
+}
 fresh_snapshot_provenance <- data.frame(
     evidence_origin = "fresh-execution",
     source_corpus_schema_version = as.character(fertility_schema_version),
@@ -620,6 +1271,794 @@ preflight_item$expected_sha512 <- ""
 stopifnot(is.null(fertility_inventory_preflight(
     preflight_item, preflight_mismatch
 )))
+
+# Explicit accepted-current-hash evidence is a private immutable commitment for
+# exactly F0633-F0637. It remains distinct from the unchanged manifest signatures.
+acceptance_checkout <- file.path(root, "acceptance-checkout")
+dir.create(acceptance_checkout)
+acceptance_checkout <- normalizePath(acceptance_checkout, winslash = "/")
+acceptance_checkout_raw <- file.path(
+    acceptance_checkout, "target", "fertility-surveys", "raw"
+)
+stopifnot(identical(
+    fertility_assert_acceptance_raw_root(
+        acceptance_checkout_raw, acceptance_checkout
+    ),
+    acceptance_checkout_raw
+))
+symlink_checkout <- file.path(root, "acceptance-symlink-checkout")
+dir.create(symlink_checkout)
+symlink_checkout <- normalizePath(symlink_checkout, winslash = "/")
+symlink_destination <- file.path(root, "acceptance-symlink-destination")
+dir.create(symlink_destination)
+symlink_destination <- normalizePath(symlink_destination, winslash = "/")
+stopifnot(file.symlink(
+    symlink_destination, file.path(symlink_checkout, "target")
+))
+expect_error(fertility_assert_acceptance_raw_root(
+    file.path(symlink_checkout, "target", "fertility-surveys", "raw"),
+    symlink_checkout
+), "must not be symlinks")
+acceptance_raw <- file.path(root, "acceptance-raw")
+dir.create(acceptance_raw, mode = "0700")
+acceptance_paths <- file.path(root, paste0("accepted-", seq_len(5L), ".dta"))
+for (index in seq_along(acceptance_paths)) {
+    writeBin(as.raw(c(118L, index, 0:15)), acceptance_paths[[index]])
+}
+acceptance_actual <- vapply(acceptance_paths, fertility_file_sha512, character(1))
+acceptance_expected <- vapply(seq_along(acceptance_actual), function(index) {
+    candidate <- paste(rep(sprintf("%x", index - 1L), 128L), collapse = "")
+    if (identical(candidate, acceptance_actual[[index]])) {
+        paste(rep(sprintf("%x", index), 128L), collapse = "")
+    } else candidate
+}, character(1))
+acceptance_inventory <- data.frame(
+    id = fertility_accepted_ids(), program = "dhs", level = "women",
+    release = 118L, path = normalizePath(acceptance_paths, winslash = "/"),
+    expected_sha512 = acceptance_expected,
+    stringsAsFactors = FALSE, check.names = FALSE
+)
+acceptance_id <- fertility_capture_acceptance(
+    acceptance_inventory, acceptance_raw
+)
+acceptance <- fertility_load_acceptance(
+    acceptance_raw, acceptance_id, acceptance_inventory
+)
+sequential_reuse_refuses_changed_early_input <- function() {
+    original_capture_input <- fertility_capture_input
+    capture_count <- 0L
+    on.exit(assign(
+        "fertility_capture_input", original_capture_input, envir = .GlobalEnv
+    ), add = TRUE)
+    on.exit(writeBin(
+        as.raw(c(118L, 1L, 0:15)), acceptance_paths[[1L]]
+    ), add = TRUE)
+    assign("fertility_capture_input", function(...) {
+        capture_count <<- capture_count + 1L
+        if (capture_count == 2L) {
+            writeBin(as.raw(c(118L, 93L, 0:15)), acceptance_paths[[1L]])
+        }
+        original_capture_input(...)
+    }, envir = .GlobalEnv)
+    expect_error(fertility_capture_acceptance(
+        acceptance_inventory, acceptance_raw
+    ), "input changed during capture")
+}
+sequential_reuse_refuses_changed_early_input()
+old_hook <- getOption("dtaparser.fertility.publication_test_hook")
+options(dtaparser.fertility.publication_test_hook = function(boundary, context) {
+    if (identical(boundary, "acceptance-before-existing-reuse-revalidation")) {
+        writeBin(as.raw(c(118L, 92L, 0:15)), acceptance_paths[[1L]])
+    }
+})
+expect_error(fertility_capture_acceptance(
+    acceptance_inventory, acceptance_raw
+), "input changed during capture")
+options(dtaparser.fertility.publication_test_hook = old_hook)
+writeBin(as.raw(c(118L, 1L, 0:15)), acceptance_paths[[1L]])
+for (with_content in c(FALSE, TRUE)) {
+    refusal_raw <- file.path(
+        root, paste0("acceptance-existing-", as.integer(with_content))
+    )
+    dir.create(file.path(refusal_raw, "accepted-current-hashes", acceptance_id),
+               recursive = TRUE)
+    sentinel <- file.path(
+        refusal_raw, "accepted-current-hashes", acceptance_id, "sentinel"
+    )
+    if (with_content) writeLines("untouched", sentinel)
+    before <- list.files(
+        file.path(refusal_raw, "accepted-current-hashes", acceptance_id),
+        all.files = TRUE, no.. = TRUE
+    )
+    expect_error(fertility_capture_acceptance(
+        acceptance_inventory, refusal_raw
+    ), "accepted-current-hash")
+    stopifnot(identical(list.files(
+        file.path(refusal_raw, "accepted-current-hashes", acceptance_id),
+        all.files = TRUE, no.. = TRUE
+    ), before))
+    if (with_content) stopifnot(identical(readLines(sentinel), "untouched"))
+}
+race_raw <- file.path(root, "acceptance-race")
+dir.create(race_raw)
+race_destination <- file.path(
+    race_raw, "accepted-current-hashes", acceptance_id
+)
+old_hook <- getOption("dtaparser.fertility.publication_test_hook")
+options(dtaparser.fertility.publication_test_hook = function(boundary, context) {
+    if (identical(boundary, "acceptance-before-destination-publication")) {
+        dir.create(context$destination)
+        writeLines("race-winner", file.path(context$destination, "sentinel"))
+    }
+})
+expect_error(fertility_capture_acceptance(
+    acceptance_inventory, race_raw
+), "accepted-current-hash")
+options(dtaparser.fertility.publication_test_hook = old_hook)
+stopifnot(
+    identical(readLines(file.path(race_destination, "sentinel")), "race-winner"),
+    !file.exists(file.path(race_destination, "commitment.rds"))
+)
+complete_race_raw <- file.path(root, "acceptance-complete-race")
+dir.create(complete_race_raw)
+complete_race_destination <- file.path(
+    complete_race_raw, "accepted-current-hashes", acceptance_id
+)
+source_commitment <- file.path(
+    acceptance_raw, "accepted-current-hashes", acceptance_id, "commitment.rds"
+)
+options(dtaparser.fertility.publication_test_hook = function(boundary, context) {
+    if (identical(boundary, "acceptance-before-destination-publication")) {
+        dir.create(context$destination)
+        stopifnot(file.copy(
+            source_commitment, file.path(context$destination, "commitment.rds")
+        ))
+    }
+})
+stopifnot(identical(
+    fertility_capture_acceptance(acceptance_inventory, complete_race_raw),
+    acceptance_id
+))
+options(dtaparser.fertility.publication_test_hook = old_hook)
+stopifnot(identical(
+    list.files(complete_race_destination, all.files = TRUE, no.. = TRUE),
+    "commitment.rds"
+))
+publication_winner_raw <- file.path(root, "acceptance-publication-winner")
+dir.create(publication_winner_raw)
+publication_winner_destination <- file.path(
+    publication_winner_raw, "accepted-current-hashes", acceptance_id
+)
+options(dtaparser.fertility.publication_test_hook = function(boundary, context) {
+    if (identical(boundary, "atomic-noreplace-before-operation") &&
+        identical(context$label, "accepted-current-hash commitment")) {
+        dir.create(context$to)
+        stopifnot(file.copy(
+            source_commitment, file.path(context$to, "commitment.rds")
+        ))
+    }
+})
+stopifnot(identical(
+    fertility_capture_acceptance(acceptance_inventory, publication_winner_raw),
+    acceptance_id
+))
+options(dtaparser.fertility.publication_test_hook = old_hook)
+stopifnot(identical(
+    list.files(publication_winner_destination, all.files = TRUE, no.. = TRUE),
+    "commitment.rds"
+))
+extra_claim_raw <- file.path(root, "acceptance-extra-claim")
+dir.create(extra_claim_raw)
+extra_claim_destination <- file.path(
+    extra_claim_raw, "accepted-current-hashes", acceptance_id
+)
+options(dtaparser.fertility.publication_test_hook = function(boundary, context) {
+    if (identical(boundary, "acceptance-before-destination-publication")) {
+        writeLines("unexpected", file.path(context$stage, ".extra"))
+    }
+})
+expect_error(fertility_capture_acceptance(
+    acceptance_inventory, extra_claim_raw
+), "exactly commitment.rds")
+options(dtaparser.fertility.publication_test_hook = old_hook)
+stopifnot(!file.exists(extra_claim_destination))
+atomic_mutation_raw <- file.path(root, "acceptance-atomic-source-mutation")
+dir.create(atomic_mutation_raw)
+atomic_mutation_destination <- file.path(
+    atomic_mutation_raw, "accepted-current-hashes", acceptance_id
+)
+options(dtaparser.fertility.publication_test_hook = function(boundary, context) {
+    if (identical(boundary, "atomic-noreplace-before-operation") &&
+        identical(context$label, "accepted-current-hash commitment")) {
+        writeLines("invalid", file.path(context$from, ".invalid"))
+    }
+})
+expect_error(fertility_capture_acceptance(
+    acceptance_inventory, atomic_mutation_raw
+), "exactly commitment.rds")
+options(dtaparser.fertility.publication_test_hook = old_hook)
+stopifnot(
+    !file.exists(atomic_mutation_destination),
+    identical(
+        fertility_capture_acceptance(acceptance_inventory, atomic_mutation_raw),
+        acceptance_id
+    )
+)
+rollback_raw <- file.path(root, "acceptance-post-publication-rollback")
+dir.create(rollback_raw)
+rollback_destination <- file.path(
+    rollback_raw, "accepted-current-hashes", acceptance_id
+)
+options(dtaparser.fertility.publication_test_hook = function(boundary, context) {
+    if (identical(
+        boundary, "acceptance-before-new-publication-revalidation"
+    )) writeLines("invalid", file.path(context$destination, ".invalid"))
+})
+expect_error(fertility_capture_acceptance(
+    acceptance_inventory, rollback_raw
+), "exactly commitment.rds")
+options(dtaparser.fertility.publication_test_hook = old_hook)
+stopifnot(
+    !file.exists(rollback_destination),
+    identical(
+        fertility_capture_acceptance(acceptance_inventory, rollback_raw),
+        acceptance_id
+    )
+)
+concurrent_reuse_raw <- file.path(root, "acceptance-concurrent-final-check")
+dir.create(concurrent_reuse_raw)
+concurrent_reuse_destination <- file.path(
+    concurrent_reuse_raw, "accepted-current-hashes", acceptance_id
+)
+concurrent_inventory_path <- file.path(root, "concurrent-inventory.rds")
+saveRDS(acceptance_inventory, concurrent_inventory_path)
+concurrent_reuse_script <- file.path(root, "concurrent-acceptance-reuse.R")
+writeLines(c(
+    paste0("source(", encodeString(file.path(script_dir, "common.R"), quote = "\""), ")"),
+    paste0("source(", encodeString(file.path(script_dir, "runner.R"), quote = "\""), ")"),
+    paste0("source(", encodeString(file.path(script_dir, "accepted.R"), quote = "\""), ")"),
+    paste0("inventory <- readRDS(", encodeString(concurrent_inventory_path, quote = "\""), ")"),
+    paste0(
+        "fertility_capture_acceptance(inventory, ",
+        encodeString(concurrent_reuse_raw, quote = "\""), ")"
+    )
+), concurrent_reuse_script)
+options(dtaparser.fertility.publication_test_hook = function(boundary, context) {
+    if (identical(
+        boundary, "acceptance-before-new-publication-revalidation"
+    )) {
+        child_status <- suppressWarnings(system2(
+            file.path(R.home("bin"), "Rscript"),
+            c("--vanilla", shQuote(concurrent_reuse_script)),
+            stdout = FALSE, stderr = FALSE
+        ))
+        stopifnot(identical(child_status, 0L))
+        writeBin(as.raw(c(118L, 94L, 0:15)), acceptance_paths[[2L]])
+    }
+})
+expect_error(fertility_capture_acceptance(
+    acceptance_inventory, concurrent_reuse_raw
+), "input changed during capture")
+options(dtaparser.fertility.publication_test_hook = old_hook)
+writeBin(as.raw(c(118L, 2L, 0:15)), acceptance_paths[[2L]])
+stopifnot(
+    identical(
+        list.files(
+            concurrent_reuse_destination, all.files = TRUE, no.. = TRUE
+        ),
+        "commitment.rds"
+    ),
+    identical(
+        fertility_capture_acceptance(
+            acceptance_inventory, concurrent_reuse_raw
+        ),
+        acceptance_id
+    )
+)
+terminated_raw <- file.path(root, "acceptance-terminated-publication")
+dir.create(terminated_raw)
+terminated_destination <- file.path(
+    terminated_raw, "accepted-current-hashes", acceptance_id
+)
+terminated_inventory_path <- file.path(root, "terminated-inventory.rds")
+saveRDS(acceptance_inventory, terminated_inventory_path)
+terminated_script <- file.path(root, "terminate-acceptance.R")
+writeLines(c(
+    paste0("source(", encodeString(file.path(script_dir, "common.R"), quote = "\""), ")"),
+    paste0("source(", encodeString(file.path(script_dir, "runner.R"), quote = "\""), ")"),
+    paste0("source(", encodeString(file.path(script_dir, "accepted.R"), quote = "\""), ")"),
+    paste0("inventory <- readRDS(", encodeString(terminated_inventory_path, quote = "\""), ")"),
+    "options(dtaparser.fertility.publication_test_hook = function(boundary, context) {",
+    "    if (identical(boundary, 'acceptance-before-destination-publication')) {",
+    "        tools::pskill(Sys.getpid(), 9L)",
+    "    }",
+    "})",
+    paste0(
+        "fertility_capture_acceptance(inventory, ", encodeString(terminated_raw, quote = "\""), ")"
+    )
+), terminated_script)
+terminated_result <- suppressWarnings(system2(
+    file.path(R.home("bin"), "Rscript"), c("--vanilla", shQuote(terminated_script)),
+    stdout = FALSE, stderr = FALSE
+))
+stopifnot(
+    !identical(terminated_result, 0L),
+    !file.exists(terminated_destination),
+    length(list.files(
+        file.path(terminated_raw, "accepted-current-hashes"),
+        pattern = "^\\.acceptance\\.", all.files = TRUE
+    )) == 1L,
+    identical(
+        fertility_capture_acceptance(acceptance_inventory, terminated_raw),
+        acceptance_id
+    )
+)
+unlink(list.files(
+    file.path(terminated_raw, "accepted-current-hashes"),
+    pattern = "^\\.acceptance\\.", all.files = TRUE, full.names = TRUE
+), recursive = TRUE)
+input_race_raw <- file.path(root, "acceptance-input-race")
+dir.create(input_race_raw)
+options(dtaparser.fertility.publication_test_hook = function(boundary, context) {
+    if (identical(boundary, "acceptance-before-destination-publication")) {
+        writeBin(as.raw(c(118L, 91L, 0:15)), acceptance_paths[[4L]])
+    }
+})
+expect_error(fertility_capture_acceptance(
+    acceptance_inventory, input_race_raw
+), "input changed during capture")
+options(dtaparser.fertility.publication_test_hook = old_hook)
+writeBin(as.raw(c(118L, 4L, 0:15)), acceptance_paths[[4L]])
+stopifnot(!file.exists(file.path(
+    input_race_raw, "accepted-current-hashes", acceptance_id
+)))
+stopifnot(
+    grepl("^[0-9a-f]{64}$", acceptance_id),
+    identical(acceptance$authority, fertility_acceptance_authority()),
+    identical(acceptance$entries$id, fertility_accepted_ids()),
+    identical(acceptance$entries$expected_sha512, acceptance_expected),
+    identical(acceptance$entries$accepted_sha512, unname(acceptance_actual)),
+    !"path" %in% names(acceptance$entries),
+    isTRUE(fertility_validate_acceptance_current(
+        acceptance, acceptance_inventory
+    ))
+)
+expect_rejected_acceptance_shape <- function(label, populate, pattern) {
+    shape_raw <- file.path(root, paste0("acceptance-shape-", label))
+    shape_destination <- file.path(
+        shape_raw, "accepted-current-hashes", acceptance_id
+    )
+    dir.create(shape_destination, recursive = TRUE)
+    populate(shape_destination)
+    expect_error(fertility_load_acceptance(
+        shape_raw, acceptance_id, acceptance_inventory
+    ), pattern)
+}
+expect_rejected_acceptance_shape("missing", function(destination) NULL,
+                                 "exactly commitment.rds")
+expect_rejected_acceptance_shape("additional", function(destination) {
+    stopifnot(file.copy(
+        source_commitment, file.path(destination, "commitment.rds")
+    ))
+    writeLines("unexpected", file.path(destination, "extra"))
+}, "exactly commitment.rds")
+expect_rejected_acceptance_shape("symlink", function(destination) {
+    stopifnot(file.symlink(
+        source_commitment, file.path(destination, "commitment.rds")
+    ))
+}, "regular nonsymlink")
+expect_rejected_acceptance_shape("nonregular", function(destination) {
+    dir.create(file.path(destination, "commitment.rds"))
+}, "regular nonsymlink")
+expect_error(fertility_validate_acceptance_entries(transform(
+    acceptance$entries, accepted_sha512 = toupper(accepted_sha512)
+)), "invalid")
+expect_error(fertility_validate_acceptance_entries(
+    acceptance$entries[c(2:5, 1), , drop = FALSE]
+), "invalid")
+expect_error(fertility_parse_arguments("--accepted-current-hashes=BAD"),
+             "exact commitment ID")
+accepted_options <- fertility_parse_arguments(c(
+    paste0("--accepted-current-hashes=", acceptance_id),
+    paste0("--id=", paste(fertility_accepted_ids(), collapse = ","))
+))
+fertility_validate_accepted_selection(accepted_options, acceptance_inventory)
+expect_error(fertility_validate_accepted_selection(
+    fertility_parse_arguments(c(
+        paste0("--accepted-current-hashes=", acceptance_id),
+        "--id=F0633,F0634,F0635,F0636"
+    )), acceptance_inventory[1:4, , drop = FALSE]
+), "exactly F0633 through F0637")
+expect_error(fertility_validate_accepted_selection(
+    fertility_parse_arguments(c(
+        paste0("--accepted-current-hashes=", acceptance_id),
+        paste0("--id=", paste(fertility_accepted_ids(), collapse = ",")),
+        "--shard-index=1", "--shard-count=2"
+    )), acceptance_inventory
+), "exactly F0633 through F0637")
+legacy_config_identity <- fertility_tile_configuration(
+    fertility_parse_arguments(character())
+)$config_id
+accepted_config <- fertility_tile_configuration(accepted_options, acceptance)
+stopifnot(
+    !identical(legacy_config_identity, accepted_config$config_id),
+    !identical(
+        fertility_framework_id(test_build_id, datasigs),
+        fertility_framework_id(test_build_id, datasigs, acceptance)
+    )
+)
+accepted_item <- as.list(acceptance_inventory[1L, , drop = FALSE])
+accepted_input <- fertility_capture_input(accepted_item, acceptance)
+stopifnot(
+    identical(accepted_input$manifest_hash_status, "signature-mismatch"),
+    identical(accepted_input$local_evidence_status,
+              "accepted-current-sha512-match"),
+    is.null(fertility_inventory_preflight(accepted_item, accepted_input))
+)
+accepted_result <- fertility_base_result(
+    accepted_item, test_framework_id, accepted_config$timeout_seconds,
+    accepted_input, "pass"
+)
+accepted_result$config_id <- accepted_config$config_id
+accepted_result$component <- NULL
+stopifnot(
+    isTRUE(fertility_validate_recorded_input_attestation(accepted_result)),
+    fertility_recorded_result_valid(
+        accepted_result, accepted_item, test_framework_id, accepted_config
+    ),
+    !identical(
+        fertility_input_attestation_id(list(accepted_result)),
+        fertility_input_attestation_id(list(transform(
+            accepted_result, input_id = paste(rep("9", 64L), collapse = "")
+        )))
+    )
+)
+accepted_public <- fertility_result_frame(list(accepted_result))
+accepted_public$build_provenance_id <- test_build_id
+stopifnot(
+    isTRUE(fertility_validate_public_results(accepted_public)),
+    !any(grepl("accept|sha512|manifest", names(accepted_public))),
+    fertility_file_result_valid(
+        accepted_result, accepted_item, test_framework_id, accepted_config,
+        accepted_input
+    )
+)
+accepted_tile <- fertility_value_tile(1L, 0, 1L, "x")
+accepted_tile_path <- file.path(root, "accepted-tile.rds")
+accepted_tile_execute <- function(item, tile, input) list(
+    schema_version = fertility_schema_version, framework_id = test_framework_id,
+    id = item$id, tile_id = tile$tile_id, tile_type = tile$type,
+    batch = tile$batch, skip = tile$skip, n_max = tile$n_max,
+    classification = "pass", secondary = character(),
+    mismatches = fertility_bind_mismatches(list()), rows = 1L,
+    reader_rows = c(direct = 1L, rust = 1L, haven = 1L),
+    columns = 1L, column_names = character(), storage = character(),
+    structural_rows = NA_real_, column_bytes = numeric(), strl = logical(),
+    projection_expected_count = 1L,
+    projection_expected_hash = fertility_projection_hash("x", test_framework_id),
+    projection_counts = c(direct = 1L, rust = 1L, haven = 1L),
+    projection_hashes = setNames(rep(
+        fertility_projection_hash("x", test_framework_id), 3L
+    ), c("direct", "rust", "haven")),
+    projection_ok = c(direct = TRUE, rust = TRUE, haven = TRUE),
+    elapsed_seconds = 0
+)
+accepted_tile_result <- fertility_process_tile(
+    accepted_item, accepted_tile, accepted_tile_path, test_framework_id,
+    accepted_config, accepted_input, FALSE, accepted_tile_execute
+)$result
+stopifnot(
+    identical(accepted_tile_result$acceptance_authority,
+              acceptance$authority),
+    identical(accepted_tile_result$acceptance_commitment_id,
+              acceptance$commitment_id),
+    isTRUE(fertility_validate_recorded_tile(accepted_tile_result))
+)
+changed_acceptance <- acceptance
+changed_acceptance$artifact_sha256 <- paste(rep("8", 64L), collapse = "")
+stopifnot(
+    !identical(
+        fertility_tile_configuration(accepted_options, changed_acceptance)$config_id,
+        accepted_config$config_id
+    ),
+    !identical(
+        fertility_capture_input(accepted_item, changed_acceptance)$input_id,
+        accepted_input$input_id
+    ),
+    !fertility_file_result_valid(
+        accepted_result, accepted_item, test_framework_id,
+        fertility_tile_configuration(accepted_options, changed_acceptance),
+        fertility_capture_input(accepted_item, changed_acceptance)
+    )
+)
+changed_acceptance_inventory <- acceptance_inventory
+writeBin(as.raw(c(118L, 99L, 0:15)), changed_acceptance_inventory$path[[1L]])
+expect_error(fertility_validate_acceptance_current(
+    acceptance, changed_acceptance_inventory
+), "input validation failed")
+writeBin(as.raw(c(118L, 1L, 0:15)), changed_acceptance_inventory$path[[1L]])
+stopifnot(isTRUE(fertility_validate_acceptance_current(
+    acceptance, changed_acceptance_inventory
+)))
+artifact_path <- file.path(
+    acceptance_raw, "accepted-current-hashes", acceptance_id, "commitment.rds"
+)
+artifact <- readRDS(artifact_path)
+artifact$entries$accepted_sha512[[1L]] <- paste(rep("f", 128L), collapse = "")
+fertility_atomic_save_rds(artifact, artifact_path)
+expect_error(fertility_load_acceptance(
+    acceptance_raw, acceptance_id, acceptance_inventory
+), "commitment identity")
+artifact$entries$accepted_sha512[[1L]] <- acceptance_actual[[1L]]
+artifact$created_at_utc <- "2026-01-01T00:00:00Z"
+fertility_atomic_save_rds(artifact, artifact_path)
+acceptance_reloaded <- fertility_load_acceptance(
+    acceptance_raw, acceptance_id, acceptance_inventory
+)
+stopifnot(!identical(acceptance_reloaded$artifact_sha256,
+                    acceptance$artifact_sha256))
+recorded_acceptance <- data.frame(
+    acceptance_authority = acceptance_reloaded$authority,
+    acceptance_commitment_id = acceptance_reloaded$commitment_id,
+    acceptance_artifact_sha256 = acceptance_reloaded$artifact_sha256,
+    inventory_id = fertility_inventory_id(acceptance_inventory),
+    stringsAsFactors = FALSE, check.names = FALSE
+)
+stopifnot(identical(
+    fertility_revalidate_recorded_acceptance(
+        acceptance_raw, recorded_acceptance, acceptance_inventory
+    )$artifact_sha256,
+    acceptance_reloaded$artifact_sha256
+))
+writeBin(as.raw(c(118L, 77L, 0:15)), acceptance_inventory$path[[2L]])
+expect_error(fertility_revalidate_recorded_acceptance(
+    acceptance_raw, recorded_acceptance, acceptance_inventory
+), "input validation failed")
+writeBin(as.raw(c(118L, 2L, 0:15)), acceptance_inventory$path[[2L]])
+artifact_saved <- readRDS(artifact_path)
+artifact_saved$created_at_utc <- "2026-01-02T00:00:00Z"
+fertility_atomic_save_rds(artifact_saved, artifact_path)
+expect_error(fertility_revalidate_recorded_acceptance(
+    acceptance_raw, recorded_acceptance, acceptance_inventory
+), "artifact identity changed")
+artifact_saved$created_at_utc <- "2026-01-01T00:00:00Z"
+fertility_atomic_save_rds(artifact_saved, artifact_path)
+deleted_artifact <- paste0(artifact_path, ".deleted")
+stopifnot(file.rename(artifact_path, deleted_artifact))
+expect_error(fertility_revalidate_recorded_acceptance(
+    acceptance_raw, recorded_acceptance, acceptance_inventory
+), "accepted-current-hash")
+stopifnot(file.rename(deleted_artifact, artifact_path))
+stopifnot(identical(
+    fertility_revalidate_recorded_acceptance(
+        acceptance_raw, recorded_acceptance, acceptance_inventory
+    )$artifact_sha256,
+    acceptance_reloaded$artifact_sha256
+))
+publication_inventory <- full_canonical
+publication_inventory$path <- rep(acceptance_inventory$path[[1L]], nrow(publication_inventory))
+publication_inventory$expected_sha512 <- rep("", nrow(publication_inventory))
+accepted_positions <- match(fertility_accepted_ids(), publication_inventory$id)
+publication_inventory$path[accepted_positions] <- acceptance_inventory$path
+publication_inventory$expected_sha512[accepted_positions] <- acceptance_expected
+publication_framework_id <- fertility_framework_id(
+    test_build_id, datasigs, acceptance_reloaded
+)
+publication_snapshot <- file.path(
+    acceptance_raw, "framework", publication_framework_id
+)
+dir.create(publication_snapshot, recursive = TRUE)
+fertility_atomic_write_table(
+    full_canonical, file.path(publication_snapshot, "inventory-manifest.tsv")
+)
+publication_inventory_id <- fertility_inventory_id(publication_inventory)
+publication_inventory_provenance <- data.frame(
+    schema_version = fertility_schema_version,
+    report_schema_version = fertility_report_schema_version,
+    framework_id = publication_framework_id,
+    inventory_id = publication_inventory_id,
+    inventory_manifest_id = fertility_manifest_id(full_canonical),
+    report_schema_id = fertility_report_schema_id(),
+    files = nrow(full_canonical), stringsAsFactors = FALSE, check.names = FALSE
+)
+fertility_atomic_write_table(
+    publication_inventory_provenance,
+    file.path(publication_snapshot, "inventory-manifest-provenance.tsv")
+)
+fertility_atomic_write_table(data.frame(
+    authority = acceptance_reloaded$authority,
+    commitment_id = acceptance_reloaded$commitment_id,
+    artifact_sha256 = acceptance_reloaded$artifact_sha256,
+    stringsAsFactors = FALSE, check.names = FALSE
+), file.path(publication_snapshot, "acceptance-provenance.tsv"))
+publication_provenance <- data.frame(
+    evidence_origin = "fresh-execution",
+    source_corpus_schema_version = as.character(fertility_schema_version),
+    framework_id = publication_framework_id,
+    build_provenance_id = test_build_id,
+    inventory_id = publication_inventory_id,
+    report_schema_id = fertility_report_schema_id(),
+    acceptance_authority = acceptance_reloaded$authority,
+    acceptance_commitment_id = acceptance_reloaded$commitment_id,
+    acceptance_artifact_sha256 = acceptance_reloaded$artifact_sha256,
+    stringsAsFactors = FALSE, check.names = FALSE
+)
+stopifnot(identical(
+    fertility_revalidate_accepted_publication(
+        acceptance_raw, publication_provenance, publication_inventory, datasigs
+    )$acceptance$artifact_sha256,
+    acceptance_reloaded$artifact_sha256
+))
+foreign_publication_framework <- publication_provenance
+foreign_publication_framework$framework_id <- test_framework_id
+expect_error(fertility_revalidate_accepted_publication(
+    acceptance_raw, foreign_publication_framework, publication_inventory, datasigs
+), "framework provenance changed")
+changed_publication_path <- publication_inventory$path[[accepted_positions[[3L]]]]
+writeBin(as.raw(c(118L, 88L, 0:15)), changed_publication_path)
+expect_error(fertility_revalidate_accepted_publication(
+    acceptance_raw, publication_provenance, publication_inventory, datasigs
+), "input validation failed")
+writeBin(as.raw(c(118L, 3L, 0:15)), changed_publication_path)
+
+accepted_family_fixture <- make_bundle_family(
+    full_canonical, accepted_options, classifications = rep("pass", nrow(full_canonical)),
+    inventory_id = paste(rep("e", 64L), collapse = ""),
+    acceptance = acceptance_reloaded
+)
+accepted_family_validated <- fertility_validate_shard_bundles(
+    accepted_family_fixture$bundles, accepted_family_fixture$id, full_canonical
+)
+stopifnot(
+    identical(accepted_family_validated$results$id, fertility_accepted_ids()),
+    identical(
+        accepted_family_validated$provenance$acceptance_commitment_id[[1L]],
+        acceptance_id
+    )
+)
+accepted_wrong_member <- accepted_family_fixture$bundles
+accepted_wrong_member[[1L]]$results$id[[1L]] <- "F0632"
+expect_error(fertility_validate_shard_bundles(
+    accepted_wrong_member, accepted_family_fixture$id, full_canonical
+), "canonical family membership|exact executable five-ID")
+accepted_foreign_artifact <- accepted_family_fixture$bundles
+accepted_foreign_artifact[[1L]]$provenance$acceptance_artifact_sha256 <-
+    paste(rep("7", 64L), collapse = "")
+expect_error(fertility_validate_shard_bundles(
+    accepted_foreign_artifact, accepted_family_fixture$id, full_canonical
+), "configuration provenance identity")
+merge_live_inventory <- full_canonical
+merge_live_inventory$expected_sha512 <- rep(
+    paste(rep("a", 128L), collapse = ""), nrow(merge_live_inventory)
+)
+make_merged_bundle <- function(validated, family_id) {
+    provenance <- validated$provenance
+    family_input_attestation_id <- fertility_family_input_attestation_id(provenance)
+    evidence_family_id <- fertility_evidence_family_id(
+        family_id, family_input_attestation_id,
+        provenance$evidence_origin[[1L]],
+        as.integer(provenance$source_corpus_schema_version[[1L]]),
+        provenance$report_schema_id[[1L]],
+        provenance$acceptance_authority[[1L]],
+        provenance$acceptance_commitment_id[[1L]]
+    )
+    merge_provenance <- data.frame(
+        schema_version = as.character(fertility_schema_version),
+        report_schema_version = as.character(fertility_report_schema_version),
+        evidence_origin = provenance$evidence_origin[[1L]],
+        source_corpus_schema_version = provenance$source_corpus_schema_version[[1L]],
+        replayed_at_utc = provenance$replayed_at_utc[[1L]],
+        acceptance_authority = provenance$acceptance_authority[[1L]],
+        acceptance_commitment_id = provenance$acceptance_commitment_id[[1L]],
+        acceptance_artifact_sha256 = provenance$acceptance_artifact_sha256[[1L]],
+        family_id = family_id, evidence_family_id = evidence_family_id,
+        family_input_attestation_id = family_input_attestation_id,
+        framework_id = provenance$framework_id[[1L]],
+        config_id = provenance$config_id[[1L]],
+        build_provenance_id = provenance$build_provenance_id[[1L]],
+        inventory_id = fertility_inventory_id(merge_live_inventory),
+        family_manifest_id = provenance$family_manifest_id[[1L]],
+        report_schema_id = provenance$report_schema_id[[1L]],
+        results_id = fertility_merged_results_id(validated$results),
+        merge_id = "", shard_count = as.character(validated$shard_count),
+        files = as.character(nrow(validated$results)),
+        full_default_family = if (validated$full_default) "TRUE" else "FALSE",
+        created_at_utc = "2026-01-01T00:00:00Z",
+        stringsAsFactors = FALSE, check.names = FALSE
+    )
+    merge_provenance$merge_id <- fertility_merge_identity(merge_provenance)
+    merge_provenance <- merge_provenance[fertility_merge_provenance_fields()]
+    list(
+        provenance = merge_provenance, results = validated$results,
+        summary = fertility_classification_summary(validated$results),
+        family_manifest = validated$family_manifest,
+        input_attestation = fertility_family_input_attestation(provenance)
+    )
+}
+full_merged_bundle <- make_merged_bundle(full_validated, full_fixture$id)
+accepted_merged_bundle <- make_merged_bundle(
+    accepted_family_validated, accepted_family_fixture$id
+)
+full_assessment <- fertility_validate_merged_bundle(
+    full_merged_bundle, full_fixture$id, merge_live_inventory
+)
+accepted_assessment <- fertility_validate_merged_bundle(
+    accepted_merged_bundle, accepted_family_fixture$id, merge_live_inventory
+)
+stopifnot(
+    grepl("^[0-9a-f]{64}$", full_assessment$merge_id),
+    grepl("^[0-9a-f]{64}$", accepted_assessment$merge_id)
+)
+tampered_merged_results <- accepted_merged_bundle
+tampered_merged_results$results$classification[[1L]] <- "timeout"
+expect_error(fertility_validate_merged_bundle(
+    tampered_merged_results, accepted_family_fixture$id, merge_live_inventory
+), "results are not bound")
+tampered_merged_attestation <- accepted_merged_bundle
+tampered_merged_attestation$provenance$family_input_attestation_id <-
+    paste(rep("9", 64L), collapse = "")
+expect_error(fertility_validate_merged_bundle(
+    tampered_merged_attestation, accepted_family_fixture$id, merge_live_inventory
+), "input attestation identity")
+tampered_input_attestation <- accepted_merged_bundle
+tampered_input_attestation$input_attestation$input_attestation_id[[1L]] <-
+    paste(rep("8", 64L), collapse = "")
+expect_error(fertility_validate_merged_bundle(
+    tampered_input_attestation, accepted_family_fixture$id, merge_live_inventory
+), "input attestation identity")
+tampered_merged_evidence <- accepted_merged_bundle
+tampered_merged_evidence$provenance$evidence_family_id <-
+    paste(rep("9", 64L), collapse = "")
+expect_error(fertility_validate_merged_bundle(
+    tampered_merged_evidence, accepted_family_fixture$id, merge_live_inventory
+), "evidence family identity")
+tampered_merged_manifest <- accepted_merged_bundle
+tampered_merged_manifest$family_manifest$id[[1L]] <- "F0632"
+expect_error(fertility_validate_merged_bundle(
+    tampered_merged_manifest, accepted_family_fixture$id, merge_live_inventory
+), "manifest")
+assessment_gates <- fertility_validate_assessment_families(
+    full_assessment, accepted_assessment
+)
+stopifnot(
+    identical(assessment_gates$manifest_gate, "blocked-signature-mismatch"),
+    identical(assessment_gates$explicit_local_evidence_gate, "validated")
+)
+assessment_replaced_full <- full_assessment
+assessment_replaced_full$results$classification[
+    assessment_replaced_full$results$id == "F0633"
+] <- "pass"
+expect_error(fertility_validate_assessment_families(
+    assessment_replaced_full, accepted_assessment
+), "preserved manifest-gated family")
+for (reason in c("hash-read-error", "input-changed")) {
+    assessment_wrong_reason <- full_assessment
+    assessment_wrong_reason$results$secondary_categories[
+        assessment_wrong_reason$results$id == "F0633"
+    ] <- reason
+    expect_error(fertility_validate_assessment_families(
+        assessment_wrong_reason, accepted_assessment
+    ), "preserved manifest-gated family")
+}
+assessment_mixed_reasons <- full_assessment
+assessment_mixed_reasons$results$secondary_categories[
+    assessment_mixed_reasons$results$id == "F0634"
+] <- "hash-read-error"
+expect_error(fertility_validate_assessment_families(
+    assessment_mixed_reasons, accepted_assessment
+), "preserved manifest-gated family")
+assessment_multiple_reasons <- full_assessment
+assessment_multiple_reasons$results$secondary_categories[
+    assessment_multiple_reasons$results$id == "F0635"
+] <- "signature-mismatch,input-changed"
+expect_error(fertility_validate_assessment_families(
+    assessment_multiple_reasons, accepted_assessment
+), "preserved manifest-gated family")
+assessment_bad_accepted <- accepted_assessment
+assessment_bad_accepted$results$classification[[1L]] <- "inventory-hash-error"
+expect_error(fertility_validate_assessment_families(
+    full_assessment, assessment_bad_accepted
+), "explicit local evidence")
 
 actual <- tibble::tibble(
     number = c(1, 2 + 5e-8, haven::tagged_na("a")),
@@ -1196,7 +2635,9 @@ transaction_stages <- list(
     list(parent = "p2", stage = "s2", published = "p2/n2", old_current = NA_character_)
 )
 run_transaction_fixture <- function(fail_rename = 0L, fail_pointer = 0L,
-                                    fail_rollback = FALSE) {
+                                    fail_rollback = FALSE,
+                                    fail_before_rename = 0L,
+                                    fail_before_pointer = 0L) {
     state <- new.env(parent = emptyenv())
     state$paths <- c(s1 = TRUE, s2 = TRUE, `p1/n1` = FALSE, `p2/n2` = FALSE)
     state$pointers <- c(p1 = "old1", p2 = NA_character_)
@@ -1225,7 +2666,9 @@ run_transaction_fixture <- function(fail_rename = 0L, fail_pointer = 0L,
     expression <- function() fertility_publish_pointer_transaction(
         transaction_stages, rename_path, write_pointer, remove_path,
         pointer_state = function(parent) state$pointers[[parent]],
-        path_exists = function(path) isTRUE(state$paths[[path]])
+        path_exists = function(path) isTRUE(state$paths[[path]]),
+        before_rename = function(index, stage) index != fail_before_rename,
+        before_pointer = function(index, stage) index != fail_before_pointer
     )
     list(state = state, expression = expression)
 }
@@ -1240,6 +2683,26 @@ stopifnot(identical(pointer_failure$state$pointers[["p1"]], "old1"),
           is.na(pointer_failure$state$pointers[["p2"]]),
           !isTRUE(pointer_failure$state$paths[["p1/n1"]]),
           !isTRUE(pointer_failure$state$paths[["p2/n2"]]))
+rename_revalidation_failure <- run_transaction_fixture(fail_before_rename = 2L)
+expect_error(rename_revalidation_failure$expression(),
+             "atomically publish every report bundle")
+stopifnot(
+    identical(rename_revalidation_failure$state$pointers[["p1"]], "old1"),
+    is.na(rename_revalidation_failure$state$pointers[["p2"]]),
+    !isTRUE(rename_revalidation_failure$state$paths[["p1/n1"]]),
+    !isTRUE(rename_revalidation_failure$state$paths[["p2/n2"]])
+)
+pointer_revalidation_failure <- run_transaction_fixture(
+    fail_before_pointer = 2L
+)
+expect_error(pointer_revalidation_failure$expression(),
+             "republished shard pointer")
+stopifnot(
+    identical(pointer_revalidation_failure$state$pointers[["p1"]], "old1"),
+    is.na(pointer_revalidation_failure$state$pointers[["p2"]]),
+    !isTRUE(pointer_revalidation_failure$state$paths[["p1/n1"]]),
+    !isTRUE(pointer_revalidation_failure$state$paths[["p2/n2"]])
+)
 rollback_failure <- run_transaction_fixture(fail_pointer = 2L, fail_rollback = TRUE)
 expect_error(rollback_failure$expression(), "rollback did not restore")
 recorded_tile_spec <- fertility_value_tile(1L, 0, 2L, "a")
@@ -1429,6 +2892,53 @@ retried_tile <- fertility_process_tile(
 )
 stopifnot(!first_tile$resumed, resumed_tile$resumed, !retried_tile$resumed,
           tile_counter$n == 2L)
+metadata_retry_checkpoint <- file.path(root, "metadata-retry-checkpoint.rds")
+metadata_retry_counter <- new.env(parent = emptyenv())
+metadata_retry_counter$n <- 0L
+metadata_retry_execute <- function(item, tile, input) {
+    metadata_retry_counter$n <- metadata_retry_counter$n + 1L
+    list(
+        schema_version = fertility_schema_version, framework_id = "framework",
+        id = item$id, tile_id = tile$tile_id, tile_type = tile$type,
+        batch = tile$batch, skip = tile$skip, n_max = tile$n_max,
+        classification = "unresolved",
+        secondary = "structural-metadata-unavailable",
+        mismatches = fertility_bind_mismatches(list()), rows = 3L,
+        reader_rows = c(direct = 3L, rust = 3L, haven = NA_integer_),
+        columns = 1L, column_names = "x", storage = "double",
+        structural_rows = NA_real_, column_bytes = numeric(), strl = logical(),
+        projection_expected_count = NA_integer_,
+        projection_expected_hash = NA_character_,
+        projection_counts = c(direct = NA_integer_, rust = NA_integer_,
+                              haven = NA_integer_),
+        projection_hashes = c(direct = NA_character_, rust = NA_character_,
+                              haven = NA_character_),
+        projection_ok = c(direct = NA, rust = NA, haven = NA),
+        elapsed_seconds = 0
+    )
+}
+metadata_retry_tile <- fertility_metadata_tile()
+metadata_retry_first <- fertility_process_tile(
+    tile_item, metadata_retry_tile, metadata_retry_checkpoint, "framework",
+    tile_config, tile_input, FALSE, metadata_retry_execute
+)
+metadata_retry_resumed <- fertility_process_tile(
+    tile_item, metadata_retry_tile, metadata_retry_checkpoint, "framework",
+    tile_config, tile_input, FALSE, metadata_retry_execute
+)
+metadata_retry_rerun <- fertility_process_tile(
+    tile_item, metadata_retry_tile, metadata_retry_checkpoint, "framework",
+    tile_config, tile_input, TRUE, metadata_retry_execute
+)
+stopifnot(
+    !metadata_retry_first$resumed, metadata_retry_resumed$resumed,
+    !metadata_retry_rerun$resumed, metadata_retry_counter$n == 2L,
+    metadata_retry_rerun$result$classification == "unresolved",
+    identical(
+        metadata_retry_rerun$result$secondary,
+        "structural-metadata-unavailable"
+    )
+)
 foreign_tile_checkpoint <- first_tile$result
 foreign_tile_checkpoint$schema_version <- fertility_schema_version + 1L
 stopifnot(
@@ -1659,10 +3169,14 @@ if (dir.exists(file.path(checkout_library, "dtaparser"))) {
         structural_failure_worker, structural_planning_failure
     )
     stopifnot(
-        structural_failure_worker$classification == "pass",
+        structural_failure_worker$classification == "unresolved",
         all(structural_failure_worker$reader_rows[c("direct", "rust")] ==
             nrow(bounded_data)),
         is.na(structural_failure_worker$reader_rows[["haven"]]),
+        identical(
+            structural_failure_worker$secondary,
+            "structural-metadata-unavailable"
+        ),
         !any(grepl("reader-error", structural_failure_worker$secondary, fixed = TRUE)),
         is.na(structural_failure_worker$structural_rows),
         !length(structural_failure_worker$column_bytes),
@@ -1671,7 +3185,7 @@ if (dir.exists(file.path(checkout_library, "dtaparser"))) {
             structural_failure_tiles, complete = FALSE
         ) == "unresolved",
         identical(
-            fertility_tile_secondary(structural_failure_tiles),
+            unique(fertility_tile_secondary(structural_failure_tiles)),
             "structural-metadata-unavailable"
         ),
         !any(grepl(

--- a/benchmarks/fertility-surveys/test-framework.R
+++ b/benchmarks/fertility-surveys/test-framework.R
@@ -203,6 +203,73 @@ local({
         identical(unname(tools::sha256sum(external_dta)), external_before)
     )
     options(dtaparser.fertility.output_inventory_test_hook = NULL)
+
+    root_saved <- paste0(fixture, ".saved")
+    restorer <- NULL
+    options(dtaparser.fertility.output_inventory_test_hook = function(
+        boundary, context
+    ) {
+        if (identical(boundary, "before-descriptor-content-read")) {
+            stopifnot(file.rename(fixture, root_saved), file.symlink(outside, fixture))
+            restorer <<- callr::r_bg(function(path, saved) {
+                Sys.sleep(0.5)
+                unlink(path)
+                if (!file.rename(saved, path)) stop("could not restore output root")
+                TRUE
+            }, args = list(fixture, root_saved), supervise = TRUE,
+            user_profile = FALSE, system_profile = FALSE)
+        }
+    })
+    expect_error(
+        fertility_output_descriptor_manifest(fertility_output_root, TRUE),
+        "descriptor-bound regular files"
+    )
+    stopifnot(!is.null(restorer))
+    restorer$wait(timeout = 5000L)
+    stopifnot(
+        identical(restorer$get_result(), TRUE),
+        !fertility_path_is_symlink(fixture),
+        identical(unname(tools::sha256sum(external_dta)), external_before)
+    )
+
+    capture_parent <- file.path(fixture, "capture-parent")
+    capture_parent_saved <- paste0(capture_parent, ".saved")
+    external_parent <- file.path(outside, "capture-parent")
+    dir.create(capture_parent)
+    dir.create(external_parent)
+    capture_target <- file.path(capture_parent, "target.dta")
+    writeBin(c(as.raw(113L), as.raw(rep(1L, 40L))), capture_target)
+    writeBin(c(as.raw(118L), as.raw(rep(2L, 40L))),
+             file.path(external_parent, "target.dta"))
+    restorer <- NULL
+    options(dtaparser.fertility.output_inventory_test_hook = function(
+        boundary, context
+    ) {
+        if (identical(boundary, "before-descriptor-file-read")) {
+            stopifnot(
+                file.rename(capture_parent, capture_parent_saved),
+                file.symlink(external_parent, capture_parent)
+            )
+            restorer <<- callr::r_bg(function(path, saved) {
+                Sys.sleep(0.5)
+                unlink(path)
+                if (!file.rename(saved, path)) stop("could not restore capture parent")
+                TRUE
+            }, args = list(capture_parent, capture_parent_saved),
+            supervise = TRUE, user_profile = FALSE, system_profile = FALSE)
+        }
+    })
+    expect_error(
+        fertility_nofollow_file_capture(capture_target, include_release = TRUE),
+        "descriptor-bound file capture failed"
+    )
+    stopifnot(!is.null(restorer))
+    restorer$wait(timeout = 5000L)
+    stopifnot(
+        identical(restorer$get_result(), TRUE),
+        !fertility_path_is_symlink(capture_parent)
+    )
+    options(dtaparser.fertility.output_inventory_test_hook = NULL)
 })
 
 # Output confinement rejects symlinked roots, publication descendants, CURRENT

--- a/benchmarks/fertility-surveys/test-framework.R
+++ b/benchmarks/fertility-surveys/test-framework.R
@@ -76,6 +76,22 @@ expect_error(fertility_parse_arguments("--beyond-end-windows=9"), "must not exce
 expect_error(fertility_filter_inventory(
     inventory, fertility_parse_arguments("--id=F9999")
 ), "unknown --id")
+preflight_item <- list(expected_sha512 = paste(rep("a", 128L), collapse = ""))
+preflight_match <- list(hash_status = "ok", actual_sha512 = preflight_item$expected_sha512)
+preflight_mismatch <- list(hash_status = "ok",
+                           actual_sha512 = paste(rep("b", 128L), collapse = ""))
+preflight_read_error <- list(hash_status = "error", actual_sha512 = NA_character_)
+stopifnot(is.null(fertility_inventory_preflight(preflight_item, preflight_match)),
+          identical(fertility_inventory_preflight(
+              preflight_item, preflight_mismatch
+          )$reason, "signature-mismatch"),
+          identical(fertility_inventory_preflight(
+              preflight_item, preflight_read_error
+          )$reason, "hash-read-error"))
+preflight_item$expected_sha512 <- ""
+stopifnot(is.null(fertility_inventory_preflight(
+    preflight_item, preflight_mismatch
+)))
 
 actual <- tibble::tibble(
     number = c(1, 2 + 5e-8, haven::tagged_na("a")),
@@ -524,6 +540,44 @@ if (dir.exists(file.path(checkout_library, "dtaparser"))) {
                   bounded_worker[c("projection_hashes", "projection_expected_hash")],
                   use.names = FALSE
               )))
+    # The isolated callr worker must install comparator functions in the worker's
+    # lexical environment, not only in the transient fertility_worker_tile frame.
+    isolated_worker <- callr::r(
+        function(common_script, runtime_script, worker_script, compare_script,
+                 item, tile, package_library, expected_package_path, raw_root) {
+            source(common_script, local = environment())
+            source(runtime_script, local = environment())
+            invisible(fertility_assert_tempdir(raw_root))
+            source(worker_script, local = environment())
+            result <- fertility_worker_tile(
+                item, tile, compare_script, package_library,
+                expected_package_path, "framework", 10L
+            )
+            helpers <- c("fertility_bind_mismatches",
+                         "fertility_compare_available_pairs")
+            stopifnot(!any(vapply(helpers, exists, logical(1),
+                                  envir = globalenv(), inherits = FALSE)))
+            result
+        },
+        args = list(
+            file.path(script_dir, "common.R"), file.path(script_dir, "runtime.R"),
+            file.path(script_dir, "worker.R"), file.path(script_dir, "compare.R"),
+            bounded_item, fertility_metadata_tile(), dirname(installed_dtaparser),
+            installed_dtaparser,
+            normalizePath(Sys.getenv("TMPDIR"), winslash = "/", mustWork = TRUE)
+        ),
+        libpath = .libPaths(), timeout = 30, spinner = FALSE, show = FALSE,
+        user_profile = FALSE, system_profile = FALSE,
+        env = c(R_ENVIRON_USER = "/dev/null", R_PROFILE_USER = "/dev/null",
+                R_MAX_VSIZE = "256M")
+    )
+    stopifnot(isolated_worker$classification != "crash",
+              isolated_worker$rows == 5L, isolated_worker$columns == 3L)
+} else {
+    stop(paste(
+        "checkout-local dtaparser installation is required; run a manual",
+        "benchmark.sh smoke first so the isolated worker regression cannot skip"
+    ))
 }
 worker_source <- paste(readLines(file.path(script_dir, "worker.R")), collapse = "\n")
 stopifnot(!grepl("read_dta\\(item\\$path\\)", worker_source))

--- a/benchmarks/fertility-surveys/test-framework.R
+++ b/benchmarks/fertility-surveys/test-framework.R
@@ -73,6 +73,28 @@ stopifnot(nrow(selected) == 1L, selected$id[[1L]] == "F0003",
 expect_error(fertility_parse_arguments("--shard-count=2"), "supplied together")
 expect_error(fertility_parse_arguments("--timeout-seconds=0"), "positive integer")
 expect_error(fertility_parse_arguments("--beyond-end-windows=9"), "must not exceed 8")
+encoding_options <- fertility_parse_arguments(c(
+    "--encoding-override=F0003:latin1,F0001:UTF8",
+    "--encoding-override=F0002:CP1252"
+))
+stopifnot(
+    identical(encoding_options$encoding_overrides, c(
+        F0001 = "UTF-8", F0002 = "Windows-1252", F0003 = "ISO-8859-1"
+    )),
+    identical(
+        fertility_encoding_overrides_text(encoding_options$encoding_overrides),
+        "F0001:UTF-8,F0002:Windows-1252,F0003:ISO-8859-1"
+    )
+)
+expect_error(fertility_parse_arguments(
+    c("--encoding-override=F0001:UTF-8", "--encoding-override=F0001:latin1")
+), "duplicate")
+expect_error(fertility_parse_arguments("--encoding-override=F0001:KOI8-R"),
+             "unsupported encoding")
+expect_error(fertility_parse_arguments("--encoding-override=bad:UTF-8"),
+             "invalid.*ID")
+expect_error(fertility_parse_arguments("--encoding-override=F0001"),
+             "form F0001")
 expect_error(fertility_filter_inventory(
     inventory, fertility_parse_arguments("--id=F9999")
 ), "unknown --id")
@@ -83,6 +105,12 @@ shard_two <- fertility_filter_inventory(inventory, shard_options)
 stopifnot(!length(intersect(shard_one$id, shard_two$id)),
           identical(sort(c(shard_one$id, shard_two$id)), sort(inventory$id)),
           nrow(fertility_family_selection(inventory, shard_options)) == nrow(inventory))
+expect_error(fertility_validate_encoding_overrides(
+    c(F0003 = "UTF-8"),
+    fertility_family_selection(
+        inventory, fertility_parse_arguments("--id=F0001,F0002")
+    )
+), "outside the complete selected family")
 family_a <- fertility_parse_arguments(c("--program=dhs,mics", "--shard-index=1",
                                         "--shard-count=2"))
 family_b <- fertility_parse_arguments(c("--program=mics,dhs", "--shard-index=2",
@@ -117,8 +145,9 @@ make_bundle_family <- function(
 ) {
     manifest <- fertility_family_manifest(canonical, family_options)
     manifest_id <- fertility_manifest_id(manifest)
+    family_config_id <- fertility_tile_configuration(family_options)$config_id
     family_id <- fertility_family_id_from_manifest(
-        manifest, test_framework_id, test_config_id, test_build_id, inventory_id,
+        manifest, test_framework_id, family_config_id, test_build_id, inventory_id,
         family_options$shard_count, family_options$max_files
     )
     spec <- fertility_filter_spec(family_options)
@@ -148,14 +177,18 @@ make_bundle_family <- function(
             evidence_selection_id = evidence_selection_id,
             input_attestation_id = input_attestation_id, family_id = family_id,
             family_manifest_id = manifest_id, framework_id = test_framework_id,
-            config_id = test_config_id, build_provenance_id = test_build_id,
+            config_id = family_config_id, build_provenance_id = test_build_id,
             inventory_id = inventory_id, report_schema_id = fertility_report_schema_id(),
             selected_files = as.character(nrow(expected)),
             expected_family_files = as.character(nrow(manifest)),
             full_default_family = if (fertility_full_default_family(family_options))
                 "TRUE" else "FALSE",
             program_filter = spec$program_filter, release_filter = spec$release_filter,
-            id_filter = spec$id_filter, max_files = spec$max_files,
+            id_filter = spec$id_filter,
+            encoding_overrides = fertility_encoding_overrides_text(
+                family_options$encoding_overrides
+            ),
+            max_files = spec$max_files,
             shard_index = as.character(index),
             shard_count = as.character(family_options$shard_count),
             timeout_seconds = "600", chunk_rows = "10000", column_batch = "16",
@@ -180,6 +213,21 @@ validated_merge <- fertility_validate_shard_bundles(
 )
 stopifnot(identical(validated_merge$results$id, c("F0001", "F0002")),
           validated_merge$shard_count == 2L)
+override_merge_options <- fertility_parse_arguments(c(
+    "--id=F0001,F0002", "--shard-index=1", "--shard-count=2",
+    "--encoding-override=F0001:ISO-8859-1"
+))
+override_merge_fixture <- make_bundle_family(
+    canonical_inventory, override_merge_options
+)
+stopifnot(is.list(fertility_validate_shard_bundles(
+    override_merge_fixture$bundles, override_merge_fixture$id, canonical_inventory
+)))
+foreign_override <- override_merge_fixture$bundles
+foreign_override[[2L]]$provenance$encoding_overrides <- ""
+expect_error(fertility_validate_shard_bundles(
+    foreign_override, override_merge_fixture$id, canonical_inventory
+), "identical framework/config/build/inventory")
 false_origin <- merge_bundles
 false_origin[[1L]]$provenance$evidence_origin <- "historical-schema-10-replay"
 expect_error(fertility_validate_shard_bundles(
@@ -719,6 +767,29 @@ tile_options <- fertility_parse_arguments(c(
     "--cell-budget=300", "--max-tiles-per-batch=3"
 ))
 tile_configuration <- fertility_tile_configuration(tile_options)
+legacy_configuration_fields <- tile_configuration[setdiff(
+    names(tile_configuration), c("encoding_overrides", "config_id")
+)]
+override_configuration <- fertility_tile_configuration(fertility_parse_arguments(c(
+    "--chunk-rows=100", "--column-batch=8", "--memory-mib=128",
+    "--cell-budget=300", "--max-tiles-per-batch=3",
+    "--encoding-override=F0001:latin1"
+)))
+canonical_override_configuration <- fertility_tile_configuration(
+    fertility_parse_arguments(c(
+        "--chunk-rows=100", "--column-batch=8", "--memory-mib=128",
+        "--cell-budget=300", "--max-tiles-per-batch=3",
+        "--encoding-override=F0001:ISO-8859-1"
+    ))
+)
+stopifnot(
+    identical(tile_configuration$encoding_overrides, ""),
+    identical(tile_configuration$config_id,
+              fertility_stable_id(legacy_configuration_fields)),
+    !identical(tile_configuration$config_id, override_configuration$config_id),
+    identical(override_configuration$config_id,
+              canonical_override_configuration$config_id)
+)
 stopifnot(identical(fertility_adaptive_rows(8, tile_configuration), 100L),
           identical(fertility_adaptive_rows(rep(8, 8), tile_configuration), 12L),
           identical(fertility_adaptive_rows(2045, tile_configuration), 100L),
@@ -1369,6 +1440,11 @@ stopifnot(
         foreign_tile_checkpoint, tile_item, tile, "framework", tile_config$config_id,
         tile_input$input_id, tile_config$timeout_seconds,
         corpus_schema_version = fertility_schema_version + 1L
+    ),
+    !fertility_tile_checkpoint_valid(
+        first_tile$result, tile_item, tile, "framework",
+        override_configuration$config_id, tile_input$input_id,
+        tile_config$timeout_seconds
     )
 )
 sizing_tile <- fertility_sizing_tile(1L, "long", 10000000,
@@ -1471,10 +1547,39 @@ stopifnot(hash_failure$classification == "input-signature-mismatch")
 bounded_path <- file.path(root, "bounded.dta")
 bounded_data <- tibble::tibble(
     number = 1:5,
-    text = c("a", "b", "c", "d", "e"),
-    day = as.Date("2020-01-01") + 0:4
+    text = c("encoding_probe_ascii", "b", "c", "d", "e"),
+    day = as.Date("2020-01-01") + 0:4,
+    encoding_name_ascii = 6:10
 )
-haven::write_dta(bounded_data, bounded_path)
+haven::write_dta(bounded_data, bounded_path, version = 14)
+encoding_probe_path <- file.path(root, "encoding-probe.dta")
+encoding_probe_bytes <- readBin(
+    bounded_path, "raw", n = file.info(bounded_path)$size
+)
+encoding_needle <- charToRaw("encoding_probe_ascii")
+encoding_starts <- seq_len(length(encoding_probe_bytes) - length(encoding_needle) + 1L)
+encoding_matches <- encoding_starts[vapply(encoding_starts, function(start) {
+    identical(
+        encoding_probe_bytes[start:(start + length(encoding_needle) - 1L)],
+        encoding_needle
+    )
+}, logical(1))]
+stopifnot(length(encoding_matches) == 1L)
+encoding_probe_bytes[[encoding_matches[[1L]]]] <- as.raw(0x80)
+encoding_name_needle <- charToRaw("encoding_name_ascii")
+encoding_name_starts <- seq_len(
+    length(encoding_probe_bytes) - length(encoding_name_needle) + 1L
+)
+encoding_name_matches <- encoding_name_starts[vapply(
+    encoding_name_starts, function(start) identical(
+        encoding_probe_bytes[start:(start + length(encoding_name_needle) - 1L)],
+        encoding_name_needle
+    ), logical(1)
+)]
+stopifnot(length(encoding_name_matches) == 1L)
+encoding_probe_bytes[[encoding_name_matches[[1L]]]] <- as.raw(0x80)
+writeBin(encoding_probe_bytes, encoding_probe_path)
+stopifnot(fertility_release(encoding_probe_path) == 118L)
 rare_strl_path <- file.path(root, "rare-strl.dta")
 haven::write_dta(data.frame(
     long_string = c(rep("x", 999L), strrep("z", 100000L))
@@ -1508,7 +1613,8 @@ if (dir.exists(file.path(checkout_library, "dtaparser"))) {
         bounded_item, fertility_metadata_tile(), file.path(script_dir, "compare.R"),
         dirname(installed_dtaparser), installed_dtaparser, "framework", 10L
     )
-    stopifnot(metadata_worker$rows == 5L, metadata_worker$columns == 3L,
+    stopifnot(metadata_worker$rows == 5L,
+              metadata_worker$columns == ncol(bounded_data),
               identical(metadata_worker$column_names, names(bounded_data)))
     bounded_tile <- fertility_value_tile(1L, 1L, 2L, c("number", "day"))
     bounded_worker <- fertility_worker_tile(
@@ -1524,6 +1630,81 @@ if (dir.exists(file.path(checkout_library, "dtaparser"))) {
                   bounded_worker[c("projection_hashes", "projection_expected_hash")],
                   use.names = FALSE
               )))
+    default_tile <- fertility_value_tile(1L, 0L, 1L, "text")
+    stopifnot(
+        identical(
+            fertility_tile_read("direct", bounded_path, default_tile),
+            dtaparser::read_dta(
+                bounded_path, col_select = tidyselect::all_of("text"),
+                skip = 0L, n_max = 1L, .name_repair = "minimal"
+            )
+        ),
+        identical(
+            fertility_tile_read("rust", bounded_path, default_tile),
+            dtaparser:::.read_dta_rust_vectors(
+                bounded_path, col_select = tidyselect::all_of("text"),
+                skip = 0L, n_max = 1L, .name_repair = "minimal"
+            )
+        ),
+        identical(
+            fertility_tile_read("haven", bounded_path, default_tile),
+            haven::read_dta(
+                bounded_path, col_select = tidyselect::all_of("text"),
+                skip = 0L, n_max = 1L, .name_repair = "minimal"
+            )
+        )
+    )
+    encoding_item <- bounded_item
+    encoding_item$id <- "F9903"
+    encoding_item$path <- normalizePath(encoding_probe_path, winslash = "/")
+    encoding_item$encoding_override <- "ISO-8859-1"
+    encoding_values <- lapply(c("direct", "rust", "haven"), function(reader) {
+        fertility_tile_read(
+            reader, encoding_item$path, default_tile,
+            encoding = encoding_item$encoding_override
+        )
+    })
+    stopifnot(
+        identical(encoding_values[[1L]], encoding_values[[2L]]),
+        identical(encoding_values[[1L]], encoding_values[[3L]]),
+        startsWith(encoding_values[[1L]]$text[[1L]], intToUtf8(128L))
+    )
+    encoding_worker <- fertility_worker_tile(
+        encoding_item, default_tile, file.path(script_dir, "compare.R"),
+        dirname(installed_dtaparser), installed_dtaparser, "framework", 10L
+    )
+    encoding_metadata <- fertility_worker_tile(
+        encoding_item, fertility_metadata_tile(), file.path(script_dir, "compare.R"),
+        dirname(installed_dtaparser), installed_dtaparser, "framework", 10L
+    )
+    encoding_terminal <- fertility_worker_tile(
+        encoding_item, fertility_value_tile(
+            1L, nrow(bounded_data), 1L,
+            encoding_metadata$column_names[[4L]], type = "terminal", probe = 1L
+        ), file.path(script_dir, "compare.R"), dirname(installed_dtaparser),
+        installed_dtaparser, "framework", 10L
+    )
+    encoding_sizing <- fertility_worker_tile(
+        encoding_item, fertility_sizing_tile(1L, "text", 1, 1L),
+        file.path(script_dir, "compare.R"), dirname(installed_dtaparser),
+        installed_dtaparser, "framework", 10L
+    )
+    stopifnot(
+        encoding_worker$classification == "pass",
+        all(encoding_worker$projection_ok),
+        encoding_metadata$classification == "pass",
+        startsWith(encoding_metadata$column_names[[4L]], intToUtf8(128L)),
+        identical(
+            encoding_metadata$column_names,
+            as.character(dtaparser:::.dta_metadata(
+                encoding_item$path, encoding = "ISO-8859-1"
+            ))
+        ),
+        encoding_terminal$classification == "pass",
+        all(encoding_terminal$reader_rows == 0L),
+        encoding_sizing$classification == "pass",
+        encoding_sizing$samples_completed == 1L
+    )
     wide_item <- bounded_item
     wide_item$id <- "F9901"
     wide_item$path <- normalizePath(wide_path, winslash = "/")
@@ -1583,7 +1764,8 @@ if (dir.exists(file.path(checkout_library, "dtaparser"))) {
                 R_MAX_VSIZE = "256M")
     )
     stopifnot(isolated_worker$classification != "crash",
-              isolated_worker$rows == 5L, isolated_worker$columns == 3L)
+              isolated_worker$rows == 5L,
+              isolated_worker$columns == ncol(bounded_data))
 } else {
     stop(paste(
         "checkout-local dtaparser installation is required; run a manual",

--- a/benchmarks/fertility-surveys/test-framework.R
+++ b/benchmarks/fertility-surveys/test-framework.R
@@ -18,6 +18,7 @@ expect_error <- function(expression, pattern) {
     invisible(error)
 }
 
+local({
 root <- tempfile("fertility-framework-")
 dir.create(root)
 root <- normalizePath(root, winslash = "/", mustWork = TRUE)
@@ -1099,13 +1100,13 @@ for (entry_name in names(missing_root_entry_points)) {
     )
 }
 
-options <- fertility_parse_arguments(c(
+filter_options <- fertility_parse_arguments(c(
     "--program=dhs,mics", "--release=113,114", "--shard-index=1",
     "--shard-count=2", "--max-files=1", "--timeout-seconds=9", "--retry"
 ))
-selected <- fertility_filter_inventory(inventory, options)
+selected <- fertility_filter_inventory(inventory, filter_options)
 stopifnot(nrow(selected) == 1L, selected$id[[1L]] == "F0003",
-          options$timeout_seconds == 9L, options$retry)
+          filter_options$timeout_seconds == 9L, filter_options$retry)
 expect_error(fertility_parse_arguments("--shard-count=2"), "supplied together")
 expect_error(fertility_parse_arguments("--timeout-seconds=0"), "positive integer")
 expect_error(fertility_parse_arguments("--beyond-end-windows=9"), "must not exceed 8")
@@ -1175,6 +1176,17 @@ make_public_results <- function(expected, classifications = "pass") {
         stringsAsFactors = FALSE, check.names = FALSE
     )
 }
+mixed_width_manifest <- data.frame(
+    id = c("F0001", "F0002"), shard_index = c(1L, 10L),
+    stringsAsFactors = FALSE, check.names = FALSE
+)
+stopifnot(identical(
+    fertility_manifest_id(mixed_width_manifest),
+    fertility_manifest_id(fertility_manifest_character(
+        mixed_width_manifest, names(mixed_width_manifest)
+    ))
+))
+
 make_bundle_family <- function(
     canonical, family_options, classifications = NULL,
     inventory_id = paste(rep("d", 64L), collapse = ""), acceptance = NULL
@@ -3132,6 +3144,15 @@ attr(actual$number, "label") <- "number"
 expected <- actual
 stopifnot(fertility_compare_internal(actual, actual)$ok)
 stopifnot(fertility_compare_haven(actual, expected)$ok)
+integer_values <- c(1L, NA_integer_, 3L)
+stopifnot(nrow(fertility_compare_column_values(
+    integer_values, integer_values, 1L
+)) == 0L)
+changed_integers <- integer_values
+changed_integers[[3L]] <- 4L
+stopifnot(nrow(fertility_compare_column_values(
+    integer_values, changed_integers, 1L
+)) == 1L)
 expected$number[[2L]] <- expected$number[[2L]] + 4e-8
 stopifnot(fertility_compare_haven(actual, expected)$ok)
 large_actual <- tibble::tibble(value = c(1e15, 2))
@@ -4073,6 +4094,8 @@ stopifnot(fertility_checkpoint_valid(
               checkpoint, item, "framework", item_input, 2L
           ),
           !fertility_should_retry(checkpoint))
+checkpoint$classification <- "expected-unsupported-111"
+stopifnot(!fertility_should_retry(checkpoint))
 checkpoint$classification <- "timeout"
 stopifnot(fertility_should_retry(checkpoint))
 checkpoint$expected_sha512 <- "changed"
@@ -4487,10 +4510,19 @@ if (dir.exists(file.path(checkout_library, "dtaparser"))) {
                 "/dev/fd/3", input, dirname(tempdir())
             )
             on.exit(unlink(path), add = TRUE)
+            copied_path <- fertility_materialize_bound_input(
+                "/dev/fd/3", input, dirname(tempdir()), prefer_clone = FALSE
+            )
+            on.exit(unlink(copied_path), add = TRUE)
             source(worker_script, local = environment())
-            lapply(c("direct", "rust", "haven"), function(reader) {
-                fertility_tile_read(reader, path, tile)
-            })
+            list(
+                preferred = lapply(c("direct", "rust", "haven"), function(reader) {
+                    fertility_tile_read(reader, path, tile)
+                }),
+                copied = lapply(c("direct", "rust", "haven"), function(reader) {
+                    fertility_tile_read(reader, copied_path, tile)
+                })
+            )
         },
         args = list(file.path(script_dir, "common.R"),
                     file.path(script_dir, "runtime.R"),
@@ -4501,9 +4533,11 @@ if (dir.exists(file.path(checkout_library, "dtaparser"))) {
     fertility_close_bound_input_connection(fd_connection)
     stopifnot(
         identical(processx::conn_get_fileno(fd_connection), -1L),
-        identical(fd_values[[1L]], fd_values[[2L]]),
-        identical(fd_values[[1L]], fd_values[[3L]]),
-        identical(as.character(fd_values[[1L]]$text), "encoding_probe_ascii")
+        identical(fd_values$preferred[[1L]], fd_values$preferred[[2L]]),
+        identical(fd_values$preferred[[1L]], fd_values$preferred[[3L]]),
+        identical(fd_values$preferred, fd_values$copied),
+        identical(as.character(fd_values$preferred[[1L]]$text),
+                  "encoding_probe_ascii")
     )
     encoding_item <- bounded_item
     encoding_item$id <- "F9903"
@@ -5133,3 +5167,4 @@ Sys.setenv(DTAPARSER_FERTILITY_CORPUS = fertility_opt_in_value)
 stopifnot(is.null(fertility_assert_manual_run()))
 
 message("fertility framework synthetic tests passed")
+})

--- a/benchmarks/fertility-surveys/test-framework.R
+++ b/benchmarks/fertility-surveys/test-framework.R
@@ -2210,6 +2210,22 @@ stopifnot(
         merge_source, fixed = TRUE
     )
 )
+assessment_source <- paste(
+    readLines(file.path(script_dir, "assessment.R"), warn = FALSE), collapse = "\n"
+)
+stopifnot(
+    grepl('load_family(full_family_id, inventory, "original")',
+          assessment_source, fixed = TRUE),
+    grepl('load_family(accepted_family_id, inventory, "accepted")',
+          assessment_source, fixed = TRUE),
+    grepl("original_source_id = full$source_id", assessment_source, fixed = TRUE),
+    grepl("assessment_source_snapshot(current$full)",
+          assessment_source, fixed = TRUE),
+    grepl("assessment_source_snapshot(current$accepted)",
+          assessment_source, fixed = TRUE),
+    grepl("assessment-before-bundle-revalidation", assessment_source, fixed = TRUE),
+    grepl("assessment-before-current-revalidation", assessment_source, fixed = TRUE)
+)
 tampered_merged_results <- accepted_merged_bundle
 tampered_merged_results$results$classification[[1L]] <- "timeout"
 expect_error(fertility_validate_merged_bundle(
@@ -2238,6 +2254,181 @@ tampered_merged_manifest$family_manifest$id[[1L]] <- "F0632"
 expect_error(fertility_validate_merged_bundle(
     tampered_merged_manifest, accepted_family_fixture$id, merge_live_inventory
 ), "manifest")
+
+make_legacy_assessment_original <- function() {
+    manifest <- fertility_family_manifest(
+        merge_live_inventory,
+        fertility_parse_arguments(c("--shard-index=1", "--shard-count=8"))
+    )
+    family_id <- fertility_family_id_from_manifest(
+        manifest, test_framework_id, test_config_id, test_build_id,
+        fertility_inventory_id(merge_live_inventory), 8L, Inf
+    )
+    results <- make_public_results(manifest, full_classes)
+    hash_rows <- results$classification == "inventory-hash-error"
+    results$secondary_categories[hash_rows] <- "signature-mismatch"
+    family_input_attestation_id <- fertility_stable_id(list(
+        synthetic_legacy_family = family_id, shards = 8L
+    ))
+    evidence_family_id <- fertility_evidence_family_id(
+        family_id, family_input_attestation_id, "fresh-execution",
+        fertility_schema_version, fertility_report_schema_id()
+    )
+    provenance <- data.frame(
+        schema_version = as.character(fertility_schema_version),
+        report_schema_version = as.character(fertility_report_schema_version),
+        evidence_origin = "fresh-execution",
+        source_corpus_schema_version = as.character(fertility_schema_version),
+        replayed_at_utc = "", family_id = family_id,
+        evidence_family_id = evidence_family_id,
+        family_input_attestation_id = family_input_attestation_id,
+        framework_id = test_framework_id, config_id = test_config_id,
+        build_provenance_id = test_build_id,
+        inventory_id = fertility_inventory_id(merge_live_inventory),
+        family_manifest_id = fertility_manifest_id(manifest),
+        report_schema_id = fertility_report_schema_id(), shard_count = "8",
+        files = as.character(fertility_expected_rows), full_default_family = "TRUE",
+        created_at_utc = "2026-01-01T00:00:00Z",
+        stringsAsFactors = FALSE, check.names = FALSE
+    )
+    provenance <- provenance[fertility_assessment_legacy_provenance_fields()]
+    list(
+        family_id = family_id,
+        bundle = list(
+            provenance = provenance, results = results,
+            summary = fertility_classification_summary(results),
+            family_manifest = manifest
+        )
+    )
+}
+legacy_original_fixture <- make_legacy_assessment_original()
+legacy_original <- fertility_validate_assessment_legacy_original_bundle(
+    legacy_original_fixture$bundle, legacy_original_fixture$family_id,
+    merge_live_inventory
+)
+stopifnot(
+    identical(legacy_original$source_format,
+              "legacy-original-merged-report-v2"),
+    grepl("^[0-9a-f]{64}$", legacy_original$source_id),
+    identical(legacy_original$merge_id, ""),
+    identical(legacy_original$source_content_ids$results_id,
+              fertility_merged_results_id(legacy_original$results)),
+    identical(
+        fertility_assessment_bundle_format(
+            unname(fertility_assessment_bundle_files("legacy-original")),
+            "original"
+        ),
+        "legacy-original-merged-report-v2"
+    ),
+    identical(
+        fertility_assessment_bundle_format(
+            unname(fertility_assessment_bundle_files("current")), "accepted"
+        ),
+        "current-merged-report-v2"
+    )
+)
+legacy_assessment_gates <- fertility_validate_assessment_families(
+    legacy_original, accepted_assessment
+)
+stopifnot(
+    identical(legacy_assessment_gates$manifest_gate,
+              "blocked-signature-mismatch"),
+    identical(legacy_assessment_gates$explicit_local_evidence_gate, "validated")
+)
+expect_error(fertility_assessment_bundle_format(
+    unname(fertility_assessment_bundle_files("legacy-original")), "accepted"
+), "unsupported exact file set")
+expect_error(fertility_validate_assessment_families(
+    accepted_assessment, legacy_original
+), "assessment family evidence")
+for (entries in list(
+    c(unname(fertility_assessment_bundle_files("legacy-original")), "extra.tsv"),
+    setdiff(unname(fertility_assessment_bundle_files("legacy-original")),
+            "summary.tsv")
+)) expect_error(fertility_assessment_bundle_format(
+    entries, "original"
+), "unsupported exact file set")
+legacy_shape_parent <- file.path(root, "legacy-assessment-shape")
+legacy_shape_run <- file.path(legacy_shape_parent, "bundle")
+dir.create(legacy_shape_run, recursive = TRUE)
+writeLines("bundle", file.path(legacy_shape_parent, "CURRENT"))
+for (name in unname(fertility_assessment_bundle_files("legacy-original"))) {
+    writeLines("synthetic", file.path(legacy_shape_run, name))
+}
+legacy_shape_external <- file.path(root, "legacy-assessment-external.tsv")
+writeLines("external", legacy_shape_external)
+unlink(file.path(legacy_shape_run, "results.tsv"))
+stopifnot(file.symlink(legacy_shape_external, file.path(legacy_shape_run, "results.tsv")))
+expect_error(fertility_current_bundle_paths(
+    legacy_shape_parent, fertility_assessment_bundle_files("legacy-original"),
+    "legacy assessment shape"
+), "symlink")
+
+legacy_mutation <- function(field, value) {
+    changed <- legacy_original_fixture$bundle
+    changed$provenance[[field]] <- value
+    changed
+}
+legacy_reject <- function(bundle, family_id = legacy_original_fixture$family_id,
+                          pattern) expect_error(
+    fertility_validate_assessment_legacy_original_bundle(
+        bundle, family_id, merge_live_inventory
+    ), pattern
+)
+legacy_reject(legacy_original_fixture$bundle,
+              paste(rep("f", 64L), collapse = ""), "provenance")
+for (case in list(
+    list("schema_version", "9", "provenance"),
+    list("report_schema_version", "1", "provenance"),
+    list("evidence_origin", "historical-schema-10-replay", "provenance"),
+    list("shard_count", "7", "provenance"),
+    list("files", "1003", "provenance"),
+    list("full_default_family", "FALSE", "provenance"),
+    list("inventory_id", paste(rep("1", 64L), collapse = ""), "inventory authority"),
+    list("framework_id", paste(rep("2", 64L), collapse = ""), "family identity"),
+    list("report_schema_id", fertility_report_schema_id(
+        fertility_legacy_report_schema_version
+    ), "provenance"),
+    list("evidence_family_id", paste(rep("3", 64L), collapse = ""),
+         "evidence family identity"),
+    list("family_input_attestation_id", "not-a-hash", "provenance")
+)) legacy_reject(legacy_mutation(case[[1L]], case[[2L]]), pattern = case[[3L]])
+legacy_wrong_manifest <- legacy_original_fixture$bundle
+legacy_wrong_manifest$family_manifest$shard_index[[1L]] <- "2"
+legacy_reject(legacy_wrong_manifest, pattern = "family manifest")
+legacy_wrong_results <- legacy_original_fixture$bundle
+legacy_wrong_results$results$classification[[1L]] <- "pass"
+legacy_reject(legacy_wrong_results, pattern = "preserved manifest-gated family")
+legacy_wrong_result_count <- legacy_original_fixture$bundle
+legacy_wrong_result_count$results <- legacy_wrong_result_count$results[-1L, , drop = FALSE]
+legacy_reject(legacy_wrong_result_count, pattern = "results are not bound")
+legacy_wrong_result_schema <- legacy_original_fixture$bundle
+legacy_wrong_result_schema$results$elapsed_seconds <- NULL
+legacy_reject(legacy_wrong_result_schema, pattern = "manifest schema")
+legacy_wrong_summary <- legacy_original_fixture$bundle
+legacy_wrong_summary$summary$files[[1L]] <- "999"
+legacy_reject(legacy_wrong_summary, pattern = "classification summary")
+legacy_extra_table <- legacy_original_fixture$bundle
+legacy_extra_table$input_attestation <- data.frame(value = "forbidden")
+legacy_reject(legacy_extra_table, pattern = "bundle schema")
+legacy_missing_table <- legacy_original_fixture$bundle
+legacy_missing_table$summary <- NULL
+legacy_reject(legacy_missing_table, pattern = "bundle schema")
+legacy_extra_provenance <- legacy_original_fixture$bundle
+legacy_extra_provenance$provenance$merge_id <- paste(rep("4", 64L), collapse = "")
+legacy_reject(legacy_extra_provenance, pattern = "manifest schema")
+legacy_wrong_reason <- legacy_original_fixture$bundle
+legacy_wrong_reason$results$secondary_categories[
+    legacy_wrong_reason$results$id == fertility_accepted_ids()[[1L]]
+] <- "hash-read-error"
+legacy_reject(legacy_wrong_reason, pattern = "preserved manifest-gated family")
+legacy_source_changed <- legacy_original_fixture$bundle
+legacy_source_changed$provenance$created_at_utc <- "2026-01-02T00:00:00Z"
+legacy_source_changed <- fertility_validate_assessment_legacy_original_bundle(
+    legacy_source_changed, legacy_original_fixture$family_id, merge_live_inventory
+)
+stopifnot(!identical(legacy_source_changed$source_id, legacy_original$source_id))
+
 assessment_gates <- fertility_validate_assessment_families(
     full_assessment, accepted_assessment
 )

--- a/benchmarks/fertility-surveys/test-framework.R
+++ b/benchmarks/fertility-surveys/test-framework.R
@@ -72,6 +72,7 @@ stopifnot(nrow(selected) == 1L, selected$id[[1L]] == "F0003",
           options$timeout_seconds == 9L, options$retry)
 expect_error(fertility_parse_arguments("--shard-count=2"), "supplied together")
 expect_error(fertility_parse_arguments("--timeout-seconds=0"), "positive integer")
+expect_error(fertility_parse_arguments("--beyond-end-windows=9"), "must not exceed 8")
 expect_error(fertility_filter_inventory(
     inventory, fertility_parse_arguments("--id=F9999")
 ), "unknown --id")
@@ -112,11 +113,282 @@ stopifnot(fertility_compare_haven(actual_missing, expected)$classification ==
 expected <- actual
 attr(expected$text, "label") <- "different"
 stopifnot(fertility_compare_haven(actual, expected)$classification ==
-          "attribute-mismatch")
+          "attribute-label-mismatch")
 changed <- actual
 changed$text[[1L]] <- "different"
 stopifnot(fertility_compare_internal(actual, changed)$classification ==
           "internal-collector-mismatch")
+internal_float <- actual
+internal_float$number[[2L]] <- internal_float$number[[2L]] + 1e-12
+stopifnot(!fertility_compare_internal(actual, internal_float)$ok)
+date_float <- actual
+date_float$day[[1L]] <- structure(
+    unclass(date_float$day[[1L]]) + 1e-8, class = "Date"
+)
+stopifnot("date-mismatch" %in%
+          fertility_compare_haven(actual, date_float)$mismatches$category)
+posix_actual <- tibble::tibble(
+    time = as.POSIXct("1970-01-01 00:00:00", tz = "UTC")
+)
+posix_expected <- posix_actual
+posix_expected$time <- structure(
+    unclass(posix_expected$time) + 1e-8,
+    class = c("POSIXct", "POSIXt"), tzone = "UTC"
+)
+stopifnot("date-mismatch" %in%
+          fertility_compare_haven(posix_actual, posix_expected)$mismatches$category)
+
+# Exhaustive comparison records independent mismatches in early and late columns.
+multi_expected <- actual
+multi_expected$number[[1L]] <- 9
+multi_expected$text[[3L]] <- "different"
+multi <- fertility_compare_haven(actual, multi_expected)$mismatches
+stopifnot(all(c(1L, 2L) %in% multi$component),
+          all(c("value-mismatch", "encoding-mismatch") %in% multi$category))
+paired <- multi[1L, , drop = FALSE]
+paired$pair <- "direct-haven"
+unpaired <- fertility_mismatch_record("metadata-mismatch", "source-name-mismatch")
+stopifnot(nrow(fertility_bind_mismatches(list(paired, unpaired))) == 2L)
+short_actual <- tibble::tibble(value = c(1, 2, 3))
+short_expected <- tibble::tibble(value = c(9, 2))
+short_mismatches <- fertility_compare_haven(short_actual, short_expected)$mismatches
+stopifnot(all(c("row-count-mismatch", "value-mismatch") %in%
+              short_mismatches$detail))
+pair_frames <- list(
+    direct = tibble::tibble(value = c(1, 2)),
+    rust = tibble::tibble(value = c(1, 3)),
+    haven = tibble::tibble(value = c(4, 2))
+)
+pair_result <- fertility_compare_available_pairs(
+    pair_frames, c(direct = FALSE, rust = FALSE, haven = FALSE)
+)
+stopifnot(identical(sort(unique(pair_result$mismatches$pair)),
+                    c("direct-haven", "direct-rust", "rust-haven")))
+private_attribute <- pair_frames$haven
+attr(private_attribute$value, "private_source_attribute") <- "different"
+private_pair_result <- fertility_compare_available_pairs(
+    list(direct = pair_frames$direct, rust = pair_frames$direct,
+         haven = private_attribute),
+    c(direct = FALSE, rust = FALSE, haven = FALSE)
+)
+stopifnot(any(grepl("private_source_attribute",
+                   private_pair_result$mismatches$detail)),
+          !any(grepl("private_source_attribute", private_pair_result$secondary)))
+date_expected <- actual
+date_expected$day[[1L]] <- date_expected$day[[1L]] + 1
+stopifnot("date-mismatch" %in%
+          fertility_compare_haven(actual, date_expected)$mismatches$category)
+tag_expected <- actual
+tag_expected$number[[3L]] <- haven::tagged_na("b")
+stopifnot("tag-mismatch" %in%
+          fertility_compare_haven(actual, tag_expected)$mismatches$category)
+metadata_expected <- actual
+attr(metadata_expected, "notes") <- "different"
+stopifnot("metadata-mismatch" %in%
+          fertility_compare_haven(actual, metadata_expected)$mismatches$category)
+
+# Sizing and batching are deterministic, preserve fixed-string widths, isolate
+# strL columns, and cannot create an unbounded traversal plan.
+tile_options <- fertility_parse_arguments(c(
+    "--chunk-rows=100", "--column-batch=8", "--memory-mib=128",
+    "--cell-budget=300", "--max-tiles-per-batch=3"
+))
+tile_configuration <- fertility_tile_configuration(tile_options)
+stopifnot(identical(fertility_adaptive_rows(8, tile_configuration), 100L),
+          identical(fertility_adaptive_rows(rep(8, 8), tile_configuration), 12L),
+          identical(fertility_adaptive_rows(2045, tile_configuration), 100L),
+          identical(fertility_adaptive_rows(Inf, tile_configuration), 1L),
+          identical(
+              fertility_column_batches(c("a", "wide", "long", "b"), 8L,
+                                        c(8, 2045, Inf, 8)),
+              list(c("a", "wide"), "long", "b")
+          ))
+finite_plan <- fertility_plan_offsets(5, 2L, 3L)
+stopifnot(!finite_plan$ceiling, identical(finite_plan$offsets, c(0, 2, 4)))
+stopifnot(fertility_plan_offsets(7, 2L, 3L)$ceiling,
+          fertility_plan_offsets(Inf, 2L, 3L)$ceiling)
+stopifnot(fertility_memory_error(simpleError("vector memory exhausted")),
+          !fertility_memory_error(simpleError("reader failed")))
+
+# Structural parsing independently binds traversal to the source header and
+# retains both wide fixed-string widths and strL identity.
+wide_path <- file.path(root, "wide.dta")
+haven::write_dta(data.frame(
+    number = 1:3, fixed = rep(strrep("x", 2000), 3),
+    long_string = rep(strrep("y", 3000), 3)
+), wide_path, version = 14)
+wide_structure <- fertility_structural_metadata(wide_path)
+stopifnot(wide_structure$rows == 3, wide_structure$columns == 3L,
+          identical(wide_structure$column_bytes, c(8, 2000, Inf)),
+          identical(wide_structure$strl, c(FALSE, FALSE, TRUE)))
+legacy_path <- file.path(root, "legacy.dta")
+haven::write_dta(data.frame(number = 1:3, fixed = c("a", "bb", "ccc")),
+                 legacy_path, version = 10)
+legacy_structure <- fertility_structural_metadata(legacy_path)
+stopifnot(legacy_structure$rows == 3, legacy_structure$columns == 2L,
+          identical(legacy_structure$column_bytes, c(8, 3)))
+tag_path <- file.path(root, "tag-values.dta")
+haven::write_dta(data.frame(text = c("<N>", "</N>", "<variable_types>")),
+                 tag_path, version = 14)
+tag_structure <- fertility_structural_metadata(tag_path)
+stopifnot(tag_structure$rows == 3, tag_structure$columns == 1L)
+# A reader that keeps returning rows beyond the independent count is classified
+# immediately; the configured window count, rather than reader behavior, bounds
+# the number of probes.
+nonterminating <- replicate(tile_configuration$beyond_end_windows,
+                            c(direct = 1L, rust = 1L, haven = 1L), simplify = FALSE)
+stopifnot(length(nonterminating) == 1L,
+          all(vapply(nonterminating, fertility_row_termination_mismatch,
+                     logical(1))))
+stopifnot(fertility_structural_shape_mismatch(
+              c(direct = 3L, rust = 3L), 4, 2L, 2L
+          ),
+          !fertility_structural_shape_mismatch(
+              c(direct = 3L, rust = 3L), 3, 2L, 2L
+          ))
+if (requireNamespace("callr", quietly = TRUE)) {
+    memory_failure <- tryCatch(callr::r(
+        function() raw(512L * 1024L * 1024L), timeout = 30,
+        env = c(R_MAX_VSIZE = "128M"), spinner = FALSE, show = FALSE,
+        user_profile = FALSE, system_profile = FALSE
+    ), error = identity)
+    stopifnot(inherits(memory_failure, "error"),
+              fertility_memory_error(memory_failure))
+}
+
+# Metadata plus every deterministic value tile is required for completeness. A
+# mismatch in the first tile does not prevent later tiles from being assessed.
+empty_mismatches <- fertility_bind_mismatches(list())
+metadata_result <- list(
+    tile_type = "metadata", classification = "pass", secondary = character(),
+    mismatches = empty_mismatches, rows = 3L, elapsed_seconds = 0
+)
+synthetic_batches <- list("a", "b")
+make_tile_result <- function(batch, skip, rows, classification = "pass",
+                             mismatches = empty_mismatches) {
+    expected_names <- synthetic_batches[[batch]]
+    expected_hash <- fertility_projection_hash(expected_names, "test-framework")
+    list(
+        framework_id = "test-framework", tile_type = "value", batch = batch,
+        skip = as.double(skip), n_max = 2L, rows = rows,
+        classification = classification, secondary = character(),
+        mismatches = mismatches,
+        projection_expected_count = length(expected_names),
+        projection_expected_hash = expected_hash,
+        projection_counts = setNames(rep(length(expected_names), 3L),
+                                     c("direct", "rust", "haven")),
+        projection_hashes = setNames(rep(expected_hash, 3L),
+                                     c("direct", "rust", "haven")),
+        projection_ok = setNames(rep(TRUE, 3L),
+                                 c("direct", "rust", "haven")),
+        elapsed_seconds = 0
+    )
+}
+make_terminal_result <- function(skip = 3, n_max = 1L, batch = 1L) {
+    expected_names <- synthetic_batches[[1L]]
+    expected_hash <- fertility_projection_hash(expected_names, "test-framework")
+    list(
+        framework_id = "test-framework", tile_type = "terminal", batch = batch,
+        skip = as.double(skip), n_max = as.integer(n_max), rows = 0L,
+        reader_rows = setNames(rep(0L, 3L), c("direct", "rust", "haven")),
+        classification = "pass", secondary = character(),
+        mismatches = empty_mismatches,
+        projection_expected_count = length(expected_names),
+        projection_expected_hash = expected_hash,
+        projection_counts = setNames(rep(length(expected_names), 3L),
+                                     c("direct", "rust", "haven")),
+        projection_hashes = setNames(rep(expected_hash, 3L),
+                                     c("direct", "rust", "haven")),
+        projection_ok = setNames(rep(TRUE, 3L), c("direct", "rust", "haven")),
+        elapsed_seconds = 0
+    )
+}
+early_issue <- fertility_mismatch_record("value-mismatch", "value-mismatch", 1L)
+traversed_tiles <- list(
+    metadata_result,
+    make_tile_result(1L, 0, 2L, "value-mismatch", early_issue),
+    make_tile_result(1L, 2, 1L),
+    make_tile_result(2L, 0, 2L),
+    make_tile_result(2L, 2, 1L),
+    make_terminal_result()
+)
+stopifnot(fertility_validate_tile_completeness(
+              traversed_tiles, synthetic_batches, 3, tile_configuration
+          ),
+          fertility_aggregate_classification(traversed_tiles, TRUE) ==
+              "value-mismatch")
+missing_terminal <- traversed_tiles[-length(traversed_tiles)]
+duplicate_terminal <- c(traversed_tiles, list(make_terminal_result()))
+wrong_terminal_skip <- traversed_tiles
+wrong_terminal_skip[[length(wrong_terminal_skip)]]$skip <- 4
+wrong_terminal_n_max <- traversed_tiles
+wrong_terminal_n_max[[length(wrong_terminal_n_max)]]$n_max <- 2L
+wrong_terminal_batch <- traversed_tiles
+wrong_terminal_batch[[length(wrong_terminal_batch)]]$batch <- 2L
+for (invalid in list(missing_terminal, duplicate_terminal, wrong_terminal_skip,
+                     wrong_terminal_n_max, wrong_terminal_batch)) {
+    stopifnot(!fertility_validate_tile_completeness(
+        invalid, synthetic_batches, 3, tile_configuration
+    ))
+}
+two_probe_configuration <- tile_configuration
+two_probe_configuration$beyond_end_windows <- 2L
+two_probe_tiles <- c(traversed_tiles, list(make_terminal_result(skip = 4)))
+stopifnot(fertility_validate_tile_completeness(
+    two_probe_tiles, synthetic_batches, 3, two_probe_configuration
+))
+zero_batches <- fertility_structural_batches(character(), 8L, numeric(), 0L)
+stopifnot(length(zero_batches) == 1L, identical(zero_batches[[1L]], character()))
+retarget_projection <- function(tile, names) {
+    hash <- fertility_projection_hash(names, "test-framework")
+    tile$projection_expected_count <- length(names)
+    tile$projection_expected_hash <- hash
+    tile$projection_counts[] <- length(names)
+    tile$projection_hashes[] <- hash
+    tile
+}
+zero_column_tiles <- list(
+    metadata_result,
+    retarget_projection(make_tile_result(1L, 0, 2L), character()),
+    retarget_projection(make_tile_result(1L, 2, 1L), character()),
+    retarget_projection(make_terminal_result(), character())
+)
+stopifnot(fertility_validate_tile_completeness(
+    zero_column_tiles, zero_batches, 3, tile_configuration
+))
+shared_empty <- fertility_projection_attestation(
+    list(direct = data.frame(), rust = data.frame(), haven = data.frame()),
+    c(direct = FALSE, rust = FALSE, haven = FALSE), "a", "test-framework"
+)
+stopifnot(!any(shared_empty$ok), all(shared_empty$counts == 0L),
+          nchar(shared_empty$expected_hash) == 64L)
+wrong_projection_tiles <- traversed_tiles
+for (i in 2:length(wrong_projection_tiles)) {
+    wrong_projection_tiles[[i]]$projection_counts[] <- 0L
+    wrong_projection_tiles[[i]]$projection_hashes[] <-
+        fertility_projection_hash(character(), "test-framework")
+    wrong_projection_tiles[[i]]$projection_ok[] <- FALSE
+    wrong_projection_tiles[[i]]$classification <- "metadata-mismatch"
+}
+stopifnot(!fertility_validate_tile_completeness(
+              wrong_projection_tiles, synthetic_batches, 3, tile_configuration
+          ),
+          fertility_aggregate_classification(wrong_projection_tiles, FALSE) != "pass")
+public_projection_result <- fertility_result_frame(list(list(
+    framework_id = "framework", id = "F0001", program = "dhs", level = "women",
+    release = 118L, classification = "metadata-mismatch",
+    projection_expected_hash = shared_empty$expected_hash,
+    projection_hashes = shared_empty$hashes
+)))
+stopifnot(!any(grepl("projection", names(public_projection_result))))
+unresolved_tiles <- traversed_tiles
+unresolved_tiles[[2L]]$classification <- "unresolved"
+unresolved_tiles[[2L]]$mismatches <- empty_mismatches
+stopifnot(fertility_aggregate_classification(unresolved_tiles, TRUE) == "unresolved")
+changed_tiles <- traversed_tiles
+changed_tiles[[2L]]$classification <- "input-changed"
+stopifnot(fertility_aggregate_classification(changed_tiles, FALSE) ==
+          "inventory-hash-error")
 
 item <- as.list(inventory[1L, , drop = FALSE])
 item_input <- fertility_capture_input(item)
@@ -141,6 +413,45 @@ stopifnot(!fertility_checkpoint_valid(checkpoint, item, "framework"))
 checkpoint_path <- file.path(root, "checkpoint.rds")
 fertility_atomic_save_rds(checkpoint, checkpoint_path)
 stopifnot(identical(readRDS(checkpoint_path), checkpoint))
+
+# Tile checkpoints resume independently. Resource failures rerun only with
+# --retry, while completed semantic mismatches remain reusable.
+tile_item <- item
+tile_input <- item_input
+tile <- fertility_value_tile(1L, 0, 2L, "x")
+tile_checkpoint <- file.path(root, "tile-checkpoint.rds")
+tile_counter <- new.env(parent = emptyenv())
+tile_counter$n <- 0L
+tile_execute <- function(item, tile, input) {
+    tile_counter$n <- tile_counter$n + 1L
+    list(
+        schema_version = fertility_schema_version, framework_id = "framework",
+        id = item$id, tile_id = tile$tile_id, tile_type = tile$type,
+        batch = tile$batch, skip = tile$skip, n_max = tile$n_max,
+        classification = "timeout", secondary = character(),
+        mismatches = fertility_bind_mismatches(list()), rows = NA_integer_,
+        columns = NA_integer_, column_names = character(), storage = character(),
+        elapsed_seconds = 0
+    )
+}
+tile_config <- fertility_tile_configuration(fertility_parse_arguments(
+    "--timeout-seconds=1"
+))
+first_tile <- fertility_process_tile(
+    tile_item, tile, tile_checkpoint, "framework", tile_config, tile_input,
+    FALSE, tile_execute
+)
+resumed_tile <- fertility_process_tile(
+    tile_item, tile, tile_checkpoint, "framework", tile_config, tile_input,
+    FALSE, tile_execute
+)
+retried_tile <- fertility_process_tile(
+    tile_item, tile, tile_checkpoint, "framework", tile_config, tile_input,
+    TRUE, tile_execute
+)
+stopifnot(!first_tile$resumed, resumed_tile$resumed, !retried_tile$resumed,
+          tile_counter$n == 2L)
+
 supported_item <- as.list(inventory[2L, , drop = FALSE])
 supported_item$path <- normalizePath(primary_second, winslash = "/")
 supported_input <- fertility_capture_input(supported_item)
@@ -160,7 +471,7 @@ unsupported <- fertility_worker(
     unsupported_item, file.path(script_dir, "compare.R"),
     root, root, "framework", 1L, fertility_file_sha512(unsupported_item$path)
 )
-stopifnot(unsupported$classification == "unsupported-release")
+stopifnot(unsupported$classification == "expected-unsupported-111")
 hash_item <- as.list(inventory[2L, , drop = FALSE])
 hash_item$expected_sha512 <- paste(rep("0", 128L), collapse = "")
 hash_failure <- fertility_worker(
@@ -168,6 +479,54 @@ hash_failure <- fertility_worker(
     fertility_file_sha512(hash_item$path)
 )
 stopifnot(hash_failure$classification == "input-signature-mismatch")
+
+# Real metadata discovery uses zero-row frames plus zero-column shape reads; value
+# workers materialize only their explicit row/column window.
+bounded_path <- file.path(root, "bounded.dta")
+bounded_data <- tibble::tibble(
+    number = 1:5,
+    text = c("a", "b", "c", "d", "e"),
+    day = as.Date("2020-01-01") + 0:4
+)
+haven::write_dta(bounded_data, bounded_path)
+bounded_item <- list(
+    id = "F9900", program = "dhs", level = "women", release = 118L,
+    path = normalizePath(bounded_path, winslash = "/"), expected_sha512 = ""
+)
+haven_zero_column <- tryCatch(
+    haven::read_dta(bounded_path, col_select = character()), error = identity
+)
+stopifnot(inherits(haven_zero_column, "error"))
+checkout_library <- file.path(script_dir, "..", "..", "target",
+                              "fertility-surveys", "raw", "library")
+if (dir.exists(file.path(checkout_library, "dtaparser"))) {
+    old_paths <- .libPaths()
+    .libPaths(c(checkout_library, old_paths))
+    on.exit(.libPaths(old_paths), add = TRUE)
+    installed_dtaparser <- normalizePath(find.package("dtaparser"), winslash = "/")
+    metadata_worker <- fertility_worker_tile(
+        bounded_item, fertility_metadata_tile(), file.path(script_dir, "compare.R"),
+        dirname(installed_dtaparser), installed_dtaparser, "framework", 10L
+    )
+    stopifnot(metadata_worker$rows == 5L, metadata_worker$columns == 3L,
+              identical(metadata_worker$column_names, names(bounded_data)))
+    bounded_tile <- fertility_value_tile(1L, 1L, 2L, c("number", "day"))
+    bounded_worker <- fertility_worker_tile(
+        bounded_item, bounded_tile, file.path(script_dir, "compare.R"),
+        dirname(installed_dtaparser), installed_dtaparser, "framework", 10L
+    )
+    stopifnot(bounded_worker$rows == 2L, bounded_worker$columns == 2L,
+              all(bounded_worker$projection_ok),
+              all(bounded_worker$projection_counts == 2L),
+              all(bounded_worker$projection_hashes ==
+                  bounded_worker$projection_expected_hash),
+              !any(c("number", "day") %in% unlist(
+                  bounded_worker[c("projection_hashes", "projection_expected_hash")],
+                  use.names = FALSE
+              )))
+}
+worker_source <- paste(readLines(file.path(script_dir, "worker.R")), collapse = "\n")
+stopifnot(!grepl("read_dta\\(item\\$path\\)", worker_source))
 
 # Timeout checkpoints retain the parent hash, publish, resume without retry, and
 # execute again only when retry is requested.

--- a/benchmarks/fertility-surveys/test-framework.R
+++ b/benchmarks/fertility-surveys/test-framework.R
@@ -3821,6 +3821,20 @@ recorded_tile_fixture <- c(make_tile_result(1L, 0, 2L), list(
 recorded_tile_fixture <- recorded_tile_fixture[!duplicated(names(recorded_tile_fixture),
                                                            fromLast = TRUE)]
 stopifnot(isTRUE(fertility_validate_recorded_tile(recorded_tile_fixture)))
+recorded_input_changed <- fertility_mark_tile_input_changed(recorded_tile_fixture)
+stopifnot(isTRUE(fertility_validate_recorded_tile(recorded_input_changed)))
+input_changed_wrong_class <- recorded_input_changed
+input_changed_wrong_class$classification <- "pass"
+expect_error(fertility_validate_recorded_tile(input_changed_wrong_class),
+             "malformed or non-canonical")
+input_changed_extra_secondary <- recorded_input_changed
+input_changed_extra_secondary$secondary <- c("input-changed", "value-mismatch")
+expect_error(fertility_validate_recorded_tile(input_changed_extra_secondary),
+             "malformed or non-canonical")
+input_changed_with_mismatch <- recorded_input_changed
+input_changed_with_mismatch$mismatches <- early_issue
+expect_error(fertility_validate_recorded_tile(input_changed_with_mismatch),
+             "malformed or non-canonical")
 current_artifact_tile <- recorded_tile_fixture
 current_artifact_tile$secondary <- "-reader-error"
 expect_error(fertility_validate_recorded_tile(current_artifact_tile),
@@ -3960,9 +3974,20 @@ unresolved_tiles[[2L]]$classification <- "unresolved"
 unresolved_tiles[[2L]]$mismatches <- empty_mismatches
 stopifnot(fertility_aggregate_classification(unresolved_tiles, TRUE) == "unresolved")
 changed_tiles <- traversed_tiles
-changed_tiles[[2L]]$classification <- "input-changed"
-stopifnot(fertility_aggregate_classification(changed_tiles, FALSE) ==
-          "inventory-hash-error")
+changed_tiles[[2L]] <- fertility_mark_tile_input_changed(changed_tiles[[2L]])
+changed_result <- fertility_tiled_result(
+    execution_item, test_framework_id, tile_configuration, execution_input,
+    changed_tiles, synthetic_batches, 3, tiles_expected = length(changed_tiles)
+)
+stopifnot(
+    fertility_aggregate_classification(changed_tiles, FALSE) ==
+        "inventory-hash-error",
+    changed_result$classification == "inventory-hash-error",
+    changed_result$secondary_categories == "input-changed",
+    changed_result$mismatch_count == 0L,
+    identical(changed_result$mismatch_categories, ""),
+    identical(changed_result$mismatch_signatures, "")
+)
 
 item <- as.list(inventory[1L, , drop = FALSE])
 item_input <- fertility_capture_input(item)
@@ -4025,6 +4050,25 @@ retried_tile <- fertility_process_tile(
 )
 stopifnot(!first_tile$resumed, resumed_tile$resumed, !retried_tile$resumed,
           tile_counter$n == 2L)
+changed_tile_checkpoint <- fertility_mark_tile_input_changed(first_tile$result)
+fertility_atomic_save_rds(changed_tile_checkpoint, tile_checkpoint)
+changed_tile_resumed <- fertility_process_tile(
+    tile_item, tile, tile_checkpoint, "framework", tile_config, tile_input,
+    FALSE, tile_execute
+)
+changed_tile_retried <- fertility_process_tile(
+    tile_item, tile, tile_checkpoint, "framework", tile_config, tile_input,
+    TRUE, tile_execute
+)
+stopifnot(
+    changed_tile_resumed$resumed,
+    changed_tile_resumed$result$classification == "input-changed",
+    identical(changed_tile_resumed$result$secondary, "input-changed"),
+    fertility_tile_should_retry(changed_tile_resumed$result),
+    !changed_tile_retried$resumed,
+    changed_tile_retried$result$classification == "timeout",
+    tile_counter$n == 3L
+)
 metadata_retry_checkpoint <- file.path(root, "metadata-retry-checkpoint.rds")
 metadata_retry_counter <- new.env(parent = emptyenv())
 metadata_retry_counter$n <- 0L

--- a/benchmarks/fertility-surveys/worker.R
+++ b/benchmarks/fertility-surveys/worker.R
@@ -22,25 +22,42 @@ fertility_load_readers <- function(package_library, expected_package_path) {
     invisible(NULL)
 }
 
-fertility_tile_read <- function(reader, path, tile) {
+fertility_worker_encoding <- function(item) {
+    encoding <- item$encoding_override
+    if (is.null(encoding)) return(NULL)
+    allowed <- c("UTF-8", "Windows-1252", "ISO-8859-1")
+    if (!is.character(encoding) || length(encoding) != 1L ||
+        is.na(encoding) || !encoding %in% allowed) {
+        stop("invalid-encoding-override")
+    }
+    encoding
+}
+
+fertility_tile_read <- function(reader, path, tile, encoding = NULL) {
     if (!is.finite(tile$n_max) || tile$n_max < 0L) stop("tile row bound is invalid")
     if (identical(tile$type, "metadata")) {
         frame <- if (identical(reader, "direct")) {
-            dtaparser::read_dta(path, n_max = 0L, .name_repair = "minimal")
+            dtaparser::read_dta(
+                path, encoding = encoding, n_max = 0L, .name_repair = "minimal"
+            )
         } else if (identical(reader, "rust")) {
             dtaparser:::.read_dta_rust_vectors(
-                path, n_max = 0L, .name_repair = "minimal"
+                path, encoding = encoding, n_max = 0L, .name_repair = "minimal"
             )
         } else {
-            haven::read_dta(path, n_max = 0L, .name_repair = "minimal")
+            haven::read_dta(
+                path, encoding = encoding, n_max = 0L, .name_repair = "minimal"
+            )
         }
         shape <- if (identical(reader, "direct")) {
             dtaparser::read_dta(
-                path, col_select = character(), .name_repair = "minimal"
+                path, encoding = encoding, col_select = character(),
+                .name_repair = "minimal"
             )
         } else if (identical(reader, "rust")) {
             dtaparser:::.read_dta_rust_vectors(
-                path, col_select = character(), .name_repair = "minimal"
+                path, encoding = encoding, col_select = character(),
+                .name_repair = "minimal"
             )
         } else {
             NULL
@@ -54,28 +71,35 @@ fertility_tile_read <- function(reader, path, tile) {
     columns <- tile$column_names
     if (!length(columns)) {
         if (identical(reader, "direct")) {
-            return(dtaparser::read_dta(path, skip = tile$skip, n_max = tile$n_max, .name_repair = "minimal"))
+            return(dtaparser::read_dta(
+                path, encoding = encoding, skip = tile$skip, n_max = tile$n_max,
+                .name_repair = "minimal"
+            ))
         }
         if (identical(reader, "rust")) {
             return(dtaparser:::.read_dta_rust_vectors(
-                path, skip = tile$skip, n_max = tile$n_max, .name_repair = "minimal"
+                path, encoding = encoding, skip = tile$skip, n_max = tile$n_max,
+                .name_repair = "minimal"
             ))
         }
-        return(haven::read_dta(path, skip = tile$skip, n_max = tile$n_max, .name_repair = "minimal"))
+        return(haven::read_dta(
+            path, encoding = encoding, skip = tile$skip, n_max = tile$n_max,
+            .name_repair = "minimal"
+        ))
     }
     if (identical(reader, "direct")) {
         dtaparser::read_dta(
-            path, col_select = tidyselect::all_of(columns),
+            path, encoding = encoding, col_select = tidyselect::all_of(columns),
             skip = tile$skip, n_max = tile$n_max, .name_repair = "minimal"
         )
     } else if (identical(reader, "rust")) {
         dtaparser:::.read_dta_rust_vectors(
-            path, col_select = tidyselect::all_of(columns),
+            path, encoding = encoding, col_select = tidyselect::all_of(columns),
             skip = tile$skip, n_max = tile$n_max, .name_repair = "minimal"
         )
     } else {
         haven::read_dta(
-            path, col_select = tidyselect::all_of(columns),
+            path, encoding = encoding, col_select = tidyselect::all_of(columns),
             skip = tile$skip, n_max = tile$n_max, .name_repair = "minimal"
         )
     }
@@ -170,7 +194,7 @@ fertility_string_payload_bytes <- function(frame) {
 }
 
 fertility_worker_sizing_tile <- function(item, tile, framework_id,
-                                         timeout_seconds) {
+                                         timeout_seconds, encoding = NULL) {
     readers <- c("direct", "rust", "haven")
     maximum <- 0
     completed <- 0L
@@ -185,7 +209,9 @@ fertility_worker_sizing_tile <- function(item, tile, framework_id,
             sample_tile$skip <- as.double(offset)
             sample_tile$n_max <- 1L
             value <- tryCatch({
-                frame <- fertility_tile_read(reader, item$path, sample_tile)
+                frame <- fertility_tile_read(
+                    reader, item$path, sample_tile, encoding = encoding
+                )
                 fertility_string_payload_bytes(frame)
             }, error = identity)
             if (inherits(value, "error")) {
@@ -231,17 +257,21 @@ fertility_worker_tile <- function(item, tile, compare_script, package_library,
                                   timeout_seconds) {
     source(compare_script, local = environment(fertility_worker_tile))
     fertility_load_readers(package_library, expected_package_path)
+    encoding <- fertility_worker_encoding(item)
     started <- proc.time()[["elapsed"]]
     if (identical(tile$type, "sizing")) {
         result <- fertility_worker_sizing_tile(
-            item, tile, framework_id, timeout_seconds
+            item, tile, framework_id, timeout_seconds, encoding = encoding
         )
         result$elapsed_seconds <- unname(proc.time()[["elapsed"]] - started)
         return(result)
     }
     readers <- c("direct", "rust", "haven")
     values <- setNames(lapply(readers, function(reader) {
-        tryCatch(fertility_tile_read(reader, item$path, tile), error = identity)
+        tryCatch(
+            fertility_tile_read(reader, item$path, tile, encoding = encoding),
+            error = identity
+        )
     }), readers)
     errors <- vapply(values, inherits, logical(1), what = "error")
     memory_errors <- vapply(values, function(value) {
@@ -280,7 +310,7 @@ fertility_worker_tile <- function(item, tile, compare_script, package_library,
         secondary <- c(secondary, "metadata-mismatch")
     }
     structural <- if (identical(tile$type, "metadata")) tryCatch(
-        dtaparser:::.dta_metadata(item$path), error = identity
+        dtaparser:::.dta_metadata(item$path, encoding = encoding), error = identity
     ) else NULL
     source_structure <- if (identical(tile$type, "metadata")) tryCatch(
         fertility_structural_metadata(item$path), error = identity

--- a/benchmarks/fertility-surveys/worker.R
+++ b/benchmarks/fertility-surveys/worker.R
@@ -1,92 +1,341 @@
+fertility_memory_error <- function(error) {
+    grepl("vector memory exhausted|cannot allocate|memory limit|out of memory",
+          conditionMessage(error), ignore.case = TRUE)
+}
+
+fertility_worker_base <- function(item, framework_id, timeout_seconds) {
+    list(
+        schema_version = fertility_schema_version, framework_id = framework_id,
+        id = item$id, program = item$program, level = item$level,
+        release = as.integer(item$release), expected_sha512 = item$expected_sha512,
+        timeout_seconds = timeout_seconds
+    )
+}
+
+fertility_load_readers <- function(package_library, expected_package_path) {
+    .libPaths(c(package_library, .libPaths()))
+    if (!requireNamespace("dtaparser", quietly = TRUE)) stop("dtaparser-load-error")
+    loaded <- normalizePath(getNamespaceInfo(asNamespace("dtaparser"), "path"),
+                            winslash = "/", mustWork = TRUE)
+    if (!identical(loaded, expected_package_path)) stop("foreign-dtaparser-installation")
+    if (!requireNamespace("haven", quietly = TRUE)) stop("haven-load-error")
+    invisible(NULL)
+}
+
+fertility_tile_read <- function(reader, path, tile) {
+    if (!is.finite(tile$n_max) || tile$n_max < 0L) stop("tile row bound is invalid")
+    if (identical(tile$type, "metadata")) {
+        frame <- if (identical(reader, "direct")) {
+            dtaparser::read_dta(path, n_max = 0L, .name_repair = "minimal")
+        } else if (identical(reader, "rust")) {
+            dtaparser:::.read_dta_rust_vectors(
+                path, n_max = 0L, .name_repair = "minimal"
+            )
+        } else {
+            haven::read_dta(path, n_max = 0L, .name_repair = "minimal")
+        }
+        shape <- if (identical(reader, "direct")) {
+            dtaparser::read_dta(
+                path, col_select = character(), .name_repair = "minimal"
+            )
+        } else if (identical(reader, "rust")) {
+            dtaparser:::.read_dta_rust_vectors(
+                path, col_select = character(), .name_repair = "minimal"
+            )
+        } else {
+            NULL
+        }
+        return(list(
+            frame = frame,
+            shape_rows = if (is.null(shape)) NA_integer_ else nrow(shape),
+            shape_columns = if (is.null(shape)) 0L else ncol(shape)
+        ))
+    }
+    columns <- tile$column_names
+    if (!length(columns)) {
+        if (identical(reader, "direct")) {
+            return(dtaparser::read_dta(path, skip = tile$skip, n_max = tile$n_max, .name_repair = "minimal"))
+        }
+        if (identical(reader, "rust")) {
+            return(dtaparser:::.read_dta_rust_vectors(
+                path, skip = tile$skip, n_max = tile$n_max, .name_repair = "minimal"
+            ))
+        }
+        return(haven::read_dta(path, skip = tile$skip, n_max = tile$n_max, .name_repair = "minimal"))
+    }
+    if (identical(reader, "direct")) {
+        dtaparser::read_dta(
+            path, col_select = tidyselect::all_of(columns),
+            skip = tile$skip, n_max = tile$n_max, .name_repair = "minimal"
+        )
+    } else if (identical(reader, "rust")) {
+        dtaparser:::.read_dta_rust_vectors(
+            path, col_select = tidyselect::all_of(columns),
+            skip = tile$skip, n_max = tile$n_max, .name_repair = "minimal"
+        )
+    } else {
+        haven::read_dta(
+            path, col_select = tidyselect::all_of(columns),
+            skip = tile$skip, n_max = tile$n_max, .name_repair = "minimal"
+        )
+    }
+}
+
+fertility_compare_available_pairs <- function(frames, errors) {
+    mismatches <- fertility_bind_mismatches(list())
+    secondary <- character()
+    pairs <- list(
+        list(left = "direct", right = "rust", id = "direct-rust", internal = TRUE),
+        list(left = "direct", right = "haven", id = "direct-haven", internal = FALSE),
+        list(left = "rust", right = "haven", id = "rust-haven", internal = FALSE)
+    )
+    for (pair in pairs) {
+        if (errors[[pair$left]] || errors[[pair$right]]) next
+        compared <- if (pair$internal) {
+            fertility_compare_internal(frames[[pair$left]], frames[[pair$right]])
+        } else {
+            fertility_compare_haven(frames[[pair$left]], frames[[pair$right]])
+        }
+        current <- compared$mismatches
+        if (!nrow(current)) next
+        current$pair <- pair$id
+        mismatches <- fertility_bind_mismatches(list(mismatches, current))
+        if (pair$internal) secondary <- c(secondary, "direct-vs-rust-mismatch")
+        secondary <- c(secondary, current$category)
+    }
+    list(mismatches = mismatches, secondary = sort(unique(secondary)))
+}
+
+fertility_projection_hash <- function(column_names, framework_id) {
+    fertility_stable_id(list(
+        framework_id = framework_id,
+        ordered_names = paste(column_names, collapse = "\037")
+    ))
+}
+
+fertility_projection_attestation <- function(frames, errors, expected_names,
+                                             framework_id) {
+    readers <- names(errors)
+    expected_count <- length(expected_names)
+    expected_hash <- fertility_projection_hash(expected_names, framework_id)
+    counts <- setNames(rep(NA_integer_, length(readers)), readers)
+    hashes <- setNames(rep(NA_character_, length(readers)), readers)
+    ok <- setNames(rep(FALSE, length(readers)), readers)
+    for (reader in readers[!errors]) {
+        returned <- names(frames[[reader]])
+        counts[[reader]] <- length(returned)
+        hashes[[reader]] <- fertility_projection_hash(returned, framework_id)
+        ok[[reader]] <- identical(returned, expected_names)
+    }
+    list(expected_count = expected_count, expected_hash = expected_hash,
+         counts = counts, hashes = hashes, ok = ok)
+}
+
+fertility_row_termination_mismatch <- function(reader_rows) {
+    any(reader_rows > 0L, na.rm = TRUE)
+}
+
+fertility_structural_shape_mismatch <- function(shape_rows, expected_rows,
+                                                actual_columns, expected_columns) {
+    known <- shape_rows[!is.na(shape_rows)]
+    (length(known) > 1L && length(unique(known)) != 1L) ||
+        (length(known) && is.finite(expected_rows) && any(known != expected_rows)) ||
+        (is.finite(expected_columns) && !is.na(actual_columns) &&
+         actual_columns != expected_columns)
+}
+
+fertility_reader_error_classification <- function(errors) {
+    dta_error <- errors[["direct"]] || errors[["rust"]]
+    haven_error <- errors[["haven"]]
+    if (dta_error && haven_error) "shared-reader-error" else
+        if (dta_error) "dtaparser-only-error" else
+        if (haven_error) "haven-only-error" else NA_character_
+}
+
+fertility_worker_tile <- function(item, tile, compare_script, package_library,
+                                  expected_package_path, framework_id,
+                                  timeout_seconds) {
+    source(compare_script, local = environment())
+    fertility_load_readers(package_library, expected_package_path)
+    started <- proc.time()[["elapsed"]]
+    readers <- c("direct", "rust", "haven")
+    values <- setNames(lapply(readers, function(reader) {
+        tryCatch(fertility_tile_read(reader, item$path, tile), error = identity)
+    }), readers)
+    errors <- vapply(values, inherits, logical(1), what = "error")
+    memory_errors <- vapply(values, function(value) {
+        inherits(value, "error") && fertility_memory_error(value)
+    }, logical(1))
+    reader_rows <- setNames(rep(NA_integer_, length(readers)), readers)
+    for (reader in readers[!errors]) {
+        reader_rows[[reader]] <- if (identical(tile$type, "metadata"))
+            values[[reader]]$shape_rows else nrow(values[[reader]])
+    }
+    secondary <- paste0(readers[errors], "-reader-error")
+    frames <- values
+    if (identical(tile$type, "metadata")) {
+        frames[!errors] <- lapply(values[!errors], `[[`, "frame")
+    }
+    projection <- if (tile$type %in% c("value", "terminal")) {
+        fertility_projection_attestation(
+            frames, errors, tile$column_names, framework_id
+        )
+    } else list(
+        expected_count = NA_integer_, expected_hash = NA_character_,
+        counts = setNames(rep(NA_integer_, length(readers)), readers),
+        hashes = setNames(rep(NA_character_, length(readers)), readers),
+        ok = setNames(rep(NA, length(readers)), readers)
+    )
+    pair_comparison <- fertility_compare_available_pairs(frames, errors)
+    mismatches <- pair_comparison$mismatches
+    secondary <- c(secondary, pair_comparison$secondary)
+    if (tile$type %in% c("value", "terminal") &&
+        any(!projection$ok[!errors])) {
+        mismatches <- fertility_bind_mismatches(list(
+            mismatches, fertility_mismatch_record(
+                "metadata-mismatch", "projection-name-mismatch"
+            )
+        ))
+        secondary <- c(secondary, "metadata-mismatch")
+    }
+    structural <- if (identical(tile$type, "metadata")) tryCatch(
+        dtaparser:::.dta_metadata(item$path), error = identity
+    ) else NULL
+    source_structure <- if (identical(tile$type, "metadata")) tryCatch(
+        fertility_structural_metadata(item$path), error = identity
+    ) else NULL
+    if (inherits(structural, "error") || inherits(source_structure, "error")) {
+        secondary <- c(secondary, "metadata-reader-error")
+    }
+    if (identical(tile$type, "metadata") && !inherits(structural, "error")) {
+        if (anyNA(structural) || anyDuplicated(structural)) {
+            mismatches <- fertility_bind_mismatches(list(
+                mismatches, fertility_mismatch_record(
+                    "metadata-mismatch", "source-name-mismatch"
+                )
+            ))
+        }
+        for (reader in readers[!errors]) {
+            if (!identical(names(frames[[reader]]), as.character(structural))) {
+                mismatches <- fertility_bind_mismatches(list(
+                    mismatches, fertility_mismatch_record(
+                        "metadata-mismatch", "source-name-mismatch"
+                    )
+                ))
+            }
+        }
+    }
+    if (identical(tile$type, "metadata")) {
+        successful_shapes <- values[!errors]
+        shape_rows <- vapply(successful_shapes, `[[`, integer(1), "shape_rows")
+        shape_columns <- vapply(successful_shapes, `[[`, integer(1), "shape_columns")
+        if (length(shape_columns) && any(shape_columns != 0L)) {
+            mismatches <- fertility_bind_mismatches(list(
+                mismatches, fertility_mismatch_record(
+                    "metadata-mismatch", "zero-column-shape-mismatch"
+                )
+            ))
+        }
+        known_shape_rows <- shape_rows[!is.na(shape_rows)]
+        expected_rows <- if (inherits(source_structure, "error")) NA_real_ else
+            source_structure$rows
+        expected_columns <- if (inherits(source_structure, "error")) NA_integer_ else
+            source_structure$columns
+        if (fertility_structural_shape_mismatch(
+                known_shape_rows, expected_rows,
+                if (inherits(structural, "error")) NA_integer_ else length(structural),
+                expected_columns
+            )) {
+            mismatches <- fertility_bind_mismatches(list(
+                mismatches, fertility_mismatch_record(
+                    "metadata-mismatch", "row-count-mismatch"
+                )
+            ))
+        }
+    }
+    if (identical(tile$type, "terminal") &&
+        fertility_row_termination_mismatch(reader_rows)) {
+        mismatches <- fertility_bind_mismatches(list(
+            mismatches, fertility_mismatch_record(
+                "unresolved", "row-termination-mismatch"
+            )
+        ))
+        secondary <- c(secondary, "row-termination-mismatch")
+    }
+    error_classification <- fertility_reader_error_classification(errors)
+    classification <- if (any(memory_errors)) "memory-limit" else if ("metadata-reader-error" %in% secondary)
+        "dtaparser-only-error" else if (!is.na(error_classification))
+        error_classification else if ("row-termination-mismatch" %in% secondary)
+        "row-termination-mismatch" else if ("direct-vs-rust-mismatch" %in% secondary)
+        "direct-vs-rust-mismatch" else if (nrow(mismatches))
+        mismatches$category[[1L]] else "pass"
+    successful <- frames[!errors]
+    shape_source <- if (length(successful)) successful[[1L]] else NULL
+    column_names <- if (identical(tile$type, "metadata")) {
+        if (!inherits(structural, "error")) as.character(structural) else
+            if (!is.null(shape_source)) names(shape_source) else character()
+    } else character()
+    storage <- if (identical(tile$type, "metadata") &&
+                   !inherits(structural, "error"))
+        attr(structural, "dta_storage", exact = TRUE) else character()
+    column_bytes <- if (identical(tile$type, "metadata") &&
+                        !inherits(source_structure, "error"))
+        source_structure$column_bytes else numeric()
+    strl <- if (identical(tile$type, "metadata") &&
+                !inherits(source_structure, "error"))
+        source_structure$strl else logical()
+    structural_rows <- if (identical(tile$type, "metadata") &&
+                           !inherits(source_structure, "error"))
+        source_structure$rows else NA_real_
+    rows <- if (identical(tile$type, "metadata")) {
+        if (length(successful_shapes)) successful_shapes[[1L]]$shape_rows else NA_integer_
+    } else if (is.null(shape_source)) NA_integer_ else nrow(shape_source)
+    columns <- if (identical(tile$type, "metadata")) length(column_names) else
+        if (is.null(shape_source)) NA_integer_ else ncol(shape_source)
+    rm(values)
+    invisible(gc())
+    list(
+        schema_version = fertility_schema_version, framework_id = framework_id,
+        id = item$id, tile_id = tile$tile_id, tile_type = tile$type,
+        batch = tile$batch, skip = tile$skip, n_max = tile$n_max,
+        classification = classification, secondary = sort(unique(secondary)),
+        mismatches = mismatches, rows = rows, reader_rows = reader_rows,
+        columns = columns, column_names = column_names, storage = storage,
+        structural_rows = structural_rows, column_bytes = column_bytes, strl = strl,
+        projection_expected_count = projection$expected_count,
+        projection_expected_hash = projection$expected_hash,
+        projection_counts = projection$counts,
+        projection_hashes = projection$hashes,
+        projection_ok = projection$ok,
+        elapsed_seconds = unname(proc.time()[["elapsed"]] - started)
+    )
+}
+
+# Compatibility entry point for preflight classifications. Supported files must
+# use bounded fertility_worker_tile() calls and can never take a whole-file path.
 fertility_worker <- function(item, compare_script, package_library,
                              expected_package_path, framework_id,
                              timeout_seconds, parent_sha512) {
-    source(compare_script, local = environment())
     started <- proc.time()[["elapsed"]]
-    base <- list(
-        schema_version = fertility_schema_version,
-        framework_id = framework_id,
-        id = item$id,
-        program = item$program,
-        level = item$level,
-        release = as.integer(item$release),
-        expected_sha512 = item$expected_sha512,
-        timeout_seconds = timeout_seconds
-    )
-    finish <- function(classification, component = NA_integer_, rows = NA_real_,
-                       columns = NA_integer_, actual_sha512 = NA_character_) {
-        c(base, list(
-            classification = classification,
-            component = component,
-            rows = rows,
-            columns = columns,
-            actual_sha512 = actual_sha512,
-            elapsed_seconds = unname(proc.time()[["elapsed"]] - started)
-        ))
-    }
+    base <- fertility_worker_base(item, framework_id, timeout_seconds)
+    finish <- function(classification, actual_sha512 = NA_character_) c(base, list(
+        classification = classification, component = NA_integer_, rows = NA_real_,
+        columns = NA_integer_, actual_sha512 = actual_sha512,
+        elapsed_seconds = unname(proc.time()[["elapsed"]] - started)
+    ))
     actual_sha512 <- tryCatch(
         fertility_file_sha512(item$path), error = function(error) NA_character_
     )
     if (is.na(actual_sha512)) return(finish("input-hash-error"))
     if (!identical(actual_sha512, parent_sha512)) {
-        return(finish("input-changed-before-read", actual_sha512 = actual_sha512))
+        return(finish("input-changed-before-read", actual_sha512))
     }
     if (nzchar(item$expected_sha512) &&
         !identical(actual_sha512, tolower(item$expected_sha512))) {
-        return(finish("input-signature-mismatch", actual_sha512 = actual_sha512))
+        return(finish("input-signature-mismatch", actual_sha512))
     }
     if (!(item$release %in% fertility_supported_releases)) {
-        return(finish("unsupported-release", actual_sha512 = actual_sha512))
+        return(finish("expected-unsupported-111", actual_sha512))
     }
-
-    .libPaths(c(package_library, .libPaths()))
-    if (!requireNamespace("dtaparser", quietly = TRUE)) {
-        return(finish("dtaparser-load-error", actual_sha512 = actual_sha512))
-    }
-    loaded <- normalizePath(getNamespaceInfo(asNamespace("dtaparser"), "path"),
-                            winslash = "/", mustWork = TRUE)
-    if (!identical(loaded, expected_package_path)) {
-        return(finish("foreign-dtaparser-installation", actual_sha512 = actual_sha512))
-    }
-    if (!requireNamespace("haven", quietly = TRUE)) {
-        return(finish("haven-load-error", actual_sha512 = actual_sha512))
-    }
-
-    direct <- tryCatch(dtaparser::read_dta(item$path), error = identity)
-    if (inherits(direct, "error")) {
-        return(finish("direct-reader-error", actual_sha512 = actual_sha512))
-    }
-    rust_vectors <- tryCatch(
-        dtaparser:::.read_dta_rust_vectors(item$path), error = identity
-    )
-    if (inherits(rust_vectors, "error")) {
-        return(finish("rust-vector-reader-error", actual_sha512 = actual_sha512))
-    }
-    internal <- fertility_compare_internal(direct, rust_vectors)
-    rm(rust_vectors)
-    invisible(gc())
-    if (!internal$ok) {
-        return(finish(internal$classification, internal$component,
-                      nrow(direct), ncol(direct), actual_sha512))
-    }
-
-    reference <- tryCatch(haven::read_dta(item$path), error = identity)
-    if (inherits(reference, "error")) {
-        return(finish("haven-reader-error", rows = nrow(direct),
-                      columns = ncol(direct), actual_sha512 = actual_sha512))
-    }
-    comparison <- fertility_compare_haven(direct, reference)
-    rows <- nrow(direct)
-    columns <- ncol(direct)
-    rm(direct, reference)
-    invisible(gc())
-    final_sha512 <- tryCatch(
-        fertility_file_sha512(item$path), error = function(error) NA_character_
-    )
-    if (is.na(final_sha512) || !identical(final_sha512, actual_sha512)) {
-        return(finish("input-changed-during-read", rows = rows, columns = columns,
-                      actual_sha512 = final_sha512))
-    }
-    finish(comparison$classification, comparison$component, rows, columns,
-           actual_sha512)
+    stop("supported corpus files require bounded tile execution")
 }

--- a/benchmarks/fertility-surveys/worker.R
+++ b/benchmarks/fertility-surveys/worker.R
@@ -155,7 +155,7 @@ fertility_reader_error_classification <- function(errors) {
 fertility_worker_tile <- function(item, tile, compare_script, package_library,
                                   expected_package_path, framework_id,
                                   timeout_seconds) {
-    source(compare_script, local = environment())
+    source(compare_script, local = environment(fertility_worker_tile))
     fertility_load_readers(package_library, expected_package_path)
     started <- proc.time()[["elapsed"]]
     readers <- c("direct", "rust", "haven")

--- a/benchmarks/fertility-surveys/worker.R
+++ b/benchmarks/fertility-surveys/worker.R
@@ -152,6 +152,15 @@ fertility_reader_error_classification <- function(errors) {
         if (haven_error) "haven-only-error" else NA_character_
 }
 
+fertility_reader_error_categories <- function(errors) {
+    readers <- names(errors)
+    if (is.null(readers) || !identical(readers, c("direct", "rust", "haven"))) {
+        stop("reader error flags are not canonical")
+    }
+    if (!any(errors)) return(character())
+    paste0(readers[errors], "-reader-error")
+}
+
 fertility_string_payload_bytes <- function(frame) {
     values <- vapply(frame, function(column) {
         if (!is.character(column)) return(0)
@@ -200,7 +209,7 @@ fertility_worker_sizing_tile <- function(item, tile, framework_id,
     c(fertility_worker_base(item, framework_id, timeout_seconds), list(
         tile_id = tile$tile_id, tile_type = tile$type, batch = tile$batch,
         skip = tile$skip, n_max = tile$n_max, classification = classification,
-        secondary = paste0(readers[errors], "-reader-error"),
+        secondary = fertility_reader_error_categories(errors),
         mismatches = fertility_bind_mismatches(list()), rows = completed,
         reader_rows = setNames(rep(NA_integer_, length(readers)), readers),
         columns = length(tile$column_names), column_names = character(),
@@ -243,7 +252,7 @@ fertility_worker_tile <- function(item, tile, compare_script, package_library,
         reader_rows[[reader]] <- if (identical(tile$type, "metadata"))
             values[[reader]]$shape_rows else nrow(values[[reader]])
     }
-    secondary <- paste0(readers[errors], "-reader-error")
+    secondary <- fertility_reader_error_categories(errors)
     frames <- values
     if (identical(tile$type, "metadata")) {
         frames[!errors] <- lapply(values[!errors], `[[`, "frame")

--- a/benchmarks/fertility-surveys/worker.R
+++ b/benchmarks/fertility-surveys/worker.R
@@ -152,12 +152,84 @@ fertility_reader_error_classification <- function(errors) {
         if (haven_error) "haven-only-error" else NA_character_
 }
 
+fertility_string_payload_bytes <- function(frame) {
+    values <- vapply(frame, function(column) {
+        if (!is.character(column)) return(0)
+        sum(nchar(column, type = "bytes", allowNA = TRUE), na.rm = TRUE)
+    }, numeric(1))
+    sum(values)
+}
+
+fertility_worker_sizing_tile <- function(item, tile, framework_id,
+                                         timeout_seconds) {
+    readers <- c("direct", "rust", "haven")
+    maximum <- 0
+    completed <- 0L
+    errors <- setNames(rep(FALSE, length(readers)), readers)
+    memory_errors <- errors
+    for (offset in tile$sample_offsets) {
+        payload <- 0
+        complete <- TRUE
+        for (reader in readers) {
+            sample_tile <- tile
+            sample_tile$type <- "value"
+            sample_tile$skip <- as.double(offset)
+            sample_tile$n_max <- 1L
+            value <- tryCatch({
+                frame <- fertility_tile_read(reader, item$path, sample_tile)
+                fertility_string_payload_bytes(frame)
+            }, error = identity)
+            if (inherits(value, "error")) {
+                errors[[reader]] <- TRUE
+                memory_errors[[reader]] <- memory_errors[[reader]] ||
+                    fertility_memory_error(value)
+                complete <- FALSE
+            } else {
+                payload <- payload + value
+            }
+            rm(value)
+            gc(FALSE)
+        }
+        if (complete) {
+            maximum <- max(maximum, payload)
+            completed <- completed + 1L
+        }
+    }
+    classification <- if (any(memory_errors)) "memory-limit" else
+        if (any(errors)) fertility_reader_error_classification(errors) else "pass"
+    c(fertility_worker_base(item, framework_id, timeout_seconds), list(
+        tile_id = tile$tile_id, tile_type = tile$type, batch = tile$batch,
+        skip = tile$skip, n_max = tile$n_max, classification = classification,
+        secondary = paste0(readers[errors], "-reader-error"),
+        mismatches = fertility_bind_mismatches(list()), rows = completed,
+        reader_rows = setNames(rep(NA_integer_, length(readers)), readers),
+        columns = length(tile$column_names), column_names = character(),
+        storage = character(), structural_rows = NA_real_, column_bytes = numeric(),
+        strl = logical(), payload_bytes_per_row = if (completed) maximum else NA_real_,
+        samples_requested = length(tile$sample_offsets),
+        samples_completed = completed,
+        projection_expected_count = NA_integer_,
+        projection_expected_hash = NA_character_,
+        projection_counts = setNames(rep(NA_integer_, length(readers)), readers),
+        projection_hashes = setNames(rep(NA_character_, length(readers)), readers),
+        projection_ok = setNames(rep(NA, length(readers)), readers),
+        elapsed_seconds = 0
+    ))
+}
+
 fertility_worker_tile <- function(item, tile, compare_script, package_library,
                                   expected_package_path, framework_id,
                                   timeout_seconds) {
     source(compare_script, local = environment(fertility_worker_tile))
     fertility_load_readers(package_library, expected_package_path)
     started <- proc.time()[["elapsed"]]
+    if (identical(tile$type, "sizing")) {
+        result <- fertility_worker_sizing_tile(
+            item, tile, framework_id, timeout_seconds
+        )
+        result$elapsed_seconds <- unname(proc.time()[["elapsed"]] - started)
+        return(result)
+    }
     readers <- c("direct", "rust", "haven")
     values <- setNames(lapply(readers, function(reader) {
         tryCatch(fertility_tile_read(reader, item$path, tile), error = identity)

--- a/benchmarks/fertility-surveys/worker.R
+++ b/benchmarks/fertility-surveys/worker.R
@@ -13,7 +13,13 @@ fertility_worker_base <- function(item, framework_id, timeout_seconds) {
 }
 
 fertility_load_readers <- function(package_library, expected_package_path) {
+    package_attestation <- fertility_attest_regular_tree(
+        expected_package_path, "installed dtaparser package"
+    )
     .libPaths(c(package_library, .libPaths()))
+    fertility_revalidate_regular_tree(
+        package_attestation, "installed dtaparser package"
+    )
     if (!requireNamespace("dtaparser", quietly = TRUE)) stop("dtaparser-load-error")
     loaded <- normalizePath(getNamespaceInfo(asNamespace("dtaparser"), "path"),
                             winslash = "/", mustWork = TRUE)
@@ -373,10 +379,16 @@ fertility_worker_tile <- function(item, tile, compare_script, package_library,
         ))
         secondary <- c(secondary, "row-termination-mismatch")
     }
+    source_structure_unavailable <- identical(tile$type, "metadata") &&
+        inherits(source_structure, "error")
+    if (source_structure_unavailable) {
+        secondary <- c(secondary, "structural-metadata-unavailable")
+    }
     error_classification <- fertility_reader_error_classification(errors)
     classification <- if (any(memory_errors)) "memory-limit" else if ("metadata-reader-error" %in% secondary)
         "dtaparser-only-error" else if (!is.na(error_classification))
-        error_classification else if ("row-termination-mismatch" %in% secondary)
+        error_classification else if (source_structure_unavailable)
+        "unresolved" else if ("row-termination-mismatch" %in% secondary)
         "row-termination-mismatch" else if ("direct-vs-rust-mismatch" %in% secondary)
         "direct-vs-rust-mismatch" else if (nrow(mismatches))
         mismatches$category[[1L]] else "pass"

--- a/benchmarks/fertility-surveys/worker.R
+++ b/benchmarks/fertility-surveys/worker.R
@@ -41,6 +41,7 @@ fertility_worker_encoding <- function(item) {
 
 fertility_tile_read <- function(reader, path, tile, encoding = NULL) {
     if (!is.finite(tile$n_max) || tile$n_max < 0L) stop("tile row bound is invalid")
+    fertility_reset_bound_input(path)
     if (identical(tile$type, "metadata")) {
         frame <- if (identical(reader, "direct")) {
             dtaparser::read_dta(
@@ -55,6 +56,7 @@ fertility_tile_read <- function(reader, path, tile, encoding = NULL) {
                 path, encoding = encoding, n_max = 0L, .name_repair = "minimal"
             )
         }
+        fertility_reset_bound_input(path)
         shape <- if (identical(reader, "direct")) {
             dtaparser::read_dta(
                 path, encoding = encoding, col_select = character(),
@@ -315,6 +317,7 @@ fertility_worker_tile <- function(item, tile, compare_script, package_library,
         ))
         secondary <- c(secondary, "metadata-mismatch")
     }
+    if (identical(tile$type, "metadata")) fertility_reset_bound_input(item$path)
     structural <- if (identical(tile$type, "metadata")) tryCatch(
         dtaparser:::.dta_metadata(item$path, encoding = encoding), error = identity
     ) else NULL

--- a/benchmarks/fertility-surveys/worker.R
+++ b/benchmarks/fertility-surveys/worker.R
@@ -315,7 +315,7 @@ fertility_worker_tile <- function(item, tile, compare_script, package_library,
     source_structure <- if (identical(tile$type, "metadata")) tryCatch(
         fertility_structural_metadata(item$path), error = identity
     ) else NULL
-    if (inherits(structural, "error") || inherits(source_structure, "error")) {
+    if (inherits(structural, "error")) {
         secondary <- c(secondary, "metadata-reader-error")
     }
     if (identical(tile$type, "metadata") && !inherits(structural, "error")) {

--- a/benchmarks/fertility-surveys/worker.R
+++ b/benchmarks/fertility-surveys/worker.R
@@ -1,0 +1,92 @@
+fertility_worker <- function(item, compare_script, package_library,
+                             expected_package_path, framework_id,
+                             timeout_seconds, parent_sha512) {
+    source(compare_script, local = environment())
+    started <- proc.time()[["elapsed"]]
+    base <- list(
+        schema_version = fertility_schema_version,
+        framework_id = framework_id,
+        id = item$id,
+        program = item$program,
+        level = item$level,
+        release = as.integer(item$release),
+        expected_sha512 = item$expected_sha512,
+        timeout_seconds = timeout_seconds
+    )
+    finish <- function(classification, component = NA_integer_, rows = NA_real_,
+                       columns = NA_integer_, actual_sha512 = NA_character_) {
+        c(base, list(
+            classification = classification,
+            component = component,
+            rows = rows,
+            columns = columns,
+            actual_sha512 = actual_sha512,
+            elapsed_seconds = unname(proc.time()[["elapsed"]] - started)
+        ))
+    }
+    actual_sha512 <- tryCatch(
+        fertility_file_sha512(item$path), error = function(error) NA_character_
+    )
+    if (is.na(actual_sha512)) return(finish("input-hash-error"))
+    if (!identical(actual_sha512, parent_sha512)) {
+        return(finish("input-changed-before-read", actual_sha512 = actual_sha512))
+    }
+    if (nzchar(item$expected_sha512) &&
+        !identical(actual_sha512, tolower(item$expected_sha512))) {
+        return(finish("input-signature-mismatch", actual_sha512 = actual_sha512))
+    }
+    if (!(item$release %in% fertility_supported_releases)) {
+        return(finish("unsupported-release", actual_sha512 = actual_sha512))
+    }
+
+    .libPaths(c(package_library, .libPaths()))
+    if (!requireNamespace("dtaparser", quietly = TRUE)) {
+        return(finish("dtaparser-load-error", actual_sha512 = actual_sha512))
+    }
+    loaded <- normalizePath(getNamespaceInfo(asNamespace("dtaparser"), "path"),
+                            winslash = "/", mustWork = TRUE)
+    if (!identical(loaded, expected_package_path)) {
+        return(finish("foreign-dtaparser-installation", actual_sha512 = actual_sha512))
+    }
+    if (!requireNamespace("haven", quietly = TRUE)) {
+        return(finish("haven-load-error", actual_sha512 = actual_sha512))
+    }
+
+    direct <- tryCatch(dtaparser::read_dta(item$path), error = identity)
+    if (inherits(direct, "error")) {
+        return(finish("direct-reader-error", actual_sha512 = actual_sha512))
+    }
+    rust_vectors <- tryCatch(
+        dtaparser:::.read_dta_rust_vectors(item$path), error = identity
+    )
+    if (inherits(rust_vectors, "error")) {
+        return(finish("rust-vector-reader-error", actual_sha512 = actual_sha512))
+    }
+    internal <- fertility_compare_internal(direct, rust_vectors)
+    rm(rust_vectors)
+    invisible(gc())
+    if (!internal$ok) {
+        return(finish(internal$classification, internal$component,
+                      nrow(direct), ncol(direct), actual_sha512))
+    }
+
+    reference <- tryCatch(haven::read_dta(item$path), error = identity)
+    if (inherits(reference, "error")) {
+        return(finish("haven-reader-error", rows = nrow(direct),
+                      columns = ncol(direct), actual_sha512 = actual_sha512))
+    }
+    comparison <- fertility_compare_haven(direct, reference)
+    rows <- nrow(direct)
+    columns <- ncol(direct)
+    rm(direct, reference)
+    invisible(gc())
+    final_sha512 <- tryCatch(
+        fertility_file_sha512(item$path), error = function(error) NA_character_
+    )
+    if (is.na(final_sha512) || !identical(final_sha512, actual_sha512)) {
+        return(finish("input-changed-during-read", rows = rows, columns = columns,
+                      actual_sha512 = final_sha512))
+    }
+    finish(comparison$classification, comparison$component, rows, columns,
+           actual_sha512)
+}

--- a/benchmarks/large-scale/README.md
+++ b/benchmarks/large-scale/README.md
@@ -1,0 +1,86 @@
+# Large-scale R benchmark
+
+This report-only benchmark compares three readers in the same R process:
+
+- `direct-r`: the public `dtaparser::read_dta()` path;
+- `rust-vectors`: the retained internal `dtaparser:::.read_dta_rust_vectors()` baseline;
+- `haven`: `haven::read_dta()`.
+
+It measures full reads and a fixed eight-column projection on deterministic
+approximately 100 MB and 1 GB Stata files. The default is 101 measured
+iterations per implementation, workload, and size. Each path is warmed first,
+execution order reverses on alternating iterations, and garbage collection runs
+outside timed regions. There are no timing assertions or CI gates.
+
+Before timing, the runner requires exact identity between the direct-R and
+Rust-vector collectors for both workloads. It also compares 32-row projected
+windows at the beginning, middle, and end of each file with haven, allowing only
+`1e-7` numeric tolerance. The obsolete parser-only `dta_format_version`
+attribute is normalized uniformly for the haven comparison; direct-R versus
+Rust-vector identity is checked before that normalization. The manifest binds
+each canonical dataset path to its exact byte size, row width, row count,
+fixed-file overhead, and SHA-256. Those invariants and hashes are verified both
+before timing and immediately before atomic raw-result publication.
+
+## Run
+
+From the checkout root, run:
+
+```sh
+benchmarks/large-scale/benchmark.sh
+```
+
+The orchestration script builds the current package source, installs it into a
+fresh `target/large-scale/library/`, and sets `DTAPARSER_BENCH_LIB` itself. It
+also writes `library/dtaparser-benchmark-provenance.tsv`, recording the commit,
+dirty state, package version, canonical checkout and library paths, the built
+source tarball SHA-256, and digests of every non-ignored package input,
+large-scale harness input, and installed `library/dtaparser/` file. Package
+source is digested before the build and again after installation; any change
+aborts the run before provenance is recorded. `run.R` recomputes and verifies
+that provenance before
+loading dtaparser, then verifies the loaded namespace path itself, so direct
+invocations reject missing records, copied records, source changes, modified,
+swapped, or symlinked installations, and preloaded foreign namespaces. Orchestrated R
+processes disable user profiles and environment files as defense in depth.
+
+Each run also writes `run-provenance.tsv`. Its stable provenance ID binds the
+build provenance ID, exact iteration count, manifest and dataset SHA-256 values,
+sizes, row counts, full-column count, and projected-column count, R
+version/platform, OS/kernel and CPU identity, Python version/path,
+and versions plus resolved paths for dtaparser, haven, tidyselect, readr, rlang,
+and tibble. Every raw timing row carries the run and build IDs and its dataset
+SHA-256; summaries retain all three fields. The summarizer accepts the runtime
+provenance explicitly and rejects missing, duplicate, non-contiguous, nonfinite,
+or metadata-inconsistent cells rather than summarizing a partial matrix.
+
+Raw timings, summary, runtime provenance, and a copy of build provenance are
+staged together. Only after the runner and strict summarizer both succeed is the
+whole directory renamed beneath `target/large-scale/runs/`; the `CURRENT` text
+pointer is then replaced atomically. Failed reruns leave the prior completed
+bundle current, and replacing the working benchmark library cannot alter the
+build record copied into an older bundle. Preserve the complete pointed-to run
+directory with any dated benchmark report.
+
+Pass an iteration count only for local validation. For example, this executes
+the complete two-size matrix once:
+
+```sh
+benchmarks/large-scale/benchmark.sh 1
+```
+
+All generated inputs and reports are written beneath the ignored
+`target/large-scale/` directory. Dataset files and the manifest are replaced
+atomically, and rerunning the orchestration script recreates the same datasets
+and a duplicate-free manifest. Completed report bundles are immutable and
+selected through `CURRENT`. Python is invoked with bytecode generation disabled.
+
+The default raw report has 1,212 rows:
+
+```text
+2 sizes × 2 workloads × 3 implementations × 101 iterations
+```
+
+`summary.tsv` has four rows, one per size/workload combination, with median,
+5th percentile, 95th percentile, and median input throughput for all three
+implementations plus pairwise median speedups.

--- a/benchmarks/large-scale/README.md
+++ b/benchmarks/large-scale/README.md
@@ -31,9 +31,9 @@ benchmarks/large-scale/benchmark.sh
 ```
 
 The orchestration script builds the current package source, installs it into a
-fresh `target/large-scale/library/`, and sets `DTAPARSER_BENCH_LIB` itself. It
-also writes `library/dtaparser-benchmark-provenance.tsv`, recording the commit,
-dirty state, package version, canonical checkout and library paths, the built
+fresh ignored private library, and sets `DTAPARSER_BENCH_LIB` itself. It also
+writes a private build-provenance record containing the commit, dirty state,
+package version, canonical checkout and library identities, the built
 source tarball SHA-256, and digests of every non-ignored package input,
 large-scale harness input, and installed `library/dtaparser/` file. Package
 source is digested before the build and again after installation; any change
@@ -55,12 +55,11 @@ provenance explicitly and rejects missing, duplicate, non-contiguous, nonfinite,
 or metadata-inconsistent cells rather than summarizing a partial matrix.
 
 Raw timings, summary, runtime provenance, and a copy of build provenance are
-staged together. Only after the runner and strict summarizer both succeed is the
-whole directory renamed beneath `target/large-scale/runs/`; the `CURRENT` text
-pointer is then replaced atomically. Failed reruns leave the prior completed
-bundle current, and replacing the working benchmark library cannot alter the
-build record copied into an older bundle. Preserve the complete pointed-to run
-directory with any dated benchmark report.
+staged together. Only after the runner and strict summarizer both succeed is an
+immutable private bundle published and its private selection updated atomically.
+Failed reruns leave the prior completed bundle selected, and replacing the
+working benchmark library cannot alter the build record copied into an older
+bundle. Preserve the complete content-bound bundle with any dated report.
 
 Pass an iteration count only for local validation. For example, this executes
 the complete two-size matrix once:
@@ -69,11 +68,11 @@ the complete two-size matrix once:
 benchmarks/large-scale/benchmark.sh 1
 ```
 
-All generated inputs and reports are written beneath the ignored
-`target/large-scale/` directory. Dataset files and the manifest are replaced
-atomically, and rerunning the orchestration script recreates the same datasets
-and a duplicate-free manifest. Completed report bundles are immutable and
-selected through `CURRENT`. Python is invoked with bytecode generation disabled.
+All generated inputs and reports are written beneath an ignored checkout-local
+private artifact root. Dataset files and the manifest are replaced atomically,
+and rerunning the orchestration script recreates the same datasets and a
+duplicate-free manifest. Completed report bundles are immutable and privately
+selected. Python is invoked with bytecode generation disabled.
 
 The default raw report has 1,212 rows:
 

--- a/benchmarks/large-scale/benchmark.sh
+++ b/benchmarks/large-scale/benchmark.sh
@@ -1,0 +1,107 @@
+#!/bin/sh
+set -eu
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+checkout_root=$(CDPATH= cd -- "$script_dir/../.." && pwd)
+target_dir="$checkout_root/target/large-scale"
+R_ENVIRON_USER=/dev/null
+R_PROFILE_USER=/dev/null
+export R_ENVIRON_USER R_PROFILE_USER
+iterations=${1:-101}
+
+case "$iterations" in
+    ''|*[!0-9]*)
+        printf '%s\n' "iterations must be a positive integer" >&2
+        exit 2
+        ;;
+esac
+if [ "$iterations" -lt 1 ]; then
+    printf '%s\n' "iterations must be a positive integer" >&2
+    exit 2
+fi
+
+mkdir -p "$target_dir"
+base="$target_dir/base.dta"
+manifest="$target_dir/datasets.tsv"
+staged_manifest="$target_dir/.datasets.tsv.$$"
+build_dir="$target_dir/.build.$$"
+run_stage="$target_dir/.run.$$"
+runs_dir="$target_dir/runs"
+benchmark_library="$target_dir/library"
+build_provenance="$benchmark_library/dtaparser-benchmark-provenance.tsv"
+trap 'rm -rf "$build_dir" "$run_stage"; rm -f "$staged_manifest" "$staged_manifest.partial"' EXIT HUP INT TERM
+
+package_source_before=$(Rscript --vanilla -e \
+    'source(commandArgs(TRUE)[[1L]]); cat(benchmark_tree_digest(commandArgs(TRUE)[[2L]], "r-package/dtaparser"))' \
+    "$script_dir/provenance.R" "$checkout_root")
+
+mkdir -p "$build_dir"
+(
+    cd "$build_dir"
+    R CMD build "$checkout_root/r-package/dtaparser"
+)
+set -- "$build_dir"/dtaparser_*.tar.gz
+if [ "$#" -ne 1 ] || [ ! -f "$1" ]; then
+    printf '%s\n' "expected exactly one dtaparser source tarball" >&2
+    exit 1
+fi
+source_tarball="$1"
+source_tarball_sha256=$(Rscript --vanilla -e \
+    'cat(tolower(unname(tools::sha256sum(commandArgs(TRUE)[[1L]]))))' \
+    "$source_tarball")
+
+rm -rf "$benchmark_library"
+mkdir -p "$benchmark_library"
+R CMD INSTALL --library="$benchmark_library" "$source_tarball"
+
+package_source_after=$(Rscript --vanilla -e \
+    'source(commandArgs(TRUE)[[1L]]); cat(benchmark_tree_digest(commandArgs(TRUE)[[2L]], "r-package/dtaparser"))' \
+    "$script_dir/provenance.R" "$checkout_root")
+if [ "$package_source_before" != "$package_source_after" ]; then
+    printf '%s\n' "package source changed during build or installation" >&2
+    exit 1
+fi
+Rscript --vanilla -e \
+    'source(commandArgs(TRUE)[[1L]]); write_benchmark_provenance(commandArgs(TRUE)[[2L]], commandArgs(TRUE)[[3L]], commandArgs(TRUE)[[4L]], commandArgs(TRUE)[[5L]], commandArgs(TRUE)[[6L]])' \
+    "$script_dir/provenance.R" "$checkout_root" "$benchmark_library" \
+    "$build_provenance" "$package_source_before" "$source_tarball_sha256"
+export DTAPARSER_BENCH_LIB="$benchmark_library"
+
+Rscript --vanilla "$script_dir/generate-base.R" "$base"
+python3 -B "$script_dir/scale-dta.py" \
+    --base "$base" \
+    --output "$target_dir/synthetic-100mb.dta" \
+    --target-bytes 100000000 \
+    --label 100mb \
+    --manifest "$staged_manifest"
+python3 -B "$script_dir/scale-dta.py" \
+    --base "$base" \
+    --output "$target_dir/synthetic-1gb.dta" \
+    --target-bytes 1000000000 \
+    --label 1gb \
+    --manifest "$staged_manifest"
+mv -f "$staged_manifest" "$manifest"
+
+mkdir -p "$run_stage"
+Rscript --vanilla "$script_dir/run.R" \
+    "$manifest" "$run_stage/raw.tsv" "$iterations" \
+    "$run_stage/run-provenance.tsv"
+cp "$build_provenance" "$run_stage/build-provenance.tsv"
+Rscript --vanilla "$script_dir/summarize.R" \
+    "$run_stage/raw.tsv" "$run_stage/summary.tsv" \
+    "$run_stage/run-provenance.tsv"
+
+run_id=$(Rscript --vanilla -e \
+    'x <- read.delim(commandArgs(TRUE)[[1L]], colClasses = "character", check.names = FALSE); cat(x$provenance_id[[1L]])' \
+    "$run_stage/run-provenance.tsv")
+run_stamp=$(date -u '+%Y%m%dT%H%M%SZ')
+run_name="$run_stamp-$(printf '%s' "$run_id" | cut -c1-16)-$$"
+mkdir -p "$runs_dir"
+completed_run="$runs_dir/$run_name"
+mv "$run_stage" "$completed_run"
+current_partial="$target_dir/.CURRENT.$$"
+printf '%s\n' "runs/$run_name" > "$current_partial"
+mv -f "$current_partial" "$target_dir/CURRENT"
+rm -f "$target_dir/raw.tsv" "$target_dir/summary.tsv" \
+    "$target_dir/run-provenance.tsv"
+printf 'published %s\n' "$completed_run"

--- a/benchmarks/large-scale/generate-base.R
+++ b/benchmarks/large-scale/generate-base.R
@@ -1,0 +1,133 @@
+args <- commandArgs(trailingOnly = TRUE)
+if (length(args) < 1L) {
+    stop("usage: Rscript generate-base.R OUTPUT [ROWS]")
+}
+
+output <- normalizePath(args[[1L]], mustWork = FALSE)
+rows <- if (length(args) >= 2L) as.integer(args[[2L]]) else 100000L
+stopifnot(is.finite(rows), rows >= 1000L)
+
+if (!requireNamespace("haven", quietly = TRUE)) {
+    stop("haven is required")
+}
+
+i <- seq_len(rows)
+cycle <- function(values, offset = 0L) values[((i + offset - 1L) %% length(values)) + 1L]
+
+region <- haven::labelled(
+    as.integer((i - 1L) %% 6L + 1L),
+    labels = c(Northeast = 1L, Midwest = 2L, South = 3L, West = 4L,
+               Territory = 5L, Overseas = 6L)
+)
+education <- haven::labelled(
+    as.integer((i * 7L) %% 5L + 1L),
+    labels = c(Primary = 1L, Secondary = 2L, College = 3L,
+               Graduate = 4L, Unknown = 5L)
+)
+employment <- haven::labelled(
+    as.integer((i * 11L) %% 5L + 1L),
+    labels = c(Employed = 1L, Unemployed = 2L, Student = 3L,
+               Retired = 4L, Other = 5L)
+)
+health <- haven::labelled(
+    as.integer((i * 13L) %% 5L + 1L),
+    labels = c(Excellent = 1L, Good = 2L, Fair = 3L, Poor = 4L,
+               Missing = 5L)
+)
+
+income <- 18000 + (i %% 250000) * 1.17
+income[i %% 997L == 0L] <- haven::tagged_na("a")
+expenditure <- 9000 + (i %% 140000) * 0.83
+expenditure[i %% 991L == 0L] <- NA_real_
+
+dataset <- data.frame(
+    id = as.double(i),
+    household_id = as.double((i - 1L) %/% 3L + 1L),
+    wave = as.integer((i - 1L) %% 12L + 1L),
+    income = income,
+    expenditure = expenditure,
+    sampling_weight = 0.25 + (i %% 10000L) / 1000,
+    latitude = -44.5 + (i %% 134000L) / 1000,
+    longitude = -179.5 + (i %% 359000L) / 1000,
+    score_physical = sin(i / 113) * 12 + 50,
+    score_mental = cos(i / 127) * 11 + 51,
+    score_economic = log1p(i %% 50000L),
+    score_environment = sqrt(i %% 100000L),
+    age = as.integer(18L + i %% 83L),
+    household_size = as.integer(1L + i %% 8L),
+    children = as.integer(i %% 5L),
+    visits = as.integer(i %% 24L),
+    survey_year = as.integer(2000L + i %% 25L),
+    survey_month = as.integer(1L + i %% 12L),
+    status_code = as.integer(i %% 17L),
+    provider_count = as.integer(i %% 12L),
+    event_count = as.integer(i %% 200L),
+    quality_flag = as.integer(i %% 4L),
+    region = region,
+    education = education,
+    employment = employment,
+    self_rated_health = health,
+    birth_date = as.Date("1940-01-01") + (i %% 25000L),
+    interview_date = as.Date("2010-01-01") + (i %% 5500L),
+    created_at = as.POSIXct("2018-01-01", tz = "UTC") + (i %% 10000000L),
+    updated_at = as.POSIXct("2020-01-01", tz = "UTC") + (i %% 15000000L),
+    case_code = sprintf("CASE-%08d", i %% 100000000L),
+    state_code = cycle(state.abb),
+    county = cycle(c("Kings", "Queens", "Cook", "Harris", "Maricopa",
+                     "Orange", "Wayne", "Clark", "Franklin", "Fairfax")),
+    occupation = cycle(c("Education", "Healthcare", "Construction", "Retail",
+                         "Manufacturing", "Technology", "Hospitality",
+                         "Transportation", "Government", "Agriculture")),
+    industry = cycle(c("Public administration", "Professional services",
+                       "Health and social care", "Wholesale and retail",
+                       "Information services", "Accommodation and food")),
+    product_code = sprintf("P%05d-%04d", i %% 100000L, (i * 17L) %% 10000L),
+    cohort = cycle(c("pre-1965", "1965-1979", "1980-1994", "1995-2009",
+                     "2010-present")),
+    language = cycle(c("English", "Spanish", "French", "Mandarin", "Arabic",
+                       "Portuguese", "Hindi", "Other")),
+    description = sprintf(
+        "Household survey record %08d in rotating panel %02d with verified response",
+        i %% 100000000L, i %% 24L
+    ),
+    note = sprintf(
+        "Quality-controlled synthetic microdata row %08d; source wave %02d; deterministic benchmark payload.",
+        i %% 100000000L, i %% 12L
+    ),
+    stringsAsFactors = FALSE,
+    check.names = FALSE
+)
+
+attr(dataset, "label") <- "Synthetic mixed-type longitudinal household microdata"
+for (name in names(dataset)) {
+    attr(dataset[[name]], "label") <- paste("Benchmark field", name)
+}
+
+dir.create(dirname(output), recursive = TRUE, showWarnings = FALSE)
+temporary <- tempfile(
+    pattern = paste0(basename(output), "."),
+    tmpdir = dirname(output), fileext = ".dta"
+)
+on.exit(unlink(temporary), add = TRUE)
+haven::write_dta(dataset, temporary, version = 15)
+
+# haven records the wall-clock write time in the Stata 118 header. Replace only
+# that fixed-width field so identical inputs produce byte-identical fixtures.
+bytes <- readBin(temporary, "raw", file.info(temporary)$size)
+tag <- charToRaw("<timestamp>")
+timestamp_start <- grepRaw(tag, bytes, fixed = TRUE)
+fixed_timestamp <- charToRaw("01 Jan 2000 00:00")
+stopifnot(
+    length(timestamp_start) == 1L,
+    as.integer(bytes[[timestamp_start + length(tag)]]) == length(fixed_timestamp)
+)
+indices <- timestamp_start + length(tag) + seq_along(fixed_timestamp)
+bytes[indices] <- fixed_timestamp
+writeBin(bytes, temporary)
+rm(bytes)
+
+if (!file.rename(temporary, output)) {
+    stop("could not atomically replace ", output)
+}
+cat(sprintf("wrote %s: %d rows, %d columns, %d bytes\n",
+            output, nrow(dataset), ncol(dataset), file.info(output)$size))

--- a/benchmarks/large-scale/provenance.R
+++ b/benchmarks/large-scale/provenance.R
@@ -34,11 +34,39 @@ benchmark_git_lines <- function(checkout_root, arguments) {
     output
 }
 
-benchmark_tree_digest <- function(checkout_root, scope) {
-    paths <- benchmark_git_lines(
-        checkout_root,
-        c("ls-files", "--cached", "--others", "--exclude-standard", "--", scope)
+benchmark_git_paths <- function(checkout_root, scope) {
+    output_path <- tempfile("benchmark-git-paths-")
+    diagnostics_path <- tempfile("benchmark-git-stderr-")
+    on.exit(unlink(c(output_path, diagnostics_path)), add = TRUE)
+    status <- system2(
+        "git",
+        c("-C", shQuote(checkout_root), "ls-files", "-z", "--cached",
+          "--others", "--exclude-standard", "--", scope),
+        stdout = output_path, stderr = diagnostics_path
     )
+    if (!identical(status, 0L)) {
+        diagnostics <- if (file.exists(diagnostics_path)) {
+            readLines(diagnostics_path, warn = FALSE)
+        } else character()
+        stop("git command failed: ", paste(diagnostics, collapse = "\n"))
+    }
+    size <- file.info(output_path)$size[[1L]]
+    bytes <- readBin(output_path, "raw", n = size)
+    if (!length(bytes)) return(character())
+    nul <- which(bytes == as.raw(0L))
+    if (!length(nul) || tail(nul, 1L) != length(bytes)) {
+        stop("git path output is not NUL terminated")
+    }
+    starts <- c(1L, head(nul, -1L) + 1L)
+    ends <- nul - 1L
+    vapply(seq_along(starts), function(index) {
+        if (ends[[index]] < starts[[index]]) return("")
+        rawToChar(bytes[starts[[index]]:ends[[index]]])
+    }, character(1L))
+}
+
+benchmark_tree_digest <- function(checkout_root, scope) {
+    paths <- benchmark_git_paths(checkout_root, scope)
     paths <- sort(unique(paths[nzchar(paths)]))
     if (!length(paths)) stop("no provenance inputs found under ", scope)
     benchmark_assert_plain_text(paths, "benchmark source path")
@@ -84,37 +112,62 @@ benchmark_installed_package_path <- function(benchmark_library) {
     resolved_path
 }
 
+benchmark_directory_files <- function(directory) {
+    prefix <- paste0(directory, "/")
+    files <- character()
+    walk <- function(current, relative) {
+        if (file.access(current, 4L) != 0L ||
+            (.Platform$OS.type == "unix" && file.access(current, 1L) != 0L)) {
+            stop("installed dtaparser package tree contains an unreadable directory")
+        }
+        entries <- tryCatch(
+            list.files(
+                current, recursive = FALSE, all.files = TRUE,
+                full.names = FALSE, no.. = TRUE
+            ),
+            warning = function(condition) stop(condition),
+            error = function(condition) stop(condition)
+        )
+        entries <- sort(entries)
+        benchmark_assert_plain_text(entries, "installed package entry")
+        for (entry in entries) {
+            entry_relative <- if (nzchar(relative)) {
+                file.path(relative, entry)
+            } else entry
+            absolute <- file.path(current, entry)
+            if (nzchar(Sys.readlink(absolute))) {
+                stop("installed dtaparser package tree must not contain symbolic links")
+            }
+            info <- file.info(absolute)
+            if (is.na(info$isdir[[1L]])) {
+                stop("installed dtaparser package tree contains an unreadable entry")
+            }
+            resolved <- normalizePath(absolute, winslash = "/", mustWork = TRUE)
+            if (!startsWith(resolved, prefix)) {
+                stop("installed dtaparser package entry resolves outside its package tree")
+            }
+            if (isTRUE(info$isdir[[1L]])) {
+                walk(absolute, entry_relative)
+            } else {
+                if (!file_test("-f", absolute)) {
+                    stop("installed dtaparser package tree contains a non-regular file")
+                }
+                files <<- c(files, entry_relative)
+            }
+        }
+    }
+    walk(directory, "")
+    sort(files)
+}
+
 benchmark_directory_digest <- function(directory) {
     directory <- normalizePath(directory, winslash = "/", mustWork = TRUE)
     benchmark_assert_plain_text(directory, "installed package path")
-    entries <- list.files(
-        directory, recursive = TRUE, all.files = TRUE,
-        full.names = FALSE, include.dirs = TRUE, no.. = TRUE
-    )
-    entries <- sort(entries)
-    if (!length(entries)) {
+    paths <- benchmark_directory_files(directory)
+    if (!length(paths)) {
         stop("no installed provenance inputs found under ", directory)
     }
-    benchmark_assert_plain_text(entries, "installed package entry")
-    absolute <- file.path(directory, entries)
-    if (any(nzchar(Sys.readlink(absolute)))) {
-        stop("installed dtaparser package tree must not contain symbolic links")
-    }
-    resolved <- normalizePath(absolute, winslash = "/", mustWork = TRUE)
-    prefix <- paste0(directory, "/")
-    if (any(!startsWith(resolved, prefix))) {
-        stop("installed dtaparser package entry resolves outside its package tree")
-    }
-    info <- file.info(absolute)
-    if (anyNA(info$isdir)) {
-        stop("installed dtaparser package tree contains an unreadable entry")
-    }
-    files <- !info$isdir
-    if (!any(files) || any(!file_test("-f", absolute[files]))) {
-        stop("installed dtaparser package tree contains a non-regular file")
-    }
-    paths <- entries[files]
-    hashes <- unname(tools::md5sum(absolute[files]))
+    hashes <- unname(tools::md5sum(file.path(directory, paths)))
     if (anyNA(hashes)) stop("installed dtaparser package file could not be hashed")
     manifest <- paste(paths, hashes, sep = "\t")
     temporary <- tempfile("dtaparser-installed-provenance-")

--- a/benchmarks/large-scale/provenance.R
+++ b/benchmarks/large-scale/provenance.R
@@ -1,0 +1,178 @@
+benchmark_git_lines <- function(checkout_root, arguments) {
+    output <- system2(
+        "git",
+        c("-C", shQuote(checkout_root), arguments),
+        stdout = TRUE, stderr = TRUE
+    )
+    status <- attr(output, "status", exact = TRUE)
+    if (!is.null(status) && status != 0L) {
+        stop("git command failed: ", paste(output, collapse = "\n"))
+    }
+    output
+}
+
+benchmark_tree_digest <- function(checkout_root, scope) {
+    paths <- benchmark_git_lines(
+        checkout_root,
+        c("ls-files", "--cached", "--others", "--exclude-standard", "--", scope)
+    )
+    paths <- sort(unique(paths[nzchar(paths)]))
+    if (!length(paths)) stop("no provenance inputs found under ", scope)
+
+    absolute <- file.path(checkout_root, paths)
+    hashes <- rep.int("<missing>", length(paths))
+    present <- file.exists(absolute)
+    hashes[present] <- unname(tools::md5sum(absolute[present]))
+    manifest <- paste(paths, hashes, sep = "\t")
+    temporary <- tempfile("dtaparser-provenance-")
+    on.exit(unlink(temporary), add = TRUE)
+    writeLines(manifest, temporary, useBytes = TRUE)
+    unname(tools::md5sum(temporary))
+}
+
+benchmark_installed_package_path <- function(benchmark_library) {
+    benchmark_library <- normalizePath(
+        benchmark_library, winslash = "/", mustWork = TRUE
+    )
+    lexical_path <- file.path(benchmark_library, "dtaparser")
+    link_target <- Sys.readlink(lexical_path)
+    if (nzchar(link_target)) {
+        stop("installed dtaparser package root must not be a symbolic link")
+    }
+    resolved_path <- normalizePath(
+        lexical_path, winslash = "/", mustWork = TRUE
+    )
+    if (!identical(dirname(resolved_path), benchmark_library)) {
+        stop("installed dtaparser package must resolve directly inside DTAPARSER_BENCH_LIB")
+    }
+    resolved_path
+}
+
+benchmark_directory_digest <- function(directory) {
+    directory <- normalizePath(directory, winslash = "/", mustWork = TRUE)
+    paths <- list.files(
+        directory, recursive = TRUE, all.files = TRUE,
+        full.names = FALSE, include.dirs = FALSE, no.. = TRUE
+    )
+    paths <- sort(paths)
+    if (!length(paths)) stop("no installed provenance inputs found under ", directory)
+    hashes <- unname(tools::md5sum(file.path(directory, paths)))
+    manifest <- paste(paths, hashes, sep = "\t")
+    temporary <- tempfile("dtaparser-installed-provenance-")
+    on.exit(unlink(temporary), add = TRUE)
+    writeLines(manifest, temporary, useBytes = TRUE)
+    unname(tools::md5sum(temporary))
+}
+
+benchmark_current_provenance <- function(checkout_root, benchmark_library) {
+    checkout_root <- normalizePath(checkout_root, winslash = "/", mustWork = TRUE)
+    benchmark_library <- normalizePath(
+        benchmark_library, winslash = "/", mustWork = TRUE
+    )
+    commit <- benchmark_git_lines(checkout_root, c("rev-parse", "HEAD"))
+    stopifnot(length(commit) == 1L)
+    status <- benchmark_git_lines(
+        checkout_root,
+        c("status", "--porcelain", "--untracked-files=all", "--",
+          "r-package/dtaparser", "benchmarks/large-scale")
+    )
+    description <- read.dcf(
+        file.path(checkout_root, "r-package", "dtaparser", "DESCRIPTION")
+    )
+    data.frame(
+        schema_version = 1L,
+        checkout_root = checkout_root,
+        git_commit = commit,
+        git_dirty = length(status) > 0L,
+        package_source_md5 = benchmark_tree_digest(
+            checkout_root, "r-package/dtaparser"
+        ),
+        benchmark_source_md5 = benchmark_tree_digest(
+            checkout_root, "benchmarks/large-scale"
+        ),
+        installed_package_md5 = benchmark_directory_digest(
+            benchmark_installed_package_path(benchmark_library)
+        ),
+        package_version = unname(description[[1L, "Version"]]),
+        benchmark_library = benchmark_library,
+        stringsAsFactors = FALSE,
+        check.names = FALSE
+    )
+}
+
+benchmark_provenance_id <- function(provenance) {
+    stopifnot(is.data.frame(provenance), nrow(provenance) == 1L)
+    fields <- sort(names(provenance))
+    values <- vapply(fields, function(field) {
+        paste0(field, "=", as.character(provenance[[field]][[1L]]))
+    }, character(1))
+    unname(tools::sha256sum(bytes = charToRaw(paste(values, collapse = "\n"))))
+}
+
+write_benchmark_provenance <- function(checkout_root, benchmark_library, path,
+                                       expected_package_source_md5,
+                                       source_tarball_sha256) {
+    provenance <- benchmark_current_provenance(checkout_root, benchmark_library)
+    if (!identical(
+        as.character(provenance$package_source_md5[[1L]]),
+        as.character(expected_package_source_md5)
+    )) {
+        stop("package source changed while building the benchmark installation")
+    }
+    source_tarball_sha256 <- tolower(as.character(source_tarball_sha256))
+    if (length(source_tarball_sha256) != 1L ||
+        !grepl("^[0-9a-f]{64}$", source_tarball_sha256)) {
+        stop("source tarball SHA-256 is invalid")
+    }
+    provenance$source_tarball_sha256 <- source_tarball_sha256
+    provenance$provenance_id <- benchmark_provenance_id(provenance)
+    provenance$created_at_utc <- format(
+        Sys.time(), "%Y-%m-%dT%H:%M:%SZ", tz = "UTC"
+    )
+    temporary <- tempfile(
+        pattern = paste0(basename(path), "."), tmpdir = dirname(path)
+    )
+    on.exit(unlink(temporary), add = TRUE)
+    write.table(
+        provenance, temporary, sep = "\t", row.names = FALSE, quote = FALSE
+    )
+    if (!file.rename(temporary, path)) {
+        stop("could not atomically replace ", path)
+    }
+    invisible(provenance)
+}
+
+verify_benchmark_provenance <- function(checkout_root, benchmark_library, path) {
+    if (!file.exists(path)) {
+        stop("benchmark provenance record is missing: ", path)
+    }
+    recorded <- read.delim(
+        path, check.names = FALSE, stringsAsFactors = FALSE,
+        colClasses = "character"
+    )
+    if (nrow(recorded) != 1L) stop("benchmark provenance record must have one row")
+    current <- benchmark_current_provenance(checkout_root, benchmark_library)
+    fields <- names(current)
+    if (!all(c(fields, "source_tarball_sha256", "provenance_id",
+               "created_at_utc") %in% names(recorded))) {
+        stop("benchmark provenance record is missing required fields")
+    }
+    mismatched <- fields[!vapply(fields, function(field) {
+        identical(as.character(recorded[[field]]), as.character(current[[field]]))
+    }, logical(1))]
+    if (length(mismatched)) {
+        stop(
+            "stale or foreign benchmark installation; provenance mismatch: ",
+            paste(mismatched, collapse = ", ")
+        )
+    }
+    if (!grepl("^[0-9a-f]{64}$", recorded$source_tarball_sha256[[1L]])) {
+        stop("benchmark provenance source tarball SHA-256 is invalid")
+    }
+    stable_fields <- setdiff(names(recorded), c("provenance_id", "created_at_utc"))
+    expected_id <- benchmark_provenance_id(recorded[stable_fields])
+    if (!identical(as.character(recorded$provenance_id[[1L]]), expected_id)) {
+        stop("benchmark provenance ID does not match its stable fields")
+    }
+    invisible(recorded)
+}

--- a/benchmarks/large-scale/provenance.R
+++ b/benchmarks/large-scale/provenance.R
@@ -45,11 +45,12 @@ benchmark_tree_digest <- function(checkout_root, scope) {
 
     absolute <- file.path(checkout_root, paths)
     hashes <- rep.int("<missing>", length(paths))
+    if (any(nzchar(Sys.readlink(absolute)))) {
+        stop("benchmark source provenance input must be a regular nonsymlink file")
+    }
     present <- file.exists(absolute)
     present_paths <- absolute[present]
-    if (length(present_paths) &&
-        (any(nzchar(Sys.readlink(present_paths))) ||
-         any(!file_test("-f", present_paths)))) {
+    if (length(present_paths) && any(!file_test("-f", present_paths))) {
         stop("benchmark source provenance input must be a regular nonsymlink file")
     }
     observed_hashes <- unname(tools::md5sum(present_paths))
@@ -184,6 +185,7 @@ write_benchmark_provenance <- function(checkout_root, benchmark_library, path,
     }
     source_tarball_sha256 <- tolower(as.character(source_tarball_sha256))
     if (length(source_tarball_sha256) != 1L ||
+        is.na(source_tarball_sha256) ||
         !grepl("^[0-9a-f]{64}$", source_tarball_sha256)) {
         stop("source tarball SHA-256 is invalid")
     }

--- a/benchmarks/large-scale/provenance.R
+++ b/benchmarks/large-scale/provenance.R
@@ -46,7 +46,17 @@ benchmark_tree_digest <- function(checkout_root, scope) {
     absolute <- file.path(checkout_root, paths)
     hashes <- rep.int("<missing>", length(paths))
     present <- file.exists(absolute)
-    hashes[present] <- unname(tools::md5sum(absolute[present]))
+    present_paths <- absolute[present]
+    if (length(present_paths) &&
+        (any(nzchar(Sys.readlink(present_paths))) ||
+         any(!file_test("-f", present_paths)))) {
+        stop("benchmark source provenance input must be a regular nonsymlink file")
+    }
+    observed_hashes <- unname(tools::md5sum(present_paths))
+    if (anyNA(observed_hashes)) {
+        stop("benchmark source provenance input could not be hashed")
+    }
+    hashes[present] <- observed_hashes
     manifest <- paste(paths, hashes, sep = "\t")
     temporary <- tempfile("dtaparser-provenance-")
     on.exit(unlink(temporary), add = TRUE)

--- a/benchmarks/large-scale/provenance.R
+++ b/benchmarks/large-scale/provenance.R
@@ -1,3 +1,21 @@
+benchmark_assert_plain_text <- function(values, label) {
+    values <- as.character(values)
+    if (anyNA(values) || any(grepl("[\t\r\n]", values, perl = TRUE))) {
+        stop(label, " must not contain tabs, newlines, or missing values")
+    }
+    invisible(values)
+}
+
+benchmark_assert_provenance_fields <- function(provenance) {
+    stopifnot(is.data.frame(provenance), nrow(provenance) == 1L)
+    for (field in names(provenance)) {
+        benchmark_assert_plain_text(provenance[[field]], paste0(
+            "benchmark provenance field ", field
+        ))
+    }
+    invisible(provenance)
+}
+
 benchmark_git_lines <- function(checkout_root, arguments) {
     diagnostics_path <- tempfile("benchmark-git-stderr-")
     on.exit(unlink(diagnostics_path), add = TRUE)
@@ -23,6 +41,7 @@ benchmark_tree_digest <- function(checkout_root, scope) {
     )
     paths <- sort(unique(paths[nzchar(paths)]))
     if (!length(paths)) stop("no provenance inputs found under ", scope)
+    benchmark_assert_plain_text(paths, "benchmark source path")
 
     absolute <- file.path(checkout_root, paths)
     hashes <- rep.int("<missing>", length(paths))
@@ -39,6 +58,7 @@ benchmark_installed_package_path <- function(benchmark_library) {
     benchmark_library <- normalizePath(
         benchmark_library, winslash = "/", mustWork = TRUE
     )
+    benchmark_assert_plain_text(benchmark_library, "benchmark library path")
     lexical_path <- file.path(benchmark_library, "dtaparser")
     link_target <- Sys.readlink(lexical_path)
     if (nzchar(link_target)) {
@@ -55,13 +75,36 @@ benchmark_installed_package_path <- function(benchmark_library) {
 
 benchmark_directory_digest <- function(directory) {
     directory <- normalizePath(directory, winslash = "/", mustWork = TRUE)
-    paths <- list.files(
+    benchmark_assert_plain_text(directory, "installed package path")
+    entries <- list.files(
         directory, recursive = TRUE, all.files = TRUE,
-        full.names = FALSE, include.dirs = FALSE, no.. = TRUE
+        full.names = FALSE, include.dirs = TRUE, no.. = TRUE
     )
-    paths <- sort(paths)
-    if (!length(paths)) stop("no installed provenance inputs found under ", directory)
-    hashes <- unname(tools::md5sum(file.path(directory, paths)))
+    entries <- sort(entries)
+    if (!length(entries)) {
+        stop("no installed provenance inputs found under ", directory)
+    }
+    benchmark_assert_plain_text(entries, "installed package entry")
+    absolute <- file.path(directory, entries)
+    if (any(nzchar(Sys.readlink(absolute)))) {
+        stop("installed dtaparser package tree must not contain symbolic links")
+    }
+    resolved <- normalizePath(absolute, winslash = "/", mustWork = TRUE)
+    prefix <- paste0(directory, "/")
+    if (any(!startsWith(resolved, prefix))) {
+        stop("installed dtaparser package entry resolves outside its package tree")
+    }
+    info <- file.info(absolute)
+    if (anyNA(info$isdir)) {
+        stop("installed dtaparser package tree contains an unreadable entry")
+    }
+    files <- !info$isdir
+    if (!any(files) || any(!file_test("-f", absolute[files]))) {
+        stop("installed dtaparser package tree contains a non-regular file")
+    }
+    paths <- entries[files]
+    hashes <- unname(tools::md5sum(absolute[files]))
+    if (anyNA(hashes)) stop("installed dtaparser package file could not be hashed")
     manifest <- paste(paths, hashes, sep = "\t")
     temporary <- tempfile("dtaparser-installed-provenance-")
     on.exit(unlink(temporary), add = TRUE)
@@ -74,6 +117,9 @@ benchmark_current_provenance <- function(checkout_root, benchmark_library) {
     benchmark_library <- normalizePath(
         benchmark_library, winslash = "/", mustWork = TRUE
     )
+    benchmark_assert_plain_text(
+        c(checkout_root, benchmark_library), "benchmark provenance root"
+    )
     commit <- benchmark_git_lines(checkout_root, c("rev-parse", "HEAD"))
     stopifnot(length(commit) == 1L)
     status <- benchmark_git_lines(
@@ -84,7 +130,7 @@ benchmark_current_provenance <- function(checkout_root, benchmark_library) {
     description <- read.dcf(
         file.path(checkout_root, "r-package", "dtaparser", "DESCRIPTION")
     )
-    data.frame(
+    provenance <- data.frame(
         schema_version = 1L,
         checkout_root = checkout_root,
         git_commit = commit,
@@ -103,10 +149,12 @@ benchmark_current_provenance <- function(checkout_root, benchmark_library) {
         stringsAsFactors = FALSE,
         check.names = FALSE
     )
+    benchmark_assert_provenance_fields(provenance)
+    provenance
 }
 
 benchmark_provenance_id <- function(provenance) {
-    stopifnot(is.data.frame(provenance), nrow(provenance) == 1L)
+    benchmark_assert_provenance_fields(provenance)
     fields <- sort(names(provenance))
     values <- vapply(fields, function(field) {
         paste0(field, "=", as.character(provenance[[field]][[1L]]))
@@ -134,6 +182,7 @@ write_benchmark_provenance <- function(checkout_root, benchmark_library, path,
     provenance$created_at_utc <- format(
         Sys.time(), "%Y-%m-%dT%H:%M:%SZ", tz = "UTC"
     )
+    benchmark_assert_provenance_fields(provenance)
     temporary <- tempfile(
         pattern = paste0(basename(path), "."), tmpdir = dirname(path)
     )
@@ -156,6 +205,7 @@ verify_benchmark_provenance <- function(checkout_root, benchmark_library, path) 
         colClasses = "character"
     )
     if (nrow(recorded) != 1L) stop("benchmark provenance record must have one row")
+    benchmark_assert_provenance_fields(recorded)
     current <- benchmark_current_provenance(checkout_root, benchmark_library)
     fields <- names(current)
     if (!all(c(fields, "source_tarball_sha256", "provenance_id",

--- a/benchmarks/large-scale/provenance.R
+++ b/benchmarks/large-scale/provenance.R
@@ -1,12 +1,17 @@
 benchmark_git_lines <- function(checkout_root, arguments) {
+    diagnostics_path <- tempfile("benchmark-git-stderr-")
+    on.exit(unlink(diagnostics_path), add = TRUE)
     output <- system2(
         "git",
         c("-C", shQuote(checkout_root), arguments),
-        stdout = TRUE, stderr = TRUE
+        stdout = TRUE, stderr = diagnostics_path
     )
     status <- attr(output, "status", exact = TRUE)
     if (!is.null(status) && status != 0L) {
-        stop("git command failed: ", paste(output, collapse = "\n"))
+        diagnostics <- if (file.exists(diagnostics_path)) {
+            readLines(diagnostics_path, warn = FALSE)
+        } else character()
+        stop("git command failed: ", paste(c(output, diagnostics), collapse = "\n"))
     }
     output
 }

--- a/benchmarks/large-scale/results-2026-07-27.md
+++ b/benchmarks/large-scale/results-2026-07-27.md
@@ -1,0 +1,188 @@
+# Large-scale R benchmark results (2026-07-27)
+
+## Source and command
+
+The benchmark was launched from `benchmark-fertility-integration` at commit:
+
+```text
+34235b53c0b4b6987aaa3500d8496cf952b6394d
+34235b5 Add reproducible large-scale R benchmark
+```
+
+As a manually observed pre-run check, `git status --porcelain=v1` produced no
+output immediately before launch. That observation covered the whole checkout
+but is not itself part of the published provenance. The build provenance's
+`git_dirty = FALSE` and source digests bind the package and large-scale
+benchmark scopes at the orchestrator's verification points; they do not provide
+a continuous audit of the rest of the checkout or prove that no transient edits
+occurred between those points.
+
+The manually recorded orchestrator launch command was:
+
+```sh
+mkdir -p /Users/jmb/repos/dta-parser/target/large-scale && \
+/Users/jmb/repos/dta-parser/benchmarks/large-scale/benchmark.sh 101 \
+  > /Users/jmb/repos/dta-parser/target/large-scale/benchmark-101-2026-07-27.log 2>&1
+```
+
+The command is included as a run note; it is not a field in the published
+provenance records or independently recoverable from the captured console log.
+Strict validation and summarization succeeded, and the harness atomically
+published:
+
+```text
+/Users/jmb/repos/dta-parser/target/large-scale/runs/20260727T165751Z-968ac61a1f2009c9-65682
+```
+
+`target/large-scale/CURRENT` points to that directory.
+
+## Environment and provenance
+
+The published provenance records bind the following runtime and build values:
+
+| Component | Provenance-bound value |
+| --- | --- |
+| CPU identity | Apple M4 Max |
+| Kernel | Darwin 25.5.0, arm64 |
+| R | R 4.6.1 (2026-06-24), `aarch64-apple-darwin25.4.0` |
+| Python | Python 3.14.6, `/Users/jmb/.pyenv/shims/python3` |
+| dtaparser | 0.1.0, checkout-local benchmark library |
+| haven | 2.5.5, `/opt/homebrew/lib/R/4.6/site-library/haven` |
+| tidyselect | 1.2.1, `/opt/homebrew/lib/R/4.6/site-library/tidyselect` |
+| readr | 2.2.0, `/opt/homebrew/lib/R/4.6/site-library/readr` |
+| rlang | 1.3.0, `/opt/homebrew/lib/R/4.6/site-library/rlang` |
+| tibble | 3.3.1, `/opt/homebrew/lib/R/4.6/site-library/tibble` |
+| Iterations | 101 per size, workload, and implementation |
+| Build provenance ID | `b94de50f52d3ed66139bca288d7dea8f7d8f1952110c34212a684f1725721d75` |
+| Run provenance ID | `968ac61a1f2009c97e1efdfae1dc758007dd1e99ac337b47b95df195d454ed86` |
+| Source tarball SHA-256 | `1c2611712241d79c8bb958ac7734d0318b6e2c554384dce3ae8175b1308b3df9` |
+| Manifest SHA-256 | `4677c05789070547038a0d8b4d75134d59f3b03346e5e28437522316427d37b9` |
+
+The exact C compiler is recorded in lines 22–24 of the preserved, hashed
+console log, so it is independently auditable from that artifact even though it
+is not a field bound into the provenance records:
+
+| Component | Console-log-recorded value |
+| --- | --- |
+| C compiler | Apple clang 21.0.0 (clang-2100.1.1.101) |
+
+The following supplementary environment details are manually recorded run
+notes, not fields in the published provenance records or console log and
+therefore not independently auditable from the result bundle:
+
+| Component | Manually recorded value |
+| --- | --- |
+| Host | Mac Studio, 128 GB RAM |
+| OS product version | macOS 26.5.2 (build 25F84) |
+| Rust | rustc 1.97.1 (8bab26f4f, Homebrew) |
+| Cargo | cargo 1.97.1 (c980f4866, Homebrew) |
+
+The package source digest was checked before the build and after installation.
+The installed package tree, loaded namespace path, scoped source trees,
+benchmark harness, source tarball, dependencies, runtime, dataset identities,
+and matrix shape are bound into the two provenance records.
+
+## Datasets
+
+Both deterministic Stata 15 files contain the same 40-column mixed schema. The
+projected workload reads eight fixed representative columns.
+
+| Dataset | Target bytes | Actual bytes | Rows | Bytes/row | SHA-256 |
+| --- | ---: | ---: | ---: | ---: | --- |
+| 100 MB | 100,000,000 | 99,999,790 | 222,656 | 449 | `730f0233c663bd5d83a73e5b6d36b083bc0621f18fdbf13df8c3d737abe14e3e` |
+| 1 GB | 1,000,000,000 | 1,000,000,085 | 2,227,111 | 449 | `0b8dc727a0fe25963607cd6645edcbe896746c50ce41c5d02b3745a3de73da19` |
+
+## Timing results
+
+Times are elapsed seconds. Throughput is actual input bytes divided by elapsed
+time using decimal GB. All figures below are copied from the same four-row
+`summary.tsv` produced by the strict summarizer.
+
+| Input | Workload | Implementation | Iterations | Median (s) | p05 (s) | p95 (s) | Median GB/s |
+| --- | --- | --- | ---: | ---: | ---: | ---: | ---: |
+| 100 MB | Full, 40 columns | Direct-R | 101 | 0.303 | 0.28 | 0.364 | 0.330032310231023 |
+| 100 MB | Full, 40 columns | Rust vectors | 101 | 0.247 | 0.237 | 0.29 | 0.404857449392713 |
+| 100 MB | Full, 40 columns | haven | 101 | 1.19 | 1.15 | 1.36 | 0.0840334369747899 |
+| 100 MB | Projected, 8 columns | Direct-R | 101 | 0.082 | 0.076 | 0.088 | 1.21950963414634 |
+| 100 MB | Projected, 8 columns | Rust vectors | 101 | 0.082 | 0.078 | 0.089 | 1.21950963414634 |
+| 100 MB | Projected, 8 columns | haven | 101 | 0.306 | 0.29 | 0.328 | 0.326796699346405 |
+| 1 GB | Full, 40 columns | Direct-R | 101 | 2.185 | 2.108 | 2.412 | 0.457665942791762 |
+| 1 GB | Full, 40 columns | Rust vectors | 101 | 2.337 | 2.286 | 2.613 | 0.42789905220368 |
+| 1 GB | Full, 40 columns | haven | 101 | 11.795 | 11.008 | 12.972 | 0.0847816943620178 |
+| 1 GB | Projected, 8 columns | Direct-R | 101 | 0.755 | 0.732 | 0.78 | 1.32450342384106 |
+| 1 GB | Projected, 8 columns | Rust vectors | 101 | 0.744 | 0.715 | 0.778 | 1.34408613575269 |
+| 1 GB | Projected, 8 columns | haven | 101 | 2.903 | 2.879 | 2.966 | 0.344471265931795 |
+
+## Median speedups
+
+A value greater than one means the implementation named before “vs” was faster.
+For example, Direct-R vs haven is `haven median / Direct-R median`.
+
+| Input | Workload | Direct-R vs Rust vectors | Direct-R vs haven | Rust vectors vs haven |
+| --- | --- | ---: | ---: | ---: |
+| 100 MB | Full, 40 columns | 0.815181518151815x | 3.92739273927393x | 4.81781376518219x |
+| 100 MB | Projected, 8 columns | 1x | 3.73170731707317x | 3.73170731707317x |
+| 1 GB | Full, 40 columns | 1.0695652173913x | 5.39816933638444x | 5.04706889174155x |
+| 1 GB | Projected, 8 columns | 0.985430463576159x | 3.84503311258278x | 3.90188172043011x |
+
+Direct-R and the retained Rust-vector path were close and workload-dependent:
+Direct-R was faster for the 1 GB full read, tied at the reported 100 MB
+projection median, and slower for the other two cells. Direct-R was 3.73x to
+5.40x faster than haven by median elapsed time in this run.
+
+## Validation
+
+Before timing each dataset/workload cell, the harness:
+
+- required exact identity between the public Direct-R collector and the retained
+  internal Rust-vector collector;
+- compared projected 32-row windows at the beginning, middle, and end with
+  haven, allowing only `1e-7` tolerance for nonmissing floating-point values;
+- warmed all three implementations;
+- alternated forward and reverse implementation order;
+- ran garbage collection outside timed regions.
+
+The dataset canonical paths, sizes, row counts, row widths, fixed overhead, and
+SHA-256 values were checked before timing and again before raw publication. The
+summarizer required the exact Cartesian matrix:
+
+```text
+2 sizes × 2 workloads × 3 implementations × 101 iterations = 1,212 rows
+```
+
+It also rejected duplicate or missing cells, wrong iteration ranges, nonfinite
+or nonpositive timings, inconsistent throughput, dataset metadata, shape, or
+provenance. The completed raw file has 1,212 data rows and the summary has four.
+
+## Artifacts
+
+| Artifact | Location | SHA-256 |
+| --- | --- | --- |
+| Exact console log | `target/large-scale/benchmark-101-2026-07-27.log` | `e561b48b88229c98037ebdc3bd17290e6d51333601a3508fb5cf9c6b5a727c47` |
+| Raw timings | `target/large-scale/runs/20260727T165751Z-968ac61a1f2009c9-65682/raw.tsv` | `fa29f4357ff78a84f0d0f5cfe7d8ac75e43e8984966d1ae2bfc078fe47a2fdc0` |
+| Summary | `target/large-scale/runs/20260727T165751Z-968ac61a1f2009c9-65682/summary.tsv` | `06eca86e3905756936e31d602a4aa8fc50b60e696b5d79e1bbc7d942e70ebb60` |
+| Runtime provenance | `target/large-scale/runs/20260727T165751Z-968ac61a1f2009c9-65682/run-provenance.tsv` | `9c0d10c9e8c3a959715454fb3188c4048fa17e15cae85ff9a8852b3f816b9bd5` |
+| Build provenance | `target/large-scale/runs/20260727T165751Z-968ac61a1f2009c9-65682/build-provenance.tsv` | `0466b100a3bf04885751a3170af82cfa500afe052b80de23e961ef4be99014ff` |
+
+These paths are intentionally ignored by Git. `target/large-scale/CURRENT`
+selects the completed bundle.
+
+## Interpretation and caveats
+
+These are warm-cache, machine- and workload-specific measurements, not API
+promises, release gates, or timing assertions. The generated files are
+synthetic mixed-type microdata and do not represent every real Stata schema,
+storage mix, filesystem, cache state, or downstream workload. Process startup,
+package installation, dataset generation, validation, warmup, and garbage
+collection are excluded from the timed intervals. No 10 GB file was generated
+or measured because this phase is explicitly scoped to 100 MB and 1 GB.
+
+Haven is used as the compatibility oracle because it is the established R Stata
+reader and provides the public behavior this package aims to match. It is not
+infallible: haven can contain bugs, version-specific behavior, platform-specific
+native coercions, encoding edge cases, or deliberate semantics that differ from
+Stata itself. Agreement with haven is therefore strong compatibility evidence,
+not proof of universal correctness. The independent exact Direct-R versus
+Rust-vector check, checked fixtures, parser metadata validation, and repository
+conformance suite remain separate safeguards rather than treating one external
+implementation as unquestionable ground truth.

--- a/benchmarks/large-scale/results-2026-07-27.md
+++ b/benchmarks/large-scale/results-2026-07-27.md
@@ -20,21 +20,19 @@ occurred between those points.
 The manually recorded orchestrator launch command was:
 
 ```sh
-mkdir -p /Users/jmb/repos/dta-parser/target/large-scale && \
-/Users/jmb/repos/dta-parser/benchmarks/large-scale/benchmark.sh 101 \
-  > /Users/jmb/repos/dta-parser/target/large-scale/benchmark-101-2026-07-27.log 2>&1
+benchmarks/large-scale/benchmark.sh 101 > "$PRIVATE_LOG" 2>&1
 ```
+
+`PRIVATE_LOG` named an ignored checkout-local private log; its concrete mutable
+location is intentionally not published.
 
 The command is included as a run note; it is not a field in the published
 provenance records or independently recoverable from the captured console log.
 Strict validation and summarization succeeded, and the harness atomically
-published:
-
-```text
-/Users/jmb/repos/dta-parser/target/large-scale/runs/20260727T165751Z-968ac61a1f2009c9-65682
-```
-
-`target/large-scale/CURRENT` points to that directory.
+published an immutable private bundle identified by run provenance ID
+`968ac61a1f2009c97e1efdfae1dc758007dd1e99ac337b47b95df195d454ed86`.
+Its mutable checkout selection and private location are intentionally not
+published.
 
 ## Environment and provenance
 
@@ -45,13 +43,13 @@ The published provenance records bind the following runtime and build values:
 | CPU identity | Apple M4 Max |
 | Kernel | Darwin 25.5.0, arm64 |
 | R | R 4.6.1 (2026-06-24), `aarch64-apple-darwin25.4.0` |
-| Python | Python 3.14.6, `/Users/jmb/.pyenv/shims/python3` |
+| Python | Python 3.14.6, provenance-bound executable identity |
 | dtaparser | 0.1.0, checkout-local benchmark library |
-| haven | 2.5.5, `/opt/homebrew/lib/R/4.6/site-library/haven` |
-| tidyselect | 1.2.1, `/opt/homebrew/lib/R/4.6/site-library/tidyselect` |
-| readr | 2.2.0, `/opt/homebrew/lib/R/4.6/site-library/readr` |
-| rlang | 1.3.0, `/opt/homebrew/lib/R/4.6/site-library/rlang` |
-| tibble | 3.3.1, `/opt/homebrew/lib/R/4.6/site-library/tibble` |
+| haven | 2.5.5, provenance-bound installation identity |
+| tidyselect | 1.2.1, provenance-bound installation identity |
+| readr | 2.2.0, provenance-bound installation identity |
+| rlang | 1.3.0, provenance-bound installation identity |
+| tibble | 3.3.1, provenance-bound installation identity |
 | Iterations | 101 per size, workload, and implementation |
 | Build provenance ID | `b94de50f52d3ed66139bca288d7dea8f7d8f1952110c34212a684f1725721d75` |
 | Run provenance ID | `968ac61a1f2009c97e1efdfae1dc758007dd1e99ac337b47b95df195d454ed86` |
@@ -156,16 +154,16 @@ provenance. The completed raw file has 1,212 data rows and the summary has four.
 
 ## Artifacts
 
-| Artifact | Location | SHA-256 |
+| Artifact | Private identity | SHA-256 |
 | --- | --- | --- |
-| Exact console log | `target/large-scale/benchmark-101-2026-07-27.log` | `e561b48b88229c98037ebdc3bd17290e6d51333601a3508fb5cf9c6b5a727c47` |
-| Raw timings | `target/large-scale/runs/20260727T165751Z-968ac61a1f2009c9-65682/raw.tsv` | `fa29f4357ff78a84f0d0f5cfe7d8ac75e43e8984966d1ae2bfc078fe47a2fdc0` |
-| Summary | `target/large-scale/runs/20260727T165751Z-968ac61a1f2009c9-65682/summary.tsv` | `06eca86e3905756936e31d602a4aa8fc50b60e696b5d79e1bbc7d942e70ebb60` |
-| Runtime provenance | `target/large-scale/runs/20260727T165751Z-968ac61a1f2009c9-65682/run-provenance.tsv` | `9c0d10c9e8c3a959715454fb3188c4048fa17e15cae85ff9a8852b3f816b9bd5` |
-| Build provenance | `target/large-scale/runs/20260727T165751Z-968ac61a1f2009c9-65682/build-provenance.tsv` | `0466b100a3bf04885751a3170af82cfa500afe052b80de23e961ef4be99014ff` |
+| Exact console log | Content-bound ignored artifact | `e561b48b88229c98037ebdc3bd17290e6d51333601a3508fb5cf9c6b5a727c47` |
+| Raw timings | Run-provenance-bound bundle member | `fa29f4357ff78a84f0d0f5cfe7d8ac75e43e8984966d1ae2bfc078fe47a2fdc0` |
+| Summary | Run-provenance-bound bundle member | `06eca86e3905756936e31d602a4aa8fc50b60e696b5d79e1bbc7d942e70ebb60` |
+| Runtime provenance | Run-provenance-bound bundle member | `9c0d10c9e8c3a959715454fb3188c4048fa17e15cae85ff9a8852b3f816b9bd5` |
+| Build provenance | Run-provenance-bound bundle member | `0466b100a3bf04885751a3170af82cfa500afe052b80de23e961ef4be99014ff` |
 
-These paths are intentionally ignored by Git. `target/large-scale/CURRENT`
-selects the completed bundle.
+All five artifacts remain ignored and private; only their content identities are
+published.
 
 ## Interpretation and caveats
 

--- a/benchmarks/large-scale/run.R
+++ b/benchmarks/large-scale/run.R
@@ -1,0 +1,449 @@
+args <- commandArgs(trailingOnly = TRUE)
+if (length(args) < 2L) {
+    stop(paste(
+        "usage: Rscript run.R DATASETS_TSV OUTPUT_TSV [ITERATIONS]",
+        "[RUNTIME_PROVENANCE_TSV]"
+    ))
+}
+
+manifest_path <- normalizePath(args[[1L]])
+output_path <- normalizePath(args[[2L]], mustWork = FALSE)
+iterations <- if (length(args) >= 3L) as.integer(args[[3L]]) else 101L
+runtime_provenance_path <- if (length(args) >= 4L) {
+    normalizePath(args[[4L]], mustWork = FALSE)
+} else {
+    file.path(dirname(output_path), "run-provenance.tsv")
+}
+stopifnot(is.finite(iterations), iterations >= 1L)
+
+script_argument <- grep("^--file=", commandArgs(trailingOnly = FALSE), value = TRUE)[[1L]]
+script_path <- normalizePath(sub("^--file=", "", script_argument), winslash = "/")
+checkout_root <- normalizePath(file.path(dirname(script_path), "..", ".."), winslash = "/")
+benchmark_library <- Sys.getenv("DTAPARSER_BENCH_LIB")
+if (!nzchar(benchmark_library)) {
+    stop("set DTAPARSER_BENCH_LIB to a library containing dtaparser built from this checkout")
+}
+benchmark_library <- normalizePath(benchmark_library, winslash = "/")
+if (!startsWith(benchmark_library, paste0(checkout_root, "/"))) {
+    stop("DTAPARSER_BENCH_LIB must point to a library inside this checkout")
+}
+sys.source(file.path(dirname(script_path), "provenance.R"), envir = environment())
+provenance_path <- file.path(
+    benchmark_library, "dtaparser-benchmark-provenance.tsv"
+)
+provenance <- verify_benchmark_provenance(
+    checkout_root, benchmark_library, provenance_path
+)
+.libPaths(c(benchmark_library, .libPaths()))
+if (!requireNamespace("dtaparser", quietly = TRUE)) {
+    stop("DTAPARSER_BENCH_LIB does not contain a loadable dtaparser installation")
+}
+loaded_library <- normalizePath(dirname(find.package("dtaparser")), winslash = "/")
+namespace_path <- normalizePath(
+    getNamespaceInfo(asNamespace("dtaparser"), "path"), winslash = "/"
+)
+expected_package_path <- benchmark_installed_package_path(benchmark_library)
+if (!identical(loaded_library, benchmark_library) ||
+    !identical(namespace_path, expected_package_path)) {
+    stop("dtaparser namespace was not loaded from DTAPARSER_BENCH_LIB")
+}
+if (!identical(
+    as.character(utils::packageVersion("dtaparser")),
+    as.character(provenance$package_version[[1L]])
+)) {
+    stop("installed dtaparser version does not match benchmark provenance")
+}
+runtime_packages <- c(
+    "dtaparser", "haven", "tidyselect", "readr", "rlang", "tibble"
+)
+for (package in runtime_packages) {
+    if (!requireNamespace(package, quietly = TRUE)) {
+        stop(package, " is required")
+    }
+}
+
+sha256_file <- function(path) {
+    tolower(unname(tools::sha256sum(path))[[1L]])
+}
+
+canonical_target <- normalizePath(
+    file.path(checkout_root, "target", "large-scale"),
+    winslash = "/", mustWork = TRUE
+)
+artifact_parents <- vapply(
+    c(output_path, runtime_provenance_path),
+    function(path) normalizePath(dirname(path), winslash = "/", mustWork = TRUE),
+    character(1)
+)
+if (length(unique(artifact_parents)) != 1L) {
+    stop("raw output and runtime provenance must share a staging directory")
+}
+artifact_parent <- artifact_parents[[1L]]
+staged_parent <- identical(dirname(artifact_parent), canonical_target) &&
+    startsWith(basename(artifact_parent), ".run.")
+if (!identical(artifact_parent, canonical_target) && !staged_parent) {
+    stop("benchmark artifacts must use target/large-scale or its run staging directory")
+}
+expected_manifest <- file.path(canonical_target, "datasets.tsv")
+if (!identical(manifest_path, expected_manifest)) {
+    stop("dataset manifest must be target/large-scale/datasets.tsv")
+}
+expected_dataset_paths <- file.path(
+    canonical_target, c("synthetic-100mb.dta", "synthetic-1gb.dta")
+)
+
+verify_dataset_files <- function(datasets) {
+    required_manifest_columns <- c(
+        "dataset", "path", "target_bytes", "actual_bytes", "sha256", "rows",
+        "obs_bytes", "base_rows"
+    )
+    if (!all(required_manifest_columns %in% names(datasets))) {
+        stop("dataset manifest is missing required fields")
+    }
+    stopifnot(
+        nrow(datasets) == 2L,
+        identical(as.character(datasets$dataset), c("100mb", "1gb")),
+        identical(as.double(datasets$target_bytes), c(100000000, 1000000000))
+    )
+    if (any(nzchar(Sys.readlink(expected_dataset_paths)))) {
+        stop("benchmark dataset paths must not be symbolic links")
+    }
+    resolved <- vapply(datasets$path, normalizePath, character(1), winslash = "/")
+    if (!identical(unname(resolved), expected_dataset_paths)) {
+        stop("manifest dataset paths are not the canonical expected paths")
+    }
+
+    numeric_fields <- c("target_bytes", "actual_bytes", "rows", "obs_bytes",
+                        "base_rows")
+    for (field in numeric_fields) {
+        value <- as.double(datasets[[field]])
+        if (any(!is.finite(value) | value <= 0 | value != floor(value))) {
+            stop("manifest field is not positive integral: ", field)
+        }
+        datasets[[field]] <- value
+    }
+    if (length(unique(datasets$obs_bytes)) != 1L ||
+        length(unique(datasets$base_rows)) != 1L) {
+        stop("scaled datasets disagree on base row metadata")
+    }
+    overhead <- datasets$actual_bytes - datasets$rows * datasets$obs_bytes
+    if (any(overhead <= 0) || length(unique(overhead)) != 1L) {
+        stop("scaled dataset row width and overhead are inconsistent")
+    }
+    if (any(abs(datasets$actual_bytes - datasets$target_bytes) >
+            datasets$obs_bytes / 2 + 0.5)) {
+        stop("scaled dataset size is inconsistent with its target")
+    }
+
+    actual_sizes <- as.double(file.info(expected_dataset_paths)$size)
+    if (!identical(actual_sizes, datasets$actual_bytes)) {
+        stop("dataset file size does not match manifest actual_bytes")
+    }
+    expected_hashes <- tolower(as.character(datasets$sha256))
+    if (any(!grepl("^[0-9a-f]{64}$", expected_hashes))) {
+        stop("dataset manifest contains an invalid SHA-256")
+    }
+    actual_hashes <- vapply(expected_dataset_paths, sha256_file, character(1))
+    if (!identical(unname(actual_hashes), expected_hashes)) {
+        stop("dataset SHA-256 does not match manifest")
+    }
+    datasets$path <- expected_dataset_paths
+    datasets$sha256 <- expected_hashes
+    datasets$overhead_bytes <- overhead
+    datasets
+}
+
+command_output <- function(command, arguments = character()) {
+    tryCatch(
+        paste(suppressWarnings(system2(
+            command, arguments, stdout = TRUE, stderr = FALSE
+        )), collapse = " "),
+        error = function(error) "unavailable"
+    )
+}
+
+cpu_identity <- function() {
+    info <- Sys.info()
+    if (identical(unname(info[["sysname"]]), "Darwin")) {
+        value <- command_output(Sys.which("sysctl"), c("-n", "machdep.cpu.brand_string"))
+        if (nzchar(value)) return(value)
+        hardware <- tryCatch(
+            suppressWarnings(system2(
+                "/usr/sbin/system_profiler", "SPHardwareDataType",
+                stdout = TRUE, stderr = FALSE
+            )), error = function(error) character()
+        )
+        chip <- trimws(sub("^.*Chip:", "", grep("Chip:", hardware, value = TRUE)))
+        if (length(chip) && nzchar(chip[[1L]])) return(chip[[1L]])
+    }
+    if (identical(unname(info[["sysname"]]), "Linux") &&
+        file.exists("/proc/cpuinfo")) {
+        lines <- readLines("/proc/cpuinfo", warn = FALSE)
+        model <- sub("^[^:]+:[[:space:]]*", "", grep(
+            "^(model name|Hardware)[[:space:]]*:", lines, value = TRUE
+        ))
+        if (length(model)) return(model[[1L]])
+    }
+    value <- Sys.getenv("PROCESSOR_IDENTIFIER")
+    if (nzchar(value)) value else unname(info[["machine"]])
+}
+
+collect_runtime_provenance <- function(datasets, full_columns, projected_columns) {
+    system <- Sys.info()
+    python_path <- unname(Sys.which("python3"))
+    runtime <- data.frame(
+        schema_version = 1L,
+        build_provenance_id = as.character(provenance$provenance_id[[1L]]),
+        manifest_sha256 = sha256_file(manifest_path),
+        iterations = iterations,
+        dataset_100mb_sha256 = datasets$sha256[[1L]],
+        dataset_1gb_sha256 = datasets$sha256[[2L]],
+        dataset_100mb_bytes = datasets$actual_bytes[[1L]],
+        dataset_1gb_bytes = datasets$actual_bytes[[2L]],
+        dataset_100mb_rows = datasets$rows[[1L]],
+        dataset_1gb_rows = datasets$rows[[2L]],
+        full_columns = full_columns,
+        projected_columns = projected_columns,
+        r_version = R.version.string,
+        r_platform = R.version$platform,
+        os_sysname = unname(system[["sysname"]]),
+        os_release = unname(system[["release"]]),
+        os_version = unname(system[["version"]]),
+        os_machine = unname(system[["machine"]]),
+        cpu_identity = cpu_identity(),
+        python_version = command_output(python_path, "--version"),
+        python_path = normalizePath(python_path, winslash = "/", mustWork = TRUE),
+        stringsAsFactors = FALSE,
+        check.names = FALSE
+    )
+    for (package in runtime_packages) {
+        runtime[[paste0(package, "_version")]] <-
+            as.character(utils::packageVersion(package))
+        runtime[[paste0(package, "_path")]] <- normalizePath(
+            find.package(package), winslash = "/", mustWork = TRUE
+        )
+    }
+    runtime$provenance_id <- benchmark_provenance_id(runtime)
+    runtime
+}
+
+write_runtime_provenance <- function(runtime) {
+    record <- runtime
+    record$created_at_utc <- format(Sys.time(), "%Y-%m-%dT%H:%M:%SZ", tz = "UTC")
+    temporary <- tempfile(
+        pattern = paste0(basename(runtime_provenance_path), "."),
+        tmpdir = dirname(runtime_provenance_path)
+    )
+    on.exit(unlink(temporary), add = TRUE)
+    write.table(record, temporary, sep = "\t", row.names = FALSE, quote = FALSE)
+    if (!file.rename(temporary, runtime_provenance_path)) {
+        stop("could not atomically replace ", runtime_provenance_path)
+    }
+}
+
+datasets <- verify_dataset_files(read.delim(
+    manifest_path, check.names = FALSE, stringsAsFactors = FALSE,
+    colClasses = "character"
+))
+
+projection <- c(
+    "id", "income", "age", "region", "interview_date", "case_code",
+    "occupation", "description"
+)
+columns <- names(dtaparser::read_dta(datasets$path[[1L]], n_max = 0))
+stopifnot(all(projection %in% columns))
+datasets$columns <- length(columns)
+runtime_provenance <- collect_runtime_provenance(
+    datasets, full_columns = length(columns),
+    projected_columns = length(projection)
+)
+write_runtime_provenance(runtime_provenance)
+
+read_one <- function(implementation, workload, path, skip = 0, n_max = Inf) {
+    full <- identical(workload, "full")
+    if (identical(implementation, "direct-r")) {
+        if (full) {
+            dtaparser::read_dta(path, skip = skip, n_max = n_max)
+        } else {
+            dtaparser::read_dta(
+                path, col_select = tidyselect::all_of(projection),
+                skip = skip, n_max = n_max
+            )
+        }
+    } else if (identical(implementation, "rust-vectors")) {
+        if (full) {
+            dtaparser:::.read_dta_rust_vectors(path, skip = skip, n_max = n_max)
+        } else {
+            dtaparser:::.read_dta_rust_vectors(
+                path, col_select = tidyselect::all_of(projection),
+                skip = skip, n_max = n_max
+            )
+        }
+    } else if (full) {
+        haven::read_dta(path, skip = skip, n_max = n_max)
+    } else {
+        haven::read_dta(
+            path, col_select = tidyselect::all_of(projection),
+            skip = skip, n_max = n_max
+        )
+    }
+}
+
+normalize_for_haven <- function(value) {
+    # Old development builds exposed this parser-only attribute. It is not part
+    # of the public tibble returned by either current dtaparser or haven.
+    attr(value, "dta_format_version") <- NULL
+    value
+}
+
+validate_direct_identity <- function(path, workload, rows, expected_columns) {
+    direct <- read_one("direct-r", workload, path)
+    rust_vectors <- read_one("rust-vectors", workload, path)
+    stopifnot(
+        identical(direct, rust_vectors),
+        nrow(direct) == rows,
+        ncol(direct) == expected_columns
+    )
+    rm(direct, rust_vectors)
+    invisible(gc())
+}
+
+validate_haven_windows <- function(path, rows) {
+    window_rows <- min(32, rows)
+    windows <- unique(c(0, max(0, floor(rows / 2) - floor(window_rows / 2)),
+                        max(0, rows - window_rows)))
+    for (skip in windows) {
+        direct <- read_one(
+            "direct-r", "projected-eight-columns", path,
+            skip = skip, n_max = window_rows
+        )
+        rust_vectors <- read_one(
+            "rust-vectors", "projected-eight-columns", path,
+            skip = skip, n_max = window_rows
+        )
+        reference <- read_one(
+            "haven", "projected-eight-columns", path,
+            skip = skip, n_max = window_rows
+        )
+        stopifnot(identical(direct, rust_vectors))
+        comparison <- all.equal(
+            normalize_for_haven(direct), normalize_for_haven(reference),
+            tolerance = 1e-7, check.attributes = TRUE
+        )
+        if (!isTRUE(comparison)) {
+            stop("haven sample parity failed for ", path, " at skip=", skip,
+                 ": ", paste(comparison, collapse = "; "))
+        }
+    }
+    invisible(gc())
+}
+
+header <- c(
+    "dataset", "target_bytes", "actual_bytes", "dataset_sha256", "rows",
+    "columns", "workload", "implementation", "iteration", "elapsed_s",
+    "input_gb_per_s", "provenance_id", "build_provenance_id"
+)
+dir.create(dirname(output_path), recursive = TRUE, showWarnings = FALSE)
+temporary_output <- tempfile(
+    pattern = paste0(basename(output_path), "."),
+    tmpdir = dirname(output_path)
+)
+on.exit(unlink(temporary_output), add = TRUE)
+writeLines(paste(header, collapse = "\t"), temporary_output)
+
+implementations <- c("direct-r", "rust-vectors", "haven")
+workloads <- c("full", "projected-eight-columns")
+for (dataset_index in seq_len(nrow(datasets))) {
+    dataset <- datasets[dataset_index, ]
+    path <- normalizePath(dataset$path)
+    rows <- as.double(dataset$rows)
+    validate_haven_windows(path, rows)
+
+    for (workload in workloads) {
+        expected_columns <- if (identical(workload, "full")) {
+            dataset$columns
+        } else {
+            length(projection)
+        }
+        validate_direct_identity(path, workload, rows, expected_columns)
+        message("validated ", dataset$dataset, " ", workload)
+
+        for (implementation in implementations) {
+            warm <- read_one(implementation, workload, path)
+            stopifnot(nrow(warm) == rows, ncol(warm) == expected_columns)
+            rm(warm)
+            invisible(gc())
+        }
+
+        for (iteration in seq_len(iterations)) {
+            order <- if (iteration %% 2L) implementations else rev(implementations)
+            for (implementation in order) {
+                invisible(gc())
+                started <- proc.time()[["elapsed"]]
+                result <- read_one(implementation, workload, path)
+                elapsed <- proc.time()[["elapsed"]] - started
+                stopifnot(nrow(result) == rows, ncol(result) == expected_columns)
+                rate <- dataset$actual_bytes / 1e9 / elapsed
+                row <- c(
+                    dataset$dataset, dataset$target_bytes, dataset$actual_bytes,
+                    dataset$sha256, format(rows, scientific = FALSE),
+                    expected_columns, workload, implementation, iteration,
+                    sprintf("%.9f", elapsed), sprintf("%.6f", rate),
+                    runtime_provenance$provenance_id,
+                    runtime_provenance$build_provenance_id
+                )
+                cat(paste(row, collapse = "\t"), "\n", sep = "",
+                    file = temporary_output, append = TRUE)
+                message(
+                    dataset$dataset, " ", workload, " ", implementation, " ",
+                    iteration, "/", iterations, ": ", sprintf("%.3fs", elapsed)
+                )
+                rm(result)
+            }
+        }
+    }
+}
+
+final_datasets <- verify_dataset_files(read.delim(
+    manifest_path, check.names = FALSE, stringsAsFactors = FALSE,
+    colClasses = "character"
+))
+if (!identical(final_datasets$sha256, datasets$sha256) ||
+    !identical(final_datasets$actual_bytes, datasets$actual_bytes)) {
+    stop("benchmark datasets changed during timing")
+}
+final_build_provenance <- verify_benchmark_provenance(
+    checkout_root, benchmark_library, provenance_path
+)
+if (!identical(
+    as.character(final_build_provenance$provenance_id[[1L]]),
+    as.character(provenance$provenance_id[[1L]])
+)) {
+    stop("build provenance changed during timing")
+}
+final_runtime_provenance <- collect_runtime_provenance(
+    final_datasets, full_columns = length(columns),
+    projected_columns = length(projection)
+)
+if (!identical(
+    as.character(final_runtime_provenance$provenance_id[[1L]]),
+    as.character(runtime_provenance$provenance_id[[1L]])
+)) {
+    stop("runtime provenance changed during timing")
+}
+
+raw <- read.delim(
+    temporary_output, check.names = FALSE, colClasses = "character"
+)
+expected_rows <- nrow(datasets) * length(workloads) *
+    length(implementations) * iterations
+stopifnot(
+    nrow(raw) == expected_rows,
+    identical(as.character(unique(raw$provenance_id)),
+              as.character(runtime_provenance$provenance_id)),
+    identical(as.character(unique(raw$build_provenance_id)),
+              as.character(runtime_provenance$build_provenance_id))
+)
+if (!file.rename(temporary_output, output_path)) {
+    stop("could not atomically replace ", output_path)
+}

--- a/benchmarks/large-scale/scale-dta.py
+++ b/benchmarks/large-scale/scale-dta.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""Scale a Stata 118/119 file by repeating complete observation rows."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+from dataclasses import dataclass
+import hashlib
+import os
+from pathlib import Path
+import struct
+
+
+MAP_ENTRIES = 14
+DATA_OPEN = b"<data>"
+DATA_CLOSE = b"</data>"
+
+
+@dataclass(frozen=True)
+class ParsedBase:
+    endian: str
+    n_start: int
+    nobs: int
+    map_start: int
+    offsets: tuple[int, ...]
+    payload_start: int
+    payload_end: int
+    obs_bytes: int
+
+
+def one_location(data: bytes, needle: bytes) -> int:
+    start = data.find(needle)
+    if start < 0 or data.find(needle, start + 1) >= 0:
+        raise ValueError(f"expected exactly one {needle!r}")
+    return start
+
+
+def parse_base(data: bytes) -> ParsedBase:
+    byte_order_start = one_location(data, b"<byteorder>") + len(b"<byteorder>")
+    byte_order = data[byte_order_start : byte_order_start + 3]
+    if byte_order == b"LSF":
+        endian = "<"
+    elif byte_order == b"MSF":
+        endian = ">"
+    else:
+        raise ValueError(f"unsupported byte order {byte_order!r}")
+
+    release_start = one_location(data, b"<release>") + len(b"<release>")
+    release = int(data[release_start : release_start + 3])
+    if release not in (118, 119):
+        raise ValueError(f"expected release 118 or 119, got {release}")
+
+    n_start = one_location(data, b"<N>") + len(b"<N>")
+    nobs = struct.unpack_from(f"{endian}Q", data, n_start)[0]
+    map_start = one_location(data, b"<map>") + len(b"<map>")
+    offsets = list(struct.unpack_from(f"{endian}{MAP_ENTRIES}Q", data, map_start))
+    if offsets[13] != len(data):
+        raise ValueError(f"map EOF {offsets[13]} != file size {len(data)}")
+    if data[offsets[9] : offsets[9] + len(DATA_OPEN)] != DATA_OPEN:
+        raise ValueError("map data offset does not point to <data>")
+    if data[offsets[10] - len(DATA_CLOSE) : offsets[10]] != DATA_CLOSE:
+        raise ValueError("map strls offset is not immediately after </data>")
+
+    payload_start = offsets[9] + len(DATA_OPEN)
+    payload_end = offsets[10] - len(DATA_CLOSE)
+    payload_length = payload_end - payload_start
+    if nobs == 0 or payload_length % nobs:
+        raise ValueError("observation payload is not an integral row matrix")
+    return ParsedBase(
+        endian=endian,
+        n_start=n_start,
+        nobs=nobs,
+        map_start=map_start,
+        offsets=tuple(offsets),
+        payload_start=payload_start,
+        payload_end=payload_end,
+        obs_bytes=payload_length // nobs,
+    )
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        while chunk := stream.read(16 * 1024 * 1024):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def update_manifest(path: Path, row: dict[str, object]) -> None:
+    rows: list[dict[str, str | object]] = []
+    if path.exists():
+        with path.open(newline="") as stream:
+            rows.extend(csv.DictReader(stream, delimiter="\t"))
+    rows = [existing for existing in rows if existing["dataset"] != row["dataset"]]
+    rows.append(row)
+    order = {"100mb": 0, "1gb": 1}
+    rows.sort(key=lambda existing: order.get(str(existing["dataset"]), 2))
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(path.suffix + ".partial")
+    with temporary.open("w", newline="") as stream:
+        writer = csv.DictWriter(stream, fieldnames=list(row), delimiter="\t")
+        writer.writeheader()
+        writer.writerows(rows)
+    os.replace(temporary, path)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--base", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--target-bytes", type=int, required=True)
+    parser.add_argument("--label", required=True)
+    parser.add_argument("--manifest", type=Path, required=True)
+    args = parser.parse_args()
+
+    base = args.base.read_bytes()
+    parsed = parse_base(base)
+    payload_start = parsed.payload_start
+    payload_end = parsed.payload_end
+    base_rows = parsed.nobs
+    obs_bytes = parsed.obs_bytes
+    overhead = len(base) - (payload_end - payload_start)
+    rows = max(1, round((args.target_bytes - overhead) / obs_bytes))
+    actual_bytes = overhead + rows * obs_bytes
+    delta = actual_bytes - len(base)
+
+    prefix = bytearray(base[:payload_start])
+    suffix = base[payload_end:]
+    endian = parsed.endian
+    struct.pack_into(f"{endian}Q", prefix, parsed.n_start, rows)
+    map_start = parsed.map_start
+    offsets = list(parsed.offsets)
+    for index in range(10, 14):
+        offsets[index] += delta
+    struct.pack_into(f"{endian}{MAP_ENTRIES}Q", prefix, map_start, *offsets)
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    payload = memoryview(base)[payload_start:payload_end]
+    blocks, remainder = divmod(rows, base_rows)
+    temporary = args.output.with_suffix(args.output.suffix + ".partial")
+    with temporary.open("wb", buffering=16 * 1024 * 1024) as stream:
+        stream.write(prefix)
+        for _ in range(blocks):
+            stream.write(payload)
+        if remainder:
+            stream.write(payload[: remainder * obs_bytes])
+        stream.write(suffix)
+    os.replace(temporary, args.output)
+    if args.output.stat().st_size != actual_bytes:
+        raise RuntimeError("generated size differs from calculated size")
+
+    update_manifest(
+        args.manifest,
+        {
+            "dataset": args.label,
+            "path": str(args.output.resolve()),
+            "target_bytes": args.target_bytes,
+            "actual_bytes": actual_bytes,
+            "sha256": sha256_file(args.output),
+            "rows": rows,
+            "columns": "",
+            "obs_bytes": obs_bytes,
+            "base_rows": base_rows,
+        },
+    )
+    print(
+        f"wrote {args.output}: {rows} rows, {actual_bytes} bytes "
+        f"({actual_bytes / 1_000_000:.3f} MB), {obs_bytes} bytes/row"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/large-scale/summarize.R
+++ b/benchmarks/large-scale/summarize.R
@@ -1,0 +1,203 @@
+args <- commandArgs(trailingOnly = TRUE)
+if (length(args) < 3L) {
+    stop("usage: Rscript summarize.R RAW_TSV SUMMARY_TSV RUNTIME_PROVENANCE_TSV")
+}
+
+script_argument <- grep("^--file=", commandArgs(trailingOnly = FALSE), value = TRUE)[[1L]]
+script_path <- normalizePath(sub("^--file=", "", script_argument), winslash = "/")
+sys.source(file.path(dirname(script_path), "provenance.R"), envir = environment())
+
+runtime <- read.delim(
+    args[[3L]], check.names = FALSE, colClasses = "character"
+)
+if (nrow(runtime) != 1L ||
+    !all(c("iterations", "dataset_100mb_sha256", "dataset_1gb_sha256",
+          "dataset_100mb_bytes", "dataset_1gb_bytes", "dataset_100mb_rows",
+          "dataset_1gb_rows", "full_columns", "projected_columns",
+          "build_provenance_id", "provenance_id",
+          "created_at_utc") %in% names(runtime))) {
+    stop("runtime provenance is missing required fields")
+}
+stable_runtime_fields <- setdiff(
+    names(runtime), c("provenance_id", "created_at_utc")
+)
+if (!identical(
+    runtime$provenance_id[[1L]],
+    benchmark_provenance_id(runtime[stable_runtime_fields])
+)) {
+    stop("runtime provenance ID does not match its stable fields")
+}
+iterations <- suppressWarnings(as.integer(runtime$iterations[[1L]]))
+if (is.na(iterations) || iterations < 1L ||
+    !identical(as.character(iterations), runtime$iterations[[1L]])) {
+    stop("runtime provenance iterations must be a positive integer")
+}
+
+raw <- read.delim(args[[1L]], check.names = FALSE, colClasses = "character")
+keys <- c(
+    "dataset", "target_bytes", "actual_bytes", "dataset_sha256", "rows",
+    "columns", "workload", "provenance_id", "build_provenance_id"
+)
+implementations <- c("direct-r", "rust-vectors", "haven")
+workloads <- c("full", "projected-eight-columns")
+datasets <- c("100mb", "1gb")
+required <- c(
+    keys, "implementation", "iteration", "elapsed_s", "input_gb_per_s"
+)
+if (!all(required %in% names(raw))) stop("raw timings are missing required fields")
+
+numeric_fields <- c(
+    "target_bytes", "actual_bytes", "rows", "columns", "iteration",
+    "elapsed_s", "input_gb_per_s"
+)
+for (field in numeric_fields) {
+    raw[[field]] <- suppressWarnings(as.numeric(raw[[field]]))
+}
+if (any(!is.finite(raw$elapsed_s) | raw$elapsed_s <= 0) ||
+    any(!is.finite(raw$input_gb_per_s) | raw$input_gb_per_s <= 0)) {
+    stop("raw timings must be positive and finite")
+}
+for (field in c("target_bytes", "actual_bytes", "rows", "columns", "iteration")) {
+    value <- raw[[field]]
+    if (any(!is.finite(value) | value <= 0 | value != floor(value))) {
+        stop("raw matrix contains invalid integral field: ", field)
+    }
+}
+if (!setequal(unique(raw$dataset), datasets) ||
+    !setequal(unique(raw$workload), workloads) ||
+    !setequal(unique(raw$implementation), implementations)) {
+    stop("raw matrix contains unexpected datasets, workloads, or implementations")
+}
+if (any(!grepl("^[0-9a-f]{64}$", raw$dataset_sha256))) {
+    stop("raw matrix contains an invalid dataset SHA-256")
+}
+if (!identical(unique(raw$provenance_id), runtime$provenance_id) ||
+    !identical(unique(raw$build_provenance_id), runtime$build_provenance_id)) {
+    stop("raw matrix provenance IDs do not match runtime provenance")
+}
+
+expected <- expand.grid(
+    dataset = datasets,
+    workload = workloads,
+    implementation = implementations,
+    iteration = seq_len(iterations),
+    stringsAsFactors = FALSE
+)
+tuple <- function(data) paste(
+    data$dataset, data$workload, data$implementation, data$iteration, sep = "\r"
+)
+raw_tuple <- tuple(raw)
+expected_tuple <- tuple(expected)
+if (anyDuplicated(raw_tuple) || length(raw_tuple) != length(expected_tuple) ||
+    !setequal(raw_tuple, expected_tuple)) {
+    stop("raw timings do not form the exact expected Cartesian matrix")
+}
+
+expected_targets <- c(`100mb` = 100000000, `1gb` = 1000000000)
+expected_hashes <- c(
+    `100mb` = runtime$dataset_100mb_sha256[[1L]],
+    `1gb` = runtime$dataset_1gb_sha256[[1L]]
+)
+expected_sizes <- c(
+    `100mb` = as.numeric(runtime$dataset_100mb_bytes[[1L]]),
+    `1gb` = as.numeric(runtime$dataset_1gb_bytes[[1L]])
+)
+expected_rows <- c(
+    `100mb` = as.numeric(runtime$dataset_100mb_rows[[1L]]),
+    `1gb` = as.numeric(runtime$dataset_1gb_rows[[1L]])
+)
+expected_columns <- c(
+    full = as.numeric(runtime$full_columns[[1L]]),
+    `projected-eight-columns` = as.numeric(runtime$projected_columns[[1L]])
+)
+shape_values <- c(expected_sizes, expected_rows, expected_columns)
+if (any(!is.finite(shape_values) | shape_values <= 0 |
+        shape_values != floor(shape_values)) ||
+    expected_columns[["projected-eight-columns"]] != 8) {
+    stop("runtime provenance contains invalid dataset shape metadata")
+}
+for (dataset in datasets) {
+    group <- raw[raw$dataset == dataset, ]
+    metadata <- unique(group[c(
+        "target_bytes", "actual_bytes", "dataset_sha256", "rows"
+    )])
+    if (nrow(metadata) != 1L ||
+        metadata$target_bytes[[1L]] != expected_targets[[dataset]] ||
+        metadata$actual_bytes[[1L]] != expected_sizes[[dataset]] ||
+        metadata$rows[[1L]] != expected_rows[[dataset]] ||
+        !identical(metadata$dataset_sha256[[1L]], expected_hashes[[dataset]])) {
+        stop("raw dataset metadata is inconsistent with runtime provenance: ", dataset)
+    }
+    for (workload in workloads) {
+        columns <- unique(group$columns[group$workload == workload])
+        if (length(columns) != 1L ||
+            columns != expected_columns[[workload]]) {
+            stop("raw column metadata is inconsistent for ", dataset, " ", workload)
+        }
+    }
+}
+expected_rate <- raw$actual_bytes / 1e9 / raw$elapsed_s
+if (any(abs(raw$input_gb_per_s - expected_rate) > 1.1e-6)) {
+    stop("raw input throughput is inconsistent with size and elapsed time")
+}
+
+groups <- split(raw, interaction(raw[keys], drop = TRUE, lex.order = TRUE))
+stats_for <- function(group, implementation) {
+    elapsed <- group$elapsed_s[group$implementation == implementation]
+    c(
+        iterations = length(elapsed),
+        median_s = median(elapsed),
+        p05_s = unname(quantile(elapsed, 0.05)),
+        p95_s = unname(quantile(elapsed, 0.95)),
+        median_gb_s = group$actual_bytes[[1L]] / 1e9 / median(elapsed)
+    )
+}
+
+rows <- lapply(groups, function(group) {
+    statistics <- lapply(implementations, function(implementation) {
+        stats_for(group, implementation)
+    })
+    names(statistics) <- implementations
+    counts <- vapply(statistics, `[[`, numeric(1), "iterations")
+    stopifnot(length(unique(counts)) == 1L, counts[[1L]] == iterations)
+
+    data.frame(
+        group[1L, keys, drop = FALSE],
+        iterations = counts[[1L]],
+        direct_r_median_s = statistics[["direct-r"]][["median_s"]],
+        direct_r_p05_s = statistics[["direct-r"]][["p05_s"]],
+        direct_r_p95_s = statistics[["direct-r"]][["p95_s"]],
+        direct_r_median_gb_s = statistics[["direct-r"]][["median_gb_s"]],
+        rust_vectors_median_s = statistics[["rust-vectors"]][["median_s"]],
+        rust_vectors_p05_s = statistics[["rust-vectors"]][["p05_s"]],
+        rust_vectors_p95_s = statistics[["rust-vectors"]][["p95_s"]],
+        rust_vectors_median_gb_s = statistics[["rust-vectors"]][["median_gb_s"]],
+        haven_median_s = statistics[["haven"]][["median_s"]],
+        haven_p05_s = statistics[["haven"]][["p05_s"]],
+        haven_p95_s = statistics[["haven"]][["p95_s"]],
+        haven_median_gb_s = statistics[["haven"]][["median_gb_s"]],
+        direct_r_vs_rust_vectors_speedup =
+            statistics[["rust-vectors"]][["median_s"]] /
+            statistics[["direct-r"]][["median_s"]],
+        direct_r_vs_haven_speedup = statistics[["haven"]][["median_s"]] /
+            statistics[["direct-r"]][["median_s"]],
+        rust_vectors_vs_haven_speedup = statistics[["haven"]][["median_s"]] /
+            statistics[["rust-vectors"]][["median_s"]],
+        check.names = FALSE
+    )
+})
+
+summary <- do.call(rbind, rows)
+summary <- summary[order(summary$actual_bytes, summary$workload), ]
+stopifnot(nrow(summary) == 4L)
+
+dir.create(dirname(args[[2L]]), recursive = TRUE, showWarnings = FALSE)
+temporary_output <- tempfile(
+    pattern = paste0(basename(args[[2L]]), "."), tmpdir = dirname(args[[2L]])
+)
+on.exit(unlink(temporary_output), add = TRUE)
+write.table(summary, temporary_output, sep = "\t", row.names = FALSE, quote = FALSE)
+if (!file.rename(temporary_output, args[[2L]])) {
+    stop("could not atomically replace ", args[[2L]])
+}
+print(summary, row.names = FALSE)

--- a/benchmarks/results-2026-07-30.html
+++ b/benchmarks/results-2026-07-30.html
@@ -1,0 +1,256 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>dtaparser benchmark and fertility-corpus report</title>
+  <style>
+    :root {
+      color-scheme: light dark;
+      --bg: #f6f7f9;
+      --panel: #ffffff;
+      --text: #172033;
+      --muted: #5b6578;
+      --line: #d8dde7;
+      --accent: #2952cc;
+      --accent-soft: #e9efff;
+      --good: #147a4b;
+      --good-soft: #e8f7ef;
+      --warn: #8a5a00;
+      --warn-soft: #fff4d6;
+      --code: #eef1f5;
+      --shadow: 0 10px 30px rgba(23, 32, 51, 0.08);
+    }
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --bg: #11151d;
+        --panel: #1a202b;
+        --text: #edf1f7;
+        --muted: #aab3c2;
+        --line: #354052;
+        --accent: #8da8ff;
+        --accent-soft: #26365f;
+        --good: #68d5a2;
+        --good-soft: #173b2c;
+        --warn: #f2c76e;
+        --warn-soft: #4a3817;
+        --code: #252d3a;
+        --shadow: none;
+      }
+    }
+    * { box-sizing: border-box; }
+    html { scroll-behavior: smooth; }
+    body {
+      margin: 0;
+      background: var(--bg);
+      color: var(--text);
+      font: 16px/1.6 system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+    main, header { width: min(1120px, calc(100% - 32px)); margin-inline: auto; }
+    header { padding: 64px 0 28px; }
+    h1 { margin: 0 0 12px; font-size: clamp(2rem, 5vw, 3.6rem); line-height: 1.06; letter-spacing: -0.04em; }
+    h2 { margin: 0 0 18px; font-size: 1.7rem; line-height: 1.2; }
+    h3 { margin: 28px 0 10px; font-size: 1.15rem; }
+    p { margin: 10px 0; }
+    a { color: var(--accent); }
+    .lede { max-width: 850px; color: var(--muted); font-size: 1.15rem; }
+    .meta { display: flex; flex-wrap: wrap; gap: 10px; margin-top: 24px; }
+    .pill { border: 1px solid var(--line); border-radius: 999px; padding: 5px 11px; background: var(--panel); font-size: 0.88rem; }
+    nav { margin: 0 0 26px; padding: 16px 20px; border: 1px solid var(--line); border-radius: 14px; background: var(--panel); }
+    nav a { margin-right: 18px; white-space: nowrap; }
+    section { margin: 0 0 24px; padding: 28px; border: 1px solid var(--line); border-radius: 18px; background: var(--panel); box-shadow: var(--shadow); }
+    .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 14px; margin: 18px 0; }
+    .metric { padding: 18px; border: 1px solid var(--line); border-radius: 14px; background: var(--bg); }
+    .metric strong { display: block; font-size: 1.55rem; line-height: 1.2; }
+    .metric span { color: var(--muted); font-size: 0.92rem; }
+    .callout { margin: 18px 0; padding: 16px 18px; border-left: 4px solid var(--accent); border-radius: 8px; background: var(--accent-soft); }
+    .callout.good { border-color: var(--good); background: var(--good-soft); }
+    .callout.warn { border-color: var(--warn); background: var(--warn-soft); }
+    .table-wrap { overflow-x: auto; margin: 18px 0; }
+    table { width: 100%; border-collapse: collapse; font-variant-numeric: tabular-nums; }
+    th, td { padding: 10px 12px; border-bottom: 1px solid var(--line); text-align: left; }
+    th { font-size: 0.85rem; color: var(--muted); text-transform: uppercase; letter-spacing: 0.04em; }
+    td.num, th.num { text-align: right; }
+    code { padding: 0.12em 0.35em; border-radius: 5px; background: var(--code); font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+    pre { overflow-x: auto; padding: 16px; border-radius: 12px; background: var(--code); line-height: 1.45; }
+    pre code { padding: 0; background: transparent; }
+    ul { padding-left: 1.3rem; }
+    li + li { margin-top: 6px; }
+    .reason-list > li { margin-bottom: 16px; }
+    .reason-list strong { color: var(--accent); }
+    footer { width: min(1120px, calc(100% - 32px)); margin: 0 auto; padding: 12px 0 48px; color: var(--muted); font-size: 0.9rem; }
+    @media print {
+      :root { color-scheme: light; }
+      body { background: white; }
+      section, nav { box-shadow: none; break-inside: avoid; }
+      a { color: inherit; text-decoration: none; }
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>dtaparser benchmark and fertility-corpus report</h1>
+    <p class="lede">A consolidated explanation of what changed, why it changed, how the R reader performed against Haven, and what exhaustive testing found across the private raw and generated fertility-survey corpora.</p>
+    <div class="meta">
+      <span class="pill">Branch: <code>benchmark-fertility-integration</code></span>
+      <span class="pill">Report date: 2026-07-30</span>
+      <span class="pill">Tracked branch HEAD before report: <code>e29c5ef</code></span>
+      <span class="pill">No proprietary data included</span>
+    </div>
+  </header>
+
+  <main>
+    <nav aria-label="Report sections">
+      <a href="#summary">Summary</a>
+      <a href="#changes">What changed and why</a>
+      <a href="#performance">Performance</a>
+      <a href="#wave2">Raw corpus</a>
+      <a href="#wave3">Output corpus</a>
+      <a href="#validation">Validation</a>
+      <a href="#reproduce">Reproduce</a>
+    </nav>
+
+    <section id="summary">
+      <h2>Executive summary</h2>
+      <div class="grid">
+        <div class="metric"><strong>3.73×–5.40×</strong><span>Direct-R median speedup over Haven</span></div>
+        <div class="metric"><strong>2,230 files</strong><span>Raw and generated corpus files accounted for</span></div>
+        <div class="metric"><strong>24,500 / 24,500</strong><span>Wave 3 planned tiles verified; Wave 2 covered 874 supported files</span></div>
+        <div class="metric"><strong>0 defects</strong><span>Confirmed dtaparser parser or materialization defects</span></div>
+      </div>
+      <div class="callout good"><strong>Result:</strong> the public Direct-R collector and retained Rust-vector collector remained identical throughout the supported corpus. Observed differences were attributable to unsupported release 111, external manifest drift, malformed upstream textual metadata, or Haven encoding behavior—not to a confirmed dtaparser defect.</div>
+      <p>The work added two report-only systems: a reproducible same-run R performance benchmark and a manual, bounded, resumable differential corpus framework. Neither adds timing assertions or private-corpus checks to CI.</p>
+    </section>
+
+    <section id="changes">
+      <h2>What changed and why</h2>
+      <ol class="reason-list">
+        <li><strong>Reproducible R benchmark harness.</strong> Added deterministic 100 MB and 1 GB release-118 inputs, checkout-local package installation, strict build and run provenance, atomic publication, and a strict summarizer. <em>Why:</em> performance comparisons are only useful when the measured checkout, input identities, matrix shape, and methodology are auditable.</li>
+        <li><strong>Three-reader same-run comparison.</strong> Benchmarked public Direct-R, retained Rust vectors, and Haven in one run, with warmups, alternating order, and garbage collection outside timing. <em>Why:</em> this separates parser/materialization changes from machine or run-to-run effects and connects current public behavior to the historical Rust-vector baseline.</li>
+        <li><strong>Manual fertility-corpus framework.</strong> Added deterministic inventory, exact metadata/value comparison, isolated workers, bounded row/column tiling, timeouts, memory limits, resumable checkpoints, sharding, strict merges, and privacy-safe reports. <em>Why:</em> tens of gigabytes of proprietary survey files provide practical robustness coverage that small public fixtures cannot, but must remain machine-local and nonautomatic.</li>
+        <li><strong>Explicit source authorization.</strong> Raw runs now require canonical <code>--cache-root</code> and <code>--manifest</code>; generated-output runs require <code>--output-root</code>. The framework refuses CI and symlinked or ambiguous roots. <em>Why:</em> private inputs must never be inferred, recursively discovered, or accidentally read on an unauthorized machine.</li>
+        <li><strong>Exact comparison semantics.</strong> Replaced broad equality shortcuts with element- and attribute-level checks for dimensions, names, metadata, classes, labels, missing masks, tagged missings, dates, datetimes, strings, integers, nonfinite values, and finite floating values with absolute tolerance <code>1e-7</code>. <em>Why:</em> a corpus pass should prove compatibility rather than hide meaningful differences behind permissive coercion.</li>
+        <li><strong>Crash and race hardening.</strong> Added per-tile subprocesses, process-generation locks, heartbeats, descriptor-bound input snapshots, no-follow directory traversal, input revalidation, atomic no-replace publication, and exact bundle membership validation. <em>Why:</em> very long runs must survive interruption without accepting stale, mixed, partially published, or path-substituted evidence.</li>
+        <li><strong>Manifest mismatch preservation.</strong> Kept the five external Wave 2 SHA-512 mismatches as an authoritative blocked result and recorded separately authorized target-local supplemental evidence. <em>Why:</em> local acceptance must not silently rewrite the upstream manifest or erase an auditable integrity discrepancy.</li>
+        <li><strong>Generated-output support.</strong> Reused the Wave 2 machinery for 1,226 derived files, including very large top-level aggregates and upstream <code>append, force</code> output. <em>Why:</em> reader parity must be distinguished from analytical coercion already stored in the generated Stata files.</li>
+        <li><strong>Privacy-safe documentation.</strong> Added dated Markdown reports and this consolidated HTML report while removing local absolute paths, source hashes, survey values, labels, variable names, and private reader diagnostics. <em>Why:</em> methodology and aggregate conclusions should be reviewable without disclosing proprietary corpus details.</li>
+      </ol>
+      <p>The branch contains 44 incremental branch commits before this report: 2 for Wave 1, 19 for Wave 2, 21 for Wave 3, and 2 final policy corrections. These include implementation, hardening, evidence, and documentation commits. Commits were not amended or squashed during development.</p>
+    </section>
+
+    <section id="performance">
+      <h2>Wave 1: R performance</h2>
+      <p>Each cell used 101 measured iterations. Before timing, the harness required exact Direct-R/Rust-vector identity and compared representative start, middle, and end windows with Haven.</p>
+      <div class="table-wrap">
+        <table>
+          <caption>Wave 1 median benchmark results</caption>
+          <thead><tr><th>Input</th><th>Workload</th><th class="num">Direct-R</th><th class="num">Rust vectors</th><th class="num">Haven</th><th class="num">Direct-R vs Haven</th></tr></thead>
+          <tbody>
+            <tr><td>100 MB</td><td>Full, 40 columns</td><td class="num">0.303 s</td><td class="num">0.247 s</td><td class="num">1.190 s</td><td class="num">3.93×</td></tr>
+            <tr><td>100 MB</td><td>Projected, 8 columns</td><td class="num">0.082 s</td><td class="num">0.082 s</td><td class="num">0.306 s</td><td class="num">3.73×</td></tr>
+            <tr><td>1 GB</td><td>Full, 40 columns</td><td class="num">2.185 s</td><td class="num">2.337 s</td><td class="num">11.795 s</td><td class="num">5.40×</td></tr>
+            <tr><td>1 GB</td><td>Projected, 8 columns</td><td class="num">0.755 s</td><td class="num">0.744 s</td><td class="num">2.903 s</td><td class="num">3.85×</td></tr>
+          </tbody>
+        </table>
+      </div>
+      <h3>Why Haven is used as an oracle</h3>
+      <p>Haven is the established R Stata reader and <code>dtaparser::read_dta()</code> deliberately targets its public R API and object semantics. Agreement is strong compatibility evidence, but not proof of universal correctness. Every disagreement is also checked against Direct-R/Rust-vector identity, Stata storage semantics, structural validation, checked fixtures, and targeted synthetic reproductions. Haven can itself differ around malformed UTF-8, undeclared legacy encodings, modern <code>strL</code> overrides, or native coercion boundaries.</p>
+      <p><strong>Caveat:</strong> these are warm-cache, machine- and workload-specific measurements, not API promises or release thresholds.</p>
+    </section>
+
+    <section id="wave2">
+      <h2>Wave 2: raw fertility-survey corpus</h2>
+      <div class="table-wrap">
+        <table>
+          <caption>Wave 2 original raw classifications</caption>
+          <thead><tr><th>Original raw classification</th><th class="num">Files</th></tr></thead>
+          <tbody>
+            <tr><td>Expected unsupported release 111</td><td class="num">130</td></tr>
+            <tr><td>Pass</td><td class="num">459</td></tr>
+            <tr><td>Metadata mismatch</td><td class="num">409</td></tr>
+            <tr><td>Haven-only error</td><td class="num">1</td></tr>
+            <tr><td>Inventory hash error (<code>signature-mismatch</code>; external manifest/file SHA-512 discrepancy)</td><td class="num">5</td></tr>
+            <tr><td><strong>Total</strong></td><td class="num"><strong>1,004</strong></td></tr>
+          </tbody>
+        </table>
+      </div>
+      <p>The five hash mismatches remain unchanged in the authoritative manifest result. Under separately authorized, immutable local acceptance, all five completed exhaustive supplemental runs and passed. This yields complete executable evidence for all 874 supported files: 464 pass, 409 metadata mismatch, and one Haven-only error.</p>
+      <ul>
+        <li>Direct-R/Rust-vector mismatch records: <strong>0</strong>.</li>
+        <li>Confirmed dtaparser defects: <strong>0</strong>.</li>
+        <li>Unresolved supported collector differences after adjudication: <strong>0</strong>.</li>
+        <li>The default Haven-only case passed all 100 tiles with a symmetric <code>ISO-8859-1</code> override.</li>
+      </ul>
+      <div class="callout warn"><strong>Integrity distinction:</strong> the manifest gate remains blocked for the five external SHA-512 discrepancies. Supplemental local evidence satisfies coverage and compatibility, but does not alter or claim verification of the external manifest.</div>
+    </section>
+
+    <section id="wave3">
+      <h2>Wave 3: generated-output corpus</h2>
+      <div class="grid">
+        <div class="metric"><strong>1,226 files</strong><span>70,748,321,626 total bytes</span></div>
+        <div class="metric"><strong>1,096 supported</strong><span>Every supported file reached a terminal outcome</span></div>
+        <div class="metric"><strong>24,500 / 24,500</strong><span>Planned tiles verified</span></div>
+        <div class="metric"><strong>10.33 GB</strong><span>Largest aggregate qualified</span></div>
+      </div>
+      <div class="table-wrap">
+        <table>
+          <caption>Wave 3 generated-output classifications</caption>
+          <thead><tr><th>Classification</th><th class="num">Files</th></tr></thead>
+          <tbody>
+            <tr><td>Expected unsupported release 111</td><td class="num">130</td></tr>
+            <tr><td>Pass</td><td class="num">691</td></tr>
+            <tr><td>Metadata mismatch</td><td class="num">404</td></tr>
+            <tr><td>Haven-only error</td><td class="num">1</td></tr>
+            <tr><td><strong>Total</strong></td><td class="num"><strong>1,226</strong></td></tr>
+          </tbody>
+        </table>
+      </div>
+      <p>The 404 metadata-classified files produced 11,820 pairwise records: 5,910 Direct-R/Haven and 5,910 Rust-vector/Haven, with zero Direct-R/Rust-vector records. Private inspection plus a legal synthetic fixture demonstrated malformed upstream textual metadata and Haven decoding behavior; replacement decoding restored parity.</p>
+      <p>The sole Haven-only case completed 51/51 raw tiles and passed 51/51 tiles under a symmetric <code>ISO-8859-1</code> qualification. There were no timeout, memory, crash, unresolved, inventory-hash, value, tag, date, row-termination, or dtaparser-only outcomes.</p>
+    </section>
+
+    <section id="validation">
+      <h2>Final validation</h2>
+      <p>The final current-HEAD gate completed successfully:</p>
+      <ul>
+        <li>Rust source/vendor synchronization.</li>
+        <li><code>cargo fmt --check</code>.</li>
+        <li>Warning-denied Clippy across the workspace and all targets.</li>
+        <li>Complete Rust workspace test suite.</li>
+        <li>Warning-denied Rust documentation.</li>
+        <li>Selected Bun integration suite: 6 passed, 0 failed.</li>
+        <li>Required TypeScript, native, R, and Haven conformance.</li>
+        <li>R package build and check: <strong>Status OK</strong>.</li>
+        <li>Deterministic R vendor rebuild with no tracked archive difference.</li>
+        <li>Complete synthetic fertility framework, POSIX shell helpers, syntax, parsing, privacy checks, and independent review.</li>
+      </ul>
+      <p>The fertility framework remains manual-only, requires explicit opt-in and canonical source roots, refuses CI/GitHub Actions, stores mutable artifacts under ignored <code>target/</code>, and does not add release-111 support.</p>
+    </section>
+
+    <section id="reproduce">
+      <h2>Reproduction commands</h2>
+      <h3>Performance benchmark</h3>
+      <pre><code>benchmarks/large-scale/benchmark.sh</code></pre>
+      <h3>Raw corpus</h3>
+      <pre><code>export DTAPARSER_FERTILITY_CORPUS=I_UNDERSTAND_THIS_READS_PROPRIETARY_DATA
+export CACHE_ROOT=/absolute/canonical/private-cache-root
+export MANIFEST=/absolute/canonical/private-manifest.csv
+
+benchmarks/fertility-surveys/benchmark.sh \
+  --cache-root="$CACHE_ROOT" \
+  --manifest="$MANIFEST"</code></pre>
+      <h3>Generated-output corpus</h3>
+      <pre><code>export DTAPARSER_FERTILITY_CORPUS=I_UNDERSTAND_THIS_READS_PROPRIETARY_DATA
+export OUTPUT_ROOT=/absolute/canonical/private-output-root
+
+benchmarks/fertility-surveys/benchmark.sh \
+  --output-root="$OUTPUT_ROOT"</code></pre>
+      <p>Detailed methodology and evidence are in <code>benchmarks/large-scale/results-2026-07-27.md</code>, <code>benchmarks/fertility-surveys/results-2026-07-28.md</code>, and <code>benchmarks/fertility-surveys/results-2026-07-29.md</code>.</p>
+    </section>
+  </main>
+
+  <footer>
+    This report intentionally contains aggregate, privacy-safe evidence only. It excludes private source paths, survey values, variable names, labels, source hashes, reader messages, and target-local artifact locations.
+  </footer>
+</body>
+</html>

--- a/benchmarks/results-2026-07-30.html
+++ b/benchmarks/results-2026-07-30.html
@@ -118,7 +118,7 @@
         <div class="metric"><strong>24,500 / 24,500</strong><span>Wave 3 planned tiles verified; Wave 2 covered 874 supported files</span></div>
         <div class="metric"><strong>0 defects</strong><span>Confirmed dtaparser parser or materialization defects</span></div>
       </div>
-      <div class="callout good"><strong>Result:</strong> the public Direct-R collector and retained Rust-vector collector remained identical throughout the supported corpus. Observed differences were attributable to unsupported release 111, external manifest drift, malformed upstream textual metadata, or Haven encoding behavior—not to a confirmed dtaparser defect.</div>
+      <div class="callout good"><strong>Result:</strong> the public Direct-R collector and retained Rust-vector collector remained identical throughout the supported corpus. Stata/SE 7 format 111 is outside dtaparser's current supported range; supported-file differences were attributable to malformed upstream textual metadata or Haven encoding behavior—not to a confirmed dtaparser defect.</div>
       <p>The work added two report-only systems: a reproducible same-run R performance benchmark and a manual, bounded, resumable differential corpus framework. Neither adds timing assertions or private-corpus checks to CI.</p>
     </section>
 
@@ -131,7 +131,7 @@
         <li><strong>Explicit source authorization.</strong> Raw runs now require canonical <code>--cache-root</code> and <code>--manifest</code>; generated-output runs require <code>--output-root</code>. The framework refuses CI and symlinked or ambiguous roots. <em>Why:</em> private inputs must never be inferred, recursively discovered, or accidentally read on an unauthorized machine.</li>
         <li><strong>Exact comparison semantics.</strong> Replaced broad equality shortcuts with element- and attribute-level checks for dimensions, names, metadata, classes, labels, missing masks, tagged missings, dates, datetimes, strings, integers, nonfinite values, and finite floating values with absolute tolerance <code>1e-7</code>. <em>Why:</em> a corpus pass should prove compatibility rather than hide meaningful differences behind permissive coercion.</li>
         <li><strong>Crash and race hardening.</strong> Added per-tile subprocesses, process-generation locks, heartbeats, descriptor-bound input snapshots, no-follow directory traversal, input revalidation, atomic no-replace publication, and exact bundle membership validation. <em>Why:</em> very long runs must survive interruption without accepting stale, mixed, partially published, or path-substituted evidence.</li>
-        <li><strong>Manifest mismatch preservation.</strong> Kept the five external Wave 2 SHA-512 mismatches as an authoritative blocked result and recorded separately authorized target-local supplemental evidence. <em>Why:</em> local acceptance must not silently rewrite the upstream manifest or erase an auditable integrity discrepancy.</li>
+        <li><strong>External input-identity separation.</strong> Preserved five disagreements between caller-supplied manifest hashes and current bytes while recording separately authorized target-local evidence. <em>Why:</em> maintaining the external hash records is outside this repository's responsibility, but the harness must not silently treat different bytes as manifest-verified.</li>
         <li><strong>Generated-output support.</strong> Reused the Wave 2 machinery for 1,226 derived files, including very large top-level aggregates and upstream <code>append, force</code> output. <em>Why:</em> reader parity must be distinguished from analytical coercion already stored in the generated Stata files.</li>
         <li><strong>Privacy-safe documentation.</strong> Added dated Markdown reports and this consolidated HTML report while removing local absolute paths, source hashes, survey values, labels, variable names, and private reader diagnostics. <em>Why:</em> methodology and aggregate conclusions should be reviewable without disclosing proprietary corpus details.</li>
       </ol>
@@ -165,7 +165,7 @@
           <caption>Wave 2 original raw classifications</caption>
           <thead><tr><th>Original raw classification</th><th class="num">Files</th></tr></thead>
           <tbody>
-            <tr><td>Expected unsupported release 111</td><td class="num">130</td></tr>
+            <tr><td>Stata/SE 7 format 111 (outside dtaparser's current supported range)</td><td class="num">130</td></tr>
             <tr><td>Pass</td><td class="num">459</td></tr>
             <tr><td>Metadata mismatch</td><td class="num">409</td></tr>
             <tr><td>Haven-only error</td><td class="num">1</td></tr>
@@ -174,14 +174,14 @@
           </tbody>
         </table>
       </div>
-      <p>The five hash mismatches remain unchanged in the authoritative manifest result. Under separately authorized, immutable local acceptance, all five completed exhaustive supplemental runs and passed. This yields complete executable evidence for all 874 supported files: 464 pass, 409 metadata mismatch, and one Haven-only error.</p>
+      <p>Five caller-supplied manifest hashes did not identify the current local bytes. Reconciling those external records is outside this repository's responsibility. Under separately authorized, immutable local input identities, all five files completed exhaustive supplemental runs and passed. This yields complete executable evidence for all 874 supported files: 464 pass, 409 metadata mismatch, and one Haven-only error.</p>
       <ul>
         <li>Direct-R/Rust-vector mismatch records: <strong>0</strong>.</li>
         <li>Confirmed dtaparser defects: <strong>0</strong>.</li>
         <li>Unresolved supported collector differences after adjudication: <strong>0</strong>.</li>
         <li>The default Haven-only case passed all 100 tiles with a symmetric <code>ISO-8859-1</code> override.</li>
       </ul>
-      <div class="callout warn"><strong>Integrity distinction:</strong> the manifest gate remains blocked for the five external SHA-512 discrepancies. Supplemental local evidence satisfies coverage and compatibility, but does not alter or claim verification of the external manifest.</div>
+      <div class="callout warn"><strong>Scope distinction:</strong> the external hash records are not maintained or warranted by this repository. The harness preserves their recorded disagreement only to keep input identities unambiguous; parser coverage and compatibility were established separately for the current local bytes.</div>
     </section>
 
     <section id="wave3">
@@ -197,7 +197,7 @@
           <caption>Wave 3 generated-output classifications</caption>
           <thead><tr><th>Classification</th><th class="num">Files</th></tr></thead>
           <tbody>
-            <tr><td>Expected unsupported release 111</td><td class="num">130</td></tr>
+            <tr><td>Stata/SE 7 format 111 (outside dtaparser's current supported range)</td><td class="num">130</td></tr>
             <tr><td>Pass</td><td class="num">691</td></tr>
             <tr><td>Metadata mismatch</td><td class="num">404</td></tr>
             <tr><td>Haven-only error</td><td class="num">1</td></tr>

--- a/r-package/dtaparser/README.md
+++ b/r-package/dtaparser/README.md
@@ -60,31 +60,38 @@ label.
 
 ## Performance compared with haven
 
-A warm-cache benchmark on an Apple M4 Max compared full reads by
-`dtaparser::read_dta()` and `haven::read_dta()` on deterministic, mixed-type
-Stata 15 files. Each file contained 40 columns spanning numeric, labelled,
-date/time, and string data. The run warmed each implementation, alternated
-their execution order, and ran garbage collection outside the timed intervals.
+A warm-cache benchmark on an Apple M4 Max compared the public Direct-R
+`dtaparser::read_dta()` path, the retained internal Rust-vector collector, and
+`haven::read_dta()` in the same process and run. The deterministic mixed-type
+Stata 15 files contained 40 columns; the projected workload selected eight
+representative columns. Each cell used 101 measured iterations after warmup,
+alternated implementation order, and ran garbage collection outside timing.
 
-| Input | Rows | Iterations | dtaparser median | haven median | Relative throughput |
-| --- | ---: | ---: | ---: | ---: | ---: |
-| 100 MB | 222,656 | 101 | 0.236 s | 1.122 s | 4.754x |
-| 1 GB | 2,227,111 | 101 | 2.187 s | 11.045 s | 5.050x |
+| Input | Rows | Workload | Direct-R median | Rust-vector median | haven median | Direct-R vs haven |
+| --- | ---: | --- | ---: | ---: | ---: | ---: |
+| 100 MB | 222,656 | Full, 40 columns | 0.303 s | 0.247 s | 1.19 s | 3.92739273927393x |
+| 100 MB | 222,656 | Projected, 8 columns | 0.082 s | 0.082 s | 0.306 s | 3.73170731707317x |
+| 1 GB | 2,227,111 | Full, 40 columns | 2.185 s | 2.337 s | 11.795 s | 5.39816933638444x |
+| 1 GB | 2,227,111 | Projected, 8 columns | 0.755 s | 0.744 s | 2.903 s | 3.84503311258278x |
 
-Relative throughput is the haven median divided by the dtaparser median, so
-higher is faster for dtaparser. Before timing, eight representative columns in
-32-row samples from the start, middle, and end of each file were compared with
-haven. The attributes and values matched, subject to the conformance suite's
-`1e-7` tolerance for nonmissing floating-point values.
+Direct-R vs haven is the haven median divided by the Direct-R median, so higher
+means Direct-R was faster. Before timing, Direct-R and Rust-vector results were
+required to be exactly identical. Projected 32-row windows from the start,
+middle, and end were also compared with haven, subject only to the conformance
+suite's `1e-7` tolerance for nonmissing floating-point values.
 
 These are machine- and workload-specific measurements, not performance
-guarantees or CI thresholds. The haven comparison used the Rust-vector
-materialization path that is now retained as an internal differential-testing
-baseline. The current direct-R collector was benchmarked separately and was
-faster than that retained path, but haven was not measured in the same run, so
-the ratios above are not extrapolated; see the
-[direct-R materialization results](../../benchmarks/r-materialization/results-2026-07-26.md).
-No repeated 10 GB comparison was completed, so no 10 GB result is reported.
+guarantees or CI thresholds. The Rust-vector implementation remains an internal
+A/B and differential-testing baseline. Its numbers above are from the same run
+as Direct-R and haven; the earlier
+[direct-R materialization results](../../benchmarks/r-materialization/results-2026-07-26.md)
+remain useful historical evidence about the collector transition but are not
+combined with these ratios. Haven is the compatibility oracle because it is the
+established R reader, not because it is infallible; version-specific bugs,
+encoding behavior, and native coercion edge cases remain possible. See the
+[full reproducible report](../../benchmarks/large-scale/results-2026-07-27.md)
+for p05/p95 values, throughput, provenance, validation, and exact artifacts. No
+10 GB file was generated or measured in this scoped run.
 
 ## Scope and limitations
 


### PR DESCRIPTION
## Summary

- add a reproducible same-run R benchmark comparing public Direct-R materialization, retained Rust vectors, and Haven on deterministic 100 MB and 1 GB Stata inputs
- add a manual-only, resumable, privacy-safe differential framework for the private raw and generated fertility-survey corpora
- exhaustively account for all supported rows and columns while keeping proprietary paths, values, names, labels, hashes, diagnostics, and generated artifacts out of Git
- document the methodology, performance results, corpus classifications, ownership adjudication, provenance, and reproduction commands
- add a consolidated HTML report at `benchmarks/results-2026-07-30.html` explaining what changed and why

## Why

Haven is the primary R compatibility oracle because `dtaparser::read_dta()` targets its API and returned R semantics, but Haven is not treated as an infallible specification. Differences are checked against exact Direct-R/Rust-vector agreement, Stata storage semantics, structural validation, checked fixtures, explicit encoding experiments, and synthetic reproductions.

The fertility corpora are the practical workloads this package is intended to support. They are too large, slow, and proprietary for normal tests, so this PR provides an explicit-opt-in framework that is isolated from CI, bounded in memory, resumable, provenance-bound, and confined to ignored `target/` artifacts.

## Results

### Performance

Direct-R median elapsed time was 3.73x to 5.40x faster than Haven across full and projected reads:

| Input | Workload | Direct-R | Rust vectors | Haven | Direct-R vs Haven |
| --- | --- | ---: | ---: | ---: | ---: |
| 100 MB | Full | 0.303 s | 0.247 s | 1.190 s | 3.93x |
| 100 MB | 8-column projection | 0.082 s | 0.082 s | 0.306 s | 3.73x |
| 1 GB | Full | 2.185 s | 2.337 s | 11.795 s | 5.40x |
| 1 GB | 8-column projection | 0.755 s | 0.744 s | 2.903 s | 3.85x |

### Raw corpus (Wave 2)

- 1,004 files accounted for
- 130 Stata/SE 7 format-111 files outside dtaparser's current supported range
- exhaustive evidence for all 874 supported files after separately authorized local supplemental evidence for five caller-supplied external manifest/file SHA-512 discrepancies
- 464 pass, 409 metadata mismatch, 1 Haven-only error
- zero Direct-R/Rust-vector mismatches
- zero confirmed dtaparser defects
- external hash maintenance and reconciliation are outside this repository's responsibility; input identities remain fail-closed for reproducibility, and no external data or manifest was modified

### Generated-output corpus (Wave 3)

- 1,226 files and 70,748,321,626 bytes accounted for
- all 1,096 supported files reached exhaustive terminal outcomes
- 24,500/24,500 planned tiles verified
- 691 pass, 404 metadata mismatch, 1 Haven-only error
- zero Direct-R/Rust-vector, dtaparser-only, timeout, memory, crash, unresolved, or inventory-drift outcomes
- zero confirmed dtaparser defects

The metadata clusters were assigned to malformed upstream textual metadata and Haven decoding policy using private inspection and a legally distributable synthetic reproduction. Symmetric ISO-8859-1 qualifications resolved the isolated Haven-only encoding cases without changing corpus defaults.

## Safety and scope

- no Stata/SE 7 format-111 parser support added; follow-up is tracked in [#28](https://github.com/jbearak/dta-parser/issues/28)
- caller-supplied external hashes are retained as provenance inputs but are not maintained or reconciled by this repository
- no private corpus checks added to CI, Cargo/Bun/R tests, conformance hooks, or GitHub Actions
- all corpus entry points require explicit opt-in and canonical caller-supplied roots
- CI and GitHub Actions execution is refused
- no proprietary survey values, variable names, labels, paths, source hashes, reader messages, reports, checkpoints, or target artifacts are committed
- no changes were made to the source survey repositories, external manifest, or corpus files

## Validation

- `scripts/check-rust-sync.sh`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --all-targets --locked`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --locked --no-deps`
- selected Bun integration tests: 6 passed, 0 failed
- required TypeScript/native/R/Haven conformance
- R package check: Status OK
- deterministic R vendor rebuild with no tracked archive change
- complete synthetic fertility framework and shell-helper suites, including forced snapshot-copy fallback and environment-refusal regressions
- fresh one-iteration end-to-end benchmark validation of the corrected provenance path
- privacy scans, HTML validation, and independent report review
- CodeRabbit findings individually assessed; applicable fixes committed in `bddb044`

## Reports

- `benchmarks/results-2026-07-30.html` — consolidated explanation of changes and rationale
- `benchmarks/large-scale/results-2026-07-27.md` — benchmark evidence
- `benchmarks/fertility-surveys/results-2026-07-28.md` — raw corpus evidence
- `benchmarks/fertility-surveys/results-2026-07-29.md` — generated-output evidence

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added report-only large-scale benchmarking for full and projected Stata reads (~100MB and ~1GB) with deterministic iterations, provenance capture, and atomic publication.
  * Added an opt-in fertility-surveys benchmark suite with isolated execution, locking/ownership, resumable checkpoints, and new acceptance/assessment/merge/republish workflows.
  * Added cross-reader output comparison tooling (direct vs haven) with refined mismatch detection.

* **Documentation**
  * Expanded benchmark documentation, including safety/opt-in guidance and updated results/provenance wording.

* **Tests**
  * Strengthened benchmark orchestration, retry/selection logic, and CI environment rejection coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
