### PR TITLE
Fix Release 117 default text encoding

### DIFF
--- a/r-package/dtaparser/R/read-dta.R
+++ b/r-package/dtaparser/R/read-dta.R
@@ -14,7 +14,8 @@
 #' @param encoding Optional source encoding override. Supported aliases are
 #'   `"UTF-8"`/`"UTF8"`, `"Windows-1252"`/`"CP1252"`, and
 #'   `"ISO-8859-1"`/`"latin1"`, matched case-insensitively. `NULL` uses
-#'   Windows-1252 for legacy files and UTF-8 for modern files. Explicit UTF-8
+#'   Windows-1252 for releases 111, 113--115, and 117 and UTF-8 for releases
+#'   118--119. Explicit UTF-8
 #'   replaces malformed input sequences deterministically with U+FFFD. Haven
 #'   2.5.5 may instead omit an affected label.
 #' @param col_select One or more tidyselect expressions. Predicates see Stata

--- a/r-package/dtaparser/README.md
+++ b/r-package/dtaparser/README.md
@@ -46,7 +46,7 @@ custom daily-date formats beginning `%d` are converted to `Date`; `%tc` and
 numeric and retain their `format.stata` attribute.
 
 `encoding = NULL` follows the DTA release convention: Windows-1252 for
-releases 111 and 113--115 and UTF-8 for releases 117--119. To recover files whose
+releases 111, 113--115, and 117 and UTF-8 for releases 118--119. To recover files whose
 source encoding is recorded incorrectly, pass a case-insensitive UTF-8/UTF8,
 Windows-1252/CP1252, or ISO-8859-1/latin1 alias. The override is deterministic
 across platforms and applies to dataset and variable metadata, fixed strings,

--- a/r-package/dtaparser/man/read_dta.Rd
+++ b/r-package/dtaparser/man/read_dta.Rd
@@ -15,7 +15,8 @@ untrusted \code{file} values should validate or allowlist sources before calling
 \item{encoding}{Optional source encoding override. Supported aliases are
 \code{"UTF-8"}/\code{"UTF8"}, \code{"Windows-1252"}/\code{"CP1252"}, and
 \code{"ISO-8859-1"}/\code{"latin1"}, matched case-insensitively. \code{NULL}
-uses Windows-1252 for legacy files and UTF-8 for modern files. The override
+uses Windows-1252 for releases 111, 113--115, and 117 and UTF-8 for releases
+118--119. The override
 applies to metadata, fixed strings, \code{strL} payloads, and value-label
 names and text. Explicit UTF-8 replaces malformed input sequences
 deterministically with U+FFFD. Haven 2.5.5 may instead omit an affected label.}

--- a/r-package/dtaparser/src/vendor/dta-parser/README.md
+++ b/r-package/dtaparser/src/vendor/dta-parser/README.md
@@ -38,9 +38,9 @@ Numeric `ColumnValues` variants preserve the source storage width (`i8`,
 `i16`, `i32`, `f32`, or `f64`) and carry a parallel
 `Vec<Option<MissingTag>>`. Raw Stata missing values remain in the values vector,
 so consumers retain both exact storage and the classified `.`, `.a`–`.z` tag.
-Modern fixed strings and `strL` payloads use UTF-8 replacement for malformed
-sequences. Releases 111 and 113–115 use Windows-1252 for textual metadata, fixed
-strings, and value labels. All fixed fields stop at their first NUL byte.
+Releases 118–119 use UTF-8 replacement for malformed text sequences. Releases
+111, 113–115, and 117 use Windows-1252 for textual metadata, fixed strings, and
+value labels. All fixed fields stop at their first NUL byte.
 
 Every byte-slice and seekable-file path also accepts a deterministic
 `TextEncoding` override. `Utf8`, `Windows1252`, and true `Iso8859_1` decoding

--- a/r-package/dtaparser/src/vendor/dta-parser/src/text.rs
+++ b/r-package/dtaparser/src/vendor/dta-parser/src/text.rs
@@ -4,9 +4,9 @@ use crate::{DtaError, FormatVersion};
 
 /// Source encoding used for textual fields in a Stata file.
 ///
-/// [`TextEncoding::Auto`] follows the DTA release: UTF-8 for releases 117--119
-/// and Windows-1252 for releases 111 and 113--115. Explicit modes override that
-/// convention for every textual field decoded by the parser.
+/// [`TextEncoding::Auto`] follows the DTA release: UTF-8 for releases 118--119
+/// and Windows-1252 for releases 111, 113--115, and 117. Explicit modes override
+/// that convention for every textual field decoded by the parser.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
 pub enum TextEncoding {
     #[default]
@@ -38,7 +38,7 @@ impl TextEncoding {
 
     pub(crate) fn resolve(self, version: FormatVersion) -> Self {
         match self {
-            Self::Auto if version.is_modern() => Self::Utf8,
+            Self::Auto if version.uses_utf8_text() => Self::Utf8,
             Self::Auto => Self::Windows1252,
             explicit => explicit,
         }

--- a/r-package/dtaparser/src/vendor/dta-parser/src/types.rs
+++ b/r-package/dtaparser/src/vendor/dta-parser/src/types.rs
@@ -23,6 +23,10 @@ impl FormatVersion {
     pub const fn is_modern(self) -> bool {
         matches!(self, Self::V117 | Self::V118 | Self::V119)
     }
+
+    pub(crate) const fn uses_utf8_text(self) -> bool {
+        matches!(self, Self::V118 | Self::V119)
+    }
 }
 
 impl fmt::Display for FormatVersion {

--- a/rust/dta-parser/README.md
+++ b/rust/dta-parser/README.md
@@ -38,9 +38,9 @@ Numeric `ColumnValues` variants preserve the source storage width (`i8`,
 `i16`, `i32`, `f32`, or `f64`) and carry a parallel
 `Vec<Option<MissingTag>>`. Raw Stata missing values remain in the values vector,
 so consumers retain both exact storage and the classified `.`, `.a`–`.z` tag.
-Modern fixed strings and `strL` payloads use UTF-8 replacement for malformed
-sequences. Releases 111 and 113–115 use Windows-1252 for textual metadata, fixed
-strings, and value labels. All fixed fields stop at their first NUL byte.
+Releases 118–119 use UTF-8 replacement for malformed text sequences. Releases
+111, 113–115, and 117 use Windows-1252 for textual metadata, fixed strings, and
+value labels. All fixed fields stop at their first NUL byte.
 
 Every byte-slice and seekable-file path also accepts a deterministic
 `TextEncoding` override. `Utf8`, `Windows1252`, and true `Iso8859_1` decoding

--- a/rust/dta-parser/src/text.rs
+++ b/rust/dta-parser/src/text.rs
@@ -4,9 +4,9 @@ use crate::{DtaError, FormatVersion};
 
 /// Source encoding used for textual fields in a Stata file.
 ///
-/// [`TextEncoding::Auto`] follows the DTA release: UTF-8 for releases 117--119
-/// and Windows-1252 for releases 111 and 113--115. Explicit modes override that
-/// convention for every textual field decoded by the parser.
+/// [`TextEncoding::Auto`] follows the DTA release: UTF-8 for releases 118--119
+/// and Windows-1252 for releases 111, 113--115, and 117. Explicit modes override
+/// that convention for every textual field decoded by the parser.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
 pub enum TextEncoding {
     #[default]
@@ -38,7 +38,7 @@ impl TextEncoding {
 
     pub(crate) fn resolve(self, version: FormatVersion) -> Self {
         match self {
-            Self::Auto if version.is_modern() => Self::Utf8,
+            Self::Auto if version.uses_utf8_text() => Self::Utf8,
             Self::Auto => Self::Windows1252,
             explicit => explicit,
         }

--- a/rust/dta-parser/src/types.rs
+++ b/rust/dta-parser/src/types.rs
@@ -23,6 +23,10 @@ impl FormatVersion {
     pub const fn is_modern(self) -> bool {
         matches!(self, Self::V117 | Self::V118 | Self::V119)
     }
+
+    pub(crate) const fn uses_utf8_text(self) -> bool {
+        matches!(self, Self::V118 | Self::V119)
+    }
 }
 
 impl fmt::Display for FormatVersion {

--- a/rust/dta-parser/tests/encoding.rs
+++ b/rust/dta-parser/tests/encoding.rs
@@ -26,6 +26,29 @@ fn replace_first(bytes: &mut [u8], needle: &[u8], replacement: u8) {
 }
 
 #[test]
+fn auto_uses_windows_1252_for_pre_unicode_release_117() {
+    let mut bytes = fixture("auto_v117.dta");
+    replace_first(&mut bytes, b"1978 automobile data", 0x80);
+    replace_first(&mut bytes, b"Make and model", 0x80);
+    replace_first(&mut bytes, b"AMC Concord", 0x80);
+    replace_first(&mut bytes, b"Domestic", 0x80);
+
+    let auto = dta_parser::read_dta(&bytes).unwrap();
+    assert!(auto.metadata.dataset_label.starts_with('\u{20ac}'));
+    assert!(auto.metadata.variables[0].label.starts_with('\u{20ac}'));
+    let ColumnValues::FixedString { values } = &auto.columns[0].values else {
+        panic!("make must be a fixed string");
+    };
+    assert!(values[0].starts_with('\u{20ac}'));
+    assert!(auto.value_label_table("origin").unwrap().entries[0]
+        .label
+        .starts_with('\u{20ac}'));
+
+    let utf8 = read_dta_with_encoding(&bytes, TextEncoding::Utf8).unwrap();
+    assert!(utf8.metadata.dataset_label.starts_with('\u{fffd}'));
+}
+
+#[test]
 fn override_reaches_modern_metadata_fixed_strings_and_value_labels() {
     let mut bytes = fixture("auto_v118.dta");
     replace_first(&mut bytes, b"1978 automobile data", 0x80);


### PR DESCRIPTION
## What changed

- Treat Stata release 117 (Stata 13) text as Windows-1252 by default.
- Keep release 117's XML-based structural parsing separate from the Unicode text boundary; only releases 118–119 default to UTF-8.
- Add a regression covering release 117 dataset labels, variable labels, fixed strings, and value-label text.
- Synchronize the vendored R-package parser and update the Rust/R documentation.

## Why

The previous automatic encoding decision reused the structural `is_modern()` check. Release 117 uses the newer XML-framed DTA structure, but it predates Stata 14's Unicode format. As a result, non-ASCII Windows-1252 bytes in release 117 files were decoded as malformed UTF-8.

## Validation

- `cargo test --workspace --all-targets --locked`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo doc --workspace --locked --no-deps`
- `scripts/conformance.sh` (native and R/Haven conformance; R check status OK)
- `scripts/check-rust-sync.sh`
- `R CMD build r-package/dtaparser`
- `R CMD check --no-manual --as-cran dtaparser_0.1.0.tar.gz` (tests OK; environment-only checkbashisms/rustc/new-submission diagnostics)

The exhaustive physical-file audit covered all 1,881 `.dta` files in `/opt/aww_cache`, including 130 release 111 files. Of those, 1,858 use supported releases; 22 use unsupported releases 105/108/110 and one file is empty.

The fixed build was then requalified against all 565 release 117 files using the direct R interface, Rust-vector interface, and Haven. The 564 structurally readable files completed 3,045,902,476 cell comparisons. The prior release 117 encoding discrepancies were eliminated. One malformed file fails in all three readers. One residual file exposes a Haven/ReadStat bug: Haven returns raw invalid bytes while marking the string as UTF-8, whereas dtaparser returns valid decoded Unicode.

Remaining metadata differences across the broader corpus are source-preservation policy differences: dtaparser retains trailing spaces and empty value-label table associations that Haven normalizes away. Independent `foreign::read.dta` checks corroborate the preserved source values. Malformed source byte sequences are reported separately from implementation bugs.

Official Stata documentation places Unicode support at Stata 14, whose DTA release is 118: https://www.stata.com/stata14/unicode/
