### PR TITLE
Pin the R package Rust source tree

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
       - run: DTA_FUZZ_CASES=16 cargo +stable test -p dta-parser --locked --test fuzz_smoke -- --nocapture
 
   source-sync:
-    name: Offline source and archive identity
+    name: Pinned Rust/R source and archive identity
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -70,6 +70,7 @@ jobs:
       - uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # v2.0.2
         with:
           bun-version: 1.3.14
+      - run: python3 -m unittest discover -s scripts -p 'test_*.py'
       - run: scripts/check-rust-sync.sh
       - run: scripts/rebuild-r-vendor.sh
       - run: git diff --exit-code -- r-package/dtaparser/src/rust/vendor.tar.gz

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 node_modules
 target
+__pycache__/
+*.pyc
 /dtaparser.Rcheck/
 /dtaparser_*.tar.gz

--- a/README.md
+++ b/README.md
@@ -86,10 +86,16 @@ conversion, and public API.
 | [`benchmarks`](benchmarks) | Report-only TypeScript, Rust, and R benchmarks |
 
 The Rust crate is the source of truth for the Rust parser and its R binding.
-The R package mirrors it under
+The R package mirrors its runtime tree under
 `r-package/dtaparser/src/vendor/dta-parser`; do not edit only the mirror.
-`scripts/check-rust-sync.sh` checks source equality, Cargo locks, and the
-normalized offline dependency archive.
+Matching `dta-parser.tree.sha256` files pin the normalized parser manifest,
+recursive `src` contents, and an optional `build.rs` script.
+`scripts/check-rust-sync.sh` verifies both trees and
+pins, Cargo locks, and the normalized offline dependency archive. After
+mirroring a parser change, run `scripts/check-rust-sync.sh --update-pins`; it
+refuses to update the pins unless the canonical and R runtime trees agree.
+The repository synchronization checker requires Python 3.11 or newer; R
+package installation does not require Python.
 
 ## Conformance and benchmarks
 

--- a/r-package/dtaparser/README.md
+++ b/r-package/dtaparser/README.md
@@ -180,8 +180,16 @@ that the package is loaded from that freshly populated, checkout-local library
 rather than an unrelated global installation.
 
 The Rust source of truth is `rust/dta-parser`. After changing that crate,
-mirror it into `r-package/dtaparser/src/vendor/dta-parser` and run
-`scripts/check-rust-sync.sh`; the check also verifies the Cargo locks and
-deterministic offline `vendor.tar.gz` identity. Windows CI
-installs and selects `stable-x86_64-pc-windows-gnu`, confirms the rustc host,
-then actually builds and checks the package through Rtools.
+mirror its runtime tree into `r-package/dtaparser/src/vendor/dta-parser`, then
+run `scripts/check-rust-sync.sh --update-pins` and
+`scripts/check-rust-sync.sh`. Matching `dta-parser.tree.sha256` files pin the
+normalized parser manifest, recursive `src` contents, and an optional
+`build.rs` script; pin updates are refused unless both trees agree. The check
+also verifies the Cargo locks and
+deterministic offline `vendor.tar.gz` identity. The pin namespaces Cargo build
+outputs, while configure always refreshes the extracted dependencies, so
+repeated source-tree builds cannot silently reuse older inputs. Python 3.11 or
+newer is only required for repository maintenance and CI, not R package
+installation.
+Windows CI installs and selects `stable-x86_64-pc-windows-gnu`, confirms the
+rustc host, then actually builds and checks the package through Rtools.

--- a/r-package/dtaparser/configure
+++ b/r-package/dtaparser/configure
@@ -1,14 +1,27 @@
 #!/bin/sh
 set -eu
 
-if test ! -d src/rust/v; then
-  tar -xzf src/rust/vendor.tar.gz -C src/rust
+rm -rf src/rust/v
+tar -xzf src/rust/vendor.tar.gz -C src/rust
+test -d src/rust/v
+
+dta_parser_pin=src/vendor/dta-parser.tree.sha256
+dta_parser_digest=$(awk '$2 == "dta-parser-runtime-tree-v1" && NF == 2 { print $1 }' "$dta_parser_pin")
+case "$dta_parser_digest" in
+  *[!0-9a-f]*) dta_parser_digest= ;;
+esac
+if test "${#dta_parser_digest}" -ne 64; then
+  echo "dtaparser parser-tree pin is malformed" >&2
+  exit 1
 fi
+dta_parser_namespace=$(printf '%.16s' "$dta_parser_digest")
 
 case "$(uname -s)" in
   Darwin) rust_system_libs="-liconv -framework CoreFoundation -framework Security" ;;
   *) rust_system_libs="-ldl -lpthread -lm" ;;
 esac
 
-sed "s|@RUST_SYSTEM_LIBS@|$rust_system_libs|g" \
+sed \
+  -e "s|@DTA_PARSER_NAMESPACE@|$dta_parser_namespace|g" \
+  -e "s|@RUST_SYSTEM_LIBS@|$rust_system_libs|g" \
   src/Makevars.in > src/Makevars

--- a/r-package/dtaparser/configure.win
+++ b/r-package/dtaparser/configure.win
@@ -6,7 +6,20 @@ if test "$rust_host" != "$rust_target"; then
   echo "dtaparser requires the Rust $rust_target toolchain for 64-bit R on Windows; found $rust_host" >&2
   exit 1
 fi
-if test ! -d src/rust/v; then
-  tar -xzf src/rust/vendor.tar.gz -C src/rust
+rm -rf src/rust/v
+tar -xzf src/rust/vendor.tar.gz -C src/rust
+test -d src/rust/v
+
+dta_parser_pin=src/vendor/dta-parser.tree.sha256
+dta_parser_digest=$(awk '$2 == "dta-parser-runtime-tree-v1" && NF == 2 { print $1 }' "$dta_parser_pin")
+case "$dta_parser_digest" in
+  *[!0-9a-f]*) dta_parser_digest= ;;
+esac
+if test "${#dta_parser_digest}" -ne 64; then
+  echo "dtaparser parser-tree pin is malformed" >&2
+  exit 1
 fi
-cp src/Makevars.win.in src/Makevars.win
+dta_parser_namespace=$(printf '%.16s' "$dta_parser_digest")
+
+sed "s|@DTA_PARSER_NAMESPACE@|$dta_parser_namespace|g" \
+  src/Makevars.win.in > src/Makevars.win

--- a/r-package/dtaparser/src/Makevars.in
+++ b/r-package/dtaparser/src/Makevars.in
@@ -1,5 +1,8 @@
 RUST_MANIFEST = rust/Cargo.toml
-RUST_TARGET = rust/target
+DTA_PARSER_PIN = vendor/dta-parser.tree.sha256
+DTA_PARSER_NAMESPACE = @DTA_PARSER_NAMESPACE@
+RUST_TARGET_ROOT = rust/target
+RUST_TARGET = $(RUST_TARGET_ROOT)/dta-parser-$(DTA_PARSER_NAMESPACE)
 RUST_LIB = $(RUST_TARGET)/release/libdtaparser_r.a
 RUST_SOURCES = rust/src/lib.rs \
 	vendor/dta-parser/src/data_reader.rs \
@@ -15,14 +18,18 @@ RUST_SOURCES = rust/src/lib.rs \
 	vendor/dta-parser/src/text.rs \
 	vendor/dta-parser/src/types.rs \
 	vendor/dta-parser/src/value_labels.rs
+RUST_INPUTS = vendor/dta-parser/Cargo.toml \
+	vendor/dta-parser/Cargo.lock \
+	$(DTA_PARSER_PIN) \
+	$(RUST_SOURCES)
 
 OBJECTS = init.o
 PKG_LIBS = $(RUST_LIB) @RUST_SYSTEM_LIBS@
 
 $(SHLIB): $(RUST_LIB)
 
-$(RUST_LIB): $(RUST_MANIFEST) rust/Cargo.lock rust/cargo-config.toml rust/vendor.tar.gz $(RUST_SOURCES)
+$(RUST_LIB): $(RUST_MANIFEST) rust/Cargo.lock rust/cargo-config.toml rust/vendor.tar.gz $(RUST_INPUTS)
 	CARGO_TARGET_DIR=$(RUST_TARGET) cargo build --manifest-path $(RUST_MANIFEST) --config rust/cargo-config.toml --release --locked --offline
 
 clean:
-	rm -rf $(RUST_TARGET) $(SHLIB) $(OBJECTS)
+	rm -rf $(RUST_TARGET_ROOT) $(SHLIB) $(OBJECTS)

--- a/r-package/dtaparser/src/Makevars.win.in
+++ b/r-package/dtaparser/src/Makevars.win.in
@@ -1,5 +1,8 @@
 RUST_MANIFEST = rust/Cargo.toml
-RUST_TARGET_DIR = rust/target
+DTA_PARSER_PIN = vendor/dta-parser.tree.sha256
+DTA_PARSER_NAMESPACE = @DTA_PARSER_NAMESPACE@
+RUST_TARGET_ROOT = rust/target
+RUST_TARGET_DIR = $(RUST_TARGET_ROOT)/dta-parser-$(DTA_PARSER_NAMESPACE)
 RUST_WINDOWS_TARGET = x86_64-pc-windows-gnu
 RUST_LIB = $(RUST_TARGET_DIR)/$(RUST_WINDOWS_TARGET)/release/libdtaparser_r.a
 RUST_SOURCES = rust/src/lib.rs \
@@ -16,14 +19,18 @@ RUST_SOURCES = rust/src/lib.rs \
 	vendor/dta-parser/src/text.rs \
 	vendor/dta-parser/src/types.rs \
 	vendor/dta-parser/src/value_labels.rs
+RUST_INPUTS = vendor/dta-parser/Cargo.toml \
+	vendor/dta-parser/Cargo.lock \
+	$(DTA_PARSER_PIN) \
+	$(RUST_SOURCES)
 
 OBJECTS = init.o
 PKG_LIBS = $(RUST_LIB) -lws2_32 -luserenv -lbcrypt -ladvapi32 -lntdll
 
 $(SHLIB): $(RUST_LIB)
 
-$(RUST_LIB): $(RUST_MANIFEST) rust/Cargo.lock rust/cargo-config.toml rust/vendor.tar.gz $(RUST_SOURCES)
+$(RUST_LIB): $(RUST_MANIFEST) rust/Cargo.lock rust/cargo-config.toml rust/vendor.tar.gz $(RUST_INPUTS)
 	CARGO_TARGET_DIR=$(RUST_TARGET_DIR) cargo build --manifest-path $(RUST_MANIFEST) --config rust/cargo-config.toml --target $(RUST_WINDOWS_TARGET) --release --locked --offline
 
 clean:
-	rm -rf $(RUST_TARGET_DIR) $(SHLIB) $(OBJECTS)
+	rm -rf $(RUST_TARGET_ROOT) $(SHLIB) $(OBJECTS)

--- a/r-package/dtaparser/src/vendor/dta-parser.tree.sha256
+++ b/r-package/dtaparser/src/vendor/dta-parser.tree.sha256
@@ -1,0 +1,1 @@
+c553e370c587819bc9bed910f0c9802f2046968dd0b4d09feb053f025bdff147  dta-parser-runtime-tree-v1

--- a/rust/dta-parser.tree.sha256
+++ b/rust/dta-parser.tree.sha256
@@ -1,0 +1,1 @@
+c553e370c587819bc9bed910f0c9802f2046968dd0b4d09feb053f025bdff147  dta-parser-runtime-tree-v1

--- a/scripts/check-rust-sync.sh
+++ b/scripts/check-rust-sync.sh
@@ -2,50 +2,8 @@
 set -eu
 
 script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
-root=$(dirname -- "$script_dir")
-crate="$root/rust/dta-parser"
-mirror="$root/r-package/dtaparser/src/vendor/dta-parser"
-archive="$root/r-package/dtaparser/src/rust/vendor.tar.gz"
-integrity="$root/r-package/dtaparser/src/rust/vendor.sha256"
-
-sha256_file() {
-  if command -v sha256sum >/dev/null 2>&1; then
-    sha256sum "$1" | awk '{print $1}'
-  else
-    shasum -a 256 "$1" | awk '{print $1}'
-  fi
-}
-
-temporary=$(mktemp -d)
-trap 'rm -rf "$temporary"' EXIT HUP INT TERM
-root_manifest="$temporary/root-rust-sources"
-mirror_manifest="$temporary/mirror-rust-sources"
-
-(cd "$crate" && find src -type f -name '*.rs' -print | LC_ALL=C sort) > "$root_manifest"
-(cd "$mirror" && find src -type f -name '*.rs' -print | LC_ALL=C sort) > "$mirror_manifest"
-cmp "$root_manifest" "$mirror_manifest"
-while IFS= read -r relative; do
-  cmp "$crate/$relative" "$mirror/$relative"
-done < "$root_manifest"
-
-cmp "$crate/README.md" "$mirror/README.md"
-cmp "$crate/LICENSE" "$mirror/LICENSE"
-cmp "$root/Cargo.lock" "$mirror/Cargo.lock"
-
-expected_archive=$(awk '$2 == "vendor.tar.gz" { print $1 }' "$integrity")
-expected_listing=$(awk '$2 == "vendor-file-list" { print $1 }' "$integrity")
-actual_archive=$(sha256_file "$archive")
-actual_listing=$(tar -tzf "$archive" | LC_ALL=C sort | sha256_file /dev/stdin)
-
-test -n "$expected_archive"
-test -n "$expected_listing"
-test "$actual_archive" = "$expected_archive"
-test "$actual_listing" = "$expected_listing"
-
-vendor_extract="$temporary/vendor"
-mkdir "$vendor_extract"
-tar -xzf "$archive" -C "$vendor_extract"
-test -f "$vendor_extract/v/encoding_rs/.cargo-checksum.json"
-test -f "$vendor_extract/v/serde/.cargo-checksum.json"
-
-echo "rust sync: PASS (symmetric recursive sources, Cargo lock, vendor archive identity)"
+if ! python3 -c 'import sys; raise SystemExit(sys.version_info < (3, 11))'; then
+  echo "rust sync requires Python 3.11 or newer" >&2
+  exit 1
+fi
+exec python3 "$script_dir/check_rust_sync.py" "$@"

--- a/scripts/check_rust_sync.py
+++ b/scripts/check_rust_sync.py
@@ -1,0 +1,441 @@
+#!/usr/bin/env python3
+"""Validate the canonical Rust parser and the R-package mirror."""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import hashlib
+import json
+import os
+from pathlib import Path, PurePosixPath
+import re
+import sys
+import tarfile
+import tempfile
+import tomllib
+from typing import Iterable
+
+
+PIN_SCHEMA = "dta-parser-runtime-tree-v1"
+PIN_PATTERN = re.compile(rf"([0-9a-f]{{64}})  {re.escape(PIN_SCHEMA)}\n?\Z")
+
+
+class SyncError(RuntimeError):
+    """A checked Rust/R synchronization invariant failed."""
+
+
+def normalized_manifest(
+    workspace_manifest: Path, crate_manifest: Path, *, mirror: bool
+) -> dict[str, object]:
+    workspace = tomllib.loads(workspace_manifest.read_text(encoding="utf-8"))
+    manifest = copy.deepcopy(
+        tomllib.loads(crate_manifest.read_text(encoding="utf-8"))
+    )
+    package = manifest.get("package")
+    if not isinstance(package, dict):
+        raise SyncError(f"missing [package] table: {crate_manifest}")
+
+    if mirror:
+        if package.pop("publish", None) is not False:
+            raise SyncError("R mirror must set package.publish = false")
+        if manifest.pop("workspace", None) != {}:
+            raise SyncError("R mirror must contain an empty [workspace] table")
+    else:
+        workspace_package = workspace.get("workspace", {}).get("package", {})
+        if not isinstance(workspace_package, dict):
+            raise SyncError("root manifest must contain [workspace.package]")
+        for field in ("edition", "license", "rust-version"):
+            if package.get(field) != {"workspace": True}:
+                raise SyncError(
+                    f"canonical package.{field} must inherit from the workspace"
+                )
+            try:
+                package[field] = workspace_package[field]
+            except KeyError as error:
+                raise SyncError(
+                    f"root [workspace.package] is missing {field}"
+                ) from error
+        if package.pop("exclude", None) != ["tests/**"]:
+            raise SyncError(
+                'canonical package.exclude must be exactly ["tests/**"]'
+            )
+
+    return manifest
+
+
+def source_files(crate: Path) -> list[Path]:
+    source_root = crate / "src"
+    files: list[Path] = []
+    for path in source_root.rglob("*"):
+        if path.is_symlink():
+            raise SyncError(f"runtime source tree contains a symlink: {path}")
+        if path.is_dir():
+            continue
+        if not path.is_file():
+            raise SyncError(f"runtime source tree contains a non-file: {path}")
+        files.append(path.relative_to(crate))
+
+    build_script = crate / "build.rs"
+    if build_script.is_symlink():
+        raise SyncError(f"runtime source tree contains a symlink: {build_script}")
+    if build_script.exists():
+        if not build_script.is_file():
+            raise SyncError(f"runtime source tree contains a non-file: {build_script}")
+        files.append(Path("build.rs"))
+
+    return sorted(files, key=lambda item: item.as_posix())
+
+
+def framed_digest(entries: Iterable[tuple[str, bytes]]) -> str:
+    digest = hashlib.sha256()
+    digest.update(PIN_SCHEMA.encode("ascii") + b"\0")
+    for relative, contents in entries:
+        path = relative.encode("utf-8")
+        digest.update(path + b"\0")
+        digest.update(str(len(contents)).encode("ascii") + b"\0")
+        digest.update(contents)
+    return digest.hexdigest()
+
+
+def runtime_tree_digest(crate: Path, manifest: dict[str, object]) -> str:
+    normalized = json.dumps(
+        manifest, ensure_ascii=False, separators=(",", ":"), sort_keys=True
+    ).encode("utf-8")
+    entries = [("Cargo.toml.normalized.json", normalized)]
+    entries.extend(
+        (relative.as_posix(), (crate / relative).read_bytes())
+        for relative in source_files(crate)
+    )
+    return framed_digest(entries)
+
+
+def format_pin(digest: str) -> str:
+    return f"{digest}  {PIN_SCHEMA}\n"
+
+
+def stage_bytes(path: Path, contents: bytes) -> Path:
+    descriptor, temporary = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    temporary_path = Path(temporary)
+    try:
+        with os.fdopen(descriptor, "wb") as destination:
+            destination.write(contents)
+            destination.flush()
+            os.fsync(destination.fileno())
+    except BaseException:
+        temporary_path.unlink(missing_ok=True)
+        raise
+    return temporary_path
+
+
+def atomic_write_bytes(path: Path, contents: bytes) -> None:
+    temporary = stage_bytes(path, contents)
+    try:
+        os.replace(temporary, path)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def write_pin_pair(paths: tuple[Path, Path], digest: str) -> None:
+    contents = format_pin(digest).encode("ascii")
+    originals = [path.read_bytes() if path.exists() else None for path in paths]
+    staged = [stage_bytes(path, contents) for path in paths]
+    replaced = 0
+    try:
+        for path, temporary in zip(paths, staged, strict=True):
+            os.replace(temporary, path)
+            replaced += 1
+    except BaseException:
+        for path, original in zip(paths[:replaced], originals[:replaced], strict=True):
+            if original is None:
+                path.unlink(missing_ok=True)
+            else:
+                atomic_write_bytes(path, original)
+        raise
+    finally:
+        for temporary in staged:
+            temporary.unlink(missing_ok=True)
+
+
+def read_pin(path: Path) -> str:
+    match = PIN_PATTERN.fullmatch(path.read_text(encoding="ascii"))
+    if match is None:
+        raise SyncError(f"malformed Rust tree pin: {path}")
+    return match.group(1)
+
+
+def compare_runtime_sources(canonical: Path, mirror: Path) -> None:
+    canonical_files = source_files(canonical)
+    mirror_files = source_files(mirror)
+    if canonical_files != mirror_files:
+        canonical_names = {path.as_posix() for path in canonical_files}
+        mirror_names = {path.as_posix() for path in mirror_files}
+        missing = sorted(canonical_names - mirror_names)
+        extra = sorted(mirror_names - canonical_names)
+        details = []
+        if missing:
+            details.append(f"missing from R mirror: {', '.join(missing)}")
+        if extra:
+            details.append(f"extra in R mirror: {', '.join(extra)}")
+        raise SyncError("runtime source inventory differs; " + "; ".join(details))
+
+    for relative in canonical_files:
+        if (canonical / relative).read_bytes() != (mirror / relative).read_bytes():
+            raise SyncError(f"runtime source differs: {relative.as_posix()}")
+
+
+def make_variable_values(path: Path, variable: str) -> list[str]:
+    lines = path.read_text(encoding="utf-8").splitlines()
+    prefix = f"{variable} ="
+    for index, line in enumerate(lines):
+        if not line.startswith(prefix):
+            continue
+        parts: list[str] = []
+        fragment = line[len(prefix) :].strip()
+        while True:
+            continued = fragment.endswith("\\")
+            if continued:
+                fragment = fragment[:-1].strip()
+            parts.extend(fragment.split())
+            if not continued:
+                return parts
+            index += 1
+            if index >= len(lines):
+                raise SyncError(f"unterminated {variable} in {path}")
+            fragment = lines[index].strip()
+    raise SyncError(f"missing {variable} in {path}")
+
+
+def check_make_source_inventories(root: Path, mirror: Path) -> None:
+    expected = ["rust/src/lib.rs"] + [
+        f"vendor/dta-parser/{relative.as_posix()}" for relative in source_files(mirror)
+    ]
+    for name in ("Makevars.in", "Makevars.win.in"):
+        path = root / "r-package/dtaparser/src" / name
+        actual = make_variable_values(path, "RUST_SOURCES")
+        if actual != expected:
+            raise SyncError(f"{name} RUST_SOURCES does not match the runtime tree")
+
+
+def require_equal(canonical: Path, mirror: Path, label: str) -> None:
+    if canonical.read_bytes() != mirror.read_bytes():
+        raise SyncError(f"{label} differs: {canonical} != {mirror}")
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for chunk in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def read_integrity_file(path: Path) -> dict[str, str]:
+    values: dict[str, str] = {}
+    for line in path.read_text(encoding="ascii").splitlines():
+        fields = line.split()
+        if len(fields) != 2 or not re.fullmatch(r"[0-9a-f]{64}", fields[0]):
+            raise SyncError(f"malformed integrity entry: {line!r}")
+        if fields[1] in values:
+            raise SyncError(f"duplicate integrity entry: {fields[1]}")
+        values[fields[1]] = fields[0]
+    return values
+
+
+def registry_packages(lock_path: Path) -> dict[str, tuple[str, str]]:
+    lock = tomllib.loads(lock_path.read_text(encoding="utf-8"))
+    packages = lock.get("package")
+    if not isinstance(packages, list):
+        raise SyncError(f"Cargo lock has no [[package]] entries: {lock_path}")
+
+    registry: dict[str, tuple[str, str]] = {}
+    for package in packages:
+        if not isinstance(package, dict):
+            raise SyncError(f"malformed Cargo package entry: {lock_path}")
+        source = package.get("source")
+        if not isinstance(source, str) or not source.startswith("registry+"):
+            continue
+        name = package.get("name")
+        version = package.get("version")
+        checksum = package.get("checksum")
+        if not all(isinstance(value, str) for value in (name, version, checksum)):
+            raise SyncError(
+                f"registry package lacks name, version, or checksum: {lock_path}"
+            )
+        assert isinstance(name, str) and isinstance(version, str) and isinstance(checksum, str)
+        if name in registry:
+            raise SyncError(
+                f"multiple locked registry versions require archive-name handling: {name}"
+            )
+        registry[name] = (version, checksum)
+    return registry
+
+
+def check_vendor_archive(
+    archive: Path, integrity_path: Path, lock_path: Path
+) -> None:
+    expected = read_integrity_file(integrity_path)
+    try:
+        expected_archive = expected["vendor.tar.gz"]
+        expected_listing = expected["vendor-file-list"]
+    except KeyError as error:
+        raise SyncError(f"missing integrity entry: {error.args[0]}") from error
+
+    actual_archive = sha256_file(archive)
+    if actual_archive != expected_archive:
+        raise SyncError("offline vendor archive digest differs from vendor.sha256")
+
+    with tarfile.open(archive, mode="r:gz") as source:
+        members = source.getmembers()
+
+    entries: dict[str, tarfile.TarInfo] = {}
+    for member in members:
+        name = member.name.rstrip("/")
+        relative = PurePosixPath(name)
+        if (
+            not name
+            or relative.is_absolute()
+            or ".." in relative.parts
+            or "\\" in name
+        ):
+            raise SyncError(f"offline vendor archive has an unsafe path: {member.name}")
+        if not (member.isfile() or member.isdir()):
+            raise SyncError(f"offline vendor archive has a special entry: {member.name}")
+        if name in entries:
+            raise SyncError(f"offline vendor archive has a duplicate entry: {name}")
+        entries[name] = member
+
+    for name in entries:
+        for parent in PurePosixPath(name).parents:
+            if parent == PurePosixPath("."):
+                break
+            parent_member = entries.get(parent.as_posix())
+            if parent_member is not None and parent_member.isfile():
+                raise SyncError(
+                    f"offline vendor archive puts {name} below file {parent.as_posix()}"
+                )
+
+    rendered_names = [
+        f"{member.name}{'/' if member.isdir() and not member.name.endswith('/') else ''}"
+        for member in members
+    ]
+    listing = "".join(f"{name}\n" for name in sorted(rendered_names))
+    actual_listing = hashlib.sha256(listing.encode("utf-8")).hexdigest()
+    if actual_listing != expected_listing:
+        raise SyncError("offline vendor archive file-list digest differs")
+
+    locked_packages = registry_packages(lock_path)
+    expected_packages = set(locked_packages)
+    archived_packages = {
+        PurePosixPath(name).name
+        for name, member in entries.items()
+        if member.isdir() and PurePosixPath(name).parent == PurePosixPath("v")
+    }
+    if archived_packages != expected_packages:
+        missing = sorted(expected_packages - archived_packages)
+        extra = sorted(archived_packages - expected_packages)
+        details = []
+        if missing:
+            details.append(f"missing locked packages: {', '.join(missing)}")
+        if extra:
+            details.append(f"unexpected packages: {', '.join(extra)}")
+        raise SyncError("offline vendor package inventory differs; " + "; ".join(details))
+
+    required_files = tuple(
+        f"v/{name}/.cargo-checksum.json" for name in sorted(expected_packages)
+    )
+    for required in required_files:
+        member = entries.get(required)
+        if member is None or not member.isfile():
+            raise SyncError(f"offline vendor archive is missing regular file {required}")
+
+    with tempfile.TemporaryDirectory() as temporary:
+        destination = Path(temporary)
+        with tarfile.open(archive, mode="r:gz") as source:
+            source.extractall(destination)
+        for name, (locked_version, locked_checksum) in locked_packages.items():
+            package_root = destination / "v" / name
+            checksum_path = package_root / ".cargo-checksum.json"
+            manifest_path = package_root / "Cargo.toml"
+            if not checksum_path.is_file() or not manifest_path.is_file():
+                raise SyncError(f"offline vendor archive did not extract metadata for {name}")
+
+            checksum = json.loads(checksum_path.read_text(encoding="utf-8"))
+            if not isinstance(checksum, dict) or checksum.get("package") != locked_checksum:
+                raise SyncError(f"offline vendor checksum differs from Cargo.lock: {name}")
+
+            manifest = tomllib.loads(manifest_path.read_text(encoding="utf-8"))
+            package = manifest.get("package")
+            if not isinstance(package, dict):
+                raise SyncError(f"vendored Cargo.toml has no [package]: {name}")
+            if package.get("name") != name or package.get("version") != locked_version:
+                raise SyncError(f"offline vendor version differs from Cargo.lock: {name}")
+
+
+def check_repository(root: Path, *, update_pins: bool = False) -> str:
+    canonical = root / "rust/dta-parser"
+    mirror = root / "r-package/dtaparser/src/vendor/dta-parser"
+    canonical_pin_path = root / "rust/dta-parser.tree.sha256"
+    mirror_pin_path = root / "r-package/dtaparser/src/vendor/dta-parser.tree.sha256"
+
+    canonical_manifest = normalized_manifest(
+        root / "Cargo.toml", canonical / "Cargo.toml", mirror=False
+    )
+    mirror_manifest = normalized_manifest(
+        root / "Cargo.toml", mirror / "Cargo.toml", mirror=True
+    )
+    if canonical_manifest != mirror_manifest:
+        raise SyncError("canonical and R mirror Cargo.toml semantics differ")
+
+    compare_runtime_sources(canonical, mirror)
+    check_make_source_inventories(root, mirror)
+    canonical_digest = runtime_tree_digest(canonical, canonical_manifest)
+    mirror_digest = runtime_tree_digest(mirror, mirror_manifest)
+    if canonical_digest != mirror_digest:
+        raise SyncError("canonical and R runtime-tree digests differ")
+
+    require_equal(canonical / "README.md", mirror / "README.md", "crate README")
+    require_equal(canonical / "LICENSE", mirror / "LICENSE", "crate license")
+    require_equal(root / "Cargo.lock", mirror / "Cargo.lock", "Cargo lock")
+    check_vendor_archive(
+        root / "r-package/dtaparser/src/rust/vendor.tar.gz",
+        root / "r-package/dtaparser/src/rust/vendor.sha256",
+        root / "r-package/dtaparser/src/rust/Cargo.lock",
+    )
+
+    if update_pins:
+        write_pin_pair((canonical_pin_path, mirror_pin_path), canonical_digest)
+
+    canonical_pin = read_pin(canonical_pin_path)
+    mirror_pin = read_pin(mirror_pin_path)
+    if canonical_pin != mirror_pin:
+        raise SyncError("canonical and R mirror tree pins differ")
+    if canonical_pin != canonical_digest:
+        raise SyncError("Rust tree pins are stale; mirror the tree and update both pins")
+    return canonical_digest
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--update-pins", action="store_true")
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=Path(__file__).resolve().parent.parent,
+        help=argparse.SUPPRESS,
+    )
+    arguments = parser.parse_args()
+
+    try:
+        digest = check_repository(arguments.root.resolve(), update_pins=arguments.update_pins)
+    except (OSError, SyncError, tarfile.TarError, tomllib.TOMLDecodeError) as error:
+        print(f"rust sync: FAIL: {error}", file=sys.stderr)
+        return 1
+
+    action = "updated and verified" if arguments.update_pins else "verified"
+    print(f"rust sync: PASS ({action} {PIN_SCHEMA} {digest})")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_rust_sync.py
+++ b/scripts/check_rust_sync.py
@@ -352,7 +352,7 @@ def check_vendor_archive(
     with tempfile.TemporaryDirectory() as temporary:
         destination = Path(temporary)
         with tarfile.open(archive, mode="r:gz") as source:
-            source.extractall(destination)
+            source.extractall(destination, filter="data")
         for name, (locked_version, locked_checksum) in locked_packages.items():
             package_root = destination / "v" / name
             checksum_path = package_root / ".cargo-checksum.json"

--- a/scripts/test_check_rust_sync.py
+++ b/scripts/test_check_rust_sync.py
@@ -126,6 +126,7 @@ checksum = "1111111111111111111111111111111111111111111111111111111111111111"
         with tarfile.open(self.archive, mode="w:gz") as archive:
             root = tarfile.TarInfo("v")
             root.type = tarfile.DIRTYPE
+            root.mode = 0o755
             archive.addfile(root)
             for package, checksum_value in (
                 ("encoding_rs", "0" * 64),
@@ -133,12 +134,14 @@ checksum = "1111111111111111111111111111111111111111111111111111111111111111"
             ):
                 directory = tarfile.TarInfo(f"v/{package}")
                 directory.type = tarfile.DIRTYPE
+                directory.mode = 0o755
                 archive.addfile(directory)
 
                 checksum_contents = json.dumps(
                     {"files": {}, "package": checksum_value}, separators=(",", ":")
                 ).encode("utf-8")
                 checksum = tarfile.TarInfo(f"v/{package}/.cargo-checksum.json")
+                checksum.mode = 0o644
                 checksum.size = len(checksum_contents)
                 archive.addfile(checksum, io.BytesIO(checksum_contents))
 
@@ -146,6 +149,7 @@ checksum = "1111111111111111111111111111111111111111111111111111111111111111"
                     f'[package]\nname = "{package}"\nversion = "1.0.0"\n'
                 ).encode("utf-8")
                 manifest = tarfile.TarInfo(f"v/{package}/Cargo.toml")
+                manifest.mode = 0o644
                 manifest.size = len(manifest_contents)
                 archive.addfile(manifest, io.BytesIO(manifest_contents))
         self.refresh_integrity()

--- a/scripts/test_check_rust_sync.py
+++ b/scripts/test_check_rust_sync.py
@@ -1,0 +1,358 @@
+#!/usr/bin/env python3
+"""Mutation tests for the Rust/R runtime-tree pinning contract."""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import io
+import json
+from pathlib import Path
+import tarfile
+import tempfile
+import unittest
+
+
+SCRIPT = Path(__file__).with_name("check_rust_sync.py")
+SPEC = importlib.util.spec_from_file_location("check_rust_sync", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+sync = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(sync)
+
+
+ROOT_MANIFEST = """\
+[workspace]
+members = ["rust/dta-parser"]
+resolver = "2"
+
+[workspace.package]
+edition = "2021"
+license = "GPL-3.0-only"
+rust-version = "1.74"
+"""
+
+CANONICAL_MANIFEST = """\
+[package]
+name = "dta-parser"
+version = "0.1.0"
+description = "test parser"
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+repository = "https://example.test/parser"
+readme = "README.md"
+exclude = ["tests/**"]
+
+[dependencies]
+serde = { version = "1.0", features = ["derive"] }
+"""
+
+MIRROR_MANIFEST = """\
+[package]
+name = "dta-parser"
+version = "0.1.0"
+description = "test parser"
+edition = "2021"
+license = "GPL-3.0-only"
+rust-version = "1.74"
+repository = "https://example.test/parser"
+readme = "README.md"
+publish = false
+
+[dependencies]
+serde = { features = ["derive"], version = "1.0" }
+
+[workspace]
+"""
+
+
+class RepositoryFixture:
+    def __init__(self, root: Path) -> None:
+        self.root = root
+        self.canonical = root / "rust/dta-parser"
+        self.mirror = root / "r-package/dtaparser/src/vendor/dta-parser"
+        self.canonical_pin = root / "rust/dta-parser.tree.sha256"
+        self.mirror_pin = root / "r-package/dtaparser/src/vendor/dta-parser.tree.sha256"
+        self.archive = root / "r-package/dtaparser/src/rust/vendor.tar.gz"
+        self.integrity = root / "r-package/dtaparser/src/rust/vendor.sha256"
+        self.bridge_lock = root / "r-package/dtaparser/src/rust/Cargo.lock"
+
+        (root / "Cargo.toml").parent.mkdir(parents=True, exist_ok=True)
+        (root / "Cargo.toml").write_text(ROOT_MANIFEST, encoding="utf-8")
+        (root / "Cargo.lock").write_text("lock\n", encoding="utf-8")
+        for crate, manifest in (
+            (self.canonical, CANONICAL_MANIFEST),
+            (self.mirror, MIRROR_MANIFEST),
+        ):
+            (crate / "src/nested").mkdir(parents=True, exist_ok=True)
+            (crate / "Cargo.toml").write_text(manifest, encoding="utf-8")
+            (crate / "README.md").write_text("readme\n", encoding="utf-8")
+            (crate / "LICENSE").write_text("license\n", encoding="utf-8")
+            (crate / "src/lib.rs").write_text("pub mod nested;\n", encoding="utf-8")
+            (crate / "src/nested/data.bin").write_bytes(b"\x00runtime\xff")
+        (self.mirror / "Cargo.lock").write_text("lock\n", encoding="utf-8")
+        make_sources = """\
+RUST_SOURCES = rust/src/lib.rs \\
+\tvendor/dta-parser/src/lib.rs \\
+\tvendor/dta-parser/src/nested/data.bin
+"""
+        make_root = root / "r-package/dtaparser/src"
+        for name in ("Makevars.in", "Makevars.win.in"):
+            (make_root / name).write_text(make_sources, encoding="utf-8")
+        self.bridge_lock.parent.mkdir(parents=True, exist_ok=True)
+        self.bridge_lock.write_text(
+            """\
+version = 3
+
+[[package]]
+name = "encoding_rs"
+version = "1.0.0"
+source = "registry+https://example.test/index"
+checksum = "0000000000000000000000000000000000000000000000000000000000000000"
+
+[[package]]
+name = "serde"
+version = "1.0.0"
+source = "registry+https://example.test/index"
+checksum = "1111111111111111111111111111111111111111111111111111111111111111"
+""",
+            encoding="utf-8",
+        )
+        self._write_archive()
+        sync.check_repository(root, update_pins=True)
+
+    def _write_archive(self) -> None:
+        self.archive.parent.mkdir(parents=True, exist_ok=True)
+        with tarfile.open(self.archive, mode="w:gz") as archive:
+            root = tarfile.TarInfo("v")
+            root.type = tarfile.DIRTYPE
+            archive.addfile(root)
+            for package, checksum_value in (
+                ("encoding_rs", "0" * 64),
+                ("serde", "1" * 64),
+            ):
+                directory = tarfile.TarInfo(f"v/{package}")
+                directory.type = tarfile.DIRTYPE
+                archive.addfile(directory)
+
+                checksum_contents = json.dumps(
+                    {"files": {}, "package": checksum_value}, separators=(",", ":")
+                ).encode("utf-8")
+                checksum = tarfile.TarInfo(f"v/{package}/.cargo-checksum.json")
+                checksum.size = len(checksum_contents)
+                archive.addfile(checksum, io.BytesIO(checksum_contents))
+
+                manifest_contents = (
+                    f'[package]\nname = "{package}"\nversion = "1.0.0"\n'
+                ).encode("utf-8")
+                manifest = tarfile.TarInfo(f"v/{package}/Cargo.toml")
+                manifest.size = len(manifest_contents)
+                archive.addfile(manifest, io.BytesIO(manifest_contents))
+        self.refresh_integrity()
+
+    def refresh_integrity(self) -> None:
+        with tarfile.open(self.archive, mode="r:gz") as archive:
+            rendered = [
+                f"{member.name}{'/' if member.isdir() and not member.name.endswith('/') else ''}"
+                for member in archive.getmembers()
+            ]
+        listing = "".join(f"{name}\n" for name in sorted(rendered)).encode("utf-8")
+        self.integrity.write_text(
+            f"{sync.sha256_file(self.archive)}  vendor.tar.gz\n"
+            f"{hashlib.sha256(listing).hexdigest()}  vendor-file-list\n",
+            encoding="ascii",
+        )
+
+    def refresh_pins(self) -> None:
+        canonical_manifest = sync.normalized_manifest(
+            self.root / "Cargo.toml", self.canonical / "Cargo.toml", mirror=False
+        )
+        mirror_manifest = sync.normalized_manifest(
+            self.root / "Cargo.toml", self.mirror / "Cargo.toml", mirror=True
+        )
+        self.canonical_pin.write_text(
+            sync.format_pin(sync.runtime_tree_digest(self.canonical, canonical_manifest)),
+            encoding="ascii",
+        )
+        self.mirror_pin.write_text(
+            sync.format_pin(sync.runtime_tree_digest(self.mirror, mirror_manifest)),
+            encoding="ascii",
+        )
+
+
+class RustSyncTests(unittest.TestCase):
+    def setUp(self) -> None:
+        temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary.cleanup)
+        self.fixture = RepositoryFixture(Path(temporary.name))
+
+    def test_equal_trees_and_intentional_manifest_differences_pass(self) -> None:
+        digest = sync.check_repository(self.fixture.root)
+        self.assertRegex(digest, r"^[0-9a-f]{64}$")
+        self.assertEqual(sync.read_pin(self.fixture.canonical_pin), digest)
+        self.assertEqual(sync.read_pin(self.fixture.mirror_pin), digest)
+
+    def test_canonical_only_source_change_fails_even_with_refreshed_pins(self) -> None:
+        (self.fixture.canonical / "src/lib.rs").write_text(
+            "pub mod changed;\n", encoding="utf-8"
+        )
+        self.fixture.refresh_pins()
+        with self.assertRaisesRegex(sync.SyncError, "runtime source differs"):
+            sync.check_repository(self.fixture.root)
+
+    def test_mirror_only_nested_file_fails_inventory_check(self) -> None:
+        (self.fixture.mirror / "src/nested/extra.rs").write_text("// extra\n")
+        with self.assertRaisesRegex(sync.SyncError, "extra in R mirror"):
+            sync.check_repository(self.fixture.root)
+
+    def test_canonical_only_build_script_fails_inventory_check(self) -> None:
+        (self.fixture.canonical / "build.rs").write_text("fn main() {}\n")
+        with self.assertRaisesRegex(sync.SyncError, "missing from R mirror: build.rs"):
+            sync.check_repository(self.fixture.root)
+
+    def test_semantic_manifest_drift_fails(self) -> None:
+        manifest = self.fixture.mirror / "Cargo.toml"
+        manifest.write_text(
+            manifest.read_text().replace('version = "1.0"', 'version = "1.1"'),
+            encoding="utf-8",
+        )
+        with self.assertRaisesRegex(sync.SyncError, "Cargo.toml semantics differ"):
+            sync.check_repository(self.fixture.root)
+
+    def test_toml_formatting_does_not_change_the_pin(self) -> None:
+        before = sync.read_pin(self.fixture.mirror_pin)
+        manifest = self.fixture.mirror / "Cargo.toml"
+        manifest.write_text(
+            manifest.read_text().replace(
+                'serde = { features = ["derive"], version = "1.0" }',
+                'serde={version="1.0",features=["derive"]}',
+            ),
+            encoding="utf-8",
+        )
+        self.assertEqual(sync.check_repository(self.fixture.root), before)
+
+    def test_unexpected_manifest_exception_fails(self) -> None:
+        manifest = self.fixture.mirror / "Cargo.toml"
+        manifest.write_text(
+            manifest.read_text().replace("publish = false", "publish = true"),
+            encoding="utf-8",
+        )
+        with self.assertRaisesRegex(sync.SyncError, "publish = false"):
+            sync.check_repository(self.fixture.root)
+
+    def test_stale_and_disagreeing_pins_fail(self) -> None:
+        self.fixture.canonical_pin.write_text(
+            sync.format_pin("0" * 64), encoding="ascii"
+        )
+        with self.assertRaisesRegex(sync.SyncError, "tree pins differ"):
+            sync.check_repository(self.fixture.root)
+
+        self.fixture.mirror_pin.write_text(sync.format_pin("0" * 64), encoding="ascii")
+        with self.assertRaisesRegex(sync.SyncError, "pins are stale"):
+            sync.check_repository(self.fixture.root)
+
+    def test_malformed_pin_fails(self) -> None:
+        self.fixture.mirror_pin.write_text("not-a-pin\n", encoding="ascii")
+        with self.assertRaisesRegex(sync.SyncError, "malformed Rust tree pin"):
+            sync.check_repository(self.fixture.root)
+
+    def test_make_source_inventory_cannot_omit_runtime_inputs(self) -> None:
+        makevars = self.fixture.root / "r-package/dtaparser/src/Makevars.win.in"
+        makevars.write_text(
+            makevars.read_text().replace(
+                " \\\n\tvendor/dta-parser/src/nested/data.bin", ""
+            ),
+            encoding="utf-8",
+        )
+        with self.assertRaisesRegex(sync.SyncError, "RUST_SOURCES"):
+            sync.check_repository(self.fixture.root)
+
+    def test_update_pins_waits_for_all_other_invariants(self) -> None:
+        canonical_before = self.fixture.canonical_pin.read_bytes()
+        mirror_before = self.fixture.mirror_pin.read_bytes()
+        (self.fixture.mirror / "README.md").write_text("different\n")
+        with self.assertRaisesRegex(sync.SyncError, "crate README differs"):
+            sync.check_repository(self.fixture.root, update_pins=True)
+        self.assertEqual(self.fixture.canonical_pin.read_bytes(), canonical_before)
+        self.assertEqual(self.fixture.mirror_pin.read_bytes(), mirror_before)
+
+    def test_duplicate_integrity_labels_fail(self) -> None:
+        first = self.fixture.integrity.read_text(encoding="ascii").splitlines()[0]
+        with self.fixture.integrity.open("a", encoding="ascii") as destination:
+            destination.write(f"{first}\n")
+        with self.assertRaisesRegex(sync.SyncError, "duplicate integrity entry"):
+            sync.check_repository(self.fixture.root)
+
+    def test_archive_inventory_must_match_the_bridge_lock(self) -> None:
+        with self.fixture.bridge_lock.open("a", encoding="utf-8") as lock:
+            lock.write(
+                """\
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://example.test/index"
+checksum = "2222222222222222222222222222222222222222222222222222222222222222"
+"""
+            )
+        with self.assertRaisesRegex(sync.SyncError, "missing locked packages: cfg-if"):
+            sync.check_repository(self.fixture.root)
+
+    def test_archive_version_must_match_the_bridge_lock(self) -> None:
+        lock = self.fixture.bridge_lock
+        lock.write_text(
+            lock.read_text().replace(
+                'name = "serde"\nversion = "1.0.0"',
+                'name = "serde"\nversion = "1.0.1"',
+            ),
+            encoding="utf-8",
+        )
+        with self.assertRaisesRegex(sync.SyncError, "vendor version differs"):
+            sync.check_repository(self.fixture.root)
+
+    def test_archive_checksum_must_match_the_bridge_lock(self) -> None:
+        lock = self.fixture.bridge_lock
+        lock.write_text(
+            lock.read_text().replace('checksum = "' + "1" * 64, 'checksum = "' + "2" * 64),
+            encoding="utf-8",
+        )
+        with self.assertRaisesRegex(sync.SyncError, "vendor checksum differs"):
+            sync.check_repository(self.fixture.root)
+
+    def test_archive_parent_file_conflict_fails(self) -> None:
+        with tarfile.open(self.fixture.archive, mode="w:gz") as archive:
+            for name in ("v/encoding_rs/.cargo-checksum.json", "v/serde"):
+                member = tarfile.TarInfo(name)
+                member.size = 2
+                archive.addfile(member, io.BytesIO(b"{}"))
+            child = tarfile.TarInfo("v/serde/.cargo-checksum.json")
+            child.size = 2
+            archive.addfile(child, io.BytesIO(b"{}"))
+        self.fixture.refresh_integrity()
+        with self.assertRaisesRegex(sync.SyncError, "below file v/serde"):
+            sync.check_repository(self.fixture.root)
+
+    def test_required_archive_checksum_must_be_a_regular_file(self) -> None:
+        with tarfile.open(self.fixture.archive, mode="w:gz") as archive:
+            for name in ("v", "v/encoding_rs", "v/serde"):
+                package = tarfile.TarInfo(name)
+                package.type = tarfile.DIRTYPE
+                archive.addfile(package)
+            regular = tarfile.TarInfo("v/encoding_rs/.cargo-checksum.json")
+            regular.size = 2
+            archive.addfile(regular, io.BytesIO(b"{}"))
+            directory = tarfile.TarInfo("v/serde/.cargo-checksum.json")
+            directory.type = tarfile.DIRTYPE
+            archive.addfile(directory)
+        self.fixture.refresh_integrity()
+        with self.assertRaisesRegex(sync.SyncError, "missing regular file"):
+            sync.check_repository(self.fixture.root)
+
+    def test_framing_distinguishes_path_and_content_boundaries(self) -> None:
+        left = sync.framed_digest([("a", b"bc"), ("d", b"")])
+        right = sync.framed_digest([("ab", b"c"), ("d", b"")])
+        self.assertNotEqual(left, right)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/integration/r-package-config.test.ts
+++ b/tests/integration/r-package-config.test.ts
@@ -34,4 +34,50 @@ describe('R package native build configuration', () => {
             expect(makevars).toContain('--config rust/cargo-config.toml');
         }
     });
+
+    it('namespaces native outputs by the pinned parser tree', () => {
+        const canonicalPin = fs.readFileSync(
+            path.join(R_PACKAGE, '..', '..', 'rust', 'dta-parser.tree.sha256'),
+            'utf8'
+        );
+        const mirrorPin = fs.readFileSync(
+            path.join(R_PACKAGE, 'src', 'vendor', 'dta-parser.tree.sha256'),
+            'utf8'
+        );
+        expect(mirrorPin).toBe(canonicalPin);
+        expect(mirrorPin).toMatch(
+            /^[0-9a-f]{64}  dta-parser-runtime-tree-v1\n$/
+        );
+
+        for (const file of ['Makevars.in', 'Makevars.win.in']) {
+            const makevars = fs.readFileSync(
+                path.join(R_PACKAGE, 'src', file),
+                'utf8'
+            );
+            expect(makevars).toContain(
+                'DTA_PARSER_PIN = vendor/dta-parser.tree.sha256'
+            );
+            expect(makevars).toContain(
+                'DTA_PARSER_NAMESPACE = @DTA_PARSER_NAMESPACE@'
+            );
+            expect(makevars).toContain('dta-parser-$(DTA_PARSER_NAMESPACE)');
+            expect(makevars).toContain('$(DTA_PARSER_PIN)');
+            expect(makevars).toContain('$(RUST_SOURCES)');
+        }
+    });
+
+    it('refreshes extracted Cargo dependencies on every configure run', () => {
+        for (const file of ['configure', 'configure.win']) {
+            const configure = fs.readFileSync(
+                path.join(R_PACKAGE, file),
+                'utf8'
+            );
+            expect(configure).toContain('rm -rf src/rust/v');
+            expect(configure).toContain(
+                'tar -xzf src/rust/vendor.tar.gz -C src/rust'
+            );
+            expect(configure).toContain('test -d src/rust/v');
+            expect(configure).not.toContain('if test ! -d src/rust/v');
+        }
+    });
 });


### PR DESCRIPTION
## Summary
- add deterministic content pins for the canonical Rust parser and the R-package mirror
- make R native outputs depend on the pin while retaining direct source prerequisites
- validate normalized manifests, optional build scripts, Cargo locks, and the complete offline vendor graph
- add mutation tests and CI coverage for one-sided changes, stale pins, Make inventory drift, and vendor archive drift

## Testing
- python3 -m unittest discover -s scripts -p 'test_*.py'
- scripts/check-rust-sync.sh --update-pins (idempotent)
- bun test tests/integration/benchmark-config.test.ts tests/integration/fixture-inventory.test.ts tests/integration/r-package-config.test.ts
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets --locked -- -D warnings
- cargo test --workspace --all-targets --locked
- cargo package -p dta-parser --locked
- R CMD build r-package/dtaparser
- R CMD check --no-manual --as-cran dtaparser_0.1.0.tar.gz (passes tests; existing local check reports missing checkbashisms, Rust version, and new-submission notes)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated validation for synchronization between the Rust runtime and R package.
  * Added support for pinned runtime trees and namespaced native build outputs.
  * Configure steps now refresh vendored dependencies on every run.

* **Bug Fixes**
  * Improved detection of source, manifest, lockfile, archive, and dependency mismatches.
  * Added safer pin updates with rollback handling.

* **Documentation**
  * Clarified synchronization, pin management, maintenance, and prerequisite instructions.

* **Tests**
  * Added comprehensive synchronization and cross-platform configuration tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->