### PR TITLE
Add regressions for parser safety issues

### DIFF
--- a/typescript/dta-parser/tests/unit/legacy-header.test.ts
+++ b/typescript/dta-parser/tests/unit/legacy-header.test.ts
@@ -459,7 +459,9 @@ describe('parse_legacy_metadata', () => {
             negative.buffer, negative.byteOffset, negative.byteLength
         );
         negative[metadata.section_offsets.characteristics] = 1;
-        view.setInt32(metadata.section_offsets.characteristics + 1, -1, true);
+        // A length of -5 exactly cancels the five-byte field header. Without
+        // rejecting negative lengths, the scanner never advances.
+        view.setInt32(metadata.section_offsets.characteristics + 1, -5, true);
         expect(() => parse_legacy_metadata(
             negative.buffer.slice(
                 negative.byteOffset,

--- a/typescript/dta-parser/tests/unit/strl-reader.test.ts
+++ b/typescript/dta-parser/tests/unit/strl-reader.test.ts
@@ -5,6 +5,7 @@ import { parse_metadata } from '../../src/header';
 import {
     build_gso_index,
     decode_gso_entry,
+    read_strl_pointer,
     resolve_strl,
 } from '../../src/strl-reader';
 import type { DtaMetadata } from '../../src/types';
@@ -149,6 +150,24 @@ describe('build_gso_index', () => {
 
             expect(typeof my_val).toBe('string');
             expect(my_val!.length).toBeGreaterThan(0);
+        });
+
+        it('reads all six little-endian observation bytes', () => {
+            const { metadata } = load_fixture('strl_test_v118.dta');
+            const my_buffer = new ArrayBuffer(8);
+            const my_view = new DataView(my_buffer);
+
+            my_view.setUint16(0, 1, true);
+            my_view.setUint32(2, 1, true);
+            my_view.setUint16(6, 1, true);
+
+            expect(read_strl_pointer(my_view, {
+                ...metadata,
+                nobs: 0x100000001,
+            }, 0)).toEqual({
+                v: 1,
+                o: 0x100000001,
+            });
         });
     });
 


### PR DESCRIPTION
## Summary

- cover the exact negative expansion-field length that previously made the legacy scanner stop advancing
- verify release-118 little-endian strL pointers consume all six observation bytes
- document the protections already present on main against the two release-0.3.0 regressions

## Validation

- npm test: 242 passed
- npm run typecheck
- git diff --check

Closes #36
Closes #37