### PR TITLE
Attach compiled R packages to GitHub releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,8 +105,6 @@ jobs:
             rust_toolchain: 1.97.1
           - os: windows-latest
             rust_toolchain: 1.97.1-x86_64-pc-windows-gnu
-          - os: windows-11-arm
-            rust_toolchain: 1.97.1-aarch64-pc-windows-gnullvm
     env:
       _R_CHECK_FORCE_SUGGESTS_: "true"
       NOT_CRAN: "true"
@@ -117,12 +115,6 @@ jobs:
       - uses: r-lib/actions/setup-r@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2.12.1
         with:
           use-public-rspm: true
-      - name: Select ARM64 Rtools
-        if: matrix.os == 'windows-11-arm'
-        shell: pwsh
-        run: |
-          "RTOOLS45_HOME=" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-          "RTOOLS45_AARCH64_HOME=C:\rtools45-aarch64" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
       - uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # v2.0.2
         if: runner.os == 'Linux'
         with:
@@ -140,10 +132,6 @@ jobs:
           if [ "$rust_version-$rust_host" != "$RUST_TOOLCHAIN" ]; then
             echo "Rust $rust_version host $rust_host does not match $RUST_TOOLCHAIN" >&2
             exit 1
-          fi
-          if [ "$rust_host" = "aarch64-pc-windows-gnullvm" ]; then
-            rustup component add rust-mingw --toolchain "$RUST_TOOLCHAIN"
-            echo "CARGO_TARGET_AARCH64_PC_WINDOWS_GNULLVM_LINKER=rust-lld" >> "$GITHUB_ENV"
           fi
       - name: Install Rust
         if: runner.os != 'Windows'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,15 +52,16 @@ jobs:
       - run: cargo +${{ matrix.toolchain }} test --workspace --all-targets --locked
       - run: RUSTDOCFLAGS="-D warnings" cargo +${{ matrix.toolchain }} doc --workspace --locked --no-deps
       - run: cargo +${{ matrix.toolchain }} package -p dta-parser --locked
-      - name: Check isolated R bridge offline at MSRV
-        if: matrix.toolchain == '1.74.0'
+      - name: Check isolated R bridge offline
+        if: matrix.toolchain == 'stable'
         working-directory: r-package/dtaparser/src
         shell: bash
         env:
           CARGO_TARGET_DIR: ../../../target
         run: |
+          rustup toolchain install 1.97.1 --profile minimal
           tar -xzf rust/vendor.tar.gz -C rust
-          cargo +${{ matrix.toolchain }} check --manifest-path rust/Cargo.toml --config rust/cargo-config.toml --locked --offline
+          cargo +1.97.1 check --manifest-path rust/Cargo.toml --config rust/cargo-config.toml --locked --offline
 
   fuzz-smoke:
     name: Deterministic fuzz smoke
@@ -97,7 +98,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        include:
+          - os: ubuntu-latest
+            rust_toolchain: 1.97.1
+          - os: macos-latest
+            rust_toolchain: 1.97.1
+          - os: windows-latest
+            rust_toolchain: 1.97.1-x86_64-pc-windows-gnu
+          - os: windows-11-arm
+            rust_toolchain: 1.97.1-aarch64-pc-windows-gnullvm
     env:
       _R_CHECK_FORCE_SUGGESTS_: "true"
       NOT_CRAN: "true"
@@ -105,9 +114,15 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
-      - uses: r-lib/actions/setup-r@bd49c52ffe281809afa6f0fecbf37483c5dd0b93 # v2.11.3
+      - uses: r-lib/actions/setup-r@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2.12.1
         with:
           use-public-rspm: true
+      - name: Select ARM64 Rtools
+        if: matrix.os == 'windows-11-arm'
+        shell: pwsh
+        run: |
+          "RTOOLS45_HOME=" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "RTOOLS45_AARCH64_HOME=C:\rtools45-aarch64" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
       - uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # v2.0.2
         if: runner.os == 'Linux'
         with:
@@ -115,15 +130,29 @@ jobs:
       - name: Install GNU Rust for Rtools
         if: runner.os == 'Windows'
         shell: bash
+        env:
+          RUST_TOOLCHAIN: ${{ matrix.rust_toolchain }}
         run: |
-          rustup toolchain install stable-x86_64-pc-windows-gnu --profile minimal
-          rustup default stable-x86_64-pc-windows-gnu
-          rustup target add x86_64-pc-windows-gnu --toolchain stable-x86_64-pc-windows-gnu
-          rustc -vV | grep 'host: x86_64-pc-windows-gnu'
+          rustup toolchain install "$RUST_TOOLCHAIN" --profile minimal
+          rustup default "$RUST_TOOLCHAIN"
+          rust_version="$(rustc --version | awk '{print $2}')"
+          rust_host="$(rustc -vV | sed -n 's/^host: //p')"
+          if [ "$rust_version-$rust_host" != "$RUST_TOOLCHAIN" ]; then
+            echo "Rust $rust_version host $rust_host does not match $RUST_TOOLCHAIN" >&2
+            exit 1
+          fi
+          if [ "$rust_host" = "aarch64-pc-windows-gnullvm" ]; then
+            rustup component add rust-mingw --toolchain "$RUST_TOOLCHAIN"
+            echo "CARGO_TARGET_AARCH64_PC_WINDOWS_GNULLVM_LINKER=rust-lld" >> "$GITHUB_ENV"
+          fi
       - name: Install Rust
         if: runner.os != 'Windows'
         shell: bash
-        run: rustup toolchain install stable --profile minimal
+        env:
+          RUST_TOOLCHAIN: ${{ matrix.rust_toolchain }}
+        run: |
+          rustup toolchain install "$RUST_TOOLCHAIN" --profile minimal
+          rustup default "$RUST_TOOLCHAIN"
       - name: Install R dependencies
         shell: Rscript {0}
         run: install.packages(c("readr", "rlang", "tibble", "tidyselect", "testthat", "haven", "callr", "httpuv"))

--- a/.github/workflows/release-r-packages.yml
+++ b/.github/workflows/release-r-packages.yml
@@ -23,9 +23,6 @@ jobs:
           - os: windows-latest
             platform: windows-x86_64
             rust_toolchain: 1.97.1-x86_64-pc-windows-gnu
-          - os: windows-11-arm
-            platform: windows-arm64
-            rust_toolchain: 1.97.1-aarch64-pc-windows-gnullvm
     steps:
       - name: Checkout release tag
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -39,15 +36,6 @@ jobs:
           r-version: release
           use-public-rspm: true
 
-      # setup-r currently exports the x64 Rtools home on native Windows ARM.
-      # Point R 4.6 at the ARM64 toolchain installed by the action instead.
-      - name: Select ARM64 Rtools
-        if: matrix.platform == 'windows-arm64'
-        shell: pwsh
-        run: |
-          "RTOOLS45_HOME=" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-          "RTOOLS45_AARCH64_HOME=C:\rtools45-aarch64" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-
       - name: Verify R architecture
         shell: bash
         env:
@@ -55,7 +43,7 @@ jobs:
         run: |
           r_platform="$(Rscript --vanilla -e "cat(R.version[['platform']])")"
           case "$ASSET_PLATFORM:$r_platform" in
-            linux-x86_64:x86_64-*|macos-arm64:aarch64-*|macos-arm64:arm64-*|windows-x86_64:x86_64-*|windows-arm64:aarch64-*) ;;
+            linux-x86_64:x86_64-*|macos-arm64:aarch64-*|macos-arm64:arm64-*|windows-x86_64:x86_64-*) ;;
             *)
               echo "R platform $r_platform does not match release asset $ASSET_PLATFORM" >&2
               exit 1
@@ -84,10 +72,6 @@ jobs:
           if [ "$rust_version-$rust_host" != "$RUST_TOOLCHAIN" ]; then
             echo "Rust $rust_version host $rust_host does not match $RUST_TOOLCHAIN" >&2
             exit 1
-          fi
-          if [ "$rust_host" = "aarch64-pc-windows-gnullvm" ]; then
-            rustup component add rust-mingw --toolchain "$RUST_TOOLCHAIN"
-            echo "CARGO_TARGET_AARCH64_PC_WINDOWS_GNULLVM_LINKER=rust-lld" >> "$GITHUB_ENV"
           fi
 
       - name: Install R dependencies

--- a/.github/workflows/release-r-packages.yml
+++ b/.github/workflows/release-r-packages.yml
@@ -1,0 +1,178 @@
+name: Attach compiled R packages
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    name: R binary / ${{ matrix.platform }}
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            platform: linux-x86_64
+            rust_toolchain: 1.97.1
+          - os: macos-latest
+            platform: macos-arm64
+            rust_toolchain: 1.97.1
+          - os: windows-latest
+            platform: windows-x86_64
+            rust_toolchain: 1.97.1-x86_64-pc-windows-gnu
+          - os: windows-11-arm
+            platform: windows-arm64
+            rust_toolchain: 1.97.1-aarch64-pc-windows-gnullvm
+    steps:
+      - name: Checkout release tag
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.release.tag_name }}
+          persist-credentials: false
+
+      - name: Set up R release
+        uses: r-lib/actions/setup-r@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2.12.1
+        with:
+          r-version: release
+          use-public-rspm: true
+
+      # setup-r currently exports the x64 Rtools home on native Windows ARM.
+      # Point R 4.6 at the ARM64 toolchain installed by the action instead.
+      - name: Select ARM64 Rtools
+        if: matrix.platform == 'windows-arm64'
+        shell: pwsh
+        run: |
+          "RTOOLS45_HOME=" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "RTOOLS45_AARCH64_HOME=C:\rtools45-aarch64" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
+      - name: Verify R architecture
+        shell: bash
+        env:
+          ASSET_PLATFORM: ${{ matrix.platform }}
+        run: |
+          r_platform="$(Rscript --vanilla -e "cat(R.version[['platform']])")"
+          case "$ASSET_PLATFORM:$r_platform" in
+            linux-x86_64:x86_64-*|macos-arm64:aarch64-*|macos-arm64:arm64-*|windows-x86_64:x86_64-*|windows-arm64:aarch64-*) ;;
+            *)
+              echo "R platform $r_platform does not match release asset $ASSET_PLATFORM" >&2
+              exit 1
+              ;;
+          esac
+
+      - name: Install Rust
+        if: runner.os != 'Windows'
+        shell: bash
+        env:
+          RUST_TOOLCHAIN: ${{ matrix.rust_toolchain }}
+        run: |
+          rustup toolchain install "$RUST_TOOLCHAIN" --profile minimal
+          rustup default "$RUST_TOOLCHAIN"
+
+      - name: Install Rust for Rtools
+        if: runner.os == 'Windows'
+        shell: bash
+        env:
+          RUST_TOOLCHAIN: ${{ matrix.rust_toolchain }}
+        run: |
+          rustup toolchain install "$RUST_TOOLCHAIN" --profile minimal
+          rustup default "$RUST_TOOLCHAIN"
+          rust_version="$(rustc --version | awk '{print $2}')"
+          rust_host="$(rustc -vV | sed -n 's/^host: //p')"
+          if [ "$rust_version-$rust_host" != "$RUST_TOOLCHAIN" ]; then
+            echo "Rust $rust_version host $rust_host does not match $RUST_TOOLCHAIN" >&2
+            exit 1
+          fi
+          if [ "$rust_host" = "aarch64-pc-windows-gnullvm" ]; then
+            rustup component add rust-mingw --toolchain "$RUST_TOOLCHAIN"
+            echo "CARGO_TARGET_AARCH64_PC_WINDOWS_GNULLVM_LINKER=rust-lld" >> "$GITHUB_ENV"
+          fi
+
+      - name: Install R dependencies
+        shell: Rscript {0}
+        run: |
+          install.packages(
+            c("readr", "rlang", "tibble", "tidyselect"),
+            repos = "https://cloud.r-project.org",
+            Ncpus = 2L
+          )
+
+      - name: Build binary package
+        id: package
+        shell: bash
+        env:
+          ASSET_PLATFORM: ${{ matrix.platform }}
+        run: |
+          workspace="$PWD"
+          package_version="$(Rscript --vanilla -e 'cat(read.dcf("r-package/dtaparser/DESCRIPTION", fields = "Version"))')"
+          r_version="$(Rscript --vanilla -e 'cat(as.character(getRversion()))')"
+          r_platform="$(Rscript --vanilla -e "cat(R.version[['platform']])")"
+          source_dir="$workspace/release-build/source"
+          binary_dir="$workspace/release-build/binary"
+          library_dir="$workspace/release-build/library"
+          mkdir -p "$source_dir" "$binary_dir" "$library_dir"
+
+          (
+            cd "$source_dir"
+            R CMD build "$workspace/r-package/dtaparser"
+          )
+          source_archive="$source_dir/dtaparser_${package_version}.tar.gz"
+          "$workspace/scripts/check-r-package-archive.sh" "$source_archive"
+
+          (
+            cd "$binary_dir"
+            R CMD INSTALL --build --clean --library="$library_dir" "$source_archive"
+          )
+
+          case "$ASSET_PLATFORM" in
+            windows-*) generated="$binary_dir/dtaparser_${package_version}.zip"; extension=zip ;;
+            macos-*) generated="$binary_dir/dtaparser_${package_version}.tgz"; extension=tgz ;;
+            linux-*) generated="$binary_dir/dtaparser_${package_version}_R_${r_platform}.tar.gz"; extension=tar.gz ;;
+          esac
+          if [ ! -f "$generated" ]; then
+            echo "R CMD INSTALL did not create the expected binary: $generated" >&2
+            find "$binary_dir" -maxdepth 1 -type f -print >&2
+            exit 1
+          fi
+
+          asset="$binary_dir/dtaparser_${package_version}_R-${r_version}_${ASSET_PLATFORM}.${extension}"
+          mv "$generated" "$asset"
+          echo "asset=$asset" >> "$GITHUB_OUTPUT"
+          echo "artifact_name=r-package-$ASSET_PLATFORM" >> "$GITHUB_OUTPUT"
+
+      - name: Smoke test installed package
+        shell: Rscript {0}
+        run: |
+          .libPaths(c(file.path(getwd(), "release-build", "library"), .libPaths()))
+          library(dtaparser)
+          stopifnot(is.function(read_dta))
+
+      - name: Stage binary for release
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ steps.package.outputs.artifact_name }}
+          path: ${{ steps.package.outputs.asset }}
+          if-no-files-found: error
+          retention-days: 1
+
+  attach:
+    name: Attach R binaries to release
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download compiled packages
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: r-package-*
+          path: release-assets
+          merge-multiple: true
+
+      - name: Attach compiled packages
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: gh release upload "$RELEASE_TAG" release-assets/* --clobber --repo "$GITHUB_REPOSITORY"

--- a/r-package/dtaparser/DESCRIPTION
+++ b/r-package/dtaparser/DESCRIPTION
@@ -21,6 +21,7 @@ Suggests:
     httpuv,
     testthat (>= 3.1.7)
 Config/testthat/edition: 3
-SystemRequirements: Cargo and Rust >= 1.74; on Windows, the
-    x86_64-pc-windows-gnu toolchain matching 64-bit R
+SystemRequirements: Cargo and Rust >= 1.97.1; on Windows, the Rust target matching
+    R (x86_64-pc-windows-gnu for x86_64 R or
+    aarch64-pc-windows-gnullvm for aarch64 R)
 NeedsCompilation: yes

--- a/r-package/dtaparser/README.md
+++ b/r-package/dtaparser/README.md
@@ -9,11 +9,10 @@ avoid interleaving R allocation with the parser's hot loop.
 
 ## Installation
 
-Published GitHub Releases include compiled packages for R release on Linux
-x86_64, macOS ARM64, and Windows x86_64. Windows ARM64 users must build the
-package from source. The R version, platform, and architecture are part of each
-asset name. A matching asset URL can be installed with its required dependencies
-by `pak` without compiling `dtaparser` locally:
+Published GitHub Releases include compiled R packages for Windows x86_64,
+Linux x86_64, and macOS ARM64. The R version, platform, and architecture are
+part of each asset name. A matching asset URL can be installed with its required
+dependencies by `pak` without compiling `dtaparser` locally:
 
 ```r
 pak::pkg_install("url::https://github.com/jbearak/dta-parser/releases/download/vX.Y.Z/<matching-asset>")

--- a/r-package/dtaparser/README.md
+++ b/r-package/dtaparser/README.md
@@ -7,6 +7,23 @@ and materialized through an R-specific collector. Numeric values are written
 into their final R vectors during decoding; strings are batch-materialized to
 avoid interleaving R allocation with the parser's hot loop.
 
+## Installation
+
+Published GitHub Releases include compiled packages for R release on Linux
+x86_64, macOS ARM64, and Windows x86_64 and ARM64. The R version, platform, and
+architecture are part of each asset name. A matching asset URL can be installed
+with its required dependencies by `pak` without compiling `dtaparser` locally:
+
+```r
+pak::pkg_install("url::https://github.com/jbearak/dta-parser/releases/download/vX.Y.Z/<matching-asset>")
+```
+
+Base R can also install one matching URL with
+`install.packages(url, repos = NULL)` after the package's Imports are installed;
+the archive extension lets R detect the binary format. GitHub does not select
+an asset for the current platform, so callers must use the URL whose R version,
+operating system, and architecture match their R installation.
+
 ```r
 library(dtaparser)
 
@@ -147,10 +164,12 @@ These deterministic choices avoid silent truncation and platform-dependent
 overflow while retaining haven parity for meaningful row-window requests.
 
 The package includes a locked Cargo dependency graph and vendored crates so
-source builds do not contact a package registry. A Rust 1.74-or-newer toolchain
-and Cargo are required. Windows builds require 64-bit R and the
-`x86_64-pc-windows-gnu` Rust toolchain; `configure.win` rejects a mismatched
-host before compilation and the Windows Makevars passes the target explicitly.
+source builds do not contact a package registry. A Rust 1.97.1-or-newer toolchain
+and Cargo are required for the R bridge on every platform. Windows builds
+require a Rust host matching R:
+`x86_64-pc-windows-gnu` for x86_64 R or `aarch64-pc-windows-gnullvm` for
+aarch64 R. `configure.win` rejects a mismatched host before compilation and the
+Windows Makevars passes the target explicitly.
 
 ## Conformance and release checks
 
@@ -189,5 +208,7 @@ third-party Cargo dependencies, and `scripts/check-r-cargo-vendor.sh` verifies
 the archive against `vendor.sha256` and the bridge lock. Configure always
 refreshes the extracted dependencies before building. Python 3.11 or newer is
 only required for repository maintenance and CI, not R package installation.
-Windows CI installs and selects `stable-x86_64-pc-windows-gnu`, confirms the
-rustc host, then actually builds and checks the package through Rtools.
+Windows CI installs and selects Rust 1.97.1 with the
+`x86_64-pc-windows-gnu` or `aarch64-pc-windows-gnullvm` host matching R,
+confirms the exact version and host, then builds and checks the package through
+Rtools.

--- a/r-package/dtaparser/README.md
+++ b/r-package/dtaparser/README.md
@@ -165,11 +165,11 @@ overflow while retaining haven parity for meaningful row-window requests.
 
 The package includes a locked Cargo dependency graph and vendored crates so
 source builds do not contact a package registry. A Rust 1.97.1-or-newer toolchain
-and Cargo are required for the R bridge on every platform. Windows builds
-require a Rust host matching R:
-`x86_64-pc-windows-gnu` for x86_64 R or `aarch64-pc-windows-gnullvm` for
-aarch64 R. `configure.win` rejects a mismatched host before compilation and the
-Windows Makevars passes the target explicitly.
+and Cargo are required for the R bridge on every platform. The Rust target
+architecture must match R. On Windows, Rtools additionally requires a
+MinGW-compatible Rust host: `x86_64-pc-windows-gnu` for x86_64 R or
+`aarch64-pc-windows-gnullvm` for aarch64 R. `configure.win` rejects a mismatched
+host before compilation and the Windows Makevars passes the target explicitly.
 
 ## Conformance and release checks
 

--- a/r-package/dtaparser/README.md
+++ b/r-package/dtaparser/README.md
@@ -10,9 +10,10 @@ avoid interleaving R allocation with the parser's hot loop.
 ## Installation
 
 Published GitHub Releases include compiled packages for R release on Linux
-x86_64, macOS ARM64, and Windows x86_64 and ARM64. The R version, platform, and
-architecture are part of each asset name. A matching asset URL can be installed
-with its required dependencies by `pak` without compiling `dtaparser` locally:
+x86_64, macOS ARM64, and Windows x86_64. Windows ARM64 users must build the
+package from source. The R version, platform, and architecture are part of each
+asset name. A matching asset URL can be installed with its required dependencies
+by `pak` without compiling `dtaparser` locally:
 
 ```r
 pak::pkg_install("url::https://github.com/jbearak/dta-parser/releases/download/vX.Y.Z/<matching-asset>")
@@ -209,6 +210,5 @@ the archive against `vendor.sha256` and the bridge lock. Configure always
 refreshes the extracted dependencies before building. Python 3.11 or newer is
 only required for repository maintenance and CI, not R package installation.
 Windows CI installs and selects Rust 1.97.1 with the
-`x86_64-pc-windows-gnu` or `aarch64-pc-windows-gnullvm` host matching R,
-confirms the exact version and host, then builds and checks the package through
-Rtools.
+`x86_64-pc-windows-gnu` host matching R, confirms the exact version and host,
+then builds and checks the package through Rtools.

--- a/r-package/dtaparser/configure.win
+++ b/r-package/dtaparser/configure.win
@@ -1,11 +1,21 @@
 #!/bin/sh
 set -eu
-rust_target=x86_64-pc-windows-gnu
+
+r_platform=$("$R_HOME/bin/Rscript" --vanilla -e 'cat(R.version$platform)')
+case "$r_platform" in
+  x86_64-w64-mingw32) rust_target=x86_64-pc-windows-gnu ;;
+  aarch64-w64-mingw32) rust_target=aarch64-pc-windows-gnullvm ;;
+  *)
+    echo "dtaparser does not support the R platform $r_platform on Windows" >&2
+    exit 1
+    ;;
+esac
+
 rust_version=$(rustc -vV)
 printf '%s\n' "$rust_version"
 rust_host=$(printf '%s\n' "$rust_version" | sed -n 's/^host: //p')
 if test "$rust_host" != "$rust_target"; then
-  echo "dtaparser requires the Rust $rust_target toolchain for 64-bit R on Windows; found $rust_host" >&2
+  echo "dtaparser requires the Rust $rust_target toolchain for $r_platform R; found $rust_host" >&2
   exit 1
 fi
 . tools/configure-rust.sh

--- a/r-package/dtaparser/src/rust/Cargo.toml
+++ b/r-package/dtaparser/src/rust/Cargo.toml
@@ -2,7 +2,7 @@
 name = "dtaparser-r"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.74"
+rust-version = "1.97.1"
 license = "GPL-3.0-only"
 publish = false
 


### PR DESCRIPTION
## Summary

- build R 4.6 release binaries for Linux x64, macOS ARM64, and Windows x64/ARM64 when a GitHub Release is published
- attach the standard R package archives to the release with platform, architecture, and R version in each filename
- support native Windows ARM64 through the matching Rtools and Rust GNU/LLVM target
- pin every R bridge and release build to Rust 1.97.1 and enforce that minimum in Cargo and DESCRIPTION
- document installation from a release asset with pak or base R

## Validation

- actionlint on all workflows
- git diff --check
- 32 Python script tests
- R CMD check --no-manual: Status OK
- macOS ARM64 binary build and smoke test under R 4.6.1 / Rust 1.97.1
- renamed release-style binary installed successfully with install.packages(..., repos = NULL)
- offline R bridge cargo check with Rust 1.97.1
- confirmed Rust 1.96 is rejected because the bridge requires 1.97.1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added downloadable R package binaries for Linux x86_64, macOS ARM64, Windows x86_64, and Windows ARM64 through GitHub Releases.
  * Added installation guidance for release binaries and source builds.

* **Improvements**
  * Added Windows platform detection and matching Rust target configuration for Intel and ARM64 systems.
  * Updated the minimum required Rust version to 1.97.1.
  * Expanded build validation and installation smoke tests across supported platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->