### PR TITLE
Pin Python 3.11 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,9 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.11"
       - uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # v2.0.2
         with:
           bun-version: 1.3.14
@@ -76,6 +79,9 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.11"
       - uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # v2.0.2
         with:
           bun-version: 1.3.14


### PR DESCRIPTION
## Summary

- pin actions/setup-python v5.6.0 by commit SHA in the TypeScript CI job
- use Python 3.11 for fixture regeneration
- apply the same pinned interpreter to the R Cargo vendor job and its Python tooling

## Validation

- actionlint .github/workflows/ci.yml
- python3 -m unittest discover -s scripts -p test_*.py
- bun test tests/integration/benchmark-config.test.ts tests/integration/fixture-inventory.test.ts
- scripts/check-r-cargo-vendor.sh
- scripts/rebuild-r-vendor.sh
- git diff --exit-code -- r-package/dtaparser/src/rust/vendor.tar.gz

Closes #34