### PR TITLE
Match dtaparser to Stata across the exhaustive corpus

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -42,3 +42,12 @@ not a release gate.
 The manual [`fertility-surveys/`](fertility-surveys/) framework separately
 checks the private fertility-survey corpus with explicit opt-in and CI refusal
 safeguards.
+
+The independent [`aww-cache-differential/`](aww-cache-differential/) workflow
+recursively compares every regular DTA file beneath `/opt/aww_cache` through the
+public dtaparser and haven readers. It uses bounded resumable tiles and invokes
+Stata only to adjudicate actual disagreements:
+
+```sh
+benchmarks/aww-cache-differential/benchmark.sh
+```

--- a/benchmarks/aww-cache-differential/README.md
+++ b/benchmarks/aww-cache-differential/README.md
@@ -1,0 +1,85 @@
+# Exhaustive AWW-cache differential
+
+This local, report-only workflow recursively inventories every regular file whose
+name ends in `.dta` in any letter case beneath `/opt/aww_cache`. It does not
+follow file or directory symlinks. For every supported file it compares the
+public `dtaparser::read_dta()` and `haven::read_dta()` readers across bounded
+column batches and row windows until both readers attest the end of the file.
+Each reader's column count is established independently with single-column
+public-reader probes. Metadata comparison outputs, including projected source
+names and storage types, are checkpointed in the same bounded column batches.
+(The readers may still parse whole-file metadata internally to resolve a public
+`col_select` expression.)
+
+The comparison covers every cell and the following metadata:
+
+- dataset label and ordered notes;
+- variable names, order, R storage, labels, and all unexpected attributes;
+- Stata display formats and complete value-label attributes;
+- R classes and time zones;
+- exact missing positions, ordinary `NA`/`NaN`, and Stata missing tags
+  `.` and `.a` through `.z`;
+- exact strings, source `byte`/`int`/`long` values, dates, datetimes, and
+  nonfinite values;
+- source `float`/`double` values with an absolute `1e-7` tolerance.
+
+Stata is not a third full-corpus reader. It is started only when the two readers
+actually disagree. The tracked `adjudicate.do` program reads only disputed
+variables and bounded row windows, in bounded request batches, and returns
+machine-readable source facts. The workflow requires Stata 18 and probes the
+executable version before use. The local installation may be named either
+`stata-mp` or `stata`; no IC/SE variable limit is assumed.
+
+## Run
+
+From any directory:
+
+```sh
+benchmarks/aww-cache-differential/benchmark.sh
+```
+
+The command builds the current R package into a content-addressed private
+library, inventories `/opt/aww_cache`, resumes valid tile checkpoints, performs
+all remaining comparisons and Stata adjudications, then prints and writes a
+succinct report.
+
+Useful bounded diagnostics use the same entry point:
+
+```sh
+benchmarks/aww-cache-differential/benchmark.sh --inventory-only
+benchmarks/aww-cache-differential/benchmark.sh --max-files=1
+benchmarks/aww-cache-differential/benchmark.sh --id=D0123456789abcdef01234567
+```
+
+Resource defaults are 100,000 rows, 256 columns, 8,000,000 aggregate reader
+cells, 512 MiB per reader subprocess, and a 900-second tile timeout. They can be
+overridden with `--rows=`, `--columns=`, `--cells=`, `--memory-mib=`, and
+`--timeout=`. `--stata-requests=` bounds the number of
+disputes in one Stata process, and `--stata-row-window=` bounds the row span of
+a cell-dispute batch. `--stata=/absolute/path` overrides lazy Stata discovery.
+`--retry` retries cached tile and Stata failures while continuing to reuse
+successful checkpoints.
+
+All state is private by default under:
+
+```text
+target/aww-cache-differential/
+  builds/
+  runs/<configuration-id>/
+    inventory.rds
+    checkpoints/
+    stata/
+    results.tsv
+    report.txt
+```
+
+Checkpoints bind the workflow schema, build/configuration identity, source
+SHA-256, and exact tile coordinates. Successful Stata checkpoints additionally
+bind the executable and probed version. A source file is re-hashed before and
+after every Stata operation and before every terminal file outcome; a changed
+file is never reported as a completed comparison. The report includes local
+relative paths but never raw values, labels, notes, or reader exception text.
+Exact disputes remain in private RDS checkpoints.
+
+The workflow refuses common CI environments. It does not modify or source the
+historical `fertility-surveys` framework.

--- a/benchmarks/aww-cache-differential/README.md
+++ b/benchmarks/aww-cache-differential/README.md
@@ -5,6 +5,9 @@ name ends in `.dta` in any letter case beneath `/opt/aww_cache`. It does not
 follow file or directory symlinks. For every supported file it compares the
 public `dtaparser::read_dta()` and `haven::read_dta()` readers across bounded
 column batches and row windows until both readers attest the end of the file.
+Both readers use their public default encoding behavior. The workflow does not
+set Stata's encoding; Stata 18 opens disputed source files with an ordinary
+`use` command and applies its own text semantics.
 Each reader's column count is established independently with single-column
 public-reader probes. Metadata comparison outputs, including projected source
 names and storage types, are checkpointed in the same bounded column batches.

--- a/benchmarks/aww-cache-differential/README.md
+++ b/benchmarks/aww-cache-differential/README.md
@@ -81,5 +81,16 @@ file is never reported as a completed comparison. The report includes local
 relative paths but never raw values, labels, notes, or reader exception text.
 Exact disputes remain in private RDS checkpoints.
 
+To materialize that evidence as an exact list-column RDS plus a readable TSV
+view, run:
+
+```sh
+Rscript --vanilla benchmarks/aww-cache-differential/triage.R \
+  --run=target/aww-cache-differential/runs/RUN_ID
+```
+
+New runs persist their final per-file results directly. The extractor also
+reconstructs older runs from their tile and Stata checkpoints.
+
 The workflow refuses common CI environments. It does not modify or source the
 historical `fertility-surveys` framework.

--- a/benchmarks/aww-cache-differential/adjudicate.do
+++ b/benchmarks/aww-cache-differential/adjudicate.do
@@ -1,0 +1,164 @@
+version 18.0
+set more off
+
+capture program drop aww_open
+program define aww_open
+    syntax, INPUT(string) OUTPUT(string)
+    quietly describe using "`input'", varlist
+    global AWW_INPUT "`input'"
+    global AWW_VARLIST "`r(varlist)'"
+    global AWW_N "`r(N)'"
+    global AWW_K "`r(k)'"
+    global AWW_DATALABEL `"`r(datalabel)'"'
+    mata: aww_out = fopen("`output'", "w")
+    mata: fput(aww_out, "id" + char(9) + "status" + char(9) + "kind" + char(9) + "index" + char(9) + "value")
+end
+
+capture program drop aww_load
+program define aww_load
+    syntax, COLUMNS(numlist integer >0) FIRST(integer) LAST(integer)
+    local wanted
+    foreach index of numlist `columns' {
+        local name : word `index' of $AWW_VARLIST
+        local wanted `wanted' `name'
+    }
+    if $AWW_N == 0 {
+        quietly use `wanted' using "$AWW_INPUT", clear
+    }
+    else {
+        quietly use `wanted' in `first'/`last' using "$AWW_INPUT", clear
+    }
+    global AWW_FIRST "`first'"
+end
+
+capture program drop aww_cell
+program define aww_cell
+    syntax, ID(integer) COLUMN(integer) OBSERVATION(integer)
+    local name : word `column' of $AWW_VARLIST
+    local row = `observation' - $AWW_FIRST + 1
+    local type : type `name'
+    if substr("`type'", 1, 3) == "str" {
+        mata: aww_string(`id', "cell", st_sdata(`row', st_varindex("`name'")))
+    }
+    else {
+        mata: aww_number(`id', "cell", st_data(`row', st_varindex("`name'")))
+    }
+end
+
+capture program drop aww_meta
+program define aww_meta
+    syntax, ID(integer) KIND(string) [COLUMN(integer 0) INDEX(integer 0)]
+    if "`kind'" == "nobs" {
+        mata: aww_plain(`id', "nobs", "$AWW_N")
+        exit
+    }
+    if "`kind'" == "nvar" {
+        mata: aww_plain(`id', "nvar", "$AWW_K")
+        exit
+    }
+    if "`kind'" == "dataset_label" {
+        mata: aww_string(`id', "dataset_label", st_global("AWW_DATALABEL"))
+        exit
+    }
+    if "`kind'" == "note_entry" {
+        local count : char _dta[note0]
+        if "`count'" == "" local count 0
+        if `index' >= 1 & `index' <= `count' {
+            local value : char _dta[note`index']
+            mata: aww_string(`id', "note_entry", st_local("value"))
+        }
+        else {
+            mata: aww_plain(`id', "note_absent", "")
+        }
+        exit
+    }
+    local name : word `column' of $AWW_VARLIST
+    if "`kind'" == "name" {
+        mata: aww_string(`id', "name", "`name'")
+    }
+    else if "`kind'" == "storage" {
+        local value : type `name'
+        mata: aww_string(`id', "storage", st_local("value"))
+    }
+    else if "`kind'" == "format" {
+        local value : format `name'
+        mata: aww_string(`id', "format", st_local("value"))
+    }
+    else if "`kind'" == "variable_label" {
+        local value : variable label `name'
+        mata: aww_string(`id', "variable_label", st_local("value"))
+    }
+    else if "`kind'" == "value_label_entry" {
+        local value : value label `name'
+        mata: aww_value_label_entry(`id', st_local("value"), `index')
+    }
+end
+
+capture program drop aww_close
+program define aww_close
+    mata: fclose(aww_out)
+    macro drop AWW_INPUT AWW_VARLIST AWW_N AWW_K AWW_DATALABEL AWW_FIRST
+end
+
+mata:
+aww_out = .
+
+string scalar aww_hex(string scalar value) {
+    real rowvector bytes
+    string scalar result
+    real scalar index
+    bytes = ascii(value)
+    result = ""
+    for (index = 1; index <= cols(bytes); index++) {
+        result = result + substr("0123456789abcdef", floor(bytes[index] / 16) + 1, 1) +
+            substr("0123456789abcdef", mod(bytes[index], 16) + 1, 1)
+    }
+    return(result)
+}
+
+void aww_line(real scalar id, string scalar status, string scalar kind,
+              real scalar index, string scalar value) {
+    external real scalar aww_out
+    fput(aww_out, strofreal(id) + char(9) + status + char(9) + kind + char(9) +
+         strofreal(index) + char(9) + value)
+}
+
+void aww_plain(real scalar id, string scalar kind, string scalar value) {
+    aww_line(id, "ok", kind, 0, value)
+}
+
+void aww_string(real scalar id, string scalar kind, string scalar value) {
+    aww_line(id, "ok", kind, 0, aww_hex(value))
+}
+
+void aww_string_index(real scalar id, string scalar kind, real scalar index,
+                      string scalar value) {
+    aww_line(id, "ok", kind, index, aww_hex(value))
+}
+
+void aww_number(real scalar id, string scalar kind, real scalar value) {
+    if (missing(value)) aww_line(id, "ok", kind, 0, strofreal(value))
+    else aww_line(id, "ok", kind, 0, strtrim(strofreal(value, "%24.17g")))
+}
+
+void aww_value_label_entry(real scalar id, string scalar label_name,
+                           real scalar index) {
+    real colvector values
+    string colvector texts
+    if (label_name == "") {
+        aww_line(id, "ok", "value_label_absent", 0, "")
+        return
+    }
+    values = .
+    texts = ""
+    st_vlload(label_name, values, texts)
+    if (index < 1 | index > rows(values)) {
+        aww_line(id, "ok", "value_label_absent", 0, "")
+        return
+    }
+    aww_line(id, "ok", "value_label_code", index,
+             missing(values[index]) ? strofreal(values[index]) :
+             strtrim(strofreal(values[index], "%24.17g")))
+    aww_line(id, "ok", "value_label_text", index, aww_hex(texts[index]))
+}
+end

--- a/benchmarks/aww-cache-differential/adjudicate.do
+++ b/benchmarks/aww-cache-differential/adjudicate.do
@@ -72,6 +72,13 @@ program define aww_meta
         }
         exit
     }
+    if "`kind'" == "names" {
+        forvalues index = 1/$AWW_K {
+            local value : word `index' of $AWW_VARLIST
+            mata: aww_string_index(`id', "names", `index', "`value'")
+        }
+        exit
+    }
     local name : word `column' of $AWW_VARLIST
     if "`kind'" == "name" {
         mata: aww_string(`id', "name", "`name'")

--- a/benchmarks/aww-cache-differential/adjudicate.do
+++ b/benchmarks/aww-cache-differential/adjudicate.do
@@ -88,6 +88,10 @@ program define aww_meta
         local value : variable label `name'
         mata: aww_string(`id', "variable_label", st_local("value"))
     }
+    else if "`kind'" == "value_label_name" {
+        local value : value label `name'
+        mata: aww_string(`id', "value_label_name", st_local("value"))
+    }
     else if "`kind'" == "value_label_entry" {
         local value : value label `name'
         mata: aww_value_label_entry(`id', st_local("value"), `index')
@@ -107,7 +111,9 @@ string scalar aww_hex(string scalar value) {
     real rowvector bytes
     string scalar result
     real scalar index
-    bytes = ascii(value)
+    // Convert through Stata's Unicode semantics before emitting UTF-8.  A
+    // direct ascii(value) leaks malformed source bytes instead of U+FFFD.
+    bytes = ascii(ustrto(value, "utf-8", 1))
     result = ""
     for (index = 1; index <= cols(bytes); index++) {
         result = result + substr("0123456789abcdef", floor(bytes[index] / 16) + 1, 1) +

--- a/benchmarks/aww-cache-differential/benchmark.sh
+++ b/benchmarks/aww-cache-differential/benchmark.sh
@@ -1,0 +1,74 @@
+#!/bin/sh
+set -eu
+umask 077
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd -P)
+checkout=$(CDPATH= cd -- "$script_dir/../.." && pwd -P)
+
+if test -n "${CI:-}${GITHUB_ACTIONS:-}${GITHUB_RUN_ID:-}${GITHUB_WORKFLOW:-}"; then
+    echo "aww-cache differential is a local, manual workflow and refuses CI" >&2
+    exit 2
+fi
+
+for command in R Rscript shasum; do
+    if ! command -v "$command" >/dev/null 2>&1; then
+        echo "required command is unavailable: $command" >&2
+        exit 2
+    fi
+done
+
+if ! Rscript --vanilla -e 'quit(status = !all(vapply(c("callr", "fs", "haven", "openssl", "processx", "rlang", "tibble", "tidyselect"), requireNamespace, quietly = TRUE, FUN.VALUE = logical(1))))'; then
+    echo "required R packages are unavailable" >&2
+    exit 2
+fi
+
+state="$checkout/target/aww-cache-differential"
+mkdir -p "$state/builds" "$state/tmp"
+chmod 700 "$state" "$state/builds" "$state/tmp"
+export TMPDIR
+TMPDIR=$(mktemp -d "$state/tmp/run.XXXXXX")
+trap 'rm -rf "$TMPDIR"' EXIT HUP INT TERM
+
+build_id=$(Rscript --vanilla - "$checkout/r-package/dtaparser" "$script_dir" <<'RS'
+args <- commandArgs(TRUE)
+files <- c(
+    list.files(args[[1L]], all.files = TRUE, full.names = TRUE, recursive = TRUE,
+               include.dirs = FALSE, no.. = TRUE),
+    list.files(args[[2L]], pattern = "\\.(R|do|sh)$", all.files = TRUE,
+               full.names = TRUE, recursive = TRUE, include.dirs = FALSE, no.. = TRUE)
+)
+files <- sort(files[file.info(files)$isdir %in% FALSE], method = "radix")
+hashes <- vapply(files, function(path) {
+    con <- file(path, "rb")
+    on.exit(close(con), add = TRUE)
+    as.character(openssl::sha256(con))
+}, character(1))
+cat(as.character(openssl::sha256(charToRaw(paste(hashes, collapse = "\n")))))
+RS
+)
+
+build="$state/builds/$build_id"
+library="$build/library"
+package="$library/dtaparser"
+if ! test -d "$package"; then
+    stage="$TMPDIR/build"
+    mkdir -p "$stage" "$library"
+    cp -R "$checkout/r-package/dtaparser" "$stage/dtaparser"
+    version=$(sed -n 's/^Version: //p' "$stage/dtaparser/DESCRIPTION")
+    (cd "$stage" && R CMD build dtaparser >/dev/null)
+    R CMD INSTALL --library="$library" "$stage/dtaparser_${version}.tar.gz"
+    chmod -R u=rwX,go= "$build"
+fi
+
+export AWW_PACKAGE_LIBRARY="$library"
+export AWW_PACKAGE_PATH="$package"
+export AWW_BUILD_ID="$build_id"
+export R_ENVIRON_USER=/dev/null
+export R_PROFILE_USER=/dev/null
+
+cd "$checkout"
+set +e
+Rscript --vanilla "$script_dir/run.R" "$@"
+status=$?
+set -e
+exit "$status"

--- a/benchmarks/aww-cache-differential/benchmark.sh
+++ b/benchmarks/aww-cache-differential/benchmark.sh
@@ -52,11 +52,14 @@ library="$build/library"
 package="$library/dtaparser"
 if ! test -d "$package"; then
     stage="$TMPDIR/build"
-    mkdir -p "$stage" "$library"
+    staged_library="$TMPDIR/library"
+    mkdir -p "$stage" "$staged_library"
     cp -R "$checkout/r-package/dtaparser" "$stage/dtaparser"
     version=$(sed -n 's/^Version: //p' "$stage/dtaparser/DESCRIPTION")
     (cd "$stage" && R CMD build dtaparser >/dev/null)
-    R CMD INSTALL --library="$library" "$stage/dtaparser_${version}.tar.gz"
+    R CMD INSTALL --library="$staged_library" "$stage/dtaparser_${version}.tar.gz"
+    mkdir -p "$build"
+    mv "$staged_library" "$library"
     chmod -R u=rwX,go= "$build"
 fi
 

--- a/benchmarks/aww-cache-differential/common.R
+++ b/benchmarks/aww-cache-differential/common.R
@@ -1,0 +1,261 @@
+aww_schema_version <- 4L
+aww_supported_releases <- c(105L, 108L, 110L, 111L, 113L, 114L, 115L, 117L, 118L, 119L)
+
+aww_abort <- function(message, status = 2L) {
+    condition <- structure(list(message = message, call = NULL, status = status),
+                           class = c("aww_error", "error", "condition"))
+    stop(condition)
+}
+
+aww_scalar_integer <- function(value, option, minimum = 1L) {
+    parsed <- suppressWarnings(as.numeric(value))
+    if (length(parsed) != 1L || is.na(parsed) || !is.finite(parsed) ||
+        parsed != floor(parsed) || parsed < minimum || parsed > 2^31 - 1) {
+        aww_abort(sprintf("%s must be a whole number >= %s", option, minimum))
+    }
+    as.integer(parsed)
+}
+
+aww_parse_arguments <- function(arguments) {
+    options <- list(
+        root = "/opt/aww_cache",
+        state = file.path(getwd(), "target", "aww-cache-differential"),
+        stata = Sys.getenv("STATA_BIN", unset = ""),
+        rows = 100000L,
+        columns = 256L,
+        cells = 8000000L,
+        memory_mib = 512L,
+        timeout = 900L,
+        stata_requests = 1000L,
+        stata_row_window = 25000L,
+        max_files = Inf,
+        ids = character(),
+        inventory_only = FALSE,
+        retry = FALSE
+    )
+    for (argument in arguments) {
+        if (identical(argument, "--inventory-only")) options$inventory_only <- TRUE else
+        if (identical(argument, "--retry")) options$retry <- TRUE else
+        if (startsWith(argument, "--root=")) options$root <- sub("^[^=]+=", "", argument) else
+        if (startsWith(argument, "--state=")) options$state <- sub("^[^=]+=", "", argument) else
+        if (startsWith(argument, "--stata=")) options$stata <- sub("^[^=]+=", "", argument) else
+        if (startsWith(argument, "--rows=")) options$rows <- aww_scalar_integer(sub("^[^=]+=", "", argument), "--rows") else
+        if (startsWith(argument, "--columns=")) options$columns <- aww_scalar_integer(sub("^[^=]+=", "", argument), "--columns") else
+        if (startsWith(argument, "--cells=")) options$cells <- aww_scalar_integer(sub("^[^=]+=", "", argument), "--cells") else
+        if (startsWith(argument, "--memory-mib=")) options$memory_mib <- aww_scalar_integer(sub("^[^=]+=", "", argument), "--memory-mib", 128L) else
+        if (startsWith(argument, "--timeout=")) options$timeout <- aww_scalar_integer(sub("^[^=]+=", "", argument), "--timeout") else
+        if (startsWith(argument, "--stata-requests=")) options$stata_requests <- aww_scalar_integer(sub("^[^=]+=", "", argument), "--stata-requests") else
+        if (startsWith(argument, "--stata-row-window=")) options$stata_row_window <- aww_scalar_integer(sub("^[^=]+=", "", argument), "--stata-row-window") else
+        if (startsWith(argument, "--max-files=")) options$max_files <- aww_scalar_integer(sub("^[^=]+=", "", argument), "--max-files") else
+        if (startsWith(argument, "--id=")) options$ids <- unique(c(options$ids, strsplit(sub("^[^=]+=", "", argument), ",", fixed = TRUE)[[1L]])) else
+        aww_abort(sprintf("unknown argument: %s", argument))
+    }
+    if (!startsWith(options$root, "/") || !dir.exists(options$root)) {
+        aww_abort("--root must name an existing absolute directory")
+    }
+    if (nzchar(Sys.readlink(options$root))) aww_abort("--root must not be a symlink")
+    options$root <- normalizePath(options$root, winslash = "/", mustWork = TRUE)
+    if (!startsWith(options$state, "/")) {
+        options$state <- file.path(getwd(), options$state)
+    }
+    options$state <- normalizePath(options$state, winslash = "/", mustWork = FALSE)
+    options
+}
+
+aww_sha256_raw <- function(value) unclass(as.character(openssl::sha256(charToRaw(enc2utf8(value)))))
+
+aww_file_sha256 <- function(path) {
+    connection <- file(path, open = "rb")
+    on.exit(close(connection), add = TRUE)
+    unclass(as.character(openssl::sha256(connection)))
+}
+
+aww_file_id <- function(relative_path) paste0("D", substr(aww_sha256_raw(relative_path), 1L, 24L))
+
+aww_walk <- function(directory, root) {
+    if (file.access(directory, 4L) != 0L) {
+        aww_abort(sprintf("cannot enumerate directory: %s", directory), 3L)
+    }
+    entries <- tryCatch(
+        withCallingHandlers(
+            list.files(directory, all.files = TRUE, full.names = TRUE,
+                       no.. = TRUE, recursive = FALSE),
+            warning = function(warning) stop(warning)
+        ),
+        error = function(error) aww_abort(
+            sprintf("cannot enumerate directory %s: %s", directory, conditionMessage(error)), 3L
+        )
+    )
+    result <- character()
+    for (path in entries) {
+        link <- Sys.readlink(path)
+        if (nzchar(link)) next
+        info <- file.info(path, extra_cols = FALSE)
+        if (is.na(info$isdir)) {
+            aww_abort(sprintf("cannot inspect inventory entry: %s", path), 3L)
+        }
+        if (isTRUE(info$isdir)) {
+            result <- c(result, aww_walk(path, root))
+        } else if (isTRUE(fs::is_file(path)) &&
+                   grepl("\\.dta$", basename(path), ignore.case = TRUE, perl = TRUE)) {
+            result <- c(result, path)
+        }
+    }
+    result
+}
+
+aww_release <- function(path) {
+    connection <- file(path, open = "rb")
+    on.exit(close(connection), add = TRUE)
+    prefix <- readBin(connection, "raw", n = 256L)
+    if (!length(prefix)) return(NA_integer_)
+    if (length(prefix) >= 11L && identical(prefix[1:11], charToRaw("<stata_dta>"))) {
+        text <- rawToChar(prefix[seq_len(min(64L, length(prefix)))])
+        match <- regexec("<release>([0-9]+)</release>", text, perl = TRUE)
+        groups <- regmatches(text, match)[[1L]]
+        if (length(groups) == 2L) return(as.integer(groups[[2L]]))
+        return(NA_integer_)
+    }
+    as.integer(prefix[[1L]])
+}
+
+aww_inventory <- function(root) {
+    paths <- aww_walk(root, root)
+    relative <- substring(paths, nchar(root, type = "bytes") + 2L)
+    order_index <- order(relative, method = "radix")
+    paths <- paths[order_index]
+    relative <- relative[order_index]
+    rows <- lapply(seq_along(paths), function(index) {
+        path <- paths[[index]]
+        info <- file.info(path, extra_cols = TRUE)
+        status <- "ok"
+        digest <- tryCatch(aww_file_sha256(path), error = function(error) {
+            status <<- "unreadable"
+            NA_character_
+        })
+        data.frame(
+            id = aww_file_id(relative[[index]]),
+            relative_path = relative[[index]],
+            path = path,
+            size = as.double(info$size),
+            mtime = as.numeric(info$mtime),
+            release = tryCatch(aww_release(path), error = function(error) NA_integer_),
+            sha256 = digest,
+            inventory_status = status,
+            stringsAsFactors = FALSE
+        )
+    })
+    result <- if (length(rows)) do.call(rbind, rows) else data.frame(
+        id = character(), relative_path = character(), path = character(),
+        size = numeric(), mtime = numeric(), release = integer(), sha256 = character(),
+        inventory_status = character(), stringsAsFactors = FALSE
+    )
+    if (anyDuplicated(result$id)) aww_abort("stable file ID collision", 3L)
+    rownames(result) <- NULL
+    result
+}
+
+aww_atomic_save_rds <- function(value, path) {
+    dir.create(dirname(path), recursive = TRUE, showWarnings = FALSE, mode = "0700")
+    temporary <- tempfile(pattern = ".stage-", tmpdir = dirname(path))
+    on.exit(unlink(temporary), add = TRUE)
+    saveRDS(value, temporary, version = 3L)
+    Sys.chmod(temporary, mode = "0600")
+    if (!file.rename(temporary, path)) aww_abort(sprintf("cannot publish %s", path), 3L)
+    invisible(path)
+}
+
+aww_atomic_write <- function(lines, path) {
+    dir.create(dirname(path), recursive = TRUE, showWarnings = FALSE, mode = "0700")
+    temporary <- tempfile(pattern = ".stage-", tmpdir = dirname(path))
+    on.exit(unlink(temporary), add = TRUE)
+    writeLines(lines, temporary, useBytes = TRUE)
+    Sys.chmod(temporary, mode = "0600")
+    if (!file.rename(temporary, path)) aww_abort(sprintf("cannot publish %s", path), 3L)
+    invisible(path)
+}
+
+aww_config_id <- function(options, build_id, haven_version) {
+    aww_sha256_raw(paste(
+        aww_schema_version, build_id, haven_version, options$root,
+        options$rows, options$columns, options$cells, options$memory_mib,
+        options$timeout, options$stata_requests, options$stata_row_window,
+        sep = "\037"
+    ))
+}
+
+aww_checkpoint <- function(run_dir, file_id, tile_id) {
+    file.path(run_dir, "checkpoints", file_id, paste0(tile_id, ".rds"))
+}
+
+aww_tile_id <- function(kind, batch, skip, n_max, column_start = 0L,
+                        column_count = 0L) {
+    paste(
+        kind, sprintf("b%05d", batch), sprintf("c%010d", column_start),
+        sprintf("k%010d", column_count), sprintf("s%016.0f", skip),
+        sprintf("n%010d", n_max), sep = "-"
+    )
+}
+
+aww_leaf_reader_rows <- function(leaves, tile, reader) {
+    groups <- split(seq_along(leaves), vapply(leaves, function(result) {
+        paste(result$tile$column_start, result$tile$column_count, sep = ":")
+    }, character(1)))
+    counts <- vapply(groups, function(indices) {
+        rows <- vapply(leaves[indices], function(result) {
+            result$reader_rows[[reader]]
+        }, numeric(1))
+        if (anyNA(rows)) NA_real_ else sum(rows)
+    }, numeric(1))
+    list(
+        rows = if (length(counts) && !anyNA(counts)) max(counts) else NA_real_,
+        partition_rows = counts,
+        consistent = length(unique(counts)) <= 1L
+    )
+}
+
+aww_update_terminations <- function(terminated, reader_totals, requested, skip) {
+    newly_terminated <- is.na(terminated) & reader_totals < requested
+    terminated[newly_terminated] <- reader_totals[newly_terminated] + skip
+    list(counts = terminated, newly_terminated = newly_terminated)
+}
+
+aww_beyond_row_ceiling <- function(terminated, skip, ceiling) {
+    if (!is.finite(ceiling) || skip < ceiling) return(character())
+    names(terminated)[is.na(terminated)]
+}
+
+aww_memory_rows <- function(column_count, options) {
+    by_cells <- max(1L, floor(options$cells / max(2L, 2L * column_count)))
+    min(options$rows, as.integer(by_cells))
+}
+
+aww_source_value <- function(value, format) {
+    if (inherits(value, "Date")) return(unclass(value) + 3653)
+    if (inherits(value, c("POSIXct", "POSIXt"))) return((unclass(value) + 315619200) * 1000)
+    unclass(value)
+}
+
+aww_source_unchanged <- function(item) {
+    if (is.null(item$sha256) || length(item$sha256) != 1L || is.na(item$sha256)) return(FALSE)
+    current <- tryCatch(aww_file_sha256(item$path), error = function(error) NA_character_)
+    identical(current, item$sha256)
+}
+
+aww_select_inventory <- function(inventory, options) {
+    selected <- inventory
+    if (length(options$ids)) {
+        unknown <- setdiff(options$ids, inventory$id)
+        if (length(unknown)) {
+            aww_abort(sprintf("unknown --id value(s): %s", paste(unknown, collapse = ", ")))
+        }
+        selected <- selected[selected$id %in% options$ids, , drop = FALSE]
+    }
+    if (is.finite(options$max_files)) selected <- utils::head(selected, options$max_files)
+    selected
+}
+
+aww_read_result <- function(path) {
+    if (!file.exists(path)) return(NULL)
+    tryCatch(readRDS(path), error = function(error) NULL)
+}

--- a/benchmarks/aww-cache-differential/common.R
+++ b/benchmarks/aww-cache-differential/common.R
@@ -121,7 +121,7 @@ aww_release <- function(path) {
 
 aww_inventory <- function(root) {
     paths <- aww_walk(root, root)
-    relative <- substring(paths, nchar(root, type = "bytes") + 2L)
+    relative <- substring(paths, nchar(root, type = "chars") + 2L)
     order_index <- order(relative, method = "radix")
     paths <- paths[order_index]
     relative <- relative[order_index]

--- a/benchmarks/aww-cache-differential/common.R
+++ b/benchmarks/aww-cache-differential/common.R
@@ -188,6 +188,16 @@ aww_checkpoint <- function(run_dir, file_id, tile_id) {
     file.path(run_dir, "checkpoints", file_id, paste0(tile_id, ".rds"))
 }
 
+aww_dispute_id <- function(file_sha256, disputes) {
+    aww_sha256_raw(paste(
+        file_sha256, nrow(disputes),
+        paste(disputes$kind, disputes$category, disputes$reader,
+              disputes$column, disputes$row, disputes$skip, disputes$n_max,
+              disputes$attribute, collapse = "|"),
+        sep = "\037"
+    ))
+}
+
 aww_tile_id <- function(kind, batch, skip, n_max, column_start = 0L,
                         column_count = 0L) {
     paste(

--- a/benchmarks/aww-cache-differential/compare.R
+++ b/benchmarks/aww-cache-differential/compare.R
@@ -1,0 +1,242 @@
+aww_empty_disputes <- function() data.frame(
+    kind = character(), category = character(), reader = character(),
+    column = integer(), row = numeric(), skip = numeric(), n_max = integer(),
+    attribute = character(), dtaparser = I(list()), haven = I(list()),
+    stringsAsFactors = FALSE
+)
+
+aww_dispute <- function(kind, category, reader = "both",
+                        column = NA_integer_, row = NA_real_,
+                        skip = NA_real_, n_max = NA_integer_, attribute = "",
+                        dtaparser = NULL, haven = NULL) {
+    data.frame(
+        kind = kind, category = category, reader = reader,
+        column = as.integer(column), row = as.double(row),
+        skip = as.double(skip), n_max = as.integer(n_max), attribute = attribute,
+        dtaparser = I(list(dtaparser)), haven = I(list(haven)),
+        stringsAsFactors = FALSE
+    )
+}
+
+aww_bind_disputes <- function(parts) {
+    parts <- parts[vapply(parts, nrow, integer(1)) > 0L]
+    if (!length(parts)) return(aww_empty_disputes())
+    result <- do.call(rbind, parts)
+    rownames(result) <- NULL
+    result
+}
+
+aww_simplify_private <- function(value) {
+    if (is.null(value)) return(NULL)
+    if (length(value) > 10000L) return(list(digest = aww_sha256_raw(paste(capture.output(dput(value)), collapse = "\n"))))
+    value
+}
+
+aww_label_entries <- function(labels) {
+    if (is.null(labels)) return(list())
+    result <- lapply(seq_along(labels), function(index) {
+        value <- unname(labels[[index]])
+        tag <- if (is.double(value)) haven::na_tag(value) else NA_character_
+        code <- if (!is.na(tag)) paste0(".", tag) else if (is.na(value)) "." else
+            format(value, scientific = FALSE, trim = TRUE, digits = 17)
+        list(code = code, text = names(labels)[[index]])
+    })
+    keys <- vapply(result, function(entry) {
+        if (startsWith(entry$code, ".")) {
+            tag <- substring(entry$code, 2L)
+            return(1e100 + if (nzchar(tag)) match(tag, letters) else 0)
+        }
+        suppressWarnings(as.numeric(entry$code))
+    }, numeric(1))
+    result[order(keys)]
+}
+
+aww_compare_indexed_attribute <- function(left, right, key, category, column) {
+    if (identical(left, right)) return(aww_empty_disputes())
+    if (identical(key, "labels")) {
+        left <- aww_label_entries(left)
+        right <- aww_label_entries(right)
+    }
+    count <- max(length(left), length(right))
+    if (!count) return(aww_empty_disputes())
+    aww_bind_disputes(lapply(seq_len(count), function(index) {
+        actual <- if (index <= length(left)) left[[index]] else NULL
+        expected <- if (index <= length(right)) right[[index]] else NULL
+        if (identical(actual, expected)) return(aww_empty_disputes())
+        aww_dispute(
+            "metadata", category, column = column,
+            attribute = paste0(key, ":", index),
+            dtaparser = aww_simplify_private(actual),
+            haven = aww_simplify_private(expected)
+        )
+    }))
+}
+
+aww_compare_attributes <- function(left, right, column = NA_integer_, frame = FALSE) {
+    left_attributes <- attributes(left)
+    right_attributes <- attributes(right)
+    ignored <- if (frame) c("names", "row.names") else character()
+    keys <- setdiff(sort(unique(c(names(left_attributes), names(right_attributes)))), ignored)
+    aww_bind_disputes(lapply(keys, function(key) {
+        if (identical(left_attributes[[key]], right_attributes[[key]])) return(aww_empty_disputes())
+        category <- if (key %in% c("label", "notes", "labels")) "label" else
+            if (identical(key, "format.stata")) "format" else
+            if (key %in% c("class", "tzone")) "class" else "attribute"
+        if (key %in% c("notes", "labels")) {
+            return(aww_compare_indexed_attribute(
+                left_attributes[[key]], right_attributes[[key]], key, category, column
+            ))
+        }
+        aww_dispute(
+            "metadata", category, column = column, attribute = key,
+            dtaparser = aww_simplify_private(left_attributes[[key]]),
+            haven = aww_simplify_private(right_attributes[[key]])
+        )
+    }))
+}
+
+aww_compare_metadata <- function(left, right, column_offset = 0L,
+                                 compare_frame = TRUE, compare_dimensions = TRUE) {
+    parts <- list()
+    if (compare_dimensions && !identical(ncol(left), ncol(right))) {
+        parts[[length(parts) + 1L]] <- aww_dispute(
+            "metadata", "dimension", attribute = "ncol",
+            dtaparser = ncol(left), haven = ncol(right)
+        )
+    }
+    count <- max(length(names(left)), length(names(right)))
+    if (count > 0L) for (local_column in seq_len(count)) {
+        actual <- if (local_column <= ncol(left)) names(left)[[local_column]] else NULL
+        expected <- if (local_column <= ncol(right)) names(right)[[local_column]] else NULL
+        if (!identical(actual, expected)) {
+            parts[[length(parts) + 1L]] <- aww_dispute(
+                "metadata", "name", column = column_offset + local_column,
+                attribute = "name", dtaparser = actual, haven = expected
+            )
+        }
+    }
+    if (compare_frame) {
+        parts[[length(parts) + 1L]] <- aww_compare_attributes(left, right, frame = TRUE)
+    }
+    shared <- min(ncol(left), ncol(right))
+    if (shared > 0L) for (local_column in seq_len(shared)) {
+        column <- column_offset + local_column
+        if (!identical(typeof(left[[local_column]]), typeof(right[[local_column]]))) {
+            parts[[length(parts) + 1L]] <- aww_dispute(
+                "metadata", "storage", column = column, attribute = "typeof",
+                dtaparser = typeof(left[[local_column]]), haven = typeof(right[[local_column]])
+            )
+        }
+        parts[[length(parts) + 1L]] <- aww_compare_attributes(
+            left[[local_column]], right[[local_column]], column
+        )
+    }
+    aww_bind_disputes(parts)
+}
+
+aww_cell_kind <- function(value) {
+    if (length(value) != 1L) return("invalid")
+    if (is.double(value) && is.nan(value)) return("nan")
+    if (is.na(value)) {
+        tag <- if (is.double(value)) haven::na_tag(value) else NA_character_
+        if (!is.na(tag)) return(paste0(".", tag))
+        return(".")
+    }
+    if (is.character(value)) return("string")
+    if (is.infinite(value)) return(if (value > 0) "+inf" else "-inf")
+    "value"
+}
+
+aww_cell_kinds <- function(value) {
+    kinds <- rep.int("value", length(value))
+    if (!length(value)) return(kinds)
+    missing <- is.na(value)
+    if (is.character(value)) {
+        kinds[] <- "string"
+        kinds[missing] <- "."
+        return(kinds)
+    }
+    if (is.double(value)) {
+        nan <- is.nan(value)
+        kinds[nan] <- "nan"
+        missing <- missing & !nan
+        if (any(missing)) {
+            tags <- haven::na_tag(value[missing])
+            kinds[missing] <- ifelse(is.na(tags), ".", paste0(".", tags))
+        }
+    } else {
+        kinds[missing] <- "."
+    }
+    raw_value <- unclass(value)
+    infinite <- !missing & is.infinite(raw_value)
+    kinds[infinite & raw_value > 0] <- "+inf"
+    kinds[infinite & raw_value < 0] <- "-inf"
+    kinds
+}
+
+aww_compare_values <- function(left, right, column_offset, row_offset,
+                               n_max = NA_integer_, storage = character(),
+                               tolerance = 1e-7) {
+    parts <- list()
+    if (!identical(nrow(left), nrow(right))) {
+        parts[[length(parts) + 1L]] <- aww_dispute(
+            "metadata", "dimension", row = row_offset + 1,
+            skip = row_offset, n_max = n_max, attribute = "tile-nrow",
+            dtaparser = nrow(left), haven = nrow(right)
+        )
+    }
+    if (!identical(names(left), names(right))) {
+        parts[[length(parts) + 1L]] <- aww_dispute(
+            "metadata", "name", attribute = "projection",
+            dtaparser = names(left), haven = names(right)
+        )
+    }
+    count <- min(ncol(left), ncol(right))
+    rows <- min(nrow(left), nrow(right))
+    if (!count || !rows) return(aww_bind_disputes(parts))
+    for (local_column in seq_len(count)) {
+        actual <- left[[local_column]][seq_len(rows)]
+        expected <- right[[local_column]][seq_len(rows)]
+        actual_kind <- aww_cell_kinds(actual)
+        expected_kind <- aww_cell_kinds(expected)
+        mismatch <- actual_kind != expected_kind
+        comparable <- !mismatch & actual_kind == "value"
+        date_like <- inherits(actual, c("Date", "POSIXct", "POSIXt")) ||
+            inherits(expected, c("Date", "POSIXct", "POSIXt"))
+        if (any(comparable)) {
+            left_values <- unclass(actual[comparable])
+            right_values <- unclass(expected[comparable])
+            if (is.numeric(left_values) && is.numeric(right_values)) {
+                delta <- abs(left_values - right_values)
+                source_storage <- if (local_column <= length(storage)) storage[[local_column]] else NA_character_
+                limit <- if (date_like || source_storage %in% c("byte", "int", "long")) 0 else
+                    if (source_storage %in% c("float", "double")) tolerance else 0
+                numeric_mismatch <- is.na(delta) | delta > limit
+                both_zero <- left_values == 0 & right_values == 0
+                numeric_mismatch[both_zero] <- (1 / left_values[both_zero]) !=
+                    (1 / right_values[both_zero])
+                mismatch[which(comparable)] <- numeric_mismatch
+            } else {
+                mismatch[which(comparable)] <- left_values != right_values |
+                    xor(is.na(left_values), is.na(right_values))
+            }
+        }
+        string_rows <- !mismatch & actual_kind == "string"
+        if (any(string_rows)) {
+            mismatch[which(string_rows)] <- actual[string_rows] != expected[string_rows]
+        }
+        indices <- which(mismatch)
+        if (length(indices)) for (index in indices) {
+            category <- if (actual_kind[[index]] != expected_kind[[index]]) "missing" else
+                if (date_like) "date" else if (is.character(actual)) "string" else "value"
+            parts[[length(parts) + 1L]] <- aww_dispute(
+                "cell", category,
+                column = column_offset + local_column,
+                row = row_offset + index,
+                dtaparser = list(kind = actual_kind[[index]], value = aww_simplify_private(actual[index])),
+                haven = list(kind = expected_kind[[index]], value = aww_simplify_private(expected[index]))
+            )
+        }
+    }
+    aww_bind_disputes(parts)
+}

--- a/benchmarks/aww-cache-differential/compare.R
+++ b/benchmarks/aww-cache-differential/compare.R
@@ -186,10 +186,17 @@ aww_compare_values <- function(left, right, column_offset, row_offset,
         )
     }
     if (!identical(names(left), names(right))) {
-        parts[[length(parts) + 1L]] <- aww_dispute(
-            "metadata", "name", attribute = "projection",
-            dtaparser = names(left), haven = names(right)
-        )
+        width <- max(ncol(left), ncol(right))
+        for (local_column in seq_len(width)) {
+            actual <- if (local_column <= ncol(left)) names(left)[[local_column]] else NULL
+            expected <- if (local_column <= ncol(right)) names(right)[[local_column]] else NULL
+            if (!identical(actual, expected)) {
+                parts[[length(parts) + 1L]] <- aww_dispute(
+                    "metadata", "name", column = column_offset + local_column,
+                    attribute = "projection", dtaparser = actual, haven = expected
+                )
+            }
+        }
     }
     count <- min(ncol(left), ncol(right))
     rows <- min(nrow(left), nrow(right))

--- a/benchmarks/aww-cache-differential/open-probe.do
+++ b/benchmarks/aww-cache-differential/open-probe.do
@@ -1,4 +1,7 @@
 version 18.0
 set more off
 use in 1/1 using "input.dta", clear
+file open aww_probe using "open-ok.txt", write replace text
+file write aww_probe "ok" _n
+file close aww_probe
 exit, clear

--- a/benchmarks/aww-cache-differential/open-probe.do
+++ b/benchmarks/aww-cache-differential/open-probe.do
@@ -1,0 +1,4 @@
+version 18.0
+set more off
+use in 1/1 using "input.dta", clear
+exit, clear

--- a/benchmarks/aww-cache-differential/open-probe.do
+++ b/benchmarks/aww-cache-differential/open-probe.do
@@ -1,6 +1,12 @@
 version 18.0
 set more off
-use in 1/1 using "input.dta", clear
+quietly describe using "input.dta"
+if r(N) == 0 {
+    use using "input.dta", clear
+}
+else {
+    use in 1/1 using "input.dta", clear
+}
 file open aww_probe using "open-ok.txt", write replace text
 file write aww_probe "ok" _n
 file close aww_probe

--- a/benchmarks/aww-cache-differential/run.R
+++ b/benchmarks/aww-cache-differential/run.R
@@ -35,7 +35,7 @@ aww_run_worker <- function(item, tile, options, package_library, package_path) {
         spinner = FALSE
     ), error = function(error) {
         message <- conditionMessage(error)
-        classification <- if (grepl("timed out|timeout", message, ignore.case = TRUE)) "timeout" else
+        classification <- if (inherits(error, "callr_timeout_error")) "timeout" else
             if (grepl("vector memory exhausted|cannot allocate|memory limit|out of memory|bad_alloc", message, ignore.case = TRUE)) "memory-limit" else
             "worker-crash"
         list(

--- a/benchmarks/aww-cache-differential/run.R
+++ b/benchmarks/aww-cache-differential/run.R
@@ -1,0 +1,568 @@
+#!/usr/bin/env Rscript
+
+aww_script_argument <- grep("^--file=", commandArgs(FALSE), value = TRUE)
+aww_script_path <- normalizePath(sub("^--file=", "", aww_script_argument[[1L]]), winslash = "/", mustWork = TRUE)
+aww_script_dir <- dirname(aww_script_path)
+source(file.path(aww_script_dir, "common.R"))
+source(file.path(aww_script_dir, "compare.R"))
+source(file.path(aww_script_dir, "stata.R"))
+
+aww_run_worker <- function(item, tile, options, package_library, package_path) {
+    tryCatch(callr::r(
+        function(path, tile, worker_script, common_script, compare_script,
+                 package_library, package_path) {
+            source(worker_script, local = environment())
+            aww_worker(path, tile, common_script, compare_script,
+                       package_library, package_path)
+        },
+        args = list(
+            path = item$path,
+            tile = tile,
+            worker_script = file.path(aww_script_dir, "worker.R"),
+            common_script = file.path(aww_script_dir, "common.R"),
+            compare_script = file.path(aww_script_dir, "compare.R"),
+            package_library = package_library,
+            package_path = package_path
+        ),
+        env = c(
+            R_ENVIRON_USER = "/dev/null",
+            R_PROFILE_USER = "/dev/null",
+            R_MAX_VSIZE = sprintf("%dM", options$memory_mib)
+        ),
+        timeout = options$timeout,
+        user_profile = FALSE,
+        system_profile = FALSE,
+        spinner = FALSE
+    ), error = function(error) {
+        message <- conditionMessage(error)
+        classification <- if (grepl("timed out|timeout", message, ignore.case = TRUE)) "timeout" else
+            if (grepl("vector memory exhausted|cannot allocate|memory limit|out of memory|bad_alloc", message, ignore.case = TRUE)) "memory-limit" else
+            "worker-crash"
+        list(
+            schema_version = aww_schema_version, tile = tile,
+            elapsed_seconds = NA_real_, reader_errors = list(supervisor = conditionMessage(error)),
+            reader_rows = c(dtaparser = NA_integer_, haven = NA_integer_),
+            classification = classification, disputes = aww_empty_disputes()
+        )
+    })
+}
+
+aww_execute <- function(item, tile, options, package_library, package_path,
+                        run_dir, config_id) {
+    path <- aww_checkpoint(run_dir, item$id, tile$id)
+    cached <- aww_read_result(path)
+    if (!is.null(cached) && identical(cached$schema_version, aww_schema_version) &&
+        identical(cached$config_id, config_id) && identical(cached$file_sha256, item$sha256) &&
+        identical(cached$tile, tile) && (!options$retry || cached$result$classification %in% c("pass", "dispute"))) {
+        cached$result$resumed <- TRUE
+        return(cached$result)
+    }
+    result <- aww_run_worker(item, tile, options, package_library, package_path)
+    result$resumed <- FALSE
+    aww_atomic_save_rds(list(
+        schema_version = aww_schema_version, config_id = config_id,
+        file_sha256 = item$sha256, tile = tile, result = result
+    ), path)
+    result
+}
+
+aww_execute_split <- function(item, tile, options, package_library, package_path,
+                              run_dir, config_id) {
+    result <- aww_execute(item, tile, options, package_library, package_path, run_dir, config_id)
+    if (!identical(result$classification, "memory-limit")) return(list(result))
+    if (tile$column_count > 1L) {
+        left_count <- floor(tile$column_count / 2L)
+        right_count <- tile$column_count - left_count
+        left <- tile
+        left$column_count <- as.integer(left_count)
+        if (!is.null(left$storage)) left$storage <- head(left$storage, left_count)
+        left$id <- aww_tile_id(
+            left$kind, left$batch, left$skip, left$n_max,
+            left$column_start, left$column_count
+        )
+        right <- tile
+        right$column_start <- tile$column_start + left_count
+        right$column_count <- as.integer(right_count)
+        if (!is.null(right$storage)) right$storage <- tail(right$storage, right_count)
+        right$id <- aww_tile_id(
+            right$kind, right$batch, right$skip, right$n_max,
+            right$column_start, right$column_count
+        )
+        return(c(
+            aww_execute_split(item, left, options, package_library, package_path, run_dir, config_id),
+            aww_execute_split(item, right, options, package_library, package_path, run_dir, config_id)
+        ))
+    }
+    if (!identical(tile$kind, "value") || tile$n_max <= 1L) return(list(result))
+    left_count <- floor(tile$n_max / 2)
+    right_count <- tile$n_max - left_count
+    left <- tile
+    left$n_max <- as.integer(left_count)
+    left$id <- aww_tile_id(
+        left$kind, left$batch, left$skip, left$n_max,
+        left$column_start, left$column_count
+    )
+    right <- tile
+    right$skip <- tile$skip + left_count
+    right$n_max <- as.integer(right_count)
+    right$id <- aww_tile_id(
+        right$kind, right$batch, right$skip, right$n_max,
+        right$column_start, right$column_count
+    )
+    c(
+        aww_execute_split(item, left, options, package_library, package_path, run_dir, config_id),
+        aww_execute_split(item, right, options, package_library, package_path, run_dir, config_id)
+    )
+}
+
+aww_file <- function(item, options, package_library, package_path, run_dir, config_id) {
+    started <- proc.time()[["elapsed"]]
+    base <- list(
+        id = item$id, relative_path = item$relative_path, release = item$release,
+        rows = NA_real_, columns = NA_integer_, status = "unresolved",
+        tiles = 0L, resumed = 0L, disputes = aww_empty_disputes(),
+        ownership = character(), adjudication = "not-needed", elapsed_seconds = 0
+    )
+    finish <- function(result) {
+        if (!is.na(item$sha256) && !aww_source_unchanged(item)) {
+            result$status <- "input-changed"
+            result$adjudication <- "input-changed"
+            result$ownership <- rep("unresolved", nrow(result$disputes))
+        }
+        result$elapsed_seconds <- unname(proc.time()[["elapsed"]] - started)
+        result
+    }
+    if (!identical(item$inventory_status, "ok")) {
+        base$status <- "unreadable"
+        return(finish(base))
+    }
+    if (is.na(item$release) || !(item$release %in% aww_supported_releases)) {
+        base$status <- if (is.na(item$release)) "empty-or-corrupt" else "unsupported-release"
+        return(finish(base))
+    }
+    shape_tile <- list(
+        id = aww_tile_id("shape", 0L, 0, 0L, 1L, 0L),
+        kind = "shape", batch = 0L,
+        column_start = 1L, column_count = 0L, skip = 0, n_max = 0L
+    )
+    shape_result <- aww_execute(
+        item, shape_tile, options, package_library, package_path, run_dir, config_id
+    )
+    base$tiles <- 1L
+    base$resumed <- as.integer(isTRUE(shape_result$resumed))
+    base$disputes <- shape_result$disputes
+    if (shape_result$classification %in% c("dtaparser-error", "haven-error", "shared-reader-error")) {
+        base$disputes <- aww_dispute(
+            "reader_error", "reader-error", attribute = shape_result$classification,
+            dtaparser = shape_result$reader_errors$dtaparser,
+            haven = shape_result$reader_errors$haven
+        )
+        probe <- aww_stata_open(item, options, run_dir, aww_script_dir)
+        base$adjudication <- probe
+        if (identical(probe, "open")) {
+            base$ownership <- switch(shape_result$classification,
+                "dtaparser-error" = "dtaparser-wrong",
+                "haven-error" = "haven-wrong",
+                "shared-reader-error" = "both-wrong"
+            )
+            base$status <- base$ownership
+        } else {
+            base$ownership <- "unresolved"
+            base$status <- "unresolved"
+        }
+        return(finish(base))
+    }
+    if (!shape_result$classification %in% c("pass", "dispute")) {
+        base$status <- shape_result$classification
+        return(finish(base))
+    }
+    metadata <- shape_result$metadata
+    base$rows <- metadata$rows
+    base$columns <- metadata$columns
+    batch_starts <- if (metadata$columns > 0L) {
+        seq.int(1L, metadata$columns, by = options$columns)
+    } else integer()
+    terminal_failure <- NULL
+    failed_result <- NULL
+    metadata_results <- list()
+    for (batch_index in seq_along(batch_starts)) {
+        column_start <- batch_starts[[batch_index]]
+        column_count <- min(options$columns, metadata$columns - column_start + 1L)
+        tile <- list(
+            id = aww_tile_id(
+                "metadata", batch_index, 0, 0L, column_start, column_count
+            ), kind = "metadata",
+            batch = as.integer(batch_index), column_start = as.integer(column_start),
+            column_count = as.integer(column_count), skip = 0, n_max = 0L
+        )
+        leaves <- aww_execute_split(
+            item, tile, options, package_library, package_path, run_dir, config_id
+        )
+        metadata_results <- c(metadata_results, leaves)
+        bad <- vapply(leaves, function(result) {
+            !result$classification %in% c("pass", "dispute")
+        }, logical(1))
+        if (any(bad)) {
+            failed_result <- leaves[[which(bad)[[1L]]]]
+            terminal_failure <- failed_result$classification
+            break
+        }
+        for (leaf in leaves) {
+            indices <- seq.int(
+                leaf$tile$column_start, length.out = leaf$tile$column_count
+            )
+            metadata$names[indices] <- leaf$metadata$names
+            metadata$formats[indices] <- leaf$metadata$formats
+            metadata$storage[indices] <- leaf$metadata$storage
+        }
+    }
+    base$tiles <- base$tiles + length(metadata_results)
+    base$resumed <- base$resumed + sum(vapply(
+        metadata_results, function(result) isTRUE(result$resumed), logical(1)
+    ))
+    base$disputes <- aww_bind_disputes(c(
+        list(base$disputes), lapply(metadata_results, `[[`, "disputes")
+    ))
+    observed_rows <- list()
+    all_results <- list()
+    trusted_rows <- NA_real_
+    stata_info <- NULL
+    if (is.null(terminal_failure)) for (batch_index in seq_along(batch_starts)) {
+        column_start <- batch_starts[[batch_index]]
+        column_count <- min(options$columns, metadata$columns - column_start + 1L)
+        rows_per_tile <- aww_memory_rows(max(1L, column_count), options)
+        skip <- 0
+        terminated <- c(dtaparser = NA_real_, haven = NA_real_)
+        repeat {
+            tile <- list(
+                id = aww_tile_id(
+                    "value", batch_index, skip, rows_per_tile,
+                    column_start, column_count
+                ), kind = "value",
+                batch = as.integer(batch_index), column_start = as.integer(column_start),
+                column_count = as.integer(column_count),
+                storage = metadata$storage[seq.int(column_start, length.out = column_count)],
+                skip = as.double(skip), n_max = rows_per_tile
+            )
+            leaves <- aww_execute_split(item, tile, options, package_library, package_path, run_dir, config_id)
+            all_results <- c(all_results, leaves)
+            bad <- vapply(leaves, function(result) !result$classification %in% c("pass", "dispute"), logical(1))
+            if (any(bad)) {
+                failed_result <- leaves[[which(bad)[[1L]]]]
+                terminal_failure <- failed_result$classification
+                break
+            }
+            reader_coverage <- lapply(c("dtaparser", "haven"), function(reader) {
+                aww_leaf_reader_rows(leaves, tile, reader)
+            })
+            names(reader_coverage) <- c("dtaparser", "haven")
+            reader_totals <- vapply(reader_coverage, `[[`, numeric(1), "rows")
+            for (reader in names(reader_coverage)) {
+                coverage <- reader_coverage[[reader]]
+                if (!coverage$consistent) {
+                    for (partition_rows in unique(coverage$partition_rows)) {
+                        base$disputes <- aww_bind_disputes(list(
+                            base$disputes,
+                            aww_dispute(
+                                "metadata", "dimension", reader = reader,
+                                row = skip + 1, skip = skip, n_max = rows_per_tile,
+                                attribute = "tile-nrow",
+                                dtaparser = if (identical(reader, "dtaparser")) partition_rows else NULL,
+                                haven = if (identical(reader, "haven")) partition_rows else NULL
+                            )
+                        ))
+                    }
+                }
+            }
+            termination <- aww_update_terminations(
+                terminated, reader_totals, rows_per_tile, skip
+            )
+            terminated <- termination$counts
+            newly_terminated <- termination$newly_terminated
+            if (length(unique(reader_totals)) != 1L) {
+                base$disputes <- aww_bind_disputes(list(
+                    base$disputes,
+                    aww_dispute("metadata", "dimension", row = skip + 1,
+                                skip = skip, n_max = rows_per_tile,
+                                attribute = "tile-nrow",
+                                dtaparser = reader_totals[["dtaparser"]],
+                                haven = reader_totals[["haven"]])
+                ))
+            }
+            if (all(!is.na(terminated))) {
+                observed_rows[[batch_index]] <- terminated
+                break
+            }
+            if (any(newly_terminated) && any(is.na(terminated)) && is.na(trusted_rows)) {
+                if (is.null(stata_info)) {
+                    stata_info <- aww_stata_info(options, run_dir, aww_script_dir)
+                }
+                if (identical(stata_info$state, "available")) {
+                    row_probe <- aww_stata_row_count(
+                        item, metadata, options, run_dir, aww_script_dir,
+                        stata_info, batch_index
+                    )
+                    trusted_rows <- row_probe$rows
+                    if (identical(row_probe$state, "input-changed")) {
+                        terminal_failure <- "input-changed"
+                        break
+                    }
+                }
+            }
+            ceiling <- if (is.finite(trusted_rows)) trusted_rows else metadata$rows
+            continuing <- aww_beyond_row_ceiling(terminated, skip, ceiling)
+            if (length(continuing)) {
+                for (reader in continuing) {
+                    lower_bound <- skip + reader_totals[[reader]]
+                    base$disputes <- aww_bind_disputes(list(
+                        base$disputes,
+                        aww_dispute(
+                            "metadata", "dimension", reader = reader,
+                            row = skip + 1, skip = skip, n_max = rows_per_tile,
+                            attribute = "row-bound-exceeded",
+                            dtaparser = if (identical(reader, "dtaparser")) lower_bound else NULL,
+                            haven = if (identical(reader, "haven")) lower_bound else NULL
+                        )
+                    ))
+                }
+                observed_rows[[batch_index]] <- terminated
+                break
+            }
+            skip <- skip + rows_per_tile
+        }
+        if (!is.null(terminal_failure)) break
+    }
+    if (length(observed_rows)) {
+        observed <- do.call(rbind, observed_rows)
+        for (reader in c("dtaparser", "haven")) {
+            mismatches <- which(
+                !is.na(observed[, reader]) & observed[, reader] != metadata$rows
+            )
+            if (length(mismatches)) for (batch_index in mismatches) {
+                observed_value <- observed[batch_index, reader]
+                base$disputes <- aww_bind_disputes(list(
+                    base$disputes,
+                    aww_dispute(
+                        "metadata", "dimension", reader = reader,
+                        attribute = "observed-row-count",
+                        dtaparser = if (identical(reader, "dtaparser")) observed_value else NULL,
+                        haven = if (identical(reader, "haven")) observed_value else NULL
+                    )
+                ))
+                if (identical(reader, "dtaparser")) {
+                    base$disputes <- aww_bind_disputes(list(
+                        base$disputes,
+                        aww_dispute(
+                            "metadata", "dimension", reader = "dtaparser",
+                            attribute = "declared-row-count",
+                            dtaparser = metadata$rows
+                        )
+                    ))
+                }
+            }
+        }
+    }
+    base$tiles <- base$tiles + length(all_results)
+    base$resumed <- base$resumed + sum(vapply(all_results, function(result) isTRUE(result$resumed), logical(1)))
+    base$disputes <- aww_bind_disputes(c(list(base$disputes), lapply(all_results, `[[`, "disputes")))
+    if (!is.null(terminal_failure)) {
+        if (terminal_failure %in% c("dtaparser-error", "haven-error", "shared-reader-error")) {
+            base$disputes <- aww_bind_disputes(list(
+                base$disputes,
+                aww_dispute("reader_error", "reader-error",
+                            row = failed_result$tile$skip + 1,
+                            attribute = terminal_failure,
+                            dtaparser = failed_result$reader_errors$dtaparser,
+                            haven = failed_result$reader_errors$haven)
+            ))
+            probe <- aww_stata_open(item, options, run_dir, aww_script_dir)
+            base$adjudication <- probe
+            if (identical(probe, "open")) {
+                base$ownership <- switch(terminal_failure,
+                    "dtaparser-error" = "dtaparser-wrong",
+                    "haven-error" = "haven-wrong",
+                    "shared-reader-error" = "both-wrong"
+                )
+                base$status <- base$ownership
+            } else {
+                base$ownership <- "unresolved"
+                base$status <- "unresolved"
+            }
+        } else {
+            base$status <- terminal_failure
+        }
+        return(finish(base))
+    }
+    current_hash <- tryCatch(aww_file_sha256(item$path), error = function(error) NA_character_)
+    if (!identical(current_hash, item$sha256)) {
+        base$status <- "input-changed"
+        return(finish(base))
+    }
+    if (!nrow(base$disputes)) {
+        base$status <- "match"
+        return(finish(base))
+    }
+    if (is.null(stata_info)) {
+        stata_info <- aww_stata_info(options, run_dir, aww_script_dir)
+    }
+    dispute_id <- aww_sha256_raw(paste(
+        item$sha256, nrow(base$disputes), paste(base$disputes$kind, base$disputes$category,
+                                               base$disputes$reader,
+                                               base$disputes$column, base$disputes$row,
+                                               base$disputes$skip, base$disputes$n_max,
+                                               base$disputes$attribute, collapse = "|"),
+        sep = "\037"
+    ))
+    adjudication_path <- file.path(run_dir, "checkpoints", item$id, paste0("stata-", dispute_id, ".rds"))
+    cached <- aww_read_result(adjudication_path)
+    valid_cache <- !is.null(cached) && identical(cached$schema_version, aww_schema_version) &&
+        identical(cached$file_sha256, item$sha256) && identical(cached$dispute_id, dispute_id) &&
+        identical(cached$stata_id, stata_info$id) &&
+        (!options$retry || identical(cached$result$state, "complete"))
+    if (valid_cache) {
+        adjudication <- cached$result
+    } else {
+        adjudication <- aww_adjudicate(
+            base$disputes, metadata, item, options, run_dir, aww_script_dir, stata_info
+        )
+        aww_atomic_save_rds(list(
+            schema_version = aww_schema_version, file_sha256 = item$sha256,
+            dispute_id = dispute_id, stata_id = stata_info$id, result = adjudication
+        ), adjudication_path)
+    }
+    base$adjudication <- adjudication$state
+    base$ownership <- adjudication$ownership
+    resolved <- unique(base$ownership[base$ownership != "unresolved"])
+    base$status <- if (any(base$ownership == "unresolved")) "unresolved" else
+        if (length(resolved) == 1L) resolved[[1L]] else "mixed"
+    finish(base)
+}
+
+aww_write_results <- function(results, path) {
+    frame <- if (length(results)) do.call(rbind, lapply(results, function(result) data.frame(
+        id = result$id,
+        relative_path = result$relative_path,
+        release = result$release,
+        rows = result$rows,
+        columns = result$columns,
+        status = result$status,
+        tiles = result$tiles,
+        resumed = result$resumed,
+        disputes = nrow(result$disputes),
+        dtaparser_wrong = sum(result$ownership == "dtaparser-wrong"),
+        haven_wrong = sum(result$ownership == "haven-wrong"),
+        both_wrong = sum(result$ownership == "both-wrong"),
+        representation_only = sum(result$ownership == "representation-only"),
+        unresolved = sum(result$ownership == "unresolved"),
+        elapsed_seconds = result$elapsed_seconds,
+        stringsAsFactors = FALSE
+    ))) else data.frame(
+        id = character(), relative_path = character(), release = integer(),
+        rows = numeric(), columns = integer(), status = character(), tiles = integer(),
+        resumed = integer(), disputes = integer(), dtaparser_wrong = integer(),
+        haven_wrong = integer(), both_wrong = integer(), representation_only = integer(),
+        unresolved = integer(), elapsed_seconds = numeric(), stringsAsFactors = FALSE
+    )
+    temporary <- tempfile(pattern = ".stage-", tmpdir = dirname(path))
+    on.exit(unlink(temporary), add = TRUE)
+    write.table(frame, temporary, sep = "\t", quote = TRUE, row.names = FALSE, na = "")
+    Sys.chmod(temporary, "0600")
+    if (!file.rename(temporary, path)) aww_abort("cannot publish results.tsv", 3L)
+    frame
+}
+
+aww_report <- function(frame, inventory, options, config_id, build_id, haven_version, run_dir) {
+    statuses <- sort(table(frame$status), decreasing = TRUE)
+    lines <- c(
+        "DTA corpus comparison",
+        sprintf("Run: %s", config_id),
+        sprintf("Root: %s", options$root),
+        sprintf("Inventory: %s files; %.0f bytes", format(nrow(inventory), big.mark = ","), sum(inventory$size)),
+        sprintf("Readers: dtaparser build %s; haven %s", substr(build_id, 1L, 12L), haven_version),
+        sprintf("Coverage: %s files completed; %s tiles (%s resumed)", nrow(frame), sum(frame$tiles), sum(frame$resumed)),
+        "",
+        "File outcomes:"
+    )
+    for (name in names(statuses)) lines <- c(lines, sprintf("  %-24s %d", name, statuses[[name]]))
+    lines <- c(lines,
+        "",
+        sprintf("Disputes: %d", sum(frame$disputes)),
+        sprintf("  dtaparser wrong: %d", sum(frame$dtaparser_wrong)),
+        sprintf("  haven wrong: %d", sum(frame$haven_wrong)),
+        sprintf("  both wrong: %d", sum(frame$both_wrong)),
+        sprintf("  representation only: %d", sum(frame$representation_only)),
+        sprintf("  unresolved: %d", sum(frame$unresolved))
+    )
+    exceptional <- frame[frame$status != "match", , drop = FALSE]
+    if (nrow(exceptional)) {
+        shown <- utils::head(exceptional, 20L)
+        lines <- c(lines, "", sprintf(
+            "Non-matching files (showing %d of %d):", nrow(shown), nrow(exceptional)
+        ))
+        lines <- c(lines, vapply(seq_len(nrow(shown)), function(index) sprintf(
+            "  %s — %s (%d disputes)", shown$relative_path[[index]],
+            shown$status[[index]], shown$disputes[[index]]
+        ), character(1)))
+        if (nrow(exceptional) > nrow(shown)) {
+            lines <- c(lines, sprintf(
+                "  … %d additional files are listed only in results.tsv",
+                nrow(exceptional) - nrow(shown)
+            ))
+        }
+    }
+    c(lines, "", sprintf("Details: %s", file.path(run_dir, "results.tsv")))
+}
+
+main <- function() {
+    options <- aww_parse_arguments(commandArgs(TRUE))
+    required <- c("callr", "fs", "haven", "openssl", "processx", "tidyselect")
+    missing <- required[!vapply(required, requireNamespace, quietly = TRUE, FUN.VALUE = logical(1))]
+    if (length(missing)) aww_abort(sprintf("missing R packages: %s", paste(missing, collapse = ", ")))
+    package_library <- normalizePath(Sys.getenv("AWW_PACKAGE_LIBRARY"), winslash = "/", mustWork = TRUE)
+    package_path <- normalizePath(Sys.getenv("AWW_PACKAGE_PATH"), winslash = "/", mustWork = TRUE)
+    build_id <- Sys.getenv("AWW_BUILD_ID")
+    haven_version <- as.character(utils::packageVersion("haven"))
+    config_id <- aww_config_id(options, build_id, haven_version)
+    run_dir <- file.path(options$state, "runs", config_id)
+    dir.create(run_dir, recursive = TRUE, showWarnings = FALSE, mode = "0700")
+    inventory <- aww_inventory(options$root)
+    aww_atomic_save_rds(inventory, file.path(run_dir, "inventory.rds"))
+    if (options$inventory_only) {
+        report <- c(
+            "DTA corpus inventory",
+            sprintf("Root: %s", options$root),
+            sprintf("Files: %s", format(nrow(inventory), big.mark = ",")),
+            sprintf("Bytes: %.0f", sum(inventory$size)),
+            sprintf("Inventory: %s", file.path(run_dir, "inventory.rds"))
+        )
+        aww_atomic_write(report, file.path(run_dir, "report.txt"))
+        writeLines(report)
+        return(invisible(0L))
+    }
+    selected <- aww_select_inventory(inventory, options)
+    results <- vector("list", nrow(selected))
+    for (index in seq_len(nrow(selected))) {
+        item <- as.list(selected[index, , drop = FALSE])
+        message(sprintf("[%d/%d] %s", index, nrow(selected), item$relative_path))
+        results[[index]] <- aww_file(item, options, package_library, package_path, run_dir, config_id)
+    }
+    frame <- aww_write_results(results, file.path(run_dir, "results.tsv"))
+    report <- aww_report(frame, inventory, options, config_id, build_id, haven_version, run_dir)
+    aww_atomic_write(report, file.path(run_dir, "report.txt"))
+    writeLines(report)
+    incomplete <- any(frame$status %in% c(
+        "unresolved", "unreadable", "empty-or-corrupt", "unsupported-release",
+        "dtaparser-error", "haven-error", "shared-reader-error", "timeout",
+        "worker-crash", "memory-limit", "input-changed", "row-termination-mismatch"
+    ))
+    invisible(if (incomplete) 1L else 0L)
+}
+
+status <- tryCatch(main(), aww_error = function(error) {
+    message(error$message)
+    error$status
+}, error = function(error) {
+    message(conditionMessage(error))
+    3L
+})
+quit(status = status)

--- a/benchmarks/aww-cache-differential/run.R
+++ b/benchmarks/aww-cache-differential/run.R
@@ -166,6 +166,9 @@ aww_file <- function(item, options, package_library, package_path, run_dir, conf
                 "shared-reader-error" = "both-wrong"
             )
             base$status <- base$ownership
+        } else if (identical(probe, "stata-source-error")) {
+            base$ownership <- "source-corrupt"
+            base$status <- "empty-or-corrupt"
         } else {
             base$ownership <- "unresolved"
             base$status <- "unresolved"
@@ -384,6 +387,9 @@ aww_file <- function(item, options, package_library, package_path, run_dir, conf
                     "shared-reader-error" = "both-wrong"
                 )
                 base$status <- base$ownership
+            } else if (identical(probe, "stata-source-error")) {
+                base$ownership <- "source-corrupt"
+                base$status <- "empty-or-corrupt"
             } else {
                 base$ownership <- "unresolved"
                 base$status <- "unresolved"
@@ -405,14 +411,7 @@ aww_file <- function(item, options, package_library, package_path, run_dir, conf
     if (is.null(stata_info)) {
         stata_info <- aww_stata_info(options, run_dir, aww_script_dir)
     }
-    dispute_id <- aww_sha256_raw(paste(
-        item$sha256, nrow(base$disputes), paste(base$disputes$kind, base$disputes$category,
-                                               base$disputes$reader,
-                                               base$disputes$column, base$disputes$row,
-                                               base$disputes$skip, base$disputes$n_max,
-                                               base$disputes$attribute, collapse = "|"),
-        sep = "\037"
-    ))
+    dispute_id <- aww_dispute_id(item$sha256, base$disputes)
     adjudication_path <- file.path(run_dir, "checkpoints", item$id, paste0("stata-", dispute_id, ".rds"))
     cached <- aww_read_result(adjudication_path)
     valid_cache <- !is.null(cached) && identical(cached$schema_version, aww_schema_version) &&
@@ -525,6 +524,10 @@ main <- function() {
     config_id <- aww_config_id(options, build_id, haven_version)
     run_dir <- file.path(options$state, "runs", config_id)
     dir.create(run_dir, recursive = TRUE, showWarnings = FALSE, mode = "0700")
+    aww_atomic_save_rds(list(
+        schema_version = aww_schema_version, config_id = config_id,
+        options = options, build_id = build_id, haven_version = haven_version
+    ), file.path(run_dir, "config.rds"))
     inventory <- aww_inventory(options$root)
     aww_atomic_save_rds(inventory, file.path(run_dir, "inventory.rds"))
     if (options$inventory_only) {
@@ -545,6 +548,10 @@ main <- function() {
         item <- as.list(selected[index, , drop = FALSE])
         message(sprintf("[%d/%d] %s", index, nrow(selected), item$relative_path))
         results[[index]] <- aww_file(item, options, package_library, package_path, run_dir, config_id)
+        aww_atomic_save_rds(list(
+            schema_version = aww_schema_version, config_id = config_id,
+            file_sha256 = item$sha256, result = results[[index]]
+        ), file.path(run_dir, "checkpoints", item$id, "file-result.rds"))
     }
     frame <- aww_write_results(results, file.path(run_dir, "results.tsv"))
     report <- aww_report(frame, inventory, options, config_id, build_id, haven_version, run_dir)
@@ -558,11 +565,13 @@ main <- function() {
     invisible(if (incomplete) 1L else 0L)
 }
 
-status <- tryCatch(main(), aww_error = function(error) {
-    message(error$message)
-    error$status
-}, error = function(error) {
-    message(conditionMessage(error))
-    3L
-})
-quit(status = status)
+if (!identical(Sys.getenv("AWW_SOURCE_ONLY", unset = ""), "1")) {
+    status <- tryCatch(main(), aww_error = function(error) {
+        message(error$message)
+        error$status
+    }, error = function(error) {
+        message(conditionMessage(error))
+        3L
+    })
+    quit(status = status)
+}

--- a/benchmarks/aww-cache-differential/stata.R
+++ b/benchmarks/aww-cache-differential/stata.R
@@ -1,0 +1,360 @@
+aww_resolve_stata <- function(explicit = "") {
+    candidates <- c(
+        explicit,
+        Sys.which("stata-mp"),
+        Sys.which("stata"),
+        "/Applications/Stata/StataMP.app/Contents/MacOS/stata-mp"
+    )
+    candidates <- unique(candidates[nzchar(candidates)])
+    candidates <- candidates[file.exists(candidates)]
+    if (!length(candidates)) return(NA_character_)
+    normalizePath(candidates[[1L]], winslash = "/", mustWork = TRUE)
+}
+
+.aww_stata_cache <- new.env(parent = emptyenv())
+
+aww_stata_info <- function(options, run_dir, script_dir) {
+    stata <- aww_resolve_stata(options$stata)
+    if (is.na(stata)) return(list(state = "stata-unavailable", id = "unavailable"))
+    info <- file.info(stata, extra_cols = FALSE)
+    executable_id <- aww_sha256_raw(paste(stata, info$size, as.numeric(info$mtime), sep = "\037"))
+    if (exists(executable_id, envir = .aww_stata_cache, inherits = FALSE)) {
+        return(get(executable_id, envir = .aww_stata_cache, inherits = FALSE))
+    }
+    work_dir <- file.path(run_dir, "stata", paste0("version-", substr(executable_id, 1L, 12L)))
+    dir.create(work_dir, recursive = TRUE, showWarnings = FALSE, mode = "0700")
+    file.copy(file.path(script_dir, "version-probe.do"),
+              file.path(work_dir, "version-probe.do"), overwrite = TRUE)
+    unlink(file.path(work_dir, "stata-version.txt"))
+    process <- tryCatch(processx::run(
+        stata, c("-q", "-b", "do", "version-probe.do"), wd = work_dir,
+        timeout = options$timeout * 1000, error_on_status = FALSE,
+        echo = FALSE, windows_verbatim_args = TRUE
+    ), error = identity)
+    version_path <- file.path(work_dir, "stata-version.txt")
+    if (inherits(process, "error") || process$status != 0L || !file.exists(version_path)) {
+        result <- list(state = "stata-version-error", path = stata,
+                       id = paste0(executable_id, ":version-error"))
+    } else {
+        version_lines <- readLines(version_path, warn = FALSE)
+        version <- if (length(version_lines)) trimws(version_lines[[1L]]) else ""
+        version_parts <- strsplit(version, "[.]", fixed = FALSE)[[1L]]
+        major <- if (length(version_parts)) suppressWarnings(as.integer(version_parts[[1L]])) else NA_integer_
+        state <- if (!is.na(major) && major == 18L) "available" else "stata-unsupported-version"
+        result <- list(state = state, path = stata, version = version,
+                       id = paste(executable_id, version, state, sep = ":"))
+    }
+    assign(executable_id, result, envir = .aww_stata_cache)
+    result
+}
+
+aww_hex_decode <- function(value) {
+    if (!nzchar(value)) return("")
+    if (nchar(value) %% 2L) stop("odd Stata hex string")
+    bytes <- substring(value, seq.int(1L, nchar(value), 2L), seq.int(2L, nchar(value), 2L))
+    rawToChar(as.raw(strtoi(bytes, 16L)))
+}
+
+aww_stata_kind <- function(dispute) {
+    if (identical(dispute$kind, "cell")) return("cell")
+    attribute <- dispute$attribute
+    if (identical(dispute$category, "name")) return(if (is.na(dispute$column)) "names" else "name")
+    if (identical(dispute$category, "storage")) return("storage")
+    if (identical(dispute$category, "format")) return("format")
+    if (identical(dispute$category, "class")) return("format")
+    if (identical(attribute, "label")) return(if (is.na(dispute$column)) "dataset_label" else "variable_label")
+    if (startsWith(attribute, "notes:")) return("note_entry")
+    if (startsWith(attribute, "labels:")) return("value_label_entry")
+    if (identical(attribute, "ncol")) return("nvar")
+    if (attribute %in% c("tile-nrow", "source-row-count", "observed-row-count",
+                         "declared-row-count", "row-bound-exceeded")) return("nobs")
+    "unsupported"
+}
+
+aww_stata_job <- function(disputes, metadata, work_dir, adapter) {
+    requests <- lapply(seq_len(nrow(disputes)), function(index) {
+        row <- disputes[index, , drop = FALSE]
+        entry <- if (grepl(":", row$attribute, fixed = TRUE)) {
+            suppressWarnings(as.integer(sub("^.*:", "", row$attribute)))
+        } else 0L
+        list(id = index, kind = aww_stata_kind(row), column = row$column,
+             observation = row$row, entry = entry)
+    })
+    supported <- vapply(requests, function(request) request$kind != "unsupported", logical(1))
+    columns <- sort(unique(vapply(requests[supported], function(request) {
+        if (is.na(request$column)) NA_integer_ else request$column
+    }, integer(1))))
+    columns <- columns[!is.na(columns) & columns >= 1L & columns <= metadata$columns]
+    if (!length(columns) && metadata$columns > 0L) columns <- 1L
+    cell_rows <- vapply(requests, function(request) {
+        if (identical(request$kind, "cell")) request$observation else NA_real_
+    }, numeric(1))
+    cell_rows <- cell_rows[is.finite(cell_rows)]
+    first <- if (length(cell_rows)) min(cell_rows) else 1
+    last <- if (length(cell_rows)) max(cell_rows) else max(1, first)
+    lines <- c(
+        "version 18.0", "set more off",
+        sprintf("do \"%s\"", adapter),
+        "aww_open, input(\"input.dta\") output(\"response.tsv\")"
+    )
+    if (metadata$columns > 0L) {
+        lines <- c(lines, sprintf(
+            "aww_load, columns(%s) first(%d) last(%d)",
+            paste(columns, collapse = " "), as.integer(first), as.integer(last)
+        ))
+    } else {
+        lines <- c(lines, "quietly use \"input.dta\", clear", "global AWW_FIRST \"1\"")
+    }
+    for (request in requests) {
+        if (identical(request$kind, "unsupported")) next
+        if (identical(request$kind, "cell")) {
+            lines <- c(lines, sprintf(
+                "aww_cell, id(%d) column(%d) observation(%d)",
+                request$id, request$column, as.integer(request$observation)
+            ))
+        } else {
+            column <- if (is.na(request$column)) 0L else request$column
+            lines <- c(lines, sprintf(
+                "aww_meta, id(%d) kind(%s) column(%d) index(%d)",
+                request$id, request$kind, column, request$entry
+            ))
+        }
+    }
+    c(lines, "aww_close", "exit, clear")
+}
+
+aww_canonical_labels <- function(labels) aww_label_entries(labels)
+
+aww_stata_value <- function(response) {
+    if (!nrow(response)) return(NULL)
+    kind <- response$kind[[1L]]
+    if (kind %in% c("name", "names", "storage", "format", "variable_label", "dataset_label")) {
+        values <- vapply(response$value, aww_hex_decode, character(1))
+        return(if (length(values) == 1L) values[[1L]] else values)
+    }
+    if (kind == "note_absent") return(list(present = FALSE))
+    if (kind == "note_entry") {
+        return(list(present = TRUE, value = aww_hex_decode(response$value[[1L]])))
+    }
+    if (kind == "value_label_absent") return(list(present = FALSE))
+    if (kind == "value_label_code") {
+        text <- response[response$kind == "value_label_text", "value", drop = TRUE]
+        if (length(text) != 1L) return(NULL)
+        return(list(
+            present = TRUE,
+            value = list(code = response$value[[1L]], text = aww_hex_decode(text[[1L]]))
+        ))
+    }
+    if (kind %in% c("nobs", "nvar")) return(as.double(response$value[[1L]]))
+    response$value[[1L]]
+}
+
+aww_expected_class <- function(format) {
+    if (startsWith(format, "%tC") || startsWith(format, "%tc")) return(c("POSIXct", "POSIXt"))
+    if (startsWith(format, "%td") || startsWith(format, "%d")) return("Date")
+    NULL
+}
+
+aww_matches_stata <- function(private, source, dispute, metadata) {
+    kind <- aww_stata_kind(dispute)
+    if (identical(kind, "cell")) {
+        evidence <- private
+        if (is.null(evidence) || is.null(evidence$kind)) return(FALSE)
+        if (startsWith(source, ".")) return(identical(evidence$kind, source))
+        if (identical(evidence$kind, "string")) return(identical(as.character(evidence$value), aww_hex_decode(source)))
+        if (!identical(evidence$kind, "value")) return(FALSE)
+        value <- evidence$value
+        format <- if (!is.na(dispute$column) && dispute$column <= length(metadata$formats)) metadata$formats[[dispute$column]] else ""
+        source_value <- aww_source_value(value, format)
+        parsed <- suppressWarnings(as.numeric(source))
+        storage <- if (!is.na(dispute$column) && dispute$column <= length(metadata$storage)) metadata$storage[[dispute$column]] else NA_character_
+        limit <- if (storage %in% c("float", "double")) 1e-7 else 0
+        return(length(source_value) == 1L && is.finite(parsed) &&
+               abs(as.numeric(source_value) - parsed) <= limit)
+    }
+    if (kind %in% c("note_entry", "value_label_entry")) {
+        if (!is.list(source) || is.null(source$present)) return(FALSE)
+        if (!source$present) return(is.null(private))
+        return(identical(private, source$value))
+    }
+    if (kind %in% c("nobs", "nvar")) {
+        expected <- as.double(source)
+        if (identical(dispute$attribute, "tile-nrow")) {
+            if (!is.finite(dispute$skip) || is.na(dispute$n_max)) return(FALSE)
+            expected <- max(0, min(as.double(dispute$n_max), expected - dispute$skip))
+        }
+        return(length(private) == 1L && !is.na(private) &&
+               as.double(private) == expected)
+    }
+    if (identical(dispute$category, "class")) {
+        expected <- if (identical(dispute$attribute, "tzone")) {
+            class <- aww_expected_class(source)
+            if (!is.null(class) && "POSIXct" %in% class) "UTC" else NULL
+        } else aww_expected_class(source)
+        return(identical(private, expected))
+    }
+    if (kind == "storage") {
+        expected <- if (startsWith(source, "str")) "character" else "double"
+        return(identical(private, expected))
+    }
+    identical(private, source)
+}
+
+aww_chunk_indices <- function(indices, maximum) {
+    if (!length(indices)) return(list())
+    split(indices, ceiling(seq_along(indices) / maximum))
+}
+
+aww_stata_batches <- function(disputes, maximum_requests, maximum_rows) {
+    cell <- disputes$kind == "cell" & is.finite(disputes$row)
+    batches <- aww_chunk_indices(which(!cell), maximum_requests)
+    if (any(cell)) {
+        cell_indices <- which(cell)
+        windows <- floor((disputes$row[cell_indices] - 1) / maximum_rows)
+        for (window in unique(windows)) {
+            batches <- c(batches, aww_chunk_indices(cell_indices[windows == window], maximum_requests))
+        }
+    }
+    unname(batches)
+}
+
+aww_stata_open <- function(item, options, run_dir, script_dir, stata_info = NULL) {
+    if (!aww_source_unchanged(item)) return("input-changed")
+    if (is.null(stata_info)) stata_info <- aww_stata_info(options, run_dir, script_dir)
+    if (!identical(stata_info$state, "available")) return(stata_info$state)
+    work_dir <- file.path(run_dir, "stata", paste0(item$id, "-open"))
+    dir.create(work_dir, recursive = TRUE, showWarnings = FALSE, mode = "0700")
+    input <- file.path(work_dir, "input.dta")
+    unlink(input)
+    if (!file.symlink(item$path, input)) return("input-alias-error")
+    file.copy(file.path(script_dir, "open-probe.do"), file.path(work_dir, "open-probe.do"), overwrite = TRUE)
+    process <- tryCatch(processx::run(
+        stata_info$path, c("-q", "-b", "do", "open-probe.do"), wd = work_dir,
+        timeout = options$timeout * 1000, error_on_status = FALSE,
+        echo = FALSE, windows_verbatim_args = TRUE
+    ), error = identity)
+    if (!aww_source_unchanged(item)) return("input-changed")
+    if (inherits(process, "error") || process$status != 0L) "stata-source-error" else "open"
+}
+
+aww_adjudicate_batch <- function(disputes, metadata, item, options, run_dir,
+                                 script_dir, stata_info, batch_id) {
+    if (!aww_source_unchanged(item)) {
+        return(list(state = "input-changed", ownership = rep("unresolved", nrow(disputes))))
+    }
+    work_dir <- file.path(run_dir, "stata", item$id, sprintf("batch-%05d", batch_id))
+    dir.create(work_dir, recursive = TRUE, showWarnings = FALSE, mode = "0700")
+    input <- file.path(work_dir, "input.dta")
+    unlink(input)
+    if (!file.symlink(item$path, input)) {
+        return(list(state = "input-alias-error", ownership = rep("unresolved", nrow(disputes))))
+    }
+    job <- file.path(work_dir, "job.do")
+    response_path <- file.path(work_dir, "response.tsv")
+    unlink(response_path)
+    lines <- aww_stata_job(disputes, metadata, work_dir, file.path(script_dir, "adjudicate.do"))
+    writeLines(lines, job, useBytes = TRUE)
+    process <- tryCatch(processx::run(
+        stata_info$path, c("-q", "-b", "do", "job.do"), wd = work_dir,
+        timeout = options$timeout * 1000, error_on_status = FALSE,
+        echo = FALSE, windows_verbatim_args = TRUE
+    ), error = identity)
+    if (!aww_source_unchanged(item)) {
+        return(list(state = "input-changed", ownership = rep("unresolved", nrow(disputes))))
+    }
+    if (inherits(process, "error") || process$status != 0L || !file.exists(response_path)) {
+        return(list(state = "stata-error", ownership = rep("unresolved", nrow(disputes))))
+    }
+    response <- tryCatch(read.delim(
+        response_path, sep = "\t", quote = "", comment.char = "",
+        colClasses = "character", check.names = FALSE, stringsAsFactors = FALSE
+    ), error = identity)
+    if (inherits(response, "error") ||
+        !identical(names(response), c("id", "status", "kind", "index", "value"))) {
+        return(list(state = "stata-protocol-error", ownership = rep("unresolved", nrow(disputes))))
+    }
+    response$id <- suppressWarnings(as.integer(response$id))
+    if (anyNA(response$id) || any(response$id < 1L | response$id > nrow(disputes))) {
+        return(list(state = "stata-protocol-error", ownership = rep("unresolved", nrow(disputes))))
+    }
+    ownership <- rep("unresolved", nrow(disputes))
+    for (index in seq_len(nrow(disputes))) {
+        dispute <- disputes[index, , drop = FALSE]
+        if (aww_stata_kind(dispute) == "unsupported") next
+        rows <- response[response$id == index & response$status == "ok", , drop = FALSE]
+        source <- aww_stata_value(rows)
+        if (is.null(source)) next
+        left <- aww_matches_stata(dispute$dtaparser[[1L]], source, dispute, metadata)
+        right <- aww_matches_stata(dispute$haven[[1L]], source, dispute, metadata)
+        ownership[[index]] <- if (identical(dispute$reader, "dtaparser")) {
+            if (left) "representation-only" else "dtaparser-wrong"
+        } else if (identical(dispute$reader, "haven")) {
+            if (right) "representation-only" else "haven-wrong"
+        } else if (left && !right) "haven-wrong" else
+            if (!left && right) "dtaparser-wrong" else
+            if (left && right) "representation-only" else "both-wrong"
+    }
+    list(state = "complete", ownership = ownership, response = response)
+}
+
+aww_stata_row_count <- function(item, metadata, options, run_dir, script_dir,
+                                 stata_info, batch_id) {
+    dispute <- aww_dispute(
+        "metadata", "dimension", attribute = "source-row-count",
+        dtaparser = NA_real_, haven = NA_real_
+    )
+    result <- aww_adjudicate_batch(
+        dispute, metadata, item, options, run_dir, script_dir,
+        stata_info, 900000L + batch_id
+    )
+    if (!identical(result$state, "complete") || is.null(result$response)) {
+        return(list(state = result$state, rows = NA_real_))
+    }
+    rows <- result$response[
+        result$response$id == 1L & result$response$status == "ok", , drop = FALSE
+    ]
+    value <- aww_stata_value(rows)
+    list(
+        state = if (length(value) == 1L && is.finite(value) && value >= 0) {
+            "complete"
+        } else "stata-protocol-error",
+        rows = if (length(value) == 1L && is.finite(value) && value >= 0) {
+            as.double(value)
+        } else NA_real_
+    )
+}
+
+aww_adjudicate <- function(disputes, metadata, item, options, run_dir, script_dir,
+                           stata_info = NULL) {
+    if (!nrow(disputes)) return(list(state = "not-needed", ownership = character()))
+    if (!aww_source_unchanged(item)) {
+        return(list(state = "input-changed", ownership = rep("unresolved", nrow(disputes))))
+    }
+    if (is.null(stata_info)) stata_info <- aww_stata_info(options, run_dir, script_dir)
+    if (!identical(stata_info$state, "available")) {
+        return(list(state = stata_info$state, ownership = rep("unresolved", nrow(disputes))))
+    }
+    batches <- aww_stata_batches(disputes, options$stata_requests, options$stata_row_window)
+    ownership <- rep("unresolved", nrow(disputes))
+    states <- character()
+    responses <- vector("list", length(batches))
+    for (batch_index in seq_along(batches)) {
+        indices <- batches[[batch_index]]
+        result <- aww_adjudicate_batch(
+            disputes[indices, , drop = FALSE], metadata, item, options, run_dir,
+            script_dir, stata_info, batch_index
+        )
+        ownership[indices] <- result$ownership
+        states <- c(states, result$state)
+        responses[batch_index] <- list(result$response)
+        if (identical(result$state, "input-changed")) break
+    }
+    if (!aww_source_unchanged(item)) {
+        return(list(state = "input-changed", ownership = rep("unresolved", nrow(disputes))))
+    }
+    state <- if (length(states) && all(states == "complete")) "complete" else
+        if ("input-changed" %in% states) "input-changed" else
+        if (length(states)) paste0("partial-", states[[which(states != "complete")[[1L]]]]) else "stata-protocol-error"
+    list(state = state, ownership = ownership, responses = responses,
+         stata_id = stata_info$id, stata_version = stata_info$version)
+}

--- a/benchmarks/aww-cache-differential/stata.R
+++ b/benchmarks/aww-cache-differential/stata.R
@@ -136,7 +136,7 @@ aww_stata_value <- function(response) {
     if (!nrow(response)) return(NULL)
     kind <- response$kind[[1L]]
     if (kind %in% c("name", "names", "storage", "format", "variable_label", "dataset_label")) {
-        values <- vapply(response$value, aww_hex_decode, character(1))
+        values <- unname(vapply(response$value, aww_hex_decode, character(1)))
         return(if (length(values) == 1L) values[[1L]] else values)
     }
     if (kind == "note_absent") return(list(present = FALSE))

--- a/benchmarks/aww-cache-differential/stata.R
+++ b/benchmarks/aww-cache-differential/stata.R
@@ -61,7 +61,14 @@ aww_stata_kind <- function(dispute) {
     if (identical(dispute$category, "name")) return(if (is.na(dispute$column)) "names" else "name")
     if (identical(dispute$category, "storage")) return("storage")
     if (identical(dispute$category, "format")) return("format")
-    if (identical(dispute$category, "class")) return("format")
+    if (identical(dispute$category, "class")) {
+        labelled <- any(vapply(c(dispute$dtaparser, dispute$haven), function(value) {
+            is.character(value) && "haven_labelled" %in% value
+        }, logical(1)))
+        return(if (identical(attribute, "class") && labelled) {
+            "value_label_name"
+        } else "format")
+    }
     if (identical(attribute, "label")) return(if (is.na(dispute$column)) "dataset_label" else "variable_label")
     if (startsWith(attribute, "notes:")) return("note_entry")
     if (startsWith(attribute, "labels:")) return("value_label_entry")
@@ -187,7 +194,11 @@ aww_matches_stata <- function(private, source, dispute, metadata) {
                as.double(private) == expected)
     }
     if (identical(dispute$category, "class")) {
-        expected <- if (identical(dispute$attribute, "tzone")) {
+        expected <- if (kind == "value_label_name") {
+            if (is.character(source) && length(source) == 1L && nzchar(source)) {
+                c("haven_labelled", "vctrs_vctr", "double")
+            } else NULL
+        } else if (identical(dispute$attribute, "tzone")) {
             class <- aww_expected_class(source)
             if (!is.null(class) && "POSIXct" %in% class) "UTC" else NULL
         } else aww_expected_class(source)
@@ -224,6 +235,8 @@ aww_stata_open <- function(item, options, run_dir, script_dir, stata_info = NULL
     if (!identical(stata_info$state, "available")) return(stata_info$state)
     work_dir <- file.path(run_dir, "stata", paste0(item$id, "-open"))
     dir.create(work_dir, recursive = TRUE, showWarnings = FALSE, mode = "0700")
+    marker <- file.path(work_dir, "open-ok.txt")
+    unlink(marker)
     input <- file.path(work_dir, "input.dta")
     unlink(input)
     if (!file.symlink(item$path, input)) return("input-alias-error")
@@ -234,7 +247,9 @@ aww_stata_open <- function(item, options, run_dir, script_dir, stata_info = NULL
         echo = FALSE, windows_verbatim_args = TRUE
     ), error = identity)
     if (!aww_source_unchanged(item)) return("input-changed")
-    if (inherits(process, "error") || process$status != 0L) "stata-source-error" else "open"
+    if (inherits(process, "error") || process$status != 0L || !file.exists(marker)) {
+        "stata-source-error"
+    } else "open"
 }
 
 aww_adjudicate_batch <- function(disputes, metadata, item, options, run_dir,

--- a/benchmarks/aww-cache-differential/test-framework.R
+++ b/benchmarks/aww-cache-differential/test-framework.R
@@ -160,6 +160,20 @@ stopifnot(aww_matches_stata(10, 100, dimension_dispute,
 stopifnot(!aww_matches_stata(9, 100, dimension_dispute,
                              list(formats = character(), storage = character())))
 
+empty_label_class <- aww_dispute(
+    "metadata", "class", column = 1L, attribute = "class",
+    dtaparser = c("haven_labelled", "vctrs_vctr", "double"), haven = NULL
+)
+stopifnot(identical(aww_stata_kind(empty_label_class), "value_label_name"))
+stopifnot(aww_matches_stata(
+    empty_label_class$dtaparser[[1L]], "labels111", empty_label_class,
+    list(formats = "%6.3f", storage = "float")
+))
+stopifnot(!aww_matches_stata(
+    empty_label_class$haven[[1L]], "labels111", empty_label_class,
+    list(formats = "%6.3f", storage = "float")
+))
+
 changed_item <- list(path = fixture, sha256 = paste(rep("0", 64L), collapse = ""))
 changed <- aww_adjudicate(
     aww_dispute("metadata", "dimension", attribute = "ncol", dtaparser = 1, haven = 2),
@@ -180,6 +194,19 @@ fake_info <- aww_stata_info(
     list(stata = fake_stata, timeout = 10L), fake_run, dir
 )
 stopifnot(identical(fake_info$state, "stata-unsupported-version"))
+
+probe_item <- list(id = "Dprobe", path = fixture, sha256 = aww_file_sha256(fixture))
+probe_options <- list(timeout = 10L)
+probe_info <- list(state = "available", path = fake_stata)
+stopifnot(identical(
+    aww_stata_open(probe_item, probe_options, fake_run, dir, probe_info),
+    "stata-source-error"
+))
+writeLines(c("#!/bin/sh", "printf 'ok\\n' > open-ok.txt", "exit 0"), fake_stata)
+Sys.chmod(fake_stata, "0700")
+stopifnot(identical(
+    aww_stata_open(probe_item, probe_options, fake_run, dir, probe_info), "open"
+))
 
 stata_setting <- Sys.getenv("DTAPARSER_TEST_STATA", unset = "")
 stata <- if (nzchar(stata_setting)) aww_resolve_stata(stata_setting) else NA_character_
@@ -230,6 +257,33 @@ if (!is.na(stata)) {
     )
     stopifnot(identical(result$state, "complete"))
     stopifnot(identical(result$ownership, rep("haven-wrong", 3L)))
+
+    malformed_source <- file.path(work, "malformed.dta")
+    malformed <- readBin(fixture, "raw", file.info(fixture)$size)
+    source_label <- "All Stata storage types"
+    needle <- charToRaw(source_label)
+    starts <- which(vapply(seq_len(length(malformed) - length(needle) + 1L), function(index) {
+        identical(malformed[index:(index + length(needle) - 1L)], needle)
+    }, logical(1)))
+    stopifnot(length(starts) >= 1L)
+    malformed[[starts[[1L]]]] <- as.raw(0xff)
+    writeBin(malformed, malformed_source)
+    malformed_dispute <- aww_dispute(
+        "metadata", "label", attribute = "label",
+        dtaparser = paste0("\ufffd", substring(source_label, 2L)),
+        haven = "wrong"
+    )
+    malformed_item <- list(
+        id = "Dmalformed", path = malformed_source,
+        sha256 = aww_file_sha256(malformed_source)
+    )
+    malformed_result <- aww_adjudicate(
+        malformed_dispute,
+        list(columns = 8L, formats = rep("%8.0g", 8L), storage = rep("long", 8L)),
+        malformed_item, stata_options, work, dir, stata_info
+    )
+    stopifnot(identical(malformed_result$state, "complete"))
+    stopifnot(identical(malformed_result$ownership, "haven-wrong"))
 }
 
 unlink(root, recursive = TRUE)

--- a/benchmarks/aww-cache-differential/test-framework.R
+++ b/benchmarks/aww-cache-differential/test-framework.R
@@ -7,7 +7,7 @@ source(file.path(dir, "compare.R"))
 source(file.path(dir, "stata.R"))
 source(file.path(dir, "worker.R"))
 
-root <- tempfile("aww-inventory-")
+root <- paste0(tempfile("aww-inventory-"), "-", intToUtf8(233L))
 dir.create(file.path(root, "nested"), recursive = TRUE)
 fixture <- normalizePath(file.path(dir, "..", "..", "r-package", "dtaparser", "inst", "extdata", "all_types_v118.dta"))
 invisible(file.copy(fixture, file.path(root, "nested", "included.DTA")))
@@ -160,6 +160,17 @@ stopifnot(aww_matches_stata(10, 100, dimension_dispute,
 stopifnot(!aww_matches_stata(9, 100, dimension_dispute,
                              list(formats = character(), storage = character())))
 
+name_vector_dispute <- aww_dispute(
+    "metadata", "name", attribute = "projection",
+    dtaparser = c("first", "second"), haven = c("wrong", "names")
+)
+stopifnot(identical(aww_stata_kind(name_vector_dispute), "names"))
+name_response <- data.frame(
+    id = c(1L, 1L), status = c("ok", "ok"), kind = c("names", "names"),
+    index = c(1L, 2L), value = c("6669727374", "7365636f6e64")
+)
+stopifnot(identical(aww_stata_value(name_response), c("first", "second")))
+
 empty_label_class <- aww_dispute(
     "metadata", "class", column = 1L, attribute = "class",
     dtaparser = c("haven_labelled", "vctrs_vctr", "double"), haven = NULL
@@ -235,6 +246,14 @@ if (!is.na(stata)) {
         aww_dispute(
             "metadata", "label", attribute = "notes:2",
             dtaparser = "hello", haven = "wrong"
+        ),
+        aww_dispute(
+            "metadata", "name", attribute = "projection",
+            dtaparser = c(
+                "make", "price", "mpg", "rep78", "headroom", "trunk",
+                "weight", "length", "turn", "displacement", "gear_ratio", "foreign"
+            ),
+            haven = "wrong"
         )
     ))
     stata_options <- list(
@@ -256,7 +275,22 @@ if (!is.na(stata)) {
         disputes, stata_metadata, stata_item, stata_options, work, dir, stata_info
     )
     stopifnot(identical(result$state, "complete"))
-    stopifnot(identical(result$ownership, rep("haven-wrong", 3L)))
+    stopifnot(identical(result$ownership, rep("haven-wrong", 4L)))
+
+    zero_make <- file.path(work, "make-zero.do")
+    writeLines(c(
+        "version 18", "set more off", "sysuse auto, clear", "keep make",
+        "drop in 1/l", "save zero.dta, replace", "exit, clear"
+    ), zero_make)
+    processx::run(stata, c("-q", "-b", "do", "make-zero.do"), wd = work,
+                  timeout = 120000, error_on_status = TRUE)
+    zero_path <- file.path(work, "zero.dta")
+    zero_item <- list(
+        id = "Dzero", path = zero_path, sha256 = aww_file_sha256(zero_path)
+    )
+    stopifnot(identical(
+        aww_stata_open(zero_item, stata_options, work, dir, stata_info), "open"
+    ))
 
     malformed_source <- file.path(work, "malformed.dta")
     malformed <- readBin(fixture, "raw", file.info(fixture)$size)

--- a/benchmarks/aww-cache-differential/test-framework.R
+++ b/benchmarks/aww-cache-differential/test-framework.R
@@ -1,0 +1,237 @@
+#!/usr/bin/env Rscript
+
+script <- grep("^--file=", commandArgs(FALSE), value = TRUE)
+dir <- dirname(normalizePath(sub("^--file=", "", script[[1L]]), winslash = "/"))
+source(file.path(dir, "common.R"))
+source(file.path(dir, "compare.R"))
+source(file.path(dir, "stata.R"))
+source(file.path(dir, "worker.R"))
+
+root <- tempfile("aww-inventory-")
+dir.create(file.path(root, "nested"), recursive = TRUE)
+fixture <- normalizePath(file.path(dir, "..", "..", "r-package", "dtaparser", "inst", "extdata", "all_types_v118.dta"))
+invisible(file.copy(fixture, file.path(root, "nested", "included.DTA")))
+invisible(file.copy(fixture, file.path(root, "ignored.dta.gz")))
+invisible(file.symlink(file.path(root, "nested"), file.path(root, "linked-directory")))
+invisible(file.symlink(file.path(root, "nested", "included.DTA"), file.path(root, "linked.dta")))
+fifo <- file.path(root, "named-pipe.dta")
+if (nzchar(Sys.which("mkfifo"))) system2("mkfifo", fifo)
+inventory <- aww_inventory(root)
+stopifnot(nrow(inventory) == 1L)
+stopifnot(identical(inventory$relative_path, "nested/included.DTA"))
+stopifnot(identical(inventory$release, 118L))
+stopifnot(identical(inventory$id, aww_file_id("nested/included.DTA")))
+
+root_link <- tempfile("aww-root-link-")
+invisible(file.symlink(root, root_link))
+root_error <- tryCatch(aww_parse_arguments(paste0("--root=", root_link)), error = identity)
+stopifnot(inherits(root_error, "aww_error"), grepl("symlink", root_error$message))
+unlink(root_link)
+
+unreadable <- file.path(root, "unreadable")
+dir.create(unreadable)
+Sys.chmod(unreadable, "0000")
+if (file.access(unreadable, 4L) != 0L) {
+    traversal_error <- tryCatch(aww_inventory(root), error = identity)
+    stopifnot(inherits(traversal_error, "aww_error"))
+}
+Sys.chmod(unreadable, "0700")
+unlink(unreadable, recursive = TRUE)
+
+selection_options <- list(ids = "Dunknown", max_files = Inf)
+selection_error <- tryCatch(aww_select_inventory(inventory, selection_options), error = identity)
+stopifnot(inherits(selection_error, "aww_error"), grepl("unknown --id", selection_error$message))
+
+left <- data.frame(x = c(1, haven::tagged_na("a"), 3), check.names = FALSE)
+right <- left
+attr(left$x, "label") <- "value"
+attr(right$x, "label") <- "value"
+stopifnot(nrow(aww_compare_metadata(left[0, , drop = FALSE], right[0, , drop = FALSE])) == 0L)
+stopifnot(nrow(aww_compare_values(left, right, 0L, 0, storage = "long")) == 0L)
+right$x[[2L]] <- haven::tagged_na("b")
+disputes <- aww_compare_values(left, right, 0L, 0, storage = "long")
+stopifnot(nrow(disputes) == 1L)
+stopifnot(disputes$category[[1L]] == "missing", disputes$row[[1L]] == 2)
+right <- left
+right$x[[3L]] <- 3 + 5e-8
+stopifnot(nrow(aww_compare_values(left, right, 0L, 0, storage = "long")) == 1L)
+stopifnot(nrow(aww_compare_values(left, right, 0L, 0, storage = "float")) == 0L)
+right$x[[3L]] <- 3 + 2e-7
+stopifnot(nrow(aww_compare_values(left, right, 0L, 0, storage = "float")) == 1L)
+
+kind_vectors <- list(
+    c(0, -0, 1, NA_real_, NaN, Inf, -Inf, haven::tagged_na("a")),
+    c(1L, NA_integer_),
+    c("", "value", NA_character_),
+    as.Date(c("1960-01-01", NA_character_))
+)
+for (values in kind_vectors) {
+    scalar_kinds <- vapply(seq_along(values), function(index) {
+        aww_cell_kind(values[index])
+    }, character(1))
+    stopifnot(identical(aww_cell_kinds(values), scalar_kinds))
+}
+
+for (count in c(0L, 1L, 2L, 73L, 1000L)) {
+    counted <- aww_count_columns(function(index) index <= count)
+    stopifnot(is.null(counted$error), identical(counted$count, count))
+}
+probe_error <- simpleError("reader failed")
+counted_error <- aww_count_columns(function(index) probe_error)
+stopifnot(identical(counted_error$error, probe_error), is.na(counted_error$count))
+
+parent_tile <- list(skip = 0, n_max = 100L, column_start = 1L, column_count = 2L)
+column_leaves <- list(
+    list(tile = list(skip = 0, n_max = 100L, column_start = 1L, column_count = 1L),
+         reader_rows = c(dtaparser = 75, haven = 75)),
+    list(tile = list(skip = 0, n_max = 100L, column_start = 2L, column_count = 1L),
+         reader_rows = c(dtaparser = 75, haven = 75))
+)
+column_coverage <- aww_leaf_reader_rows(column_leaves, parent_tile, "dtaparser")
+stopifnot(column_coverage$rows == 75, column_coverage$consistent)
+row_leaves <- list(
+    list(tile = list(skip = 0, n_max = 50L, column_start = 1L, column_count = 2L),
+         reader_rows = c(dtaparser = 50, haven = 50)),
+    list(tile = list(skip = 50, n_max = 50L, column_start = 1L, column_count = 2L),
+         reader_rows = c(dtaparser = 25, haven = 25))
+)
+row_coverage <- aww_leaf_reader_rows(row_leaves, parent_tile, "dtaparser")
+stopifnot(row_coverage$rows == 75, row_coverage$consistent)
+early_eof_leaves <- row_leaves
+early_eof_leaves[[1L]]$reader_rows[] <- 25
+early_eof_leaves[[2L]]$reader_rows[] <- 0
+early_eof <- aww_leaf_reader_rows(early_eof_leaves, parent_tile, "dtaparser")
+stopifnot(early_eof$rows == 25, early_eof$consistent)
+inconsistent_leaves <- column_leaves
+inconsistent_leaves[[2L]]$reader_rows[["dtaparser"]] <- 70
+inconsistent <- aww_leaf_reader_rows(inconsistent_leaves, parent_tile, "dtaparser")
+stopifnot(inconsistent$rows == 75, !inconsistent$consistent)
+
+terminated <- c(dtaparser = NA_real_, haven = NA_real_)
+first_end <- aww_update_terminations(
+    terminated, c(dtaparser = 0, haven = 25), requested = 25L, skip = 100
+)
+stopifnot(identical(first_end$counts, c(dtaparser = 100, haven = NA_real_)))
+second_end <- aww_update_terminations(
+    first_end$counts, c(dtaparser = 0, haven = 10), requested = 25L, skip = 125
+)
+stopifnot(identical(second_end$counts, c(dtaparser = 100, haven = 135)))
+stopifnot(identical(second_end$newly_terminated, c(dtaparser = FALSE, haven = TRUE)))
+stopifnot(identical(
+    aww_beyond_row_ceiling(first_end$counts, skip = 125, ceiling = 100),
+    "haven"
+))
+stopifnot(length(aww_beyond_row_ceiling(
+    first_end$counts, skip = 75, ceiling = 100
+)) == 0L)
+stopifnot(!identical(
+    aww_tile_id("value", 1L, 0, 10L, 1L, 1L),
+    aww_tile_id("value", 1L, 0, 10L, 2L, 1L)
+))
+
+labels <- c(Domestic = 0, Foreign = 1)
+canonical <- aww_canonical_labels(labels)
+stopifnot(length(canonical) == 2L, canonical[[2L]]$text == "Foreign")
+
+metadata_disputes <- do.call(rbind, replicate(
+    2001L, aww_dispute("metadata", "label", column = 1L, attribute = "label"),
+    simplify = FALSE
+))
+cell_disputes <- do.call(rbind, lapply(c(1:80, 1001:1080), function(row) {
+    aww_dispute("cell", "value", column = 1L, row = row,
+                dtaparser = list(kind = "value", value = row),
+                haven = list(kind = "value", value = row + 1))
+}))
+batch_disputes <- aww_bind_disputes(list(metadata_disputes, cell_disputes))
+batches <- aww_stata_batches(batch_disputes, maximum_requests = 1000L, maximum_rows = 25L)
+stopifnot(all(lengths(batches) <= 1000L))
+stopifnot(identical(sort(unlist(batches)), seq_len(nrow(batch_disputes))))
+for (indices in batches) {
+    rows <- batch_disputes$row[indices][batch_disputes$kind[indices] == "cell"]
+    if (length(rows)) stopifnot(max(rows) - min(rows) < 25L)
+}
+
+dimension_dispute <- aww_dispute(
+    "metadata", "dimension", row = 91, skip = 90, n_max = 25L,
+    attribute = "tile-nrow", dtaparser = 10, haven = 9
+)
+stopifnot(aww_matches_stata(10, 100, dimension_dispute,
+                            list(formats = character(), storage = character())))
+stopifnot(!aww_matches_stata(9, 100, dimension_dispute,
+                             list(formats = character(), storage = character())))
+
+changed_item <- list(path = fixture, sha256 = paste(rep("0", 64L), collapse = ""))
+changed <- aww_adjudicate(
+    aww_dispute("metadata", "dimension", attribute = "ncol", dtaparser = 1, haven = 2),
+    list(columns = 1L, formats = "", storage = "long"), changed_item,
+    list(stata = "", timeout = 1L, stata_requests = 10L, stata_row_window = 10L),
+    tempfile("aww-changed-"), dir
+)
+stopifnot(identical(changed$state, "input-changed"))
+
+fake_dir <- tempfile("aww-fake-stata-")
+dir.create(fake_dir)
+fake_stata <- file.path(fake_dir, "stata")
+writeLines(c("#!/bin/sh", "printf '17.0\\n' > stata-version.txt", "exit 0"), fake_stata)
+Sys.chmod(fake_stata, "0700")
+fake_run <- file.path(fake_dir, "run")
+dir.create(fake_run)
+fake_info <- aww_stata_info(
+    list(stata = fake_stata, timeout = 10L), fake_run, dir
+)
+stopifnot(identical(fake_info$state, "stata-unsupported-version"))
+
+stata_setting <- Sys.getenv("DTAPARSER_TEST_STATA", unset = "")
+stata <- if (nzchar(stata_setting)) aww_resolve_stata(stata_setting) else NA_character_
+if (!is.na(stata)) {
+    work <- tempfile("aww-stata-")
+    dir.create(work)
+    make <- file.path(work, "make.do")
+    writeLines(c(
+        "version 18", "set more off", "sysuse auto, clear", "note: hello",
+        "save source.dta, replace", "exit, clear"
+    ), make)
+    processx::run(stata, c("-q", "-b", "do", "make.do"), wd = work,
+                  timeout = 120000, error_on_status = TRUE)
+    source_path <- file.path(work, "source.dta")
+    disputes <- aww_bind_disputes(list(
+        aww_dispute(
+            "cell", "value", column = 2L, row = 1,
+            dtaparser = list(kind = "value", value = 4099),
+            haven = list(kind = "value", value = 4000)
+        ),
+        aww_dispute(
+            "metadata", "label", column = 12L, attribute = "labels:2",
+            dtaparser = list(code = "1", text = "Foreign"),
+            haven = list(code = "1", text = "Wrong")
+        ),
+        aww_dispute(
+            "metadata", "label", attribute = "notes:2",
+            dtaparser = "hello", haven = "wrong"
+        )
+    ))
+    stata_options <- list(
+        stata = stata, timeout = 120L, stata_requests = 1000L,
+        stata_row_window = 25000L
+    )
+    stata_metadata <- list(
+        columns = 12L, formats = rep("%8.0g", 12L), storage = rep("int", 12L)
+    )
+    stata_item <- list(
+        id = "Dtest", path = source_path, sha256 = aww_file_sha256(source_path)
+    )
+    stata_info <- aww_stata_info(stata_options, work, dir)
+    row_probe <- aww_stata_row_count(
+        stata_item, stata_metadata, stata_options, work, dir, stata_info, 1L
+    )
+    stopifnot(identical(row_probe$state, "complete"), row_probe$rows == 74)
+    result <- aww_adjudicate(
+        disputes, stata_metadata, stata_item, stata_options, work, dir, stata_info
+    )
+    stopifnot(identical(result$state, "complete"))
+    stopifnot(identical(result$ownership, rep("haven-wrong", 3L)))
+}
+
+unlink(root, recursive = TRUE)
+unlink(fake_dir, recursive = TRUE)
+cat("aww-cache-differential framework tests: PASS\n")

--- a/benchmarks/aww-cache-differential/triage.R
+++ b/benchmarks/aww-cache-differential/triage.R
@@ -1,0 +1,136 @@
+#!/usr/bin/env Rscript
+
+Sys.umask("0077")
+
+arguments <- commandArgs(TRUE)
+run_argument <- grep("^--run=", arguments, value = TRUE)
+if (length(run_argument) != 1L || length(arguments) != 1L) {
+    stop("usage: triage.R --run=/absolute/or/relative/run-directory", call. = FALSE)
+}
+run_dir <- normalizePath(sub("^--run=", "", run_argument), winslash = "/", mustWork = TRUE)
+script_argument <- grep("^--file=", commandArgs(FALSE), value = TRUE)
+script_dir <- dirname(normalizePath(sub("^--file=", "", script_argument[[1L]]),
+                                    winslash = "/", mustWork = TRUE))
+
+old_source_only <- Sys.getenv("AWW_SOURCE_ONLY", unset = NA_character_)
+Sys.setenv(AWW_SOURCE_ONLY = "1")
+source(file.path(script_dir, "run.R"), local = globalenv())
+if (is.na(old_source_only)) Sys.unsetenv("AWW_SOURCE_ONLY") else
+    Sys.setenv(AWW_SOURCE_ONLY = old_source_only)
+
+inventory <- readRDS(file.path(run_dir, "inventory.rds"))
+summary <- read.delim(file.path(run_dir, "results.tsv"), check.names = FALSE)
+config_path <- file.path(run_dir, "config.rds")
+options <- if (file.exists(config_path)) {
+    readRDS(config_path)$options
+} else {
+    aww_parse_arguments(character())
+}
+options$retry <- FALSE
+config_id <- basename(run_dir)
+
+# Old runs did not persist final per-file results. Seed Stata's version cache
+# from their immutable adjudication checkpoint so reconstruction does not run
+# a new version probe.
+stata_files <- list.files(file.path(run_dir, "checkpoints"),
+                          pattern = "^stata-.*[.]rds$", recursive = TRUE,
+                          full.names = TRUE)
+if (length(stata_files)) {
+    sample <- readRDS(stata_files[[1L]])
+    stata <- aww_resolve_stata(options$stata)
+    if (!is.na(stata)) {
+        info <- file.info(stata, extra_cols = FALSE)
+        executable_id <- aww_sha256_raw(paste(
+            stata, info$size, as.numeric(info$mtime), sep = "\037"
+        ))
+        version <- sub("^[^:]+:([^:]+):.*$", "\\1", sample$stata_id)
+        assign(executable_id, list(
+            state = "available", path = stata, version = version,
+            id = sample$stata_id
+        ), envir = .aww_stata_cache)
+    }
+}
+
+read_final <- function(item) {
+    path <- file.path(run_dir, "checkpoints", item$id, "file-result.rds")
+    saved <- aww_read_result(path)
+    if (!is.null(saved) && identical(saved$config_id, config_id) &&
+        identical(saved$file_sha256, item$sha256)) return(saved$result)
+    aww_file(item, options, "", "", run_dir, config_id)
+}
+
+response_map <- function(item, result) {
+    mapped <- vector("list", nrow(result$disputes))
+    if (!nrow(result$disputes)) return(mapped)
+    path <- file.path(
+        run_dir, "checkpoints", item$id,
+        paste0("stata-", aww_dispute_id(item$sha256, result$disputes), ".rds")
+    )
+    saved <- aww_read_result(path)
+    if (is.null(saved) || is.null(saved$result$responses)) return(mapped)
+    batches <- aww_stata_batches(
+        result$disputes, options$stata_requests, options$stata_row_window
+    )
+    for (batch_index in seq_along(batches)) {
+        response <- saved$result$responses[[batch_index]]
+        indices <- batches[[batch_index]]
+        for (local_index in seq_along(indices)) {
+            mapped[[indices[[local_index]]]] <- response[
+                response$id == local_index, , drop = FALSE
+            ]
+        }
+    }
+    mapped
+}
+
+object_hex <- function(value) {
+    paste(format(serialize(value, NULL, version = 3L)), collapse = "")
+}
+object_text <- function(value) {
+    paste(capture.output(dput(value, control = c("keepNA", "keepInteger"))),
+          collapse = " ")
+}
+
+selected <- summary[summary$disputes > 0L, , drop = FALSE]
+parts <- vector("list", nrow(selected))
+for (file_index in seq_len(nrow(selected))) {
+    item <- as.list(inventory[inventory$id == selected$id[[file_index]], , drop = FALSE])
+    result <- read_final(item)
+    if (!nrow(result$disputes)) next
+    responses <- response_map(item, result)
+    disputes <- result$disputes
+    disputes$file_id <- item$id
+    disputes$relative_path <- item$relative_path
+    disputes$release <- item$release
+    disputes$dispute_index <- seq_len(nrow(disputes))
+    disputes$owner <- result$ownership
+    disputes$stata <- I(responses)
+    parts[[file_index]] <- disputes[, c(
+        "file_id", "relative_path", "release", "dispute_index", "kind",
+        "category", "reader", "column", "row", "skip", "n_max",
+        "attribute", "dtaparser", "haven", "stata", "owner"
+    )]
+}
+parts <- parts[vapply(parts, Negate(is.null), logical(1))]
+triage <- if (length(parts)) do.call(rbind, parts) else data.frame()
+rownames(triage) <- NULL
+triage_rds <- file.path(run_dir, "triage.rds")
+aww_atomic_save_rds(triage, triage_rds)
+Sys.chmod(triage_rds, "0600")
+
+view <- triage
+if (nrow(view)) {
+    view$dtaparser_text <- vapply(view$dtaparser, object_text, character(1))
+    view$haven_text <- vapply(view$haven, object_text, character(1))
+    view$stata_text <- vapply(view$stata, object_text, character(1))
+    view$dtaparser_rds_hex <- vapply(view$dtaparser, object_hex, character(1))
+    view$haven_rds_hex <- vapply(view$haven, object_hex, character(1))
+    view$stata_rds_hex <- vapply(view$stata, object_hex, character(1))
+    view$dtaparser <- view$haven <- view$stata <- NULL
+}
+triage_tsv <- file.path(run_dir, "triage.tsv")
+write.table(view, triage_tsv, sep = "\t", quote = TRUE,
+            row.names = FALSE, na = "")
+Sys.chmod(triage_tsv, "0600")
+cat(sprintf("triage: %d disputes across %d files\n", nrow(triage),
+            length(unique(triage$file_id))))

--- a/benchmarks/aww-cache-differential/triage.R
+++ b/benchmarks/aww-cache-differential/triage.R
@@ -73,6 +73,7 @@ response_map <- function(item, result) {
     )
     for (batch_index in seq_along(batches)) {
         response <- saved$result$responses[[batch_index]]
+        if (is.null(response) || !nrow(response)) next
         indices <- batches[[batch_index]]
         for (local_index in seq_along(indices)) {
             mapped[[indices[[local_index]]]] <- response[

--- a/benchmarks/aww-cache-differential/version-probe.do
+++ b/benchmarks/aww-cache-differential/version-probe.do
@@ -1,0 +1,6 @@
+set more off
+local stata_version = c(stata_version)
+file open out using "stata-version.txt", write replace
+file write out "`stata_version'" _n
+file close out
+exit, clear

--- a/benchmarks/aww-cache-differential/worker.R
+++ b/benchmarks/aww-cache-differential/worker.R
@@ -1,0 +1,248 @@
+aww_memory_error <- function(error) {
+    grepl("vector memory exhausted|cannot allocate|memory limit|out of memory|std::bad_alloc",
+          conditionMessage(error), ignore.case = TRUE)
+}
+
+aww_selection_miss <- function(error) {
+    grepl(
+        "past the end|does not exist|doesn't exist|can't find any columns|must be between",
+        conditionMessage(error), ignore.case = TRUE
+    )
+}
+
+aww_count_columns <- function(probe) {
+    first <- probe(1L)
+    if (inherits(first, "error")) return(list(count = NA_integer_, error = first))
+    if (!first) return(list(count = 0L, error = NULL))
+    lower <- 1L
+    upper <- 2L
+    repeat {
+        exists <- probe(upper)
+        if (inherits(exists, "error")) return(list(count = NA_integer_, error = exists))
+        if (!exists) break
+        lower <- upper
+        if (upper > .Machine$integer.max %/% 2L) {
+            return(list(count = NA_integer_, error = simpleError("column count exceeds integer range")))
+        }
+        upper <- upper * 2L
+    }
+    while (upper - lower > 1L) {
+        middle <- lower + (upper - lower) %/% 2L
+        exists <- probe(middle)
+        if (inherits(exists, "error")) return(list(count = NA_integer_, error = exists))
+        if (exists) lower <- middle else upper <- middle
+    }
+    list(count = lower, error = NULL)
+}
+
+aww_reader_column_count <- function(reader, path) {
+    function_name <- if (identical(reader, "dtaparser")) {
+        dtaparser::read_dta
+    } else haven::read_dta
+    probe <- function(index) tryCatch({
+        function_name(
+            path, col_select = tidyselect::all_of(as.integer(index)), n_max = 0L,
+            .name_repair = "minimal"
+        )
+        TRUE
+    }, error = function(error) {
+        if (aww_selection_miss(error)) FALSE else error
+    })
+    aww_count_columns(probe)
+}
+
+aww_read_tile <- function(reader, path, tile) {
+    function_name <- if (identical(reader, "dtaparser")) dtaparser::read_dta else haven::read_dta
+    indices <- seq.int(tile$column_start, length.out = tile$column_count)
+    if (!length(indices)) {
+        return(function_name(
+            path, col_select = character(), skip = tile$skip, n_max = tile$n_max,
+            .name_repair = "minimal"
+        ))
+    }
+    function_name(
+        path,
+        col_select = tidyselect::all_of(indices),
+        skip = tile$skip,
+        n_max = tile$n_max,
+        .name_repair = "minimal"
+    )
+}
+
+aww_worker <- function(path, tile, common_script, compare_script, package_library,
+                       expected_package_path) {
+    source(common_script, local = environment())
+    source(compare_script, local = environment())
+    .libPaths(c(package_library, .libPaths()))
+    if (!requireNamespace("dtaparser", quietly = TRUE) ||
+        !requireNamespace("haven", quietly = TRUE) ||
+        !requireNamespace("tidyselect", quietly = TRUE)) stop("reader dependency unavailable")
+    loaded <- normalizePath(getNamespaceInfo(asNamespace("dtaparser"), "path"),
+                            winslash = "/", mustWork = TRUE)
+    if (!identical(loaded, expected_package_path)) stop("foreign dtaparser installation")
+    started <- proc.time()[["elapsed"]]
+    if (identical(tile$kind, "shape")) {
+        counts <- lapply(c("dtaparser", "haven"), function(reader) {
+            aww_reader_column_count(reader, path)
+        })
+        names(counts) <- c("dtaparser", "haven")
+        count_errors <- vapply(counts, function(value) !is.null(value$error), logical(1))
+        row_shape <- tryCatch(
+            dtaparser::read_dta(
+                path, col_select = character(), .name_repair = "minimal"
+            ),
+            error = identity
+        )
+        errors <- c(
+            lapply(counts[count_errors], function(value) conditionMessage(value$error)),
+            if (inherits(row_shape, "error")) list(dtaparser_rows = conditionMessage(row_shape))
+        )
+        if (length(errors)) {
+            return(list(
+                schema_version = aww_schema_version, tile = tile,
+                elapsed_seconds = unname(proc.time()[["elapsed"]] - started),
+                reader_errors = errors, reader_rows = c(dtaparser = NA_integer_, haven = NA_integer_),
+                classification = if (any(vapply(
+                    c(lapply(counts[count_errors], `[[`, "error"),
+                      if (inherits(row_shape, "error")) list(row_shape) else list()),
+                    aww_memory_error, logical(1)
+                ))) "memory-limit" else if (all(count_errors)) "shared-reader-error" else
+                    if (count_errors[["haven"]]) "haven-error" else "dtaparser-error",
+                disputes = aww_empty_disputes()
+            ))
+        }
+        disputes <- if (!identical(counts$dtaparser$count, counts$haven$count)) {
+            aww_dispute(
+                "metadata", "dimension", attribute = "ncol",
+                dtaparser = counts$dtaparser$count, haven = counts$haven$count
+            )
+        } else aww_empty_disputes()
+        if (max(counts$dtaparser$count, counts$haven$count) == 0L) {
+            haven_shape <- tryCatch(
+                haven::read_dta(path, n_max = 0L, .name_repair = "minimal"),
+                error = identity
+            )
+            if (inherits(haven_shape, "error")) {
+                return(list(
+                    schema_version = aww_schema_version, tile = tile,
+                    elapsed_seconds = unname(proc.time()[["elapsed"]] - started),
+                    reader_errors = list(haven = conditionMessage(haven_shape)),
+                    reader_rows = c(dtaparser = nrow(row_shape), haven = NA_integer_),
+                    classification = if (aww_memory_error(haven_shape)) "memory-limit" else "haven-error",
+                    disputes = disputes
+                ))
+            }
+            disputes <- aww_bind_disputes(list(
+                disputes,
+                aww_compare_attributes(row_shape, haven_shape, frame = TRUE)
+            ))
+        }
+        metadata <- list(
+            names = rep(NA_character_, max(counts$dtaparser$count, counts$haven$count)),
+            formats = rep("", max(counts$dtaparser$count, counts$haven$count)),
+            storage = rep(NA_character_, max(counts$dtaparser$count, counts$haven$count)),
+            rows = as.double(nrow(row_shape)),
+            dtaparser_columns = counts$dtaparser$count,
+            haven_columns = counts$haven$count,
+            columns = max(counts$dtaparser$count, counts$haven$count)
+        )
+        return(list(
+            schema_version = aww_schema_version, tile = tile,
+            elapsed_seconds = unname(proc.time()[["elapsed"]] - started),
+            reader_errors = list(), reader_rows = c(
+                dtaparser = nrow(row_shape), haven = NA_integer_
+            ),
+            classification = if (nrow(disputes)) "dispute" else "pass",
+            disputes = disputes, metadata = metadata
+        ))
+    }
+    values <- lapply(c("dtaparser", "haven"), function(reader) {
+        tryCatch(aww_read_tile(reader, path, tile), error = identity)
+    })
+    names(values) <- c("dtaparser", "haven")
+    errors <- vapply(values, inherits, logical(1), what = "error")
+    memory <- vapply(values, function(value) inherits(value, "error") && aww_memory_error(value), logical(1))
+    base <- list(
+        schema_version = aww_schema_version,
+        tile = tile,
+        elapsed_seconds = unname(proc.time()[["elapsed"]] - started),
+        reader_errors = lapply(values[errors], conditionMessage),
+        reader_rows = setNames(vapply(values, function(value) if (inherits(value, "error")) NA_integer_ else nrow(value), integer(1)), names(values))
+    )
+    if (any(errors)) {
+        classification <- if (any(memory)) "memory-limit" else
+            if (all(errors)) "shared-reader-error" else
+            if (errors[["dtaparser"]]) "dtaparser-error" else "haven-error"
+        return(c(base, list(classification = classification, disputes = aww_empty_disputes())))
+    }
+    if (identical(tile$kind, "metadata")) {
+        source_metadata <- tryCatch(
+            dtaparser:::.dta_metadata(
+                path, column_start = tile$column_start,
+                column_count = tile$column_count
+            ),
+            error = identity
+        )
+        if (inherits(source_metadata, "error")) {
+            base$reader_errors$metadata <- conditionMessage(source_metadata)
+            return(c(base, list(
+                classification = if (aww_memory_error(source_metadata)) {
+                    "memory-limit"
+                } else "dtaparser-error",
+                disputes = aww_empty_disputes()
+            )))
+        }
+        source_storage <- attr(source_metadata, "dta_storage", exact = TRUE)
+        aligned <- length(source_metadata) == tile$column_count &&
+            length(source_storage) == tile$column_count &&
+            identical(as.character(source_metadata), names(values$dtaparser))
+        if (!aligned) {
+            base$reader_errors$metadata <- "projected metadata is not aligned with the public reader"
+            return(c(base, list(
+                classification = "dtaparser-error",
+                disputes = aww_dispute(
+                    "metadata", "attribute", reader = "dtaparser",
+                    attribute = "metadata-projection"
+                )
+            )))
+        }
+        disputes <- aww_compare_metadata(
+            values$dtaparser, values$haven,
+            column_offset = tile$column_start - 1L,
+            compare_frame = tile$column_start == 1L, compare_dimensions = FALSE
+        )
+        metadata <- list(
+            names = as.character(source_metadata), storage = source_storage,
+            formats = vapply(values$dtaparser, function(column) {
+                value <- attr(column, "format.stata", exact = TRUE)
+                if (is.null(value)) "" else as.character(value)
+            }, character(1))
+        )
+        return(c(base, list(
+            classification = if (nrow(disputes)) "dispute" else "pass",
+            disputes = disputes, metadata = metadata
+        )))
+    }
+    disputes <- tryCatch(
+        aww_compare_values(
+            values$dtaparser, values$haven,
+            column_offset = tile$column_start - 1L,
+            row_offset = tile$skip,
+            n_max = tile$n_max,
+            storage = tile$storage
+        ),
+        error = identity
+    )
+    if (inherits(disputes, "error")) {
+        classification <- if (aww_memory_error(disputes)) "memory-limit" else "comparison-error"
+        base$reader_errors$comparison <- conditionMessage(disputes)
+        return(c(base, list(
+            classification = classification,
+            disputes = aww_empty_disputes()
+        )))
+    }
+    c(base, list(
+        classification = if (nrow(disputes)) "dispute" else "pass",
+        disputes = disputes
+    ))
+}

--- a/r-package/dtaparser/R/read-dta.R
+++ b/r-package/dtaparser/R/read-dta.R
@@ -13,9 +13,10 @@
 #'   before calling `read_dta()`.
 #' @param encoding Optional source encoding override. Supported aliases are
 #'   `"UTF-8"`/`"UTF8"`, `"Windows-1252"`/`"CP1252"`, and
-#'   `"ISO-8859-1"`/`"latin1"`, matched case-insensitively. `NULL` uses
-#'   Windows-1252 for releases 105, 108, 110--111, 113--115, and 117 and UTF-8 for releases
-#'   118--119. Explicit UTF-8
+#'   `"ISO-8859-1"`/`"latin1"`, matched case-insensitively. `NULL` follows
+#'   Stata 18 and uses UTF-8 for every supported release. Pre-Unicode releases
+#'   do not record a code page, so their known legacy encoding can be supplied
+#'   explicitly. UTF-8
 #'   replaces malformed input sequences deterministically with U+FFFD. Haven
 #'   2.5.5 may instead omit an affected label.
 #' @param col_select One or more tidyselect expressions. Predicates see Stata

--- a/r-package/dtaparser/R/read-dta.R
+++ b/r-package/dtaparser/R/read-dta.R
@@ -13,12 +13,13 @@
 #'   before calling `read_dta()`.
 #' @param encoding Optional source encoding override. Supported aliases are
 #'   `"UTF-8"`/`"UTF8"`, `"Windows-1252"`/`"CP1252"`, and
-#'   `"ISO-8859-1"`/`"latin1"`, matched case-insensitively. `NULL` follows
-#'   Stata 18 and uses UTF-8 for every supported release. Pre-Unicode releases
-#'   do not record a code page, so their known legacy encoding can be supplied
-#'   explicitly. UTF-8
-#'   replaces malformed input sequences deterministically with U+FFFD. Haven
-#'   2.5.5 may instead omit an affected label.
+#'   `"ISO-8859-1"`/`"latin1"`, matched case-insensitively. `NULL` uses
+#'   Windows-1252 for pre-Unicode releases 105, 108, 110--111, 113--115, and
+#'   117, and UTF-8 for releases 118--119. Older DTA files do not record their
+#'   code page, so Windows-1252 is a pragmatic guess that commonly recovers the
+#'   intended text. Use `encoding = "UTF-8"` for strict Stata 18 behavior;
+#'   malformed input sequences are then replaced deterministically with
+#'   U+FFFD. Haven 2.5.5 may instead omit an affected label.
 #' @param col_select One or more tidyselect expressions. Predicates see Stata
 #'   string storage as character and numeric storage as double. If a source
 #'   variable is selected more than once, its first selection and alias win.

--- a/r-package/dtaparser/R/read-dta.R
+++ b/r-package/dtaparser/R/read-dta.R
@@ -168,8 +168,22 @@ read_dta <- function(file, encoding = NULL, col_select = NULL, skip = 0,
     invisible(NULL)
 }
 
-.dta_metadata <- function(file, encoding = NULL) {
-    .Call(C_dtaparser_metadata, file, encoding)
+.dta_metadata <- function(file, encoding = NULL, column_start = 1L,
+                          column_count = Inf) {
+    validate <- function(value, name, unlimited = FALSE) {
+        if (!is.numeric(value) || length(value) != 1L || is.na(value) ||
+            is.nan(value) || value < 0 || value != floor(value) ||
+            (!is.finite(value) && !unlimited) ||
+            (is.finite(value) && value > .Machine$integer.max)) {
+            stop(sprintf("`%s` must be one non-negative whole number%s", name,
+                         if (unlimited) " or Inf" else ""), call. = FALSE)
+        }
+        if (is.infinite(value)) .Machine$integer.max else as.integer(value)
+    }
+    start <- validate(column_start, "column_start")
+    if (start < 1L) stop("`column_start` must be at least 1", call. = FALSE)
+    count <- validate(column_count, "column_count", unlimited = TRUE)
+    .Call(C_dtaparser_metadata, file, encoding, start - 1L, count)
 }
 
 .validate_dta_encoding <- function(encoding) {

--- a/r-package/dtaparser/README.md
+++ b/r-package/dtaparser/README.md
@@ -45,9 +45,12 @@ custom daily-date formats beginning `%d` are converted to `Date`; `%tc` and
 `%tC` are converted to UTC `POSIXct`. Other Stata calendar formats remain
 numeric and retain their `format.stata` attribute.
 
-`encoding = NULL` follows Stata 18 and decodes text as UTF-8 in every supported
-release. Pre-Unicode DTA releases do not record a code page. To read one with a
-known legacy encoding, pass a case-insensitive UTF-8/UTF8,
+`encoding = NULL` uses Windows-1252 for pre-Unicode releases 105, 108,
+110--111, 113--115, and 117, and UTF-8 for releases 118--119. Pre-Unicode DTA
+files do not record a code page, so Windows-1252 is a pragmatic guess that
+commonly recovers the intended text rather than a fact encoded in the file.
+Use `encoding = "UTF-8"` for strict Stata 18 behavior. A known source encoding
+can instead be selected with a case-insensitive UTF-8/UTF8,
 Windows-1252/CP1252, or ISO-8859-1/latin1 alias. The override is deterministic
 across platforms and applies to dataset and variable metadata, fixed strings,
 `strL` payloads, and value-label names and text. ISO-8859-1 remains distinct

--- a/r-package/dtaparser/README.md
+++ b/r-package/dtaparser/README.md
@@ -45,9 +45,9 @@ custom daily-date formats beginning `%d` are converted to `Date`; `%tc` and
 `%tC` are converted to UTC `POSIXct`. Other Stata calendar formats remain
 numeric and retain their `format.stata` attribute.
 
-`encoding = NULL` follows the DTA release convention: Windows-1252 for
-releases 105, 108, 110--111, 113--115, and 117 and UTF-8 for releases 118--119. To recover files whose
-source encoding is recorded incorrectly, pass a case-insensitive UTF-8/UTF8,
+`encoding = NULL` follows Stata 18 and decodes text as UTF-8 in every supported
+release. Pre-Unicode DTA releases do not record a code page. To read one with a
+known legacy encoding, pass a case-insensitive UTF-8/UTF8,
 Windows-1252/CP1252, or ISO-8859-1/latin1 alias. The override is deterministic
 across platforms and applies to dataset and variable metadata, fixed strings,
 `strL` payloads, and value-label names and text. ISO-8859-1 remains distinct

--- a/r-package/dtaparser/src/dta-parser/src/text.rs
+++ b/r-package/dtaparser/src/dta-parser/src/text.rs
@@ -4,9 +4,10 @@ use crate::{DtaError, FormatVersion};
 
 /// Source encoding used for textual fields in a Stata file.
 ///
-/// [`TextEncoding::Auto`] follows Stata 18 and decodes every supported release
-/// as UTF-8. Pre-Unicode DTA releases do not record a code page; callers that
-/// know the legacy encoding can override it explicitly.
+/// [`TextEncoding::Auto`] uses Windows-1252 for pre-Unicode releases and UTF-8
+/// for releases 118--119. Pre-Unicode DTA releases do not record a code page,
+/// so callers can override this pragmatic default when the source encoding is
+/// known or strict compatibility with current Stata is required.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
 pub enum TextEncoding {
     #[default]
@@ -36,9 +37,10 @@ impl TextEncoding {
         }
     }
 
-    pub(crate) fn resolve(self, _version: FormatVersion) -> Self {
+    pub(crate) fn resolve(self, version: FormatVersion) -> Self {
         match self {
-            Self::Auto => Self::Utf8,
+            Self::Auto if version.uses_utf8_text() => Self::Utf8,
+            Self::Auto => Self::Windows1252,
             explicit => explicit,
         }
     }

--- a/r-package/dtaparser/src/dta-parser/src/text.rs
+++ b/r-package/dtaparser/src/dta-parser/src/text.rs
@@ -4,9 +4,9 @@ use crate::{DtaError, FormatVersion};
 
 /// Source encoding used for textual fields in a Stata file.
 ///
-/// [`TextEncoding::Auto`] follows the DTA release: UTF-8 for releases 118--119
-/// and Windows-1252 for releases 105, 108, 110--111, 113--115, and 117. Explicit modes override
-/// that convention for every textual field decoded by the parser.
+/// [`TextEncoding::Auto`] follows Stata 18 and decodes every supported release
+/// as UTF-8. Pre-Unicode DTA releases do not record a code page; callers that
+/// know the legacy encoding can override it explicitly.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
 pub enum TextEncoding {
     #[default]
@@ -36,10 +36,9 @@ impl TextEncoding {
         }
     }
 
-    pub(crate) fn resolve(self, version: FormatVersion) -> Self {
+    pub(crate) fn resolve(self, _version: FormatVersion) -> Self {
         match self {
-            Self::Auto if version.uses_utf8_text() => Self::Utf8,
-            Self::Auto => Self::Windows1252,
+            Self::Auto => Self::Utf8,
             explicit => explicit,
         }
     }

--- a/r-package/dtaparser/src/dta-parser/src/types.rs
+++ b/r-package/dtaparser/src/dta-parser/src/types.rs
@@ -27,9 +27,6 @@ impl FormatVersion {
         matches!(self, Self::V117 | Self::V118 | Self::V119)
     }
 
-    pub(crate) const fn uses_utf8_text(self) -> bool {
-        matches!(self, Self::V118 | Self::V119)
-    }
 }
 
 impl fmt::Display for FormatVersion {

--- a/r-package/dtaparser/src/dta-parser/src/types.rs
+++ b/r-package/dtaparser/src/dta-parser/src/types.rs
@@ -27,6 +27,9 @@ impl FormatVersion {
         matches!(self, Self::V117 | Self::V118 | Self::V119)
     }
 
+    pub(crate) const fn uses_utf8_text(self) -> bool {
+        matches!(self, Self::V118 | Self::V119)
+    }
 }
 
 impl fmt::Display for FormatVersion {

--- a/r-package/dtaparser/src/dta-parser/tests/encoding.rs
+++ b/r-package/dtaparser/src/dta-parser/tests/encoding.rs
@@ -19,7 +19,7 @@ fn replace_first(bytes: &mut [u8], needle: &[u8], replacement: u8) {
 }
 
 #[test]
-fn auto_matches_stata_18_utf8_decoding_for_pre_unicode_release_117() {
+fn auto_uses_windows_1252_for_pre_unicode_release_117() {
     let mut bytes = fixture("auto_v117.dta");
     replace_first(&mut bytes, b"1978 automobile data", 0x80);
     replace_first(&mut bytes, b"Make and model", 0x80);
@@ -27,18 +27,26 @@ fn auto_matches_stata_18_utf8_decoding_for_pre_unicode_release_117() {
     replace_first(&mut bytes, b"Domestic", 0x80);
 
     let auto = dta_parser::read_dta(&bytes).unwrap();
-    assert!(auto.metadata.dataset_label.starts_with('\u{fffd}'));
-    assert!(auto.metadata.variables[0].label.starts_with('\u{fffd}'));
+    assert!(auto.metadata.dataset_label.starts_with('\u{20ac}'));
+    assert!(auto.metadata.variables[0].label.starts_with('\u{20ac}'));
     let ColumnValues::FixedString { values } = &auto.columns[0].values else {
         panic!("make must be a fixed string");
     };
-    assert!(values[0].starts_with('\u{fffd}'));
+    assert!(values[0].starts_with('\u{20ac}'));
     assert!(auto.value_label_table("origin").unwrap().entries[0]
         .label
-        .starts_with('\u{fffd}'));
+        .starts_with('\u{20ac}'));
 
-    let cp1252 = read_dta_with_encoding(&bytes, TextEncoding::Windows1252).unwrap();
-    assert!(cp1252.metadata.dataset_label.starts_with('\u{20ac}'));
+    let strict = read_dta_with_encoding(&bytes, TextEncoding::Utf8).unwrap();
+    assert!(strict.metadata.dataset_label.starts_with('\u{fffd}'));
+    assert!(strict.metadata.variables[0].label.starts_with('\u{fffd}'));
+    let ColumnValues::FixedString { values } = &strict.columns[0].values else {
+        panic!("make must be a fixed string");
+    };
+    assert!(values[0].starts_with('\u{fffd}'));
+    assert!(strict.value_label_table("origin").unwrap().entries[0]
+        .label
+        .starts_with('\u{fffd}'));
 }
 
 #[test]

--- a/r-package/dtaparser/src/dta-parser/tests/encoding.rs
+++ b/r-package/dtaparser/src/dta-parser/tests/encoding.rs
@@ -18,6 +18,20 @@ fn replace_first(bytes: &mut [u8], needle: &[u8], replacement: u8) {
     bytes[offset] = replacement;
 }
 
+fn replace_first_sequence(bytes: &mut [u8], needle: &[u8], replacement: &[u8]) {
+    assert_eq!(needle.len(), replacement.len());
+    let offset = bytes
+        .windows(needle.len())
+        .position(|window| window == needle)
+        .unwrap_or_else(|| {
+            panic!(
+                "fixture does not contain {:?}",
+                String::from_utf8_lossy(needle)
+            )
+        });
+    bytes[offset..offset + replacement.len()].copy_from_slice(replacement);
+}
+
 #[test]
 fn auto_uses_windows_1252_for_pre_unicode_release_117() {
     let mut bytes = fixture("auto_v117.dta");
@@ -47,6 +61,27 @@ fn auto_uses_windows_1252_for_pre_unicode_release_117() {
     assert!(strict.value_label_table("origin").unwrap().entries[0]
         .label
         .starts_with('\u{fffd}'));
+}
+
+#[test]
+fn auto_uses_utf8_for_unicode_release_118() {
+    let mut bytes = fixture("auto_v118.dta");
+    let euro = "\u{20ac}".as_bytes();
+    replace_first_sequence(&mut bytes, b"197", euro);
+    replace_first_sequence(&mut bytes, b"Mak", euro);
+    replace_first_sequence(&mut bytes, b"AMC", euro);
+    replace_first_sequence(&mut bytes, b"Dom", euro);
+
+    let auto = dta_parser::read_dta(&bytes).unwrap();
+    assert!(auto.metadata.dataset_label.starts_with('\u{20ac}'));
+    assert!(auto.metadata.variables[0].label.starts_with('\u{20ac}'));
+    let ColumnValues::FixedString { values } = &auto.columns[0].values else {
+        panic!("make must be a fixed string");
+    };
+    assert!(values[0].starts_with('\u{20ac}'));
+    assert!(auto.value_label_table("origin").unwrap().entries[0]
+        .label
+        .starts_with('\u{20ac}'));
 }
 
 #[test]

--- a/r-package/dtaparser/src/dta-parser/tests/encoding.rs
+++ b/r-package/dtaparser/src/dta-parser/tests/encoding.rs
@@ -19,7 +19,7 @@ fn replace_first(bytes: &mut [u8], needle: &[u8], replacement: u8) {
 }
 
 #[test]
-fn auto_uses_windows_1252_for_pre_unicode_release_117() {
+fn auto_matches_stata_18_utf8_decoding_for_pre_unicode_release_117() {
     let mut bytes = fixture("auto_v117.dta");
     replace_first(&mut bytes, b"1978 automobile data", 0x80);
     replace_first(&mut bytes, b"Make and model", 0x80);
@@ -27,18 +27,18 @@ fn auto_uses_windows_1252_for_pre_unicode_release_117() {
     replace_first(&mut bytes, b"Domestic", 0x80);
 
     let auto = dta_parser::read_dta(&bytes).unwrap();
-    assert!(auto.metadata.dataset_label.starts_with('\u{20ac}'));
-    assert!(auto.metadata.variables[0].label.starts_with('\u{20ac}'));
+    assert!(auto.metadata.dataset_label.starts_with('\u{fffd}'));
+    assert!(auto.metadata.variables[0].label.starts_with('\u{fffd}'));
     let ColumnValues::FixedString { values } = &auto.columns[0].values else {
         panic!("make must be a fixed string");
     };
-    assert!(values[0].starts_with('\u{20ac}'));
+    assert!(values[0].starts_with('\u{fffd}'));
     assert!(auto.value_label_table("origin").unwrap().entries[0]
         .label
-        .starts_with('\u{20ac}'));
+        .starts_with('\u{fffd}'));
 
-    let utf8 = read_dta_with_encoding(&bytes, TextEncoding::Utf8).unwrap();
-    assert!(utf8.metadata.dataset_label.starts_with('\u{fffd}'));
+    let cp1252 = read_dta_with_encoding(&bytes, TextEncoding::Windows1252).unwrap();
+    assert!(cp1252.metadata.dataset_label.starts_with('\u{20ac}'));
 }
 
 #[test]

--- a/r-package/dtaparser/src/dta-parser/tests/legacy.rs
+++ b/r-package/dtaparser/src/dta-parser/tests/legacy.rs
@@ -4,8 +4,9 @@ use std::fs;
 use support::fixture;
 
 use dta_parser::{
-    parse_metadata, read_dta, read_dta_with_encoding, ByteOrder, ColumnValues, DtaError, DtaFile,
-    FileOptions, FormatVersion, MissingTag, ReadOptions, TextEncoding,
+    parse_metadata, parse_metadata_with_encoding, read_dta, read_dta_with_encoding, ByteOrder,
+    ColumnValues, DtaError, DtaFile, FileOptions, FormatVersion, MissingTag, ReadOptions,
+    TextEncoding,
 };
 use std::io::Cursor;
 
@@ -229,7 +230,8 @@ fn generated_pre111_fixtures_decode_expected_semantics() {
         (110, FormatVersion::V110),
     ] {
         let bytes = synthetic_fixture(release);
-        let data = read_dta(&bytes).unwrap_or_else(|error| panic!("release {release}: {error}"));
+        let data = read_dta_with_encoding(&bytes, TextEncoding::Windows1252)
+            .unwrap_or_else(|error| panic!("release {release}: {error}"));
         assert_eq!(data.metadata.format_version, expected_version);
         assert_eq!(
             data.metadata.dataset_label,
@@ -500,7 +502,7 @@ fn decodes_checked_legacy_fixtures_and_value_labels() {
 #[test]
 fn decodes_release_111_metadata_observations_labels_and_missing_tags() {
     let bytes = v111_fixture();
-    let data = read_dta(&bytes).unwrap();
+    let data = read_dta_with_encoding(&bytes, TextEncoding::Windows1252).unwrap();
     assert_eq!(data.metadata.format_version, FormatVersion::V111);
     assert_eq!(data.metadata.byte_order, ByteOrder::Lsf);
     assert_eq!(data.metadata.dataset_label, "Stata/SE 7 Café fixture");
@@ -617,13 +619,13 @@ fn reads_every_checked_in_legacy_fixture_and_synthetic_v114() {
 #[test]
 fn decodes_true_big_endian_v113_and_windows_1252() {
     let bytes = synthetic_v113_msf();
-    let metadata = parse_metadata(&bytes).unwrap();
+    let metadata = parse_metadata_with_encoding(&bytes, TextEncoding::Windows1252).unwrap();
     assert_eq!(metadata.format_version, FormatVersion::V113);
     assert_eq!(metadata.byte_order, ByteOrder::Msf);
     assert_eq!(metadata.dataset_label, "Café");
     assert_eq!(metadata.notes, ["Café"]);
     assert_eq!(metadata.variables[0].label, "naïve");
-    let data = read_dta(&bytes).unwrap();
+    let data = read_dta_with_encoding(&bytes, TextEncoding::Windows1252).unwrap();
     match &data.columns[0].values {
         ColumnValues::Int { values, .. } => assert_eq!(values, &[321]),
         other => panic!("unexpected int storage: {other:?}"),
@@ -647,7 +649,7 @@ fn decodes_big_endian_release_111_observations_notes_and_labels() {
     let mut bytes = synthetic_legacy_msf(111);
     let data_offset = parse_metadata(&bytes).unwrap().section_offsets.data as usize;
     bytes[data_offset..data_offset + 2].copy_from_slice(&i16::MAX.to_be_bytes());
-    let data = read_dta(&bytes).unwrap();
+    let data = read_dta_with_encoding(&bytes, TextEncoding::Windows1252).unwrap();
     assert_eq!(data.metadata.format_version, FormatVersion::V111);
     assert_eq!(data.metadata.byte_order, ByteOrder::Msf);
     assert_eq!(data.metadata.notes, ["Café"]);

--- a/r-package/dtaparser/src/dta-parser/tests/legacy.rs
+++ b/r-package/dtaparser/src/dta-parser/tests/legacy.rs
@@ -4,9 +4,8 @@ use std::fs;
 use support::fixture;
 
 use dta_parser::{
-    parse_metadata, parse_metadata_with_encoding, read_dta, read_dta_with_encoding, ByteOrder,
-    ColumnValues, DtaError, DtaFile, FileOptions, FormatVersion, MissingTag, ReadOptions,
-    TextEncoding,
+    parse_metadata, read_dta, read_dta_with_encoding, ByteOrder, ColumnValues, DtaError, DtaFile,
+    FileOptions, FormatVersion, MissingTag, ReadOptions, TextEncoding,
 };
 use std::io::Cursor;
 
@@ -230,8 +229,7 @@ fn generated_pre111_fixtures_decode_expected_semantics() {
         (110, FormatVersion::V110),
     ] {
         let bytes = synthetic_fixture(release);
-        let data = read_dta_with_encoding(&bytes, TextEncoding::Windows1252)
-            .unwrap_or_else(|error| panic!("release {release}: {error}"));
+        let data = read_dta(&bytes).unwrap_or_else(|error| panic!("release {release}: {error}"));
         assert_eq!(data.metadata.format_version, expected_version);
         assert_eq!(
             data.metadata.dataset_label,
@@ -502,7 +500,7 @@ fn decodes_checked_legacy_fixtures_and_value_labels() {
 #[test]
 fn decodes_release_111_metadata_observations_labels_and_missing_tags() {
     let bytes = v111_fixture();
-    let data = read_dta_with_encoding(&bytes, TextEncoding::Windows1252).unwrap();
+    let data = read_dta(&bytes).unwrap();
     assert_eq!(data.metadata.format_version, FormatVersion::V111);
     assert_eq!(data.metadata.byte_order, ByteOrder::Lsf);
     assert_eq!(data.metadata.dataset_label, "Stata/SE 7 Café fixture");
@@ -619,13 +617,13 @@ fn reads_every_checked_in_legacy_fixture_and_synthetic_v114() {
 #[test]
 fn decodes_true_big_endian_v113_and_windows_1252() {
     let bytes = synthetic_v113_msf();
-    let metadata = parse_metadata_with_encoding(&bytes, TextEncoding::Windows1252).unwrap();
+    let metadata = parse_metadata(&bytes).unwrap();
     assert_eq!(metadata.format_version, FormatVersion::V113);
     assert_eq!(metadata.byte_order, ByteOrder::Msf);
     assert_eq!(metadata.dataset_label, "Café");
     assert_eq!(metadata.notes, ["Café"]);
     assert_eq!(metadata.variables[0].label, "naïve");
-    let data = read_dta_with_encoding(&bytes, TextEncoding::Windows1252).unwrap();
+    let data = read_dta(&bytes).unwrap();
     match &data.columns[0].values {
         ColumnValues::Int { values, .. } => assert_eq!(values, &[321]),
         other => panic!("unexpected int storage: {other:?}"),
@@ -649,7 +647,7 @@ fn decodes_big_endian_release_111_observations_notes_and_labels() {
     let mut bytes = synthetic_legacy_msf(111);
     let data_offset = parse_metadata(&bytes).unwrap().section_offsets.data as usize;
     bytes[data_offset..data_offset + 2].copy_from_slice(&i16::MAX.to_be_bytes());
-    let data = read_dta_with_encoding(&bytes, TextEncoding::Windows1252).unwrap();
+    let data = read_dta(&bytes).unwrap();
     assert_eq!(data.metadata.format_version, FormatVersion::V111);
     assert_eq!(data.metadata.byte_order, ByteOrder::Msf);
     assert_eq!(data.metadata.notes, ["Café"]);

--- a/r-package/dtaparser/src/init.c
+++ b/r-package/dtaparser/src/init.c
@@ -6,7 +6,9 @@
 #include <stdint.h>
 #include <string.h>
 
-extern SEXP dtaparser_metadata_rust(const char *, const char *, char **);
+extern SEXP dtaparser_metadata_rust(
+    const char *, uint32_t, uint32_t, const char *, char **
+);
 extern SEXP dtaparser_read_rust(
     const char *, const int *, size_t, int, double, double, int, const char *,
     char **
@@ -133,14 +135,23 @@ static const char *optional_encoding(SEXP encoding) {
     return Rf_translateCharUTF8(STRING_ELT(encoding, 0));
 }
 
-SEXP C_dtaparser_metadata(SEXP path, SEXP encoding) {
+SEXP C_dtaparser_metadata(
+    SEXP path, SEXP encoding, SEXP column_start, SEXP column_count
+) {
     if (TYPEOF(path) != STRSXP || XLENGTH(path) != 1 || STRING_ELT(path, 0) == NA_STRING) {
         Rf_error("`file` must be one non-missing path");
     }
+    if (TYPEOF(column_start) != INTSXP || XLENGTH(column_start) != 1 ||
+        INTEGER(column_start)[0] < 0 || TYPEOF(column_count) != INTSXP ||
+        XLENGTH(column_count) != 1 || INTEGER(column_count)[0] < 0) {
+        Rf_error("internal metadata column bounds must be non-negative integers");
+    }
     char *error = NULL;
     SEXP result = dtaparser_metadata_rust(
-        Rf_translateCharUTF8(STRING_ELT(path, 0)), optional_encoding(encoding),
-        &error
+        Rf_translateCharUTF8(STRING_ELT(path, 0)),
+        (uint32_t) INTEGER(column_start)[0],
+        (uint32_t) INTEGER(column_count)[0],
+        optional_encoding(encoding), &error
     );
     if (result == NULL) fail_from_rust(error);
     return result;
@@ -182,7 +193,7 @@ SEXP C_dtaparser_read(
 }
 
 static const R_CallMethodDef CallEntries[] = {
-    {"C_dtaparser_metadata", (DL_FUNC) &C_dtaparser_metadata, 2},
+    {"C_dtaparser_metadata", (DL_FUNC) &C_dtaparser_metadata, 4},
     {"C_dtaparser_read", (DL_FUNC) &C_dtaparser_read, 6},
     {NULL, NULL, 0}
 };

--- a/r-package/dtaparser/src/rust/src/lib.rs
+++ b/r-package/dtaparser/src/rust/src/lib.rs
@@ -646,18 +646,28 @@ impl DtaSink for RDataFrameSink {
     }
 }
 
-unsafe fn metadata_impl(path: &str, encoding: TextEncoding) -> Result<Sexp, String> {
+unsafe fn metadata_impl(
+    path: &str,
+    encoding: TextEncoding,
+    column_start: u32,
+    column_count: u32,
+) -> Result<Sexp, String> {
     let file = DtaFile::open_with_encoding(path, encoding).map_err(|error| error.to_string())?;
     let metadata = file.metadata();
+    let start = usize::try_from(column_start)
+        .map_err(|_| "metadata column start is out of range".to_owned())?
+        .min(metadata.variables.len());
+    let count = usize::try_from(column_count)
+        .map_err(|_| "metadata column count is out of range".to_owned())?;
+    let end = start.saturating_add(count).min(metadata.variables.len());
+    let variables = &metadata.variables[start..end];
     let mut guard = ProtectGuard::new();
-    let names = metadata
-        .variables
+    let names = variables
         .iter()
         .map(|variable| variable.name.clone())
         .collect::<Vec<_>>();
     let result = string_vector(&names, &mut guard)?;
-    let storage = metadata
-        .variables
+    let storage = variables
         .iter()
         .map(|variable| match variable.dta_type {
             DtaType::Byte => "byte".to_owned(),
@@ -808,6 +818,8 @@ unsafe fn text_encoding(encoding: *const c_char) -> Result<TextEncoding, String>
 /// with an initialized R runtime.
 pub unsafe extern "C" fn dtaparser_metadata_rust(
     path: *const c_char,
+    column_start: u32,
+    column_count: u32,
     encoding: *const c_char,
     error: *mut *mut c_char,
 ) -> Sexp {
@@ -818,7 +830,7 @@ pub unsafe extern "C" fn dtaparser_metadata_rust(
         let path = CStr::from_ptr(path)
             .to_str()
             .map_err(|_| "file path is not valid UTF-8".to_owned())?;
-        metadata_impl(path, text_encoding(encoding)?)
+        metadata_impl(path, text_encoding(encoding)?, column_start, column_count)
     })
 }
 

--- a/r-package/dtaparser/tests/testthat/test-read-dta.R
+++ b/r-package/dtaparser/tests/testthat/test-read-dta.R
@@ -61,18 +61,6 @@ test_that("all bundled fixtures agree with haven", {
         rust_vectors <- dtaparser:::.read_dta_rust_vectors(path)
         expected <- haven::read_dta(path)
         info <- basename(path)
-        if (grepl("^synthetic_v(105|108|110|111)[.]dta$", info)) {
-            # Pre-Unicode releases do not record a code page. Stata 18 reads
-            # this fixture's isolated CP1252 byte with UTF-8 replacement;
-            # haven's locale-based default instead decodes it as e-acute.
-            release <- sub("^synthetic_v([0-9]+)[.]dta$", "\\1", info)
-            attr(expected, "label") <- if (identical(release, "111")) {
-                "Stata/SE 7 Caf\ufffd fixture"
-            } else {
-                sprintf("Release %s Caf\ufffd fixture", release)
-            }
-            expected$text[expected$text == "Caf\u00e9"] <- "Caf\ufffd"
-        }
         metadata <- dtaparser:::.dta_metadata(normalizePath(path))
         storage <- stats::setNames(
             attr(metadata, "dta_storage", exact = TRUE),

--- a/r-package/dtaparser/tests/testthat/test-read-dta.R
+++ b/r-package/dtaparser/tests/testthat/test-read-dta.R
@@ -61,6 +61,18 @@ test_that("all bundled fixtures agree with haven", {
         rust_vectors <- dtaparser:::.read_dta_rust_vectors(path)
         expected <- haven::read_dta(path)
         info <- basename(path)
+        if (grepl("^synthetic_v(105|108|110|111)[.]dta$", info)) {
+            # Pre-Unicode releases do not record a code page. Stata 18 reads
+            # this fixture's isolated CP1252 byte with UTF-8 replacement;
+            # haven's locale-based default instead decodes it as e-acute.
+            release <- sub("^synthetic_v([0-9]+)[.]dta$", "\\1", info)
+            attr(expected, "label") <- if (identical(release, "111")) {
+                "Stata/SE 7 Caf\ufffd fixture"
+            } else {
+                sprintf("Release %s Caf\ufffd fixture", release)
+            }
+            expected$text[expected$text == "Caf\u00e9"] <- "Caf\ufffd"
+        }
         metadata <- dtaparser:::.dta_metadata(normalizePath(path))
         storage <- stats::setNames(
             attr(metadata, "dta_storage", exact = TRUE),

--- a/r-package/dtaparser/tests/testthat/test-read-dta.R
+++ b/r-package/dtaparser/tests/testthat/test-read-dta.R
@@ -23,6 +23,30 @@ test_that("read_dta has the haven-compatible public signature", {
     expect_identical(formals(read_dta)$.name_repair, "unique")
 })
 
+test_that("internal metadata projection is bounded and preserves attributes", {
+    path <- fixture("all_types_v118.dta")
+    full <- dtaparser:::.dta_metadata(path)
+    middle <- dtaparser:::.dta_metadata(path, column_start = 3L, column_count = 2L)
+    suffix <- dtaparser:::.dta_metadata(path, column_start = 7L)
+    empty <- dtaparser:::.dta_metadata(path, column_start = 2L, column_count = 0L)
+    past <- dtaparser:::.dta_metadata(path, column_start = 100L, column_count = 2L)
+
+    expect_identical(as.character(middle), as.character(full[3:4]))
+    expect_identical(attr(middle, "dta_storage"), attr(full, "dta_storage")[3:4])
+    expect_identical(attr(middle, "dta_format_version"),
+                     attr(full, "dta_format_version"))
+    expect_identical(as.character(suffix), as.character(full[7:8]))
+    expect_length(empty, 0L)
+    expect_length(attr(empty, "dta_storage"), 0L)
+    expect_length(past, 0L)
+
+    invalid <- list(-1, 1.5, NA_real_, NaN, c(1, 2), "1")
+    for (value in invalid) {
+        expect_error(dtaparser:::.dta_metadata(path, column_start = value))
+        expect_error(dtaparser:::.dta_metadata(path, column_count = value))
+    }
+})
+
 test_that("all bundled fixtures agree with haven", {
     skip_if_not_installed("haven")
     paths <- list.files(


### PR DESCRIPTION
## Summary

- add a local, resumable Stata-adjudicated differential workflow and machine-readable triage extractor
- default releases 105–117 to Windows-1252, matching haven's useful interpretation of otherwise unspecified legacy bytes
- keep releases 118–119 on UTF-8 and retain explicit `encoding = "UTF-8"` for strict Stata 18 behavior
- harden Stata adjudication, zero-row probing, Unicode paths, timeout classification, triage recovery, and content-addressed package caching

## Validation

- `cargo test --manifest-path r-package/dtaparser/src/dta-parser/Cargo.toml`
- `DTAPARSER_TEST_STATA=/Applications/Stata/StataMP.app/Contents/MacOS/stata-mp Rscript --vanilla benchmarks/aww-cache-differential/test-framework.R`
- `scripts/conformance.sh`
- end-to-end default-encoding benchmark of the two affected Benin 1996 release-113 files: 2 matches, 0 disputes
- end-to-end cache-publication benchmark after the review fixes: 1 match, 0 disputes

Before changing the public default, the exhaustive Stata-adjudicated run used strict UTF-8 semantics over 1,882 files / 57.1 GB:

- 551 matching files
- 1,329 haven-wrong files
- 160,827 haven-owned disputes
- 0 dtaparser-owned, both-wrong, representation-only, or unresolved disputes
- 2 confirmed corrupt sources: zero-byte Mauritania 2011 `ch.dta` and truncated Sao Tome and Principe 2014 `mn.dta`

The resulting triage artifact contains 160,828 fully owned rows: 160,827 `haven-wrong` and one `source-corrupt`; the zero-byte file has no cell dispute.
