### PR TITLE
Add modern DTA parallel decoding path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,6 +145,10 @@ jobs:
         if: runner.os == 'Linux'
         shell: bash
         run: scripts/test-rust-source-hash.sh
+      - name: Test corpus benchmark aggregation
+        if: runner.os == 'Linux'
+        shell: bash
+        run: Rscript --vanilla benchmarks/r-corpus-performance/test-framework.R
       - name: Build and check package from offline Cargo archive
         if: runner.os != 'Linux'
         shell: bash

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -38,7 +38,8 @@ library guard, correctness checks, orchestration command, and output matrix.
 The manual [`r-corpus-performance/`](r-corpus-performance/) suite loads every
 common-readable DHS, MICS, and NSFG DTA file beneath `/opt/aww_cache` through
 dta-parser, haven, and Stata in fresh processes. It aggregates elapsed time and
-maximum per-file peak RSS by corpus while keeping paths and raw results private.
+maximum per-file peak RSS by corpus and stored DTA release while keeping paths
+and raw results private.
 Its [2026-08-24 report](r-corpus-performance/results-2026-08-24.md) records the
 aggregate results used in the R package README.
 

--- a/benchmarks/large-scale/results-2026-08-24.md
+++ b/benchmarks/large-scale/results-2026-08-24.md
@@ -4,8 +4,32 @@ Environment: Apple M4 Max, 128 GB RAM, macOS 26.5.2, R 4.6.1, haven 2.5.5,
 and Stata/MP 18. The
 pre-change baseline used Homebrew rustc 1.97.1; the final package used Homebrew
 rustc 1.98.0 and the R bridge's optimized release profile. Both used the same
-deterministic, warm-cache, 40-column Stata 15 files. Exact internal-collector
+deterministic, warm-cache, 40-column Stata 15 files (DTA file-format release
+119). Exact internal-collector
 identity and sampled haven parity passed before timing.
+
+## Release-119 multicore refresh
+
+After the modern parallel decoder landed, dta-parser alone was rerun on the
+same two synthetic files at commit `5245856`, using its default automatic
+thread count. Both files identify themselves as release 119 in their DTA
+signatures; the generator writes them with `haven::write_dta(version = 15)`.
+Each workload was warmed up and measured seven times, and peak RSS was measured
+in three fresh processes. Haven and Stata were not rerun, so the comparison
+columns retain their archived matched values below.
+
+| Input | Workload | Single-thread dta-parser | Multicore dta-parser | Reduction | Multicore dta-parser peak RSS | dta-parser vs haven | dta-parser vs Stata |
+| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| 100 MB | Full, 40 columns | 0.139 s | 0.073 s | 47.5% | 0.277 GB | 14.42x | 0.151x |
+| 100 MB | Projected, 8 columns | 0.051 s | 0.034 s | 33.3% | 0.201 GB | 7.97x | 0.412x |
+| 1 GB | Full, 40 columns | 0.911 s | 0.254 s | 72.1% | 0.839 GB | 43.14x | 0.398x |
+| 1 GB | Projected, 8 columns | 0.333 s | 0.130 s | 61.0% | 0.302 GB | 24.00x | 1.077x |
+
+The ratio columns are archived comparator time divided by the refreshed
+dta-parser time. The 1 GB projected read is 1.08 times as fast as Stata in this
+run; Stata remains faster on the other three workloads. The sections below
+preserve the original single-thread experiment and its matched string-workload
+analysis as the implementation baseline.
 
 The baseline was captured before edits with three measured iterations. The
 final result used seven measured iterations, alternating implementation order

--- a/benchmarks/r-corpus-performance/README.md
+++ b/benchmarks/r-corpus-performance/README.md
@@ -11,11 +11,14 @@ so its application startup is excluded from timing but included in peak RSS.
 
 The published aggregate uses only files that all three readers load with identical
 dimensions. Empty, corrupt, unsupported, and one-reader-only inputs remain in
-the private raw results but are excluded symmetrically. The summary reports the
-common-readable file count and exclusion count for each corpus, total elapsed
-time over that common file set, dta-parser's speedup against each comparator,
-and the maximum per-file peak RSS observed for each reader. It never publishes
-private paths or data values.
+the private raw results but are excluded symmetrically. The inventory reads
+only the DTA signature to record the on-disk release. The summary reports one
+row per corpus and release plus an `all` subtotal for each corpus. Every row
+contains the common-readable file count and exclusion count, total elapsed time
+over that common file set, dta-parser's speedup against each comparator, and
+the maximum per-file peak RSS observed for each reader. Unrecognized or
+unreadable signatures remain accounted for as `unknown` inventory groups. The
+report never publishes private paths or data values.
 
 See the [2026-08-24 aggregate report](results-2026-08-24.md) for the complete
 1,823-file run used in the R package README.
@@ -24,6 +27,12 @@ On macOS, run the complete suite from the checkout root:
 
 ```sh
 benchmarks/r-corpus-performance/benchmark.sh
+```
+
+The release detector and aggregation contract have a public, corpus-free test:
+
+```sh
+Rscript --vanilla benchmarks/r-corpus-performance/test-framework.R
 ```
 
 `AWW_CACHE_ROOT` may name another absolute cache root with `DHS`, `MICS`, and

--- a/benchmarks/r-corpus-performance/common.R
+++ b/benchmarks/r-corpus-performance/common.R
@@ -1,0 +1,156 @@
+corpus_legacy_releases <- c(104L, 105L, 108L, 110L, 111L, 113L, 114L, 115L)
+corpus_modern_release_prefix <- charToRaw("<stata_dta><header><release>")
+
+corpus_dta_release <- function(path) {
+    tryCatch({
+        if (!file.exists(path) || dir.exists(path)) return(NA_integer_)
+        connection <- suppressWarnings(file(path, open = "rb"))
+        on.exit(close(connection), add = TRUE)
+        needed <- length(corpus_modern_release_prefix) + 3L
+        header <- readBin(connection, what = "raw", n = needed)
+        if (!length(header)) return(NA_integer_)
+
+        first <- as.integer(header[[1L]])
+        if (first %in% corpus_legacy_releases) return(first)
+        if (length(header) < needed || !identical(
+            header[seq_along(corpus_modern_release_prefix)],
+            corpus_modern_release_prefix
+        )) return(NA_integer_)
+
+        digits <- rawToChar(header[seq.int(
+            length(corpus_modern_release_prefix) + 1L, needed
+        )])
+        if (!grepl("^[0-9]{3}$", digits)) return(NA_integer_)
+        as.integer(digits)
+    }, error = function(error) NA_integer_)
+}
+
+corpus_pair_results <- function(raw, inventory) {
+    raw_required <- c(
+        "corpus", "id", "reader", "status", "elapsed_seconds", "rows",
+        "columns", "rss_bytes", "footprint_bytes"
+    )
+    inventory_required <- c("corpus", "id", "release", "bytes")
+    if (!all(raw_required %in% names(raw))) {
+        stop("raw results are missing pairing columns")
+    }
+    if (!all(inventory_required %in% names(inventory))) {
+        stop("inventory is missing pairing columns")
+    }
+    if (anyDuplicated(raw[c("corpus", "id", "reader")])) {
+        stop("raw results contain duplicate reader measurements")
+    }
+
+    direct <- raw[raw$reader == "dtaparser", , drop = FALSE]
+    haven <- raw[raw$reader == "haven", , drop = FALSE]
+    stata <- raw[raw$reader == "stata", , drop = FALSE]
+    paired <- merge(
+        direct, haven, by = c("corpus", "id"),
+        suffixes = c("_dtaparser", "_haven")
+    )
+    paired <- merge(paired, stata, by = c("corpus", "id"))
+    stata_columns <- c(
+        "reader", "reader_order", "status", "elapsed_seconds", "rows",
+        "columns", "rss_bytes", "footprint_bytes"
+    )
+    names(paired)[names(paired) %in% stata_columns] <- paste0(
+        names(paired)[names(paired) %in% stata_columns], "_stata"
+    )
+    paired <- paired[
+        paired$status_dtaparser == "ok" & paired$status_haven == "ok" &
+            paired$status_stata == "ok" &
+            paired$rows_dtaparser == paired$rows_haven &
+            paired$columns_dtaparser == paired$columns_haven &
+            paired$rows_dtaparser == paired$rows_stata &
+            paired$columns_dtaparser == paired$columns_stata,
+        , drop = FALSE
+    ]
+    merge(
+        paired, inventory[c("corpus", "id", "release", "bytes")],
+        by = c("corpus", "id")
+    )
+}
+
+corpus_summary_row <- function(corpus, release, all_files, common) {
+    has_common <- nrow(common) > 0L
+    sum_or_na <- function(values) if (has_common) sum(values) else NA_real_
+    max_or_na <- function(values) if (has_common) max(values) else NA_real_
+
+    direct_seconds <- sum_or_na(common$elapsed_seconds_dtaparser)
+    haven_seconds <- sum_or_na(common$elapsed_seconds_haven)
+    stata_seconds <- sum_or_na(common$elapsed_seconds_stata)
+    direct_rss <- max_or_na(common$rss_bytes_dtaparser)
+    haven_rss <- max_or_na(common$rss_bytes_haven)
+    stata_rss <- max_or_na(common$rss_bytes_stata)
+    data.frame(
+        corpus = corpus,
+        release = release,
+        files = nrow(common),
+        excluded_files = nrow(all_files) - nrow(common),
+        input_gb = if (has_common) sum(common$bytes) / 1e9 else 0,
+        dtaparser_seconds = direct_seconds,
+        haven_seconds = haven_seconds,
+        stata_seconds = stata_seconds,
+        vs_haven_speedup = haven_seconds / direct_seconds,
+        vs_stata_speedup = stata_seconds / direct_seconds,
+        dtaparser_peak_rss_gb = direct_rss / 1e9,
+        haven_peak_rss_gb = haven_rss / 1e9,
+        stata_peak_rss_gb = stata_rss / 1e9,
+        vs_haven_rss_reduction = 1 - direct_rss / haven_rss,
+        vs_stata_rss_reduction = 1 - direct_rss / stata_rss,
+        stringsAsFactors = FALSE
+    )
+}
+
+corpus_performance_summary <- function(inventory, paired, corpus_names) {
+    inventory_required <- c("corpus", "id", "release")
+    paired_required <- c(
+        "corpus", "id", "release", "bytes",
+        "elapsed_seconds_dtaparser", "elapsed_seconds_haven",
+        "elapsed_seconds_stata", "rss_bytes_dtaparser", "rss_bytes_haven",
+        "rss_bytes_stata"
+    )
+    if (!all(inventory_required %in% names(inventory))) {
+        stop("inventory is missing release-summary columns")
+    }
+    if (!all(paired_required %in% names(paired))) {
+        stop("paired results are missing release-summary columns")
+    }
+    if (anyDuplicated(inventory[c("corpus", "id")])) {
+        stop("inventory contains duplicate corpus IDs")
+    }
+    if (anyDuplicated(paired[c("corpus", "id")])) {
+        stop("paired results contain duplicate corpus IDs")
+    }
+
+    rows <- list()
+    append_row <- function(row) rows[[length(rows) + 1L]] <<- row
+    for (corpus in corpus_names) {
+        corpus_inventory <- inventory[inventory$corpus == corpus, , drop = FALSE]
+        corpus_common <- paired[paired$corpus == corpus, , drop = FALSE]
+        releases <- sort(unique(corpus_inventory$release[!is.na(corpus_inventory$release)]))
+        for (release in releases) {
+            append_row(corpus_summary_row(
+                corpus, as.character(release),
+                corpus_inventory[
+                    !is.na(corpus_inventory$release) &
+                        corpus_inventory$release == release,
+                    , drop = FALSE
+                ],
+                corpus_common[
+                    !is.na(corpus_common$release) & corpus_common$release == release,
+                    , drop = FALSE
+                ]
+            ))
+        }
+        if (anyNA(corpus_inventory$release)) {
+            append_row(corpus_summary_row(
+                corpus, "unknown",
+                corpus_inventory[is.na(corpus_inventory$release), , drop = FALSE],
+                corpus_common[is.na(corpus_common$release), , drop = FALSE]
+            ))
+        }
+        append_row(corpus_summary_row(corpus, "all", corpus_inventory, corpus_common))
+    }
+    do.call(rbind, rows)
+}

--- a/benchmarks/r-corpus-performance/results-2026-08-24.md
+++ b/benchmarks/r-corpus-performance/results-2026-08-24.md
@@ -21,6 +21,30 @@ the successful result until exit. Reader order rotates between inputs.
 | NSFG | 229 | 5.777 GB | 222 | 7 |
 | Total | 1,823 | 56.430 GB | 1,812 | 11 |
 
+The harness derives the stored release from the DTA signature. The same
+inventory and common-readable sets disaggregate as follows; `unknown` is the
+one MICS input without a recognized DTA signature. The release rows below
+reaggregate the archived raw timings from this run; they are not new timings.
+
+| Corpus | Stored release | Inventoried files | Common files | Excluded |
+| --- | ---: | ---: | ---: | ---: |
+| DHS | 111 | 130 | 129 | 1 |
+| DHS | 113 | 485 | 484 | 1 |
+| DHS | 114 | 24 | 24 | 0 |
+| DHS | 117 | 1 | 1 | 0 |
+| DHS | 118 | 3 | 3 | 0 |
+| MICS | 117 | 495 | 494 | 1 |
+| MICS | 118 | 455 | 455 | 0 |
+| MICS | unknown | 1 | 0 | 1 |
+| NSFG | 105 | 10 | 4 | 6 |
+| NSFG | 108 | 5 | 4 | 1 |
+| NSFG | 110 | 7 | 7 | 0 |
+| NSFG | 113 | 28 | 28 | 0 |
+| NSFG | 114 | 44 | 44 | 0 |
+| NSFG | 115 | 9 | 9 | 0 |
+| NSFG | 117 | 69 | 69 | 0 |
+| NSFG | 118 | 57 | 57 | 0 |
+
 The comparison uses only successful reads with identical row and column
 counts across all three readers. Both MICS exclusions were rejected by every
 reader. Dta-parser and Stata successfully read all DHS and NSFG files with
@@ -36,9 +60,24 @@ value observed within that same set, not a sum.
 
 | Corpus | Files | Input | dta-parser time | haven time | Stata time | dta-parser vs haven | dta-parser vs Stata | dta-parser peak RSS | haven peak RSS | Stata peak RSS |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
-| DHS | 641 | 46.903 GB | 297.810 s | 2,727.051 s | 68.806 s | 9.16x | 0.231x | 35.183 GB | 35.103 GB | 5.256 GB |
-| MICS | 949 | 3.690 GB | 31.815 s | 216.732 s | 1.155 s | 6.81x | 0.036x | 0.649 GB | 0.669 GB | 0.100 GB |
-| NSFG | 222 | 5.772 GB | 34.634 s | 234.588 s | 0.885 s | 6.77x | 0.026x | 2.458 GB | 2.470 GB | 0.435 GB |
+| DHS — release 111 | 129 | 8.320 GB | 49.235 s | 435.302 s | 63.506 s | 8.84x | 1.290x | 4.523 GB | 4.526 GB | 0.725 GB |
+| DHS — release 113 | 484 | 37.343 GB | 240.452 s | 2,226.568 s | 5.124 s | 9.26x | 0.021x | 35.183 GB | 35.103 GB | 5.256 GB |
+| DHS — release 114 | 24 | 1.162 GB | 7.574 s | 61.036 s | 0.163 s | 8.06x | 0.022x | 0.897 GB | 0.914 GB | 0.149 GB |
+| DHS — release 117 | 1 | 0.028 GB | 0.219 s | 1.505 s | 0.004 s | 6.87x | 0.018x | 0.321 GB | 0.344 GB | 0.056 GB |
+| DHS — release 118 | 3 | 0.050 GB | 0.330 s | 2.640 s | 0.009 s | 8.00x | 0.027x | 0.411 GB | 0.430 GB | 0.077 GB |
+| DHS — all releases | 641 | 46.903 GB | 297.810 s | 2,727.051 s | 68.806 s | 9.16x | 0.231x | 35.183 GB | 35.103 GB | 5.256 GB |
+| MICS — release 117 | 494 | 1.634 GB | 15.099 s | 98.402 s | 0.567 s | 6.52x | 0.038x | 0.306 GB | 0.367 GB | 0.073 GB |
+| MICS — release 118 | 455 | 2.056 GB | 16.716 s | 118.330 s | 0.588 s | 7.08x | 0.035x | 0.649 GB | 0.669 GB | 0.100 GB |
+| MICS — all releases | 949 | 3.690 GB | 31.815 s | 216.732 s | 1.155 s | 6.81x | 0.036x | 0.649 GB | 0.669 GB | 0.100 GB |
+| NSFG — release 105 | 4 | 0.005 GB | 0.078 s | 0.196 s | 0.028 s | 2.51x | 0.359x | 0.125 GB | 0.121 GB | 0.054 GB |
+| NSFG — release 108 | 4 | 0.001 GB | 0.068 s | 0.097 s | 0.006 s | 1.43x | 0.088x | 0.106 GB | 0.104 GB | 0.030 GB |
+| NSFG — release 110 | 7 | 0.015 GB | 0.149 s | 0.497 s | 0.106 s | 3.34x | 0.711x | 0.128 GB | 0.123 GB | 0.041 GB |
+| NSFG — release 113 | 28 | 0.673 GB | 1.464 s | 7.389 s | 0.079 s | 5.05x | 0.054x | 0.524 GB | 0.543 GB | 0.435 GB |
+| NSFG — release 114 | 44 | 1.171 GB | 7.761 s | 47.892 s | 0.156 s | 6.17x | 0.020x | 0.751 GB | 0.765 GB | 0.208 GB |
+| NSFG — release 115 | 9 | 0.100 GB | 0.614 s | 3.512 s | 0.015 s | 5.72x | 0.024x | 0.391 GB | 0.414 GB | 0.068 GB |
+| NSFG — release 117 | 69 | 2.180 GB | 14.856 s | 107.544 s | 0.288 s | 7.24x | 0.019x | 1.315 GB | 1.330 GB | 0.201 GB |
+| NSFG — release 118 | 57 | 1.626 GB | 9.644 s | 67.461 s | 0.207 s | 7.00x | 0.021x | 2.458 GB | 2.470 GB | 0.375 GB |
+| NSFG — all releases | 222 | 5.772 GB | 34.634 s | 234.588 s | 0.885 s | 6.77x | 0.026x | 2.458 GB | 2.470 GB | 0.435 GB |
 
 Both comparison ratios are comparator time divided by dta-parser time; values
 above 1x favor dta-parser and values below 1x favor the comparator.
@@ -51,11 +90,13 @@ R reader must construct R-compatible vectors, so the Stata result is best read
 as an eager native-format reference rather than a directly attainable R-object
 floor.
 
-Dta-parser was 9.16 times as fast as haven on DHS, 6.81 times on MICS,
-and 6.77 times on NSFG. Its peak RSS was 0.2% higher than haven on DHS,
-3.0% lower on MICS, and 0.5% lower on NSFG. Stata was 4.33, 27.55, and
-39.13 times as fast as dta-parser respectively, and its maximum peak RSS was
-82.3--85.1% lower.
+Across stored-release strata, dta-parser was 1.43--9.26 times as fast as haven.
+It was 1.29 times as fast as Stata on DHS release 111; Stata was 1.41--54.75
+times as fast on every other stratum. At the all-release corpus level,
+dta-parser was 9.16 times as fast as haven on DHS, 6.81 times on MICS, and 6.77
+times on NSFG. Its peak RSS was 0.2% higher than haven on DHS, 3.0% lower on
+MICS, and 0.5% lower on NSFG. Stata was 4.33, 27.55, and 39.13 times as fast as
+dta-parser respectively, and its maximum peak RSS was 82.3--85.1% lower.
 
 These are warm-cache, machine- and corpus-specific measurements rather than
 performance guarantees. The full private run directory contains a stable

--- a/benchmarks/r-corpus-performance/results-2026-08-24.md
+++ b/benchmarks/r-corpus-performance/results-2026-08-24.md
@@ -23,8 +23,7 @@ the successful result until exit. Reader order rotates between inputs.
 
 The harness derives the stored release from the DTA signature. The same
 inventory and common-readable sets disaggregate as follows; `unknown` is the
-one MICS input without a recognized DTA signature. The release rows below
-reaggregate the archived raw timings from this run; they are not new timings.
+one MICS input without a recognized DTA signature.
 
 | Corpus | Stored release | Inventoried files | Common files | Excluded |
 | --- | ---: | ---: | ---: | ---: |
@@ -56,7 +55,13 @@ to 7,053 columns.
 ## Paired results
 
 Times are sums over each common file set. Peak RSS is the largest fresh-process
-value observed within that same set, not a sum.
+value observed within that same set, not a sum. Dta-parser was rerun only for
+the 515 release-118 files after the multicore implementation, using its default
+automatic thread count at commit `5245856`. Every refreshed read succeeded and
+returned the same dimensions as the archived run. Haven, Stata, and dta-parser
+results for earlier releases were not rerun. The all-release rows combine the
+refreshed dta-parser values with the archived values; all comparator values are
+unchanged.
 
 | Corpus | Files | Input | dta-parser time | haven time | Stata time | dta-parser vs haven | dta-parser vs Stata | dta-parser peak RSS | haven peak RSS | Stata peak RSS |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
@@ -64,11 +69,11 @@ value observed within that same set, not a sum.
 | DHS — release 113 | 484 | 37.343 GB | 240.452 s | 2,226.568 s | 5.124 s | 9.26x | 0.021x | 35.183 GB | 35.103 GB | 5.256 GB |
 | DHS — release 114 | 24 | 1.162 GB | 7.574 s | 61.036 s | 0.163 s | 8.06x | 0.022x | 0.897 GB | 0.914 GB | 0.149 GB |
 | DHS — release 117 | 1 | 0.028 GB | 0.219 s | 1.505 s | 0.004 s | 6.87x | 0.018x | 0.321 GB | 0.344 GB | 0.056 GB |
-| DHS — release 118 | 3 | 0.050 GB | 0.330 s | 2.640 s | 0.009 s | 8.00x | 0.027x | 0.411 GB | 0.430 GB | 0.077 GB |
-| DHS — all releases | 641 | 46.903 GB | 297.810 s | 2,727.051 s | 68.806 s | 9.16x | 0.231x | 35.183 GB | 35.103 GB | 5.256 GB |
+| DHS — release 118 | 3 | 0.050 GB | 0.189 s | 2.640 s | 0.009 s | 13.97x | 0.048x | 0.411 GB | 0.430 GB | 0.077 GB |
+| DHS — all releases | 641 | 46.903 GB | 297.669 s | 2,727.051 s | 68.806 s | 9.16x | 0.231x | 35.183 GB | 35.103 GB | 5.256 GB |
 | MICS — release 117 | 494 | 1.634 GB | 15.099 s | 98.402 s | 0.567 s | 6.52x | 0.038x | 0.306 GB | 0.367 GB | 0.073 GB |
-| MICS — release 118 | 455 | 2.056 GB | 16.716 s | 118.330 s | 0.588 s | 7.08x | 0.035x | 0.649 GB | 0.669 GB | 0.100 GB |
-| MICS — all releases | 949 | 3.690 GB | 31.815 s | 216.732 s | 1.155 s | 6.81x | 0.036x | 0.649 GB | 0.669 GB | 0.100 GB |
+| MICS — release 118 | 455 | 2.056 GB | 15.588 s | 118.330 s | 0.588 s | 7.59x | 0.038x | 0.651 GB | 0.669 GB | 0.100 GB |
+| MICS — all releases | 949 | 3.690 GB | 30.687 s | 216.732 s | 1.155 s | 7.06x | 0.038x | 0.651 GB | 0.669 GB | 0.100 GB |
 | NSFG — release 105 | 4 | 0.005 GB | 0.078 s | 0.196 s | 0.028 s | 2.51x | 0.359x | 0.125 GB | 0.121 GB | 0.054 GB |
 | NSFG — release 108 | 4 | 0.001 GB | 0.068 s | 0.097 s | 0.006 s | 1.43x | 0.088x | 0.106 GB | 0.104 GB | 0.030 GB |
 | NSFG — release 110 | 7 | 0.015 GB | 0.149 s | 0.497 s | 0.106 s | 3.34x | 0.711x | 0.128 GB | 0.123 GB | 0.041 GB |
@@ -76,8 +81,8 @@ value observed within that same set, not a sum.
 | NSFG — release 114 | 44 | 1.171 GB | 7.761 s | 47.892 s | 0.156 s | 6.17x | 0.020x | 0.751 GB | 0.765 GB | 0.208 GB |
 | NSFG — release 115 | 9 | 0.100 GB | 0.614 s | 3.512 s | 0.015 s | 5.72x | 0.024x | 0.391 GB | 0.414 GB | 0.068 GB |
 | NSFG — release 117 | 69 | 2.180 GB | 14.856 s | 107.544 s | 0.288 s | 7.24x | 0.019x | 1.315 GB | 1.330 GB | 0.201 GB |
-| NSFG — release 118 | 57 | 1.626 GB | 9.644 s | 67.461 s | 0.207 s | 7.00x | 0.021x | 2.458 GB | 2.470 GB | 0.375 GB |
-| NSFG — all releases | 222 | 5.772 GB | 34.634 s | 234.588 s | 0.885 s | 6.77x | 0.026x | 2.458 GB | 2.470 GB | 0.435 GB |
+| NSFG — release 118 | 57 | 1.626 GB | 4.875 s | 67.461 s | 0.207 s | 13.84x | 0.042x | 2.460 GB | 2.470 GB | 0.375 GB |
+| NSFG — all releases | 222 | 5.772 GB | 29.865 s | 234.588 s | 0.885 s | 7.85x | 0.030x | 2.460 GB | 2.470 GB | 0.435 GB |
 
 Both comparison ratios are comparator time divided by dta-parser time; values
 above 1x favor dta-parser and values below 1x favor the comparator.
@@ -90,13 +95,17 @@ R reader must construct R-compatible vectors, so the Stata result is best read
 as an eager native-format reference rather than a directly attainable R-object
 floor.
 
-Across stored-release strata, dta-parser was 1.43--9.26 times as fast as haven.
+Across stored-release strata, dta-parser was 1.43--13.97 times as fast as haven.
 It was 1.29 times as fast as Stata on DHS release 111; Stata was 1.41--54.75
 times as fast on every other stratum. At the all-release corpus level,
-dta-parser was 9.16 times as fast as haven on DHS, 6.81 times on MICS, and 6.77
-times on NSFG. Its peak RSS was 0.2% higher than haven on DHS, 3.0% lower on
-MICS, and 0.5% lower on NSFG. Stata was 4.33, 27.55, and 39.13 times as fast as
+dta-parser was 9.16 times as fast as haven on DHS, 7.06 times on MICS, and 7.85
+times on NSFG. Its peak RSS was 0.2% higher than haven on DHS, 2.6% lower on
+MICS, and 0.4% lower on NSFG. Stata was 4.33, 26.57, and 33.75 times as fast as
 dta-parser respectively, and its maximum peak RSS was 82.3--85.1% lower.
+
+The modern-path refresh reduced aggregate dta-parser time from 0.330 to 0.189
+seconds on DHS release 118 (42.7%), from 16.716 to 15.588 seconds on MICS
+release 118 (6.7%), and from 9.644 to 4.875 seconds on NSFG release 118 (49.5%).
 
 These are warm-cache, machine- and corpus-specific measurements rather than
 performance guarantees. The full private run directory contains a stable

--- a/benchmarks/r-corpus-performance/run.R
+++ b/benchmarks/r-corpus-performance/run.R
@@ -6,6 +6,11 @@ if (!requireNamespace("processx", quietly = TRUE)) {
     stop("the processx package is required")
 }
 
+script_argument <- grep("^--file=", commandArgs(trailingOnly = FALSE), value = TRUE)[[1L]]
+script_path <- normalizePath(sub("^--file=", "", script_argument), winslash = "/")
+script_dir <- dirname(script_path)
+source(file.path(script_dir, "common.R"), local = TRUE)
+
 cache_root <- normalizePath(args[[1L]], winslash = "/", mustWork = TRUE)
 output_dir <- normalizePath(args[[2L]], winslash = "/", mustWork = FALSE)
 max_files <- if (length(args) == 3L) as.integer(args[[3L]]) else Inf
@@ -16,10 +21,8 @@ benchmark_library <- Sys.getenv("DTAPARSER_BENCH_LIB")
 if (!nzchar(benchmark_library)) stop("DTAPARSER_BENCH_LIB is required")
 benchmark_library <- normalizePath(benchmark_library, winslash = "/", mustWork = TRUE)
 
-script_argument <- grep("^--file=", commandArgs(trailingOnly = FALSE), value = TRUE)[[1L]]
-script_path <- normalizePath(sub("^--file=", "", script_argument), winslash = "/")
-worker_path <- file.path(dirname(script_path), "worker.R")
-stata_worker_path <- file.path(dirname(script_path), "stata-worker.do")
+worker_path <- file.path(script_dir, "worker.R")
+stata_worker_path <- file.path(script_dir, "stata-worker.do")
 rscript <- Sys.which("Rscript")
 time_command <- "/usr/bin/time"
 if (!nzchar(rscript) || !file.exists(time_command)) {
@@ -72,6 +75,7 @@ inventory_rows <- lapply(names(corpus_roots), function(corpus) {
         id = sprintf("%s-%04d", corpus, seq_along(paths)),
         relative_path = relative_paths,
         path = paths,
+        release = vapply(paths, corpus_dta_release, integer(1)),
         bytes = as.double(info$size),
         mtime = as.numeric(info$mtime),
         stringsAsFactors = FALSE
@@ -92,7 +96,7 @@ dir.create(output_dir, recursive = TRUE, showWarnings = FALSE)
 raw_path <- file.path(output_dir, "raw.tsv")
 inventory_path <- file.path(output_dir, "inventory.tsv")
 write.table(
-    inventory[c("corpus", "id", "relative_path", "bytes", "mtime")],
+    inventory[c("corpus", "id", "relative_path", "release", "bytes", "mtime")],
     inventory_path, sep = "\t", row.names = FALSE, quote = TRUE
 )
 
@@ -235,59 +239,8 @@ for (index in seq_len(nrow(inventory))) {
 }
 
 raw <- read.delim(raw_path, check.names = FALSE, stringsAsFactors = FALSE)
-direct <- raw[raw$reader == "dtaparser", ]
-haven <- raw[raw$reader == "haven", ]
-stata_results <- raw[raw$reader == "stata", ]
-paired <- merge(
-    direct, haven, by = c("corpus", "id"), suffixes = c("_dtaparser", "_haven")
-)
-paired <- merge(
-    paired, stata_results, by = c("corpus", "id"), suffixes = c("", "_stata")
-)
-names(paired)[names(paired) %in% c(
-    "reader", "reader_order", "status", "elapsed_seconds", "rows", "columns",
-    "rss_bytes", "footprint_bytes"
-)] <- paste0(names(paired)[names(paired) %in% c(
-    "reader", "reader_order", "status", "elapsed_seconds", "rows", "columns",
-    "rss_bytes", "footprint_bytes"
-)], "_stata")
-paired <- paired[
-    paired$status_dtaparser == "ok" & paired$status_haven == "ok" &
-        paired$status_stata == "ok" &
-        paired$rows_dtaparser == paired$rows_haven &
-        paired$columns_dtaparser == paired$columns_haven &
-        paired$rows_dtaparser == paired$rows_stata &
-        paired$columns_dtaparser == paired$columns_stata,
-]
-paired <- merge(paired, inventory[c("corpus", "id", "bytes")], by = c("corpus", "id"))
-
-summary_rows <- lapply(names(corpus_roots), function(corpus) {
-    all_files <- inventory[inventory$corpus == corpus, ]
-    common <- paired[paired$corpus == corpus, ]
-    direct_seconds <- sum(common$elapsed_seconds_dtaparser)
-    haven_seconds <- sum(common$elapsed_seconds_haven)
-    stata_seconds <- sum(common$elapsed_seconds_stata)
-    direct_rss <- max(common$rss_bytes_dtaparser)
-    haven_rss <- max(common$rss_bytes_haven)
-    stata_rss <- max(common$rss_bytes_stata)
-    data.frame(
-        corpus = corpus,
-        files = nrow(common),
-        excluded_files = nrow(all_files) - nrow(common),
-        input_gb = sum(common$bytes) / 1e9,
-        dtaparser_seconds = direct_seconds,
-        haven_seconds = haven_seconds,
-        stata_seconds = stata_seconds,
-        vs_haven_speedup = haven_seconds / direct_seconds,
-        vs_stata_speedup = stata_seconds / direct_seconds,
-        dtaparser_peak_rss_gb = direct_rss / 1e9,
-        haven_peak_rss_gb = haven_rss / 1e9,
-        stata_peak_rss_gb = stata_rss / 1e9,
-        vs_haven_rss_reduction = 1 - direct_rss / haven_rss,
-        vs_stata_rss_reduction = 1 - direct_rss / stata_rss
-    )
-})
-summary <- do.call(rbind, summary_rows)
+paired <- corpus_pair_results(raw, inventory)
+summary <- corpus_performance_summary(inventory, paired, names(corpus_roots))
 write.table(
     summary, file.path(output_dir, "summary.tsv"),
     sep = "\t", row.names = FALSE, quote = FALSE

--- a/benchmarks/r-corpus-performance/test-framework.R
+++ b/benchmarks/r-corpus-performance/test-framework.R
@@ -1,0 +1,72 @@
+script_argument <- grep("^--file=", commandArgs(trailingOnly = FALSE), value = TRUE)[[1L]]
+script_path <- normalizePath(sub("^--file=", "", script_argument), winslash = "/")
+source(file.path(dirname(script_path), "common.R"), local = TRUE)
+
+root <- tempfile("r-corpus-performance-")
+dir.create(root)
+on.exit(unlink(root, recursive = TRUE, force = TRUE), add = TRUE)
+write_fixture <- function(name, bytes) {
+    path <- file.path(root, name)
+    writeBin(bytes, path)
+    path
+}
+
+legacy <- write_fixture("legacy.dta", as.raw(c(111L, 0L, 0L)))
+modern <- write_fixture(
+    "modern.dta",
+    charToRaw("<stata_dta><header><release>118<tail>")
+)
+modern_119 <- write_fixture(
+    "modern-119.dta",
+    charToRaw("<stata_dta><header><release>119<tail>")
+)
+unknown <- write_fixture("unknown.dta", as.raw(c(1L, 2L, 3L)))
+empty <- write_fixture("empty.dta", raw())
+stopifnot(
+    identical(corpus_dta_release(legacy), 111L),
+    identical(corpus_dta_release(modern), 118L),
+    identical(corpus_dta_release(modern_119), 119L),
+    is.na(corpus_dta_release(unknown)),
+    is.na(corpus_dta_release(empty)),
+    is.na(corpus_dta_release(file.path(root, "missing.dta")))
+)
+
+inventory <- data.frame(
+    corpus = rep("DHS", 4L),
+    id = c("DHS-0001", "DHS-0002", "DHS-0003", "DHS-0004"),
+    release = c(117L, 118L, 118L, NA_integer_),
+    stringsAsFactors = FALSE
+)
+inventory$bytes <- c(1e9, 2e9, 4e9, 0.5e9)
+raw <- data.frame(
+    corpus = rep("DHS", 9L),
+    id = rep(c("DHS-0001", "DHS-0002", "DHS-0003"), each = 3L),
+    reader = rep(c("dtaparser", "haven", "stata"), 3L),
+    reader_order = rep(1:3, 3L),
+    status = c(rep("ok", 8L), "error"),
+    elapsed_seconds = c(2, 8, 1, 1, 6, 0.25, 5, 9, NA),
+    rows = rep(10, 9L),
+    columns = rep(2, 9L),
+    rss_bytes = c(4e9, 5e9, 2e9, 3e9, 4e9, 1e9, 6e9, 7e9, NA),
+    footprint_bytes = rep(NA_real_, 9L),
+    stringsAsFactors = FALSE
+)
+paired <- corpus_pair_results(raw, inventory)
+stopifnot(
+    identical(paired$id, c("DHS-0001", "DHS-0002")),
+    identical(paired$release, c(117L, 118L))
+)
+summary <- corpus_performance_summary(inventory, paired, c("DHS", "MICS"))
+stopifnot(
+    identical(summary$corpus, c("DHS", "DHS", "DHS", "DHS", "MICS")),
+    identical(summary$release, c("117", "118", "unknown", "all", "all")),
+    identical(summary$files, c(1L, 1L, 0L, 2L, 0L)),
+    identical(summary$excluded_files, c(0L, 1L, 1L, 2L, 0L)),
+    isTRUE(all.equal(summary$input_gb, c(1, 2, 0, 3, 0))),
+    isTRUE(all.equal(summary$vs_haven_speedup[c(1:2, 4)], c(4, 6, 14 / 3))),
+    isTRUE(all.equal(summary$vs_stata_speedup[c(1:2, 4)], c(0.5, 0.25, 1.25 / 3))),
+    all(is.na(summary$dtaparser_seconds[c(3, 5)])),
+    all(is.na(summary$dtaparser_peak_rss_gb[c(3, 5)]))
+)
+
+cat("R corpus performance framework: PASS\n")

--- a/r-package/dtaparser/R/read-dta.R
+++ b/r-package/dtaparser/R/read-dta.R
@@ -30,6 +30,9 @@
 #'   negative finite values read all remaining rows, following haven's
 #'   unlimited-row convention. Non-negative values must be whole numbers no
 #'   larger than `2^53`.
+#' @param threads Number of decoder threads. Zero selects an automatic count
+#'   for sufficiently large Stata 118--119 files. One always uses the serial
+#'   decoder. Earlier formats and `strL` projections currently remain serial.
 #' @param .name_repair Name repair passed to [tibble::as_tibble()].
 #' @return A tibble. `%td` columns and legacy or custom formats beginning `%d`
 #'   have class `Date`; `%tc` and `%tC` columns have classes `POSIXct` and
@@ -37,10 +40,11 @@
 #'   `format.stata` attribute.
 #' @export
 read_dta <- function(file, encoding = NULL, col_select = NULL, skip = 0,
-                     n_max = Inf, .name_repair = "unique") {
+                     n_max = Inf, .name_repair = "unique",
+                     threads = getOption("dtaparser.threads", 0L)) {
     .read_dta_impl(
         file, encoding, rlang::enquo(col_select), skip, n_max, .name_repair,
-        materialization = "direct"
+        materialization = "direct", threads = threads
     )
 }
 
@@ -51,14 +55,15 @@ read_dta <- function(file, encoding = NULL, col_select = NULL, skip = 0,
                                    .name_repair = "unique") {
     .read_dta_impl(
         file, encoding, rlang::enquo(col_select), skip, n_max, .name_repair,
-        materialization = "rust-vectors"
+        materialization = "rust-vectors", threads = 1L
     )
 }
 
 .read_dta_impl <- function(file, encoding, selection, skip, n_max,
-                           .name_repair, materialization) {
+                           .name_repair, materialization, threads) {
     encoding <- .validate_dta_encoding(encoding)
     row_window <- .normalize_row_window(skip, n_max)
+    threads <- .normalize_threads(threads)
 
     source <- .resolve_dta_source(file)
     on.exit(.cleanup_dta_source(source), add = TRUE)
@@ -87,6 +92,7 @@ read_dta <- function(file, encoding = NULL, col_select = NULL, skip = 0,
         row_window$skip,
         row_window$n_max,
         identical(materialization, "direct"),
+        threads,
         encoding
     )
     if (!is.null(column_indices)) {
@@ -99,6 +105,15 @@ read_dta <- function(file, encoding = NULL, col_select = NULL, skip = 0,
     if (!is.null(dataset_label)) attr(result, "label") <- dataset_label
     if (!is.null(dataset_notes)) attr(result, "notes") <- dataset_notes
     result
+}
+
+.normalize_threads <- function(value) {
+    if (!is.numeric(value) || length(value) != 1L || is.na(value) ||
+        !is.finite(value) || value < 0 || value != floor(value) ||
+        value > .Machine$integer.max) {
+        stop("`threads` must be one non-negative whole number", call. = FALSE)
+    }
+    as.integer(value)
 }
 
 .resolve_dta_source <- function(file) {

--- a/r-package/dtaparser/README.md
+++ b/r-package/dtaparser/README.md
@@ -1,14 +1,21 @@
 # dtaparser
 
 `dtaparser` is the R interface to this repository's bounded Rust DTA
-reader. Its exported `read_dta()` function deliberately mirrors the formal
-arguments of `haven::read_dta()`, while observation storage is decoded by Rust
+reader. Its exported `read_dta()` function follows `haven::read_dta()` and adds
+an optional `threads` execution control, while observation storage is decoded by Rust
 and materialized through an R-specific collector. Numeric values are written
 into their final R vectors during decoding. Each character column interns its
 distinct normalized UTF-8 values once and keeps compact row-to-dictionary
 indices behind an ordinary R character vector through ALTREP. Element access
 resolves the dictionary immediately; allocation of the complete row-level
 string-pointer vector is deferred, without retaining the source file.
+
+Large Stata 118--119 reads use a shared block decoder across multiple cores by
+default. `threads = 0` selects an automatic count, `threads = 1` forces the
+serial executor, and a positive larger value requests an explicit count capped
+by available parallelism and selected columns. Small inputs, earlier formats,
+and projections containing `strL` currently remain serial. Both executors use
+the same validated observation plan and scalar value-decoding semantics.
 
 ## Installation
 
@@ -83,6 +90,11 @@ deterministically with U+FFFD. Haven 2.5.5 may instead omit or empty an affected
 label.
 
 ## Performance compared with haven and Stata
+
+The published table below predates the multicore executor and records the
+single-thread dictionary implementation. It remains the reproducible baseline;
+the parallel implementation must pass the same provenance and matched-consumer
+gates before replacement results are published.
 
 On an Apple M4 Max with 128 GB RAM, the new dictionary-backed implementation
 was benchmarked against haven 2.5.5 and Stata/MP 18. The synthetic files are
@@ -169,6 +181,9 @@ performance thresholds.
 - `.name_repair` is delegated to `tibble::as_tibble()` after selection aliases
   are applied.
 - Reads are synchronous. Long reads cooperatively check for R user interrupts.
+- `threads = 0` automatically parallelizes sufficiently large release 118--119
+  reads without selected `strL` columns. Use `threads = 1` for deterministic
+  single-thread benchmarking. Option `dtaparser.threads` controls the default.
 - Character columns use dictionary-backed ALTREP vectors. Loading does not
   depend on the source path after `read_dta()` returns. Distinct R strings are
   created once during the load; operations that request a contiguous pointer

--- a/r-package/dtaparser/README.md
+++ b/r-package/dtaparser/README.md
@@ -102,7 +102,10 @@ deterministic mixed-type Stata 15 datasets with 40 columns; their time cells are
 seven-run warm-cache medians. The DHS, MICS, and NSFG suite visited all 1,823
 regular DTA files under the local corpus cache in fresh processes. Its time
 cells are sums and its memory cells are the largest per-file peak RSS on the
-common set that all three readers loaded with identical dimensions.
+common set that all three readers loaded with identical dimensions. Corpus
+rows are disaggregated by the release stored in each DTA signature; the `all
+releases` rows retain the original corpus subtotals. The release rows
+reaggregate the same archived raw timings rather than a separate benchmark run.
 
 | Dataset/workload | Common files | Input | dta-parser time | haven time | Stata time | dta-parser vs haven | dta-parser vs Stata | dta-parser peak RSS | haven peak RSS | Stata peak RSS |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
@@ -110,9 +113,24 @@ common set that all three readers loaded with identical dimensions.
 | Synthetic 100 MB, projected 8 columns | 1 | 0.100 GB | 0.051 s | 0.271 s | 0.014 s | 5.31x | 0.275x | 0.198 GB | 0.168 GB | 0.058 GB |
 | Synthetic 1 GB, full 40 columns | 1 | 1.000 GB | 0.911 s | 10.958 s | 0.101 s | 12.03x | 0.111x | 0.834 GB | 0.888 GB | 1.133 GB |
 | Synthetic 1 GB, projected 8 columns | 1 | 1.000 GB | 0.333 s | 3.120 s | 0.140 s | 9.37x | 0.420x | 0.299 GB | 0.292 GB | 0.365 GB |
-| DHS | 641 | 46.903 GB | 297.810 s | 2,727.051 s | 68.806 s | 9.16x | 0.231x | 35.183 GB | 35.103 GB | 5.256 GB |
-| MICS | 949 | 3.690 GB | 31.815 s | 216.732 s | 1.155 s | 6.81x | 0.036x | 0.649 GB | 0.669 GB | 0.100 GB |
-| NSFG | 222 | 5.772 GB | 34.634 s | 234.588 s | 0.885 s | 6.77x | 0.026x | 2.458 GB | 2.470 GB | 0.435 GB |
+| DHS — release 111 | 129 | 8.320 GB | 49.235 s | 435.302 s | 63.506 s | 8.84x | 1.290x | 4.523 GB | 4.526 GB | 0.725 GB |
+| DHS — release 113 | 484 | 37.343 GB | 240.452 s | 2,226.568 s | 5.124 s | 9.26x | 0.021x | 35.183 GB | 35.103 GB | 5.256 GB |
+| DHS — release 114 | 24 | 1.162 GB | 7.574 s | 61.036 s | 0.163 s | 8.06x | 0.022x | 0.897 GB | 0.914 GB | 0.149 GB |
+| DHS — release 117 | 1 | 0.028 GB | 0.219 s | 1.505 s | 0.004 s | 6.87x | 0.018x | 0.321 GB | 0.344 GB | 0.056 GB |
+| DHS — release 118 | 3 | 0.050 GB | 0.330 s | 2.640 s | 0.009 s | 8.00x | 0.027x | 0.411 GB | 0.430 GB | 0.077 GB |
+| DHS — all releases | 641 | 46.903 GB | 297.810 s | 2,727.051 s | 68.806 s | 9.16x | 0.231x | 35.183 GB | 35.103 GB | 5.256 GB |
+| MICS — release 117 | 494 | 1.634 GB | 15.099 s | 98.402 s | 0.567 s | 6.52x | 0.038x | 0.306 GB | 0.367 GB | 0.073 GB |
+| MICS — release 118 | 455 | 2.056 GB | 16.716 s | 118.330 s | 0.588 s | 7.08x | 0.035x | 0.649 GB | 0.669 GB | 0.100 GB |
+| MICS — all releases | 949 | 3.690 GB | 31.815 s | 216.732 s | 1.155 s | 6.81x | 0.036x | 0.649 GB | 0.669 GB | 0.100 GB |
+| NSFG — release 105 | 4 | 0.005 GB | 0.078 s | 0.196 s | 0.028 s | 2.51x | 0.359x | 0.125 GB | 0.121 GB | 0.054 GB |
+| NSFG — release 108 | 4 | 0.001 GB | 0.068 s | 0.097 s | 0.006 s | 1.43x | 0.088x | 0.106 GB | 0.104 GB | 0.030 GB |
+| NSFG — release 110 | 7 | 0.015 GB | 0.149 s | 0.497 s | 0.106 s | 3.34x | 0.711x | 0.128 GB | 0.123 GB | 0.041 GB |
+| NSFG — release 113 | 28 | 0.673 GB | 1.464 s | 7.389 s | 0.079 s | 5.05x | 0.054x | 0.524 GB | 0.543 GB | 0.435 GB |
+| NSFG — release 114 | 44 | 1.171 GB | 7.761 s | 47.892 s | 0.156 s | 6.17x | 0.020x | 0.751 GB | 0.765 GB | 0.208 GB |
+| NSFG — release 115 | 9 | 0.100 GB | 0.614 s | 3.512 s | 0.015 s | 5.72x | 0.024x | 0.391 GB | 0.414 GB | 0.068 GB |
+| NSFG — release 117 | 69 | 2.180 GB | 14.856 s | 107.544 s | 0.288 s | 7.24x | 0.019x | 1.315 GB | 1.330 GB | 0.201 GB |
+| NSFG — release 118 | 57 | 1.626 GB | 9.644 s | 67.461 s | 0.207 s | 7.00x | 0.021x | 2.458 GB | 2.470 GB | 0.375 GB |
+| NSFG — all releases | 222 | 5.772 GB | 34.634 s | 234.588 s | 0.885 s | 6.77x | 0.026x | 2.458 GB | 2.470 GB | 0.435 GB |
 
 Both ratio columns are comparator time divided by dta-parser time. Values above
 1x mean dta-parser was faster; values below 1x mean the comparator was faster.
@@ -132,13 +150,17 @@ Matching Stata while returning ordinary R-compatible objects is therefore a
 different engineering target, but the Stata time is still a valid eager-load
 reference rather than an unattainable lazy-open measurement.
 
-For the synthetic loads, dta-parser was 5.31--12.03 times as fast as haven. On
-the real corpora it was 6.77--9.16 times as fast, with peak RSS 3.0% lower on
-MICS, 0.5% lower on NSFG, and 0.2% higher on the largest DHS file. Stata was
-faster than dta-parser: 4.33 times on DHS, 27.55 times on MICS, and 39.13 times
-on NSFG. Stata also used 82.3--85.1% less peak RSS on those corpus maxima. On
-the 1 GB full synthetic load, however, dta-parser used 26.4% less peak RSS than
-Stata. These are workload- and machine-specific observations, not guarantees.
+For the synthetic loads, dta-parser was 5.31--12.03 times as fast as haven. The
+stored-release strata make the corpus spread explicit: dta-parser was
+1.43--9.26 times as fast as haven, while the all-release corpus subtotals were
+6.77--9.16 times as fast. Dta-parser was 1.29 times as fast as Stata on the DHS
+release-111 stratum; Stata was 1.41--54.75 times as fast on every other
+stratum. At corpus level Stata was 4.33, 27.55, and 39.13 times as fast as
+dta-parser on DHS, MICS, and NSFG. Dta-parser peak RSS was 3.0% lower on MICS,
+0.5% lower on NSFG, and 0.2% higher on the largest DHS file; Stata used
+82.3--85.1% less peak RSS on those corpus maxima. On the 1 GB full synthetic
+load, however, dta-parser used 26.4% less peak RSS than Stata. These are
+workload- and machine-specific observations, not guarantees.
 
 The corpus comparison is deliberately paired. Two MICS files were rejected by
 all three readers. Nine additional files (two DHS and seven NSFG) were read with

--- a/r-package/dtaparser/README.md
+++ b/r-package/dtaparser/README.md
@@ -91,10 +91,12 @@ label.
 
 ## Performance compared with haven and Stata
 
-The published table below predates the multicore executor and records the
-single-thread dictionary implementation. It remains the reproducible baseline;
-the parallel implementation must pass the same provenance and matched-consumer
-gates before replacement results are published.
+The dta-parser cells for synthetic release-119 inputs and corpus release-118
+inputs were refreshed with the automatic multicore executor at commit
+`5245856`. Haven and Stata were not rerun: their cells retain the archived
+matched comparison on the identical files. Dta-parser cells for earlier corpus
+releases also retain that single-thread baseline because the optimized path is
+specific to releases 118/119.
 
 On an Apple M4 Max with 128 GB RAM, the new dictionary-backed implementation
 was benchmarked against haven 2.5.5 and Stata/MP 18. The synthetic files are
@@ -103,25 +105,25 @@ seven-run warm-cache medians. The DHS, MICS, and NSFG suite visited all 1,823
 regular DTA files under the local corpus cache in fresh processes. Its time
 cells are sums and its memory cells are the largest per-file peak RSS on the
 common set that all three readers loaded with identical dimensions. Corpus
-rows are disaggregated by the release stored in each DTA signature; the `all
-releases` rows retain the original corpus subtotals. The release rows
-reaggregate the same archived raw timings rather than a separate benchmark run.
+rows are disaggregated by the release stored in each DTA signature. The `all
+releases` rows combine refreshed release-118 dta-parser measurements with the
+archived earlier-release measurements; comparator values are unchanged.
 
 | Dataset/workload | Common files | Input | dta-parser time | haven time | Stata time | dta-parser vs haven | dta-parser vs Stata | dta-parser peak RSS | haven peak RSS | Stata peak RSS |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
-| Synthetic 100 MB, full 40 columns | 1 | 0.100 GB | 0.139 s | 1.053 s | 0.011 s | 7.58x | 0.079x | 0.273 GB | 0.253 GB | 0.143 GB |
-| Synthetic 100 MB, projected 8 columns | 1 | 0.100 GB | 0.051 s | 0.271 s | 0.014 s | 5.31x | 0.275x | 0.198 GB | 0.168 GB | 0.058 GB |
-| Synthetic 1 GB, full 40 columns | 1 | 1.000 GB | 0.911 s | 10.958 s | 0.101 s | 12.03x | 0.111x | 0.834 GB | 0.888 GB | 1.133 GB |
-| Synthetic 1 GB, projected 8 columns | 1 | 1.000 GB | 0.333 s | 3.120 s | 0.140 s | 9.37x | 0.420x | 0.299 GB | 0.292 GB | 0.365 GB |
+| Synthetic 100 MB, full 40 columns (release 119) | 1 | 0.100 GB | 0.073 s | 1.053 s | 0.011 s | 14.42x | 0.151x | 0.277 GB | 0.253 GB | 0.143 GB |
+| Synthetic 100 MB, projected 8 columns (release 119) | 1 | 0.100 GB | 0.034 s | 0.271 s | 0.014 s | 7.97x | 0.412x | 0.201 GB | 0.168 GB | 0.058 GB |
+| Synthetic 1 GB, full 40 columns (release 119) | 1 | 1.000 GB | 0.254 s | 10.958 s | 0.101 s | 43.14x | 0.398x | 0.839 GB | 0.888 GB | 1.133 GB |
+| Synthetic 1 GB, projected 8 columns (release 119) | 1 | 1.000 GB | 0.130 s | 3.120 s | 0.140 s | 24.00x | 1.077x | 0.302 GB | 0.292 GB | 0.365 GB |
 | DHS — release 111 | 129 | 8.320 GB | 49.235 s | 435.302 s | 63.506 s | 8.84x | 1.290x | 4.523 GB | 4.526 GB | 0.725 GB |
 | DHS — release 113 | 484 | 37.343 GB | 240.452 s | 2,226.568 s | 5.124 s | 9.26x | 0.021x | 35.183 GB | 35.103 GB | 5.256 GB |
 | DHS — release 114 | 24 | 1.162 GB | 7.574 s | 61.036 s | 0.163 s | 8.06x | 0.022x | 0.897 GB | 0.914 GB | 0.149 GB |
 | DHS — release 117 | 1 | 0.028 GB | 0.219 s | 1.505 s | 0.004 s | 6.87x | 0.018x | 0.321 GB | 0.344 GB | 0.056 GB |
-| DHS — release 118 | 3 | 0.050 GB | 0.330 s | 2.640 s | 0.009 s | 8.00x | 0.027x | 0.411 GB | 0.430 GB | 0.077 GB |
-| DHS — all releases | 641 | 46.903 GB | 297.810 s | 2,727.051 s | 68.806 s | 9.16x | 0.231x | 35.183 GB | 35.103 GB | 5.256 GB |
+| DHS — release 118 | 3 | 0.050 GB | 0.189 s | 2.640 s | 0.009 s | 13.97x | 0.048x | 0.411 GB | 0.430 GB | 0.077 GB |
+| DHS — all releases | 641 | 46.903 GB | 297.669 s | 2,727.051 s | 68.806 s | 9.16x | 0.231x | 35.183 GB | 35.103 GB | 5.256 GB |
 | MICS — release 117 | 494 | 1.634 GB | 15.099 s | 98.402 s | 0.567 s | 6.52x | 0.038x | 0.306 GB | 0.367 GB | 0.073 GB |
-| MICS — release 118 | 455 | 2.056 GB | 16.716 s | 118.330 s | 0.588 s | 7.08x | 0.035x | 0.649 GB | 0.669 GB | 0.100 GB |
-| MICS — all releases | 949 | 3.690 GB | 31.815 s | 216.732 s | 1.155 s | 6.81x | 0.036x | 0.649 GB | 0.669 GB | 0.100 GB |
+| MICS — release 118 | 455 | 2.056 GB | 15.588 s | 118.330 s | 0.588 s | 7.59x | 0.038x | 0.651 GB | 0.669 GB | 0.100 GB |
+| MICS — all releases | 949 | 3.690 GB | 30.687 s | 216.732 s | 1.155 s | 7.06x | 0.038x | 0.651 GB | 0.669 GB | 0.100 GB |
 | NSFG — release 105 | 4 | 0.005 GB | 0.078 s | 0.196 s | 0.028 s | 2.51x | 0.359x | 0.125 GB | 0.121 GB | 0.054 GB |
 | NSFG — release 108 | 4 | 0.001 GB | 0.068 s | 0.097 s | 0.006 s | 1.43x | 0.088x | 0.106 GB | 0.104 GB | 0.030 GB |
 | NSFG — release 110 | 7 | 0.015 GB | 0.149 s | 0.497 s | 0.106 s | 3.34x | 0.711x | 0.128 GB | 0.123 GB | 0.041 GB |
@@ -129,8 +131,8 @@ reaggregate the same archived raw timings rather than a separate benchmark run.
 | NSFG — release 114 | 44 | 1.171 GB | 7.761 s | 47.892 s | 0.156 s | 6.17x | 0.020x | 0.751 GB | 0.765 GB | 0.208 GB |
 | NSFG — release 115 | 9 | 0.100 GB | 0.614 s | 3.512 s | 0.015 s | 5.72x | 0.024x | 0.391 GB | 0.414 GB | 0.068 GB |
 | NSFG — release 117 | 69 | 2.180 GB | 14.856 s | 107.544 s | 0.288 s | 7.24x | 0.019x | 1.315 GB | 1.330 GB | 0.201 GB |
-| NSFG — release 118 | 57 | 1.626 GB | 9.644 s | 67.461 s | 0.207 s | 7.00x | 0.021x | 2.458 GB | 2.470 GB | 0.375 GB |
-| NSFG — all releases | 222 | 5.772 GB | 34.634 s | 234.588 s | 0.885 s | 6.77x | 0.026x | 2.458 GB | 2.470 GB | 0.435 GB |
+| NSFG — release 118 | 57 | 1.626 GB | 4.875 s | 67.461 s | 0.207 s | 13.84x | 0.042x | 2.460 GB | 2.470 GB | 0.375 GB |
+| NSFG — all releases | 222 | 5.772 GB | 29.865 s | 234.588 s | 0.885 s | 7.85x | 0.030x | 2.460 GB | 2.470 GB | 0.435 GB |
 
 Both ratio columns are comparator time divided by dta-parser time. Values above
 1x mean dta-parser was faster; values below 1x mean the comparator was faster.
@@ -150,16 +152,18 @@ Matching Stata while returning ordinary R-compatible objects is therefore a
 different engineering target, but the Stata time is still a valid eager-load
 reference rather than an unattainable lazy-open measurement.
 
-For the synthetic loads, dta-parser was 5.31--12.03 times as fast as haven. The
-stored-release strata make the corpus spread explicit: dta-parser was
-1.43--9.26 times as fast as haven, while the all-release corpus subtotals were
-6.77--9.16 times as fast. Dta-parser was 1.29 times as fast as Stata on the DHS
-release-111 stratum; Stata was 1.41--54.75 times as fast on every other
-stratum. At corpus level Stata was 4.33, 27.55, and 39.13 times as fast as
-dta-parser on DHS, MICS, and NSFG. Dta-parser peak RSS was 3.0% lower on MICS,
-0.5% lower on NSFG, and 0.2% higher on the largest DHS file; Stata used
+For the synthetic release-119 loads, dta-parser was 7.97--43.14 times as fast
+as haven. The stored-release strata make the corpus spread explicit:
+dta-parser was 1.43--13.97 times as fast as haven, while the all-release corpus
+subtotals were 7.06--9.16 times as fast. Dta-parser was 1.29 times as fast as
+Stata on the DHS release-111 stratum and 1.08 times as fast on the projected
+1 GB synthetic workload; Stata was 1.41--54.75 times as fast on the remaining
+corpus strata.
+At corpus level Stata was 4.33, 26.57, and 33.75 times as fast as dta-parser on
+DHS, MICS, and NSFG. Dta-parser peak RSS was 2.6% lower on MICS,
+0.4% lower on NSFG, and 0.2% higher on the largest DHS file; Stata used
 82.3--85.1% less peak RSS on those corpus maxima. On the 1 GB full synthetic
-load, however, dta-parser used 26.4% less peak RSS than Stata. These are
+load, however, dta-parser used 26.0% less peak RSS than Stata. These are
 workload- and machine-specific observations, not guarantees.
 
 The corpus comparison is deliberately paired. Two MICS files were rejected by
@@ -170,11 +174,13 @@ reader a different input set. Private paths and values are not published.
 
 R elapsed time covers the reader call, while Stata elapsed time covers its
 `use` command; application startup is excluded from both. Peak RSS comes from a
-fresh process and includes the complete runtime. The synthetic R timings
-alternate reader order after warmup; Stata's full and projected reads use the
-same generated files. Exact dta-parser collector identity and sampled haven
-parity are checked before synthetic timing. The corpus suite rotates reader
-order between files and retains only successful, dimension-identical triples.
+fresh process and includes the complete runtime. The archived synthetic
+comparison alternated reader order after warmup; the multicore refresh reran
+only dta-parser on the same generated files. Exact dta-parser collector identity
+and sampled haven parity were checked for the archived comparison. The corpus
+suite originally rotated reader order between files and retained only
+successful, dimension-identical triples; the modern refresh reran dta-parser
+only and verified dimensions against that archive.
 
 Compared with the old eager collector rebuilt under Rust 1.98.0, the new 1 GB
 full-load median fell from 2.354 s to 0.911 s (61.3%) and dimensions-only peak

--- a/r-package/dtaparser/man/read_dta.Rd
+++ b/r-package/dtaparser/man/read_dta.Rd
@@ -3,7 +3,8 @@
 \title{Read a Stata DTA file}
 \usage{
 read_dta(file, encoding = NULL, col_select = NULL, skip = 0,
-  n_max = Inf, .name_repair = "unique")
+  n_max = Inf, .name_repair = "unique",
+  threads = getOption("dtaparser.threads", 0L))
 }
 \arguments{
 \item{file}{A path, URL, raw vector, or binary connection. Local and remote
@@ -30,6 +31,9 @@ negative finite values read all remaining rows, following haven's unlimited-row
 convention. Non-negative values must be whole numbers no larger than
 \code{2^53}.}
 \item{.name_repair}{Name repair passed to \code{tibble::as_tibble()}.}
+\item{threads}{Number of decoder threads. Zero selects an automatic count for
+sufficiently large Stata 118--119 files. One always uses the serial decoder.
+Earlier formats and \code{strL} projections currently remain serial.}
 }
 \value{A tibble containing native numeric and character vectors. \code{\%td}
 columns and legacy or custom formats beginning \code{\%d} have class

--- a/r-package/dtaparser/src/dta-parser/README.md
+++ b/r-package/dtaparser/src/dta-parser/README.md
@@ -102,6 +102,18 @@ foreign-runtime adapters can instead materialize their own column store. The
 generic sink is statically dispatched, avoiding a dynamic callback boundary in
 the per-cell loop.
 
+The file reader builds one format-neutral observation plan for every release
+before decoding. `DtaFile::parallel_thread_count` gates the current multicore
+executor to sufficiently large release 118--119 projections whose selected
+columns do not include `strL`; unsupported or small workloads return one and
+continue through the serial executor. `DtaFile::read_with_parallel_interrupt`
+materializes the built-in Rust model, while
+`read_with_parallel_sink_and_interrupt` accepts a `ParallelDtaSink` that splits
+independently owned `DtaColumnSink` values across persistent workers. Workers
+share immutable bounded input blocks and retain the ordinary scalar decoding
+rules. Earlier formats already use the same observation plan and block reader,
+but remain serial until their parallel conformance gates are enabled.
+
 `DtaMetadata` and its nested types implement `serde::Serialize` and
 `serde::Deserialize`; the observation and value-label models do as well. Their
 serialized forms use stable storage/type spellings, and every 64-bit integer is

--- a/r-package/dtaparser/src/dta-parser/src/file.rs
+++ b/r-package/dtaparser/src/dta-parser/src/file.rs
@@ -2,6 +2,8 @@ use std::collections::{HashMap, HashSet};
 use std::fs::File;
 use std::io::{ErrorKind, Read, Seek, SeekFrom};
 use std::path::Path;
+use std::sync::{mpsc::sync_channel, Arc};
+use std::thread;
 
 use encoding_rs::CoderResult;
 
@@ -24,6 +26,9 @@ use crate::{
 const DEFAULT_MAX_BUFFER_BYTES: usize = 8 * 1024 * 1024;
 const MIN_MAX_BUFFER_BYTES: usize = 1024;
 const STRL_CANCEL_CHECK_INTERVAL: usize = 1024;
+const MIN_PARALLEL_DATA_BYTES: u64 = 16 * 1024 * 1024;
+const MIN_PARALLEL_CELLS: u64 = 1_000_000;
+const MAX_AUTOMATIC_THREADS: usize = 8;
 const MODERN_SIGNATURE: &[u8] = b"<stata_dta><header><release>";
 
 /// Configuration for seekable file-backed reads.
@@ -88,6 +93,86 @@ struct FileGsoEntry {
     content_offset: u64,
     content_length: usize,
     gso_type: u8,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum ObservationKind {
+    Byte,
+    Int,
+    Long,
+    Float,
+    Double,
+    FixedString,
+    StrL,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct ObservationColumnPlan {
+    output_index: usize,
+    source_index: u32,
+    byte_offset: usize,
+    byte_width: usize,
+    kind: ObservationKind,
+}
+
+#[derive(Debug)]
+struct ObservationPlan {
+    row_width: usize,
+    columns: Vec<ObservationColumnPlan>,
+}
+
+impl ObservationPlan {
+    fn new(metadata: &DtaMetadata, indices: &[u32]) -> Result<Self, DtaError> {
+        let row_width = usize::try_from(metadata.obs_length)
+            .map_err(|_| DtaError::ArithmeticOverflow("observation length"))?;
+        let mut columns = Vec::new();
+        columns
+            .try_reserve_exact(indices.len())
+            .map_err(|_| DtaError::ArithmeticOverflow("observation plan columns"))?;
+        for (output_index, &source_index) in indices.iter().enumerate() {
+            let variable = metadata.variables.get(source_index as usize).ok_or(
+                DtaError::ArithmeticOverflow("observation plan source column"),
+            )?;
+            let byte_offset = usize::try_from(variable.byte_offset)
+                .map_err(|_| DtaError::ArithmeticOverflow("cell offset"))?;
+            let byte_width = usize::try_from(variable.byte_width)
+                .map_err(|_| DtaError::ArithmeticOverflow("cell width"))?;
+            let cell_end = byte_offset
+                .checked_add(byte_width)
+                .ok_or(DtaError::ArithmeticOverflow("cell end"))?;
+            if cell_end > row_width {
+                return Err(DtaError::Truncated {
+                    context: "observation cell",
+                    offset: byte_offset,
+                    needed: byte_width,
+                    available: row_width.saturating_sub(byte_offset),
+                });
+            }
+            let kind = match variable.dta_type {
+                DtaType::Byte => ObservationKind::Byte,
+                DtaType::Int => ObservationKind::Int,
+                DtaType::Long => ObservationKind::Long,
+                DtaType::Float => ObservationKind::Float,
+                DtaType::Double => ObservationKind::Double,
+                DtaType::FixedString(_) => ObservationKind::FixedString,
+                DtaType::StrL => ObservationKind::StrL,
+            };
+            columns.push(ObservationColumnPlan {
+                output_index,
+                source_index,
+                byte_offset,
+                byte_width,
+                kind,
+            });
+        }
+        Ok(Self { row_width, columns })
+    }
+
+    fn has_strls(&self) -> bool {
+        self.columns
+            .iter()
+            .any(|column| matches!(column.kind, ObservationKind::StrL))
+    }
 }
 
 enum ColumnBuilder {
@@ -174,10 +259,90 @@ pub trait DtaSink: Sized {
     ) -> Result<(), DtaError>;
     fn push_fixed_string(&mut self, column: usize, row: usize, value: &str)
         -> Result<(), DtaError>;
+
+    /// Consume an undecoded fixed-string field when the destination has a
+    /// representation-aware fast path. Returning `false` asks the shared
+    /// decoder to perform the normal text conversion and call
+    /// [`DtaSink::push_fixed_string`].
+    fn try_push_fixed_string_bytes(
+        &mut self,
+        _column: usize,
+        _row: usize,
+        _value: &[u8],
+        _encoding: TextEncoding,
+    ) -> Result<bool, DtaError> {
+        Ok(false)
+    }
+
     fn push_strl(&mut self, column: usize, row: usize, value: &str) -> Result<(), DtaError>;
 
     fn finish(
         self,
+        metadata: DtaMetadata,
+        row_start: u64,
+        row_count: u64,
+        value_label_tables: Vec<ValueLabelTable>,
+    ) -> Result<Self::Output, DtaError>;
+}
+
+/// One independently owned output column used by the block executor.
+///
+/// Implementations must not call a foreign runtime from these methods when
+/// they are used by the parallel executor. Each value is written by exactly
+/// one worker and rows ascend within a column.
+pub trait DtaColumnSink: Send {
+    fn push_byte(
+        &mut self,
+        row: usize,
+        value: i8,
+        missing: Option<crate::MissingTag>,
+    ) -> Result<(), DtaError>;
+    fn push_int(
+        &mut self,
+        row: usize,
+        value: i16,
+        missing: Option<crate::MissingTag>,
+    ) -> Result<(), DtaError>;
+    fn push_long(
+        &mut self,
+        row: usize,
+        value: i32,
+        missing: Option<crate::MissingTag>,
+    ) -> Result<(), DtaError>;
+    fn push_float(
+        &mut self,
+        row: usize,
+        value: f32,
+        missing: Option<crate::MissingTag>,
+    ) -> Result<(), DtaError>;
+    fn push_double(
+        &mut self,
+        row: usize,
+        value: f64,
+        missing: Option<crate::MissingTag>,
+    ) -> Result<(), DtaError>;
+    fn push_fixed_string(&mut self, row: usize, value: &str) -> Result<(), DtaError>;
+    fn try_push_fixed_string_bytes(
+        &mut self,
+        _row: usize,
+        _value: &[u8],
+        _encoding: TextEncoding,
+    ) -> Result<bool, DtaError> {
+        Ok(false)
+    }
+}
+
+/// Destination that can transfer independent columns to worker threads.
+pub trait ParallelDtaSink: Sized {
+    type Output;
+    type Column: DtaColumnSink;
+    type State;
+
+    fn split(self) -> (Self::State, Vec<Self::Column>);
+
+    fn finish_parallel(
+        state: Self::State,
+        columns: Vec<Self::Column>,
         metadata: DtaMetadata,
         row_start: u64,
         row_count: u64,
@@ -294,6 +459,111 @@ impl ColumnBuilder {
                 values: ColumnValues::StrL { values },
             },
         }
+    }
+}
+
+impl DtaColumnSink for ColumnBuilder {
+    fn push_byte(
+        &mut self,
+        _row: usize,
+        value: i8,
+        missing: Option<crate::MissingTag>,
+    ) -> Result<(), DtaError> {
+        let Self::Byte {
+            values,
+            missing_tags,
+            ..
+        } = self
+        else {
+            return Err(DtaError::ArithmeticOverflow("output column type"));
+        };
+        values.push(value);
+        missing_tags.push(missing);
+        Ok(())
+    }
+
+    fn push_int(
+        &mut self,
+        _row: usize,
+        value: i16,
+        missing: Option<crate::MissingTag>,
+    ) -> Result<(), DtaError> {
+        let Self::Int {
+            values,
+            missing_tags,
+            ..
+        } = self
+        else {
+            return Err(DtaError::ArithmeticOverflow("output column type"));
+        };
+        values.push(value);
+        missing_tags.push(missing);
+        Ok(())
+    }
+
+    fn push_long(
+        &mut self,
+        _row: usize,
+        value: i32,
+        missing: Option<crate::MissingTag>,
+    ) -> Result<(), DtaError> {
+        let Self::Long {
+            values,
+            missing_tags,
+            ..
+        } = self
+        else {
+            return Err(DtaError::ArithmeticOverflow("output column type"));
+        };
+        values.push(value);
+        missing_tags.push(missing);
+        Ok(())
+    }
+
+    fn push_float(
+        &mut self,
+        _row: usize,
+        value: f32,
+        missing: Option<crate::MissingTag>,
+    ) -> Result<(), DtaError> {
+        let Self::Float {
+            values,
+            missing_tags,
+            ..
+        } = self
+        else {
+            return Err(DtaError::ArithmeticOverflow("output column type"));
+        };
+        values.push(value);
+        missing_tags.push(missing);
+        Ok(())
+    }
+
+    fn push_double(
+        &mut self,
+        _row: usize,
+        value: f64,
+        missing: Option<crate::MissingTag>,
+    ) -> Result<(), DtaError> {
+        let Self::Double {
+            values,
+            missing_tags,
+            ..
+        } = self
+        else {
+            return Err(DtaError::ArithmeticOverflow("output column type"));
+        };
+        values.push(value);
+        missing_tags.push(missing);
+        Ok(())
+    }
+
+    fn push_fixed_string(&mut self, _row: usize, value: &str) -> Result<(), DtaError> {
+        let Self::FixedString { values, .. } = self else {
+            return Err(DtaError::ArithmeticOverflow("output column type"));
+        };
+        values.push(value.to_owned());
+        Ok(())
     }
 }
 
@@ -469,6 +739,150 @@ impl DtaSink for VecSink {
     }
 }
 
+impl ParallelDtaSink for VecSink {
+    type Output = DtaData;
+    type Column = ColumnBuilder;
+    type State = ();
+
+    fn split(self) -> (Self::State, Vec<Self::Column>) {
+        ((), self.columns)
+    }
+
+    fn finish_parallel(
+        _state: Self::State,
+        columns: Vec<Self::Column>,
+        metadata: DtaMetadata,
+        row_start: u64,
+        row_count: u64,
+        value_label_tables: Vec<ValueLabelTable>,
+    ) -> Result<Self::Output, DtaError> {
+        DtaSink::finish(
+            VecSink { columns },
+            metadata,
+            row_start,
+            row_count,
+            value_label_tables,
+        )
+    }
+}
+
+struct ParallelColumn<C> {
+    plan: ObservationColumnPlan,
+    sink: C,
+}
+
+struct ObservationBlock {
+    bytes: Vec<u8>,
+    output_row_start: usize,
+    row_count: usize,
+}
+
+enum WorkerMessage {
+    Block(Arc<ObservationBlock>),
+    Finish,
+}
+
+fn decode_parallel_cell<C: DtaColumnSink>(
+    column: &mut ParallelColumn<C>,
+    row: usize,
+    cell: &[u8],
+    metadata: &DtaMetadata,
+    encoding: TextEncoding,
+) -> Result<(), DtaError> {
+    match column.plan.kind {
+        ObservationKind::Byte => {
+            let value = read_i8(cell, 0, "byte observation")?;
+            column.sink.push_byte(
+                row,
+                value,
+                classify_byte_missing_for_version(value, metadata.format_version),
+            )
+        }
+        ObservationKind::Int => {
+            let value = read_i16(cell, 0, metadata.byte_order, "int observation")?;
+            column.sink.push_int(
+                row,
+                value,
+                classify_int_missing_for_version(value, metadata.format_version),
+            )
+        }
+        ObservationKind::Long => {
+            let value = read_i32(cell, 0, metadata.byte_order, "long observation")?;
+            column.sink.push_long(
+                row,
+                value,
+                classify_long_missing_for_version(value, metadata.format_version),
+            )
+        }
+        ObservationKind::Float => {
+            let bits = read_u32(cell, 0, metadata.byte_order, "float observation")?;
+            column.sink.push_float(
+                row,
+                f32::from_bits(bits),
+                classify_float_missing_bits_for_version(bits, metadata.format_version),
+            )
+        }
+        ObservationKind::Double => {
+            let bits = read_u64(cell, 0, metadata.byte_order, "double observation")?;
+            column.sink.push_double(
+                row,
+                f64::from_bits(bits),
+                classify_double_missing_bits_for_version(bits, metadata.format_version),
+            )
+        }
+        ObservationKind::FixedString => {
+            let field = field_bytes(cell);
+            if column
+                .sink
+                .try_push_fixed_string_bytes(row, field, encoding)?
+            {
+                Ok(())
+            } else {
+                let value = encoding.decode_cow(field);
+                column.sink.push_fixed_string(row, &value)
+            }
+        }
+        ObservationKind::StrL => Err(DtaError::Output(
+            "parallel strL decoding is not enabled".to_owned(),
+        )),
+    }
+}
+
+fn decode_worker_block<C: DtaColumnSink>(
+    columns: &mut [ParallelColumn<C>],
+    block: &ObservationBlock,
+    row_width: usize,
+    metadata: &DtaMetadata,
+    encoding: TextEncoding,
+) -> Result<(), DtaError> {
+    for column in columns {
+        for local_row in 0..block.row_count {
+            let row_at = local_row
+                .checked_mul(row_width)
+                .and_then(|value| value.checked_add(column.plan.byte_offset))
+                .ok_or(DtaError::ArithmeticOverflow("parallel cell offset"))?;
+            let cell_end = row_at
+                .checked_add(column.plan.byte_width)
+                .ok_or(DtaError::ArithmeticOverflow("parallel cell end"))?;
+            let cell = block
+                .bytes
+                .get(row_at..cell_end)
+                .ok_or(DtaError::Truncated {
+                    context: "observation cell",
+                    offset: row_at,
+                    needed: column.plan.byte_width,
+                    available: block.bytes.len().saturating_sub(row_at),
+                })?;
+            let output_row = block
+                .output_row_start
+                .checked_add(local_row)
+                .ok_or(DtaError::ArithmeticOverflow("parallel output row"))?;
+            decode_parallel_cell(column, output_row, cell, metadata, encoding)?;
+        }
+    }
+    Ok(())
+}
+
 /// A synchronous, bounded-buffer `.dta` reader over any seekable source.
 ///
 /// Construction reads only metadata. Observation data, GSO payloads, and
@@ -632,6 +1046,308 @@ impl<R: Read + Seek> DtaFile<R> {
         )
     }
 
+    /// Resolve the worker count for the validated modern parallel path.
+    ///
+    /// A requested value of zero selects an automatic count. Unsupported
+    /// formats, `strL` projections, oversized rows, and small automatic
+    /// workloads deliberately return one so callers can use the serial path.
+    pub fn parallel_thread_count(
+        &self,
+        options: &ReadOptions,
+        requested: usize,
+    ) -> Result<usize, DtaError> {
+        if requested == 1
+            || !matches!(
+                self.metadata.format_version,
+                FormatVersion::V118 | FormatVersion::V119
+            )
+        {
+            return Ok(1);
+        }
+        let indices = resolve_columns(&self.metadata, options)?;
+        let plan = ObservationPlan::new(&self.metadata, &indices)?;
+        let (_, row_count) = row_window(&self.metadata, options);
+        if plan.columns.len() < 2
+            || plan.row_width == 0
+            || plan.row_width > self.scratch.limit
+            || plan.has_strls()
+        {
+            return Ok(1);
+        }
+        let data_bytes = row_count.saturating_mul(self.metadata.obs_length);
+        let cells = row_count.saturating_mul(plan.columns.len() as u64);
+        if requested == 0 && (data_bytes < MIN_PARALLEL_DATA_BYTES || cells < MIN_PARALLEL_CELLS) {
+            return Ok(1);
+        }
+        let available = thread::available_parallelism().map_or(1, usize::from);
+        let threads = if requested == 0 {
+            available.min(MAX_AUTOMATIC_THREADS)
+        } else {
+            requested.min(available)
+        };
+        Ok(threads.min(plan.columns.len()).max(1))
+    }
+
+    /// Decode a modern projection into ordinary Rust vectors with the shared
+    /// parallel block executor.
+    pub fn read_with_parallel_interrupt<F>(
+        &mut self,
+        options: &ReadOptions,
+        thread_count: usize,
+        should_interrupt: F,
+    ) -> Result<DtaData, DtaError>
+    where
+        F: FnMut() -> bool,
+    {
+        self.read_with_parallel_sink_and_interrupt(
+            options,
+            thread_count,
+            |metadata, _row_start, row_count, indices| {
+                let capacity = usize::try_from(row_count)
+                    .map_err(|_| DtaError::ArithmeticOverflow("projected row count"))?;
+                Ok(VecSink::new(metadata, indices, capacity))
+            },
+            should_interrupt,
+        )
+    }
+
+    /// Decode a Stata 118/119 projection through independently owned columns.
+    ///
+    /// The shared scalar cell decoder is retained; workers only partition
+    /// columns and never call a foreign runtime. Use
+    /// [`DtaFile::parallel_thread_count`] before this method and fall back to
+    /// [`DtaFile::read_with_sink_and_interrupt`] when it returns one.
+    pub fn read_with_parallel_sink_and_interrupt<S, B, F>(
+        &mut self,
+        options: &ReadOptions,
+        thread_count: usize,
+        build_sink: B,
+        mut should_interrupt: F,
+    ) -> Result<S::Output, DtaError>
+    where
+        S: ParallelDtaSink,
+        B: FnOnce(&DtaMetadata, u64, u64, &[u32]) -> Result<S, DtaError>,
+        F: FnMut() -> bool,
+    {
+        check_cancel(&mut should_interrupt)?;
+        validate_layout(
+            &mut self.reader,
+            &self.metadata,
+            self.file_length,
+            &mut self.scratch,
+        )?;
+        let indices = resolve_columns(&self.metadata, options)?;
+        let (row_start, row_count) = row_window(&self.metadata, options);
+        let plan = ObservationPlan::new(&self.metadata, &indices)?;
+        if thread_count < 2
+            || !matches!(
+                self.metadata.format_version,
+                FormatVersion::V118 | FormatVersion::V119
+            )
+            || plan.columns.len() < 2
+            || plan.row_width == 0
+            || plan.row_width > self.scratch.limit
+            || plan.has_strls()
+        {
+            return Err(DtaError::Output(
+                "parallel decoder eligibility was not satisfied".to_owned(),
+            ));
+        }
+        let worker_count = thread_count.min(plan.columns.len());
+        let sink = build_sink(&self.metadata, row_start, row_count, &indices)?;
+        let (state, columns) = sink.split();
+        if columns.len() != plan.columns.len() {
+            return Err(DtaError::Output(
+                "parallel output column count mismatch".to_owned(),
+            ));
+        }
+
+        let mut shards = (0..worker_count)
+            .map(|_| Vec::<ParallelColumn<S::Column>>::new())
+            .collect::<Vec<_>>();
+        let mut shard_weights = vec![0_usize; worker_count];
+        for (column_plan, column_sink) in plan.columns.iter().copied().zip(columns) {
+            let worker = shard_weights
+                .iter()
+                .enumerate()
+                .min_by_key(|&(index, weight)| (*weight, index))
+                .map(|(index, _)| index)
+                .unwrap_or(0);
+            shard_weights[worker] =
+                shard_weights[worker].saturating_add(column_plan.byte_width.max(8));
+            shards[worker].push(ParallelColumn {
+                plan: column_plan,
+                sink: column_sink,
+            });
+        }
+
+        let payload_start =
+            checked_add_u64(self.metadata.section_offsets.data, 6, "data payload offset")?;
+        let rows_per_block = self.scratch.limit / plan.row_width;
+        let rows_per_block = u64::try_from(rows_per_block)
+            .map_err(|_| DtaError::ArithmeticOverflow("parallel rows per block"))?;
+        let metadata = &self.metadata;
+        let encoding = self.text_encoding;
+        let mut observation_buffer = Vec::new();
+
+        let decoded_columns = thread::scope(
+            |scope| -> Result<Vec<ParallelColumn<S::Column>>, DtaError> {
+                let mut senders = Vec::with_capacity(worker_count);
+                let mut ack_receivers = Vec::with_capacity(worker_count);
+                let mut handles = Vec::with_capacity(worker_count);
+                for mut shard in shards {
+                    let (sender, receiver) = sync_channel::<WorkerMessage>(0);
+                    let (worker_ack, ack_receiver) = sync_channel::<Result<(), DtaError>>(0);
+                    senders.push(sender);
+                    ack_receivers.push(ack_receiver);
+                    handles.push(scope.spawn(move || {
+                        while let Ok(message) = receiver.recv() {
+                            match message {
+                                WorkerMessage::Block(block) => {
+                                    let result = decode_worker_block(
+                                        &mut shard,
+                                        &block,
+                                        plan.row_width,
+                                        metadata,
+                                        encoding,
+                                    );
+                                    drop(block);
+                                    let failed = result.is_err();
+                                    if worker_ack.send(result).is_err() || failed {
+                                        break;
+                                    }
+                                }
+                                WorkerMessage::Finish => break,
+                            }
+                        }
+                        shard
+                    }));
+                }
+
+                let mut row = 0_u64;
+                let mut execution_error = None;
+                while row < row_count {
+                    check_cancel(&mut should_interrupt)?;
+                    let block_rows = (row_count - row).min(rows_per_block);
+                    let block_row_count = usize::try_from(block_rows)
+                        .map_err(|_| DtaError::ArithmeticOverflow("parallel block row count"))?;
+                    let block_length = plan
+                        .row_width
+                        .checked_mul(block_row_count)
+                        .ok_or(DtaError::ArithmeticOverflow("parallel block length"))?;
+                    let source_row = row_start
+                        .checked_add(row)
+                        .ok_or(DtaError::ArithmeticOverflow("parallel source row"))?;
+                    let block_offset = payload_start
+                        .checked_add(
+                            source_row
+                                .checked_mul(self.metadata.obs_length)
+                                .ok_or(DtaError::ArithmeticOverflow("parallel row offset"))?,
+                        )
+                        .ok_or(DtaError::ArithmeticOverflow("parallel block offset"))?;
+                    read_exact_at_into(
+                        &mut self.reader,
+                        block_offset,
+                        block_length,
+                        &mut self.scratch,
+                        &mut observation_buffer,
+                        "reading observation rows",
+                    )?;
+                    let block = Arc::new(ObservationBlock {
+                        bytes: std::mem::take(&mut observation_buffer),
+                        output_row_start: usize::try_from(row)
+                            .map_err(|_| DtaError::ArithmeticOverflow("parallel output row"))?,
+                        row_count: block_row_count,
+                    });
+                    for sender in &senders {
+                        sender
+                            .send(WorkerMessage::Block(Arc::clone(&block)))
+                            .map_err(|_| {
+                                DtaError::Output("parallel decoder worker stopped".to_owned())
+                            })?;
+                    }
+                    let mut errors = Vec::new();
+                    for (worker, receiver) in ack_receivers.iter().enumerate() {
+                        match receiver.recv() {
+                            Ok(Err(error)) => errors.push((worker, error)),
+                            Ok(Ok(())) => {}
+                            Err(_) => {
+                                execution_error = Some(DtaError::Output(format!(
+                                    "parallel decoder worker {worker} stopped"
+                                )));
+                                break;
+                            }
+                        }
+                    }
+                    if execution_error.is_some() {
+                        break;
+                    }
+                    if !errors.is_empty() {
+                        errors.sort_by_key(|(worker, _)| *worker);
+                        execution_error = errors.into_iter().next().map(|(_, error)| error);
+                        break;
+                    }
+                    observation_buffer = Arc::try_unwrap(block)
+                        .map_err(|_| {
+                            DtaError::Output("parallel input block remained borrowed".to_owned())
+                        })?
+                        .bytes;
+                    row = row
+                        .checked_add(block_rows)
+                        .ok_or(DtaError::ArithmeticOverflow("parallel projected row"))?;
+                }
+
+                if execution_error.is_none() {
+                    for sender in &senders {
+                        let _ = sender.send(WorkerMessage::Finish);
+                    }
+                }
+                drop(senders);
+                let mut completed = Vec::with_capacity(plan.columns.len());
+                for handle in handles {
+                    let shard = handle.join().map_err(|_| {
+                        DtaError::Output("parallel decoder worker panicked".to_owned())
+                    })?;
+                    completed.extend(shard);
+                }
+                if let Some(error) = execution_error {
+                    return Err(error);
+                }
+                Ok(completed)
+            },
+        )?;
+
+        let mut ordered = (0..plan.columns.len())
+            .map(|_| None)
+            .collect::<Vec<Option<S::Column>>>();
+        for column in decoded_columns {
+            ordered[column.plan.output_index] = Some(column.sink);
+        }
+        let columns = ordered
+            .into_iter()
+            .map(|column| {
+                column.ok_or_else(|| {
+                    DtaError::Output("parallel output column was not returned".to_owned())
+                })
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        check_cancel(&mut should_interrupt)?;
+        self.ensure_value_labels(&mut should_interrupt)?;
+        let value_label_tables = self
+            .value_label_tables
+            .clone()
+            .expect("value-label cache was initialized");
+        S::finish_parallel(
+            state,
+            columns,
+            self.metadata.clone(),
+            row_start,
+            row_count,
+            value_label_tables,
+        )
+    }
+
     /// Decode through a caller-provided typed output collector.
     ///
     /// The collector is constructed after metadata, projection, and row bounds
@@ -658,6 +1374,7 @@ impl<R: Read + Seek> DtaFile<R> {
         )?;
         let indices = resolve_columns(&self.metadata, options)?;
         let (row_start, row_count) = row_window(&self.metadata, options);
+        let plan = ObservationPlan::new(&self.metadata, &indices)?;
         let capacity = usize::try_from(row_count)
             .map_err(|_| DtaError::ArithmeticOverflow("projected row count"))?;
         let mut sink = build_sink(&self.metadata, row_start, row_count, &indices)?;
@@ -684,16 +1401,13 @@ impl<R: Read + Seek> DtaFile<R> {
             text_encoding: self.text_encoding,
         };
 
-        if !indices.is_empty()
-            && self.metadata.obs_length > 0
-            && self.metadata.obs_length <= self.scratch.limit as u64
-        {
-            let obs_length = usize::try_from(self.metadata.obs_length)
-                .map_err(|_| DtaError::ArithmeticOverflow("observation length"))?;
+        if !plan.columns.is_empty() && plan.row_width > 0 && plan.row_width <= self.scratch.limit {
+            let obs_length = plan.row_width;
             let rows_per_chunk = self.scratch.limit / obs_length;
             let rows_per_chunk = u64::try_from(rows_per_chunk)
                 .map_err(|_| DtaError::ArithmeticOverflow("rows per chunk"))?;
             let mut row = 0_u64;
+            let mut observation_buffer = Vec::new();
             while row < row_count {
                 check_cancel(&mut should_interrupt)?;
                 let chunk_rows = (row_count - row).min(rows_per_chunk);
@@ -712,13 +1426,15 @@ impl<R: Read + Seek> DtaFile<R> {
                             .ok_or(DtaError::ArithmeticOverflow("row offset"))?,
                     )
                     .ok_or(DtaError::ArithmeticOverflow("observation chunk offset"))?;
-                let staged = read_exact_at(
+                read_exact_at_into(
                     &mut self.reader,
                     chunk_offset,
                     chunk_length,
                     &mut self.scratch,
+                    &mut observation_buffer,
                     "reading observation rows",
                 )?;
+                let staged = &observation_buffer;
                 for local_row in 0..chunk_rows_usize {
                     check_cancel(&mut should_interrupt)?;
                     let row_at = local_row
@@ -728,12 +1444,10 @@ impl<R: Read + Seek> DtaFile<R> {
                         .map_err(|_| DtaError::ArithmeticOverflow("output row"))?
                         .checked_add(local_row)
                         .ok_or(DtaError::ArithmeticOverflow("output row"))?;
-                    for (output_column, &index) in indices.iter().enumerate() {
-                        let variable = &self.metadata.variables[index as usize];
-                        let width = usize::try_from(variable.byte_width)
-                            .map_err(|_| DtaError::ArithmeticOverflow("cell width"))?;
-                        let variable_at = usize::try_from(variable.byte_offset)
-                            .map_err(|_| DtaError::ArithmeticOverflow("cell offset"))?;
+                    for column in &plan.columns {
+                        let variable = &self.metadata.variables[column.source_index as usize];
+                        let width = column.byte_width;
+                        let variable_at = column.byte_offset;
                         let cell_at = row_at
                             .checked_add(variable_at)
                             .ok_or(DtaError::ArithmeticOverflow("staged cell offset"))?;
@@ -752,7 +1466,7 @@ impl<R: Read + Seek> DtaFile<R> {
                             available: staged.len().saturating_sub(cell_at),
                         })?;
                         cell_decoder.push_staged_cell(
-                            output_column,
+                            column.output_index,
                             output_row,
                             cell,
                             absolute_offset,
@@ -764,7 +1478,7 @@ impl<R: Read + Seek> DtaFile<R> {
                     .checked_add(chunk_rows)
                     .ok_or(DtaError::ArithmeticOverflow("projected row"))?;
             }
-        } else {
+        } else if !plan.columns.is_empty() {
             for row in 0..row_count {
                 check_cancel(&mut should_interrupt)?;
                 let output_row =
@@ -775,14 +1489,13 @@ impl<R: Read + Seek> DtaFile<R> {
                 let row_offset = source_row
                     .checked_mul(self.metadata.obs_length)
                     .ok_or(DtaError::ArithmeticOverflow("row offset"))?;
-                for (output_column, &index) in indices.iter().enumerate() {
-                    let variable = &self.metadata.variables[index as usize];
+                for column in &plan.columns {
+                    let variable = &self.metadata.variables[column.source_index as usize];
                     let cell_offset = payload_start
                         .checked_add(row_offset)
                         .and_then(|value| value.checked_add(variable.byte_offset))
                         .ok_or(DtaError::ArithmeticOverflow("cell offset"))?;
-                    let width = usize::try_from(variable.byte_width)
-                        .map_err(|_| DtaError::ArithmeticOverflow("cell width"))?;
+                    let width = column.byte_width;
                     if matches!(variable.dta_type, DtaType::FixedString(_)) {
                         let (value, _) = decode_range(
                             &mut self.reader,
@@ -794,9 +1507,11 @@ impl<R: Read + Seek> DtaFile<R> {
                             &mut should_interrupt,
                             "reading fixed-string observation",
                         )?;
-                        cell_decoder
-                            .sink
-                            .push_fixed_string(output_column, output_row, &value)?;
+                        cell_decoder.sink.push_fixed_string(
+                            column.output_index,
+                            output_row,
+                            &value,
+                        )?;
                         continue;
                     }
                     let cell = read_exact_at(
@@ -807,7 +1522,7 @@ impl<R: Read + Seek> DtaFile<R> {
                         "reading observation cell",
                     )?;
                     cell_decoder.push_cell(
-                        output_column,
+                        column.output_index,
                         output_row,
                         &cell,
                         cell_offset,
@@ -930,6 +1645,59 @@ fn read_exact_at<R: Read + Seek>(
             .ok_or(DtaError::ArithmeticOverflow("file read length"))?;
     }
     Ok(bytes)
+}
+
+fn read_exact_at_into<R: Read + Seek>(
+    reader: &mut R,
+    offset: u64,
+    length: usize,
+    scratch: &mut Scratch,
+    bytes: &mut Vec<u8>,
+    context: &'static str,
+) -> Result<(), DtaError> {
+    scratch.record(length)?;
+    reader
+        .seek(SeekFrom::Start(offset))
+        .map_err(|error| DtaError::Io {
+            context,
+            offset,
+            kind: error.kind(),
+        })?;
+    if bytes.len() < length {
+        bytes
+            .try_reserve_exact(length - bytes.len())
+            .map_err(|_| DtaError::ArithmeticOverflow("file read allocation"))?;
+        bytes.resize(length, 0);
+    } else {
+        bytes.truncate(length);
+    }
+    let mut completed = 0_usize;
+    while completed < length {
+        let read_offset = offset
+            .checked_add(
+                u64::try_from(completed)
+                    .map_err(|_| DtaError::ArithmeticOverflow("file read offset"))?,
+            )
+            .ok_or(DtaError::ArithmeticOverflow("file read offset"))?;
+        let count = reader
+            .read(&mut bytes[completed..length])
+            .map_err(|error| DtaError::Io {
+                context,
+                offset: read_offset,
+                kind: error.kind(),
+            })?;
+        if count == 0 {
+            return Err(DtaError::Io {
+                context,
+                offset: read_offset,
+                kind: ErrorKind::UnexpectedEof,
+            });
+        }
+        completed = completed
+            .checked_add(count)
+            .ok_or(DtaError::ArithmeticOverflow("file read length"))?;
+    }
+    Ok(())
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -1219,6 +1987,87 @@ fn modern_string_payload<R: Read + Seek>(
     let after_close = expect_file_tag(reader, close_offset, close, section_name, scratch)?;
     ensure_absolute(section_name, after_close, next_offset)?;
     Ok(payload)
+}
+
+fn read_fixed_text_fields<R: Read + Seek>(
+    reader: &mut R,
+    payload: u64,
+    count: usize,
+    width: usize,
+    encoding: TextEncoding,
+    scratch: &mut Scratch,
+    context: &'static str,
+) -> Result<Vec<String>, DtaError> {
+    let fields_per_chunk = (scratch.limit / width).max(1);
+    let mut values = Vec::new();
+    values
+        .try_reserve_exact(count)
+        .map_err(|_| DtaError::ArithmeticOverflow("metadata text fields"))?;
+    let mut first = 0_usize;
+    while first < count {
+        let field_count = (count - first).min(fields_per_chunk);
+        let length = field_count
+            .checked_mul(width)
+            .ok_or(DtaError::ArithmeticOverflow("metadata text block"))?;
+        let offset = payload
+            .checked_add(
+                u64::try_from(
+                    first
+                        .checked_mul(width)
+                        .ok_or(DtaError::ArithmeticOverflow("metadata text offset"))?,
+                )
+                .map_err(|_| DtaError::ArithmeticOverflow("metadata text offset"))?,
+            )
+            .ok_or(DtaError::ArithmeticOverflow("metadata text offset"))?;
+        let bytes = read_exact_at(reader, offset, length, scratch, context)?;
+        for field in bytes.chunks_exact(width) {
+            values.push(encoding.decode_cow(field_bytes(field)).into_owned());
+        }
+        first = first
+            .checked_add(field_count)
+            .ok_or(DtaError::ArithmeticOverflow("metadata field index"))?;
+    }
+    Ok(values)
+}
+
+fn read_modern_type_codes<R: Read + Seek>(
+    reader: &mut R,
+    payload: u64,
+    count: usize,
+    byte_order: ByteOrder,
+    scratch: &mut Scratch,
+) -> Result<Vec<u16>, DtaError> {
+    let type_width = 2_usize;
+    let fields_per_chunk = (scratch.limit / type_width).max(1);
+    let mut values = Vec::new();
+    values
+        .try_reserve_exact(count)
+        .map_err(|_| DtaError::ArithmeticOverflow("variable type codes"))?;
+    let mut first = 0_usize;
+    while first < count {
+        let field_count = (count - first).min(fields_per_chunk);
+        let length = field_count
+            .checked_mul(type_width)
+            .ok_or(DtaError::ArithmeticOverflow("variable type block"))?;
+        let offset = payload
+            .checked_add(
+                u64::try_from(
+                    first
+                        .checked_mul(type_width)
+                        .ok_or(DtaError::ArithmeticOverflow("variable type offset"))?,
+                )
+                .map_err(|_| DtaError::ArithmeticOverflow("variable type offset"))?,
+            )
+            .ok_or(DtaError::ArithmeticOverflow("variable type offset"))?;
+        let bytes = read_exact_at(reader, offset, length, scratch, "reading variable types")?;
+        for field in bytes.chunks_exact(type_width) {
+            values.push(read_u16(field, 0, byte_order, "variable type")?);
+        }
+        first = first
+            .checked_add(field_count)
+            .ok_or(DtaError::ArithmeticOverflow("variable type index"))?;
+    }
+    Ok(values)
 }
 
 fn validate_modern_sortlist<R: Read + Seek>(
@@ -1633,63 +2482,56 @@ fn read_modern_metadata<R: Read + Seek>(
     )?;
     let notes = read_modern_notes(reader, &header, encoding, scratch)?;
 
+    let type_codes = read_modern_type_codes(reader, types_start, nvar, header.byte_order, scratch)?;
+    let names = read_fixed_text_fields(
+        reader,
+        varnames,
+        nvar,
+        widths.varname,
+        encoding,
+        scratch,
+        "reading variable names",
+    )?;
+    let formats = read_fixed_text_fields(
+        reader,
+        formats,
+        nvar,
+        widths.format,
+        encoding,
+        scratch,
+        "reading variable formats",
+    )?;
+    let value_label_names = read_fixed_text_fields(
+        reader,
+        value_label_names,
+        nvar,
+        widths.value_label_name,
+        encoding,
+        scratch,
+        "reading variable value-label names",
+    )?;
+    let variable_labels = read_fixed_text_fields(
+        reader,
+        variable_labels,
+        nvar,
+        widths.variable_label,
+        encoding,
+        scratch,
+        "reading variable labels",
+    )?;
+
     let mut byte_offset = 0_u64;
     let mut variables = Vec::with_capacity(nvar);
-    let mut never_cancel = || false;
     for index in 0..nvar {
-        let field_offset = |start: u64, width: usize, context: &'static str| {
-            checked_add_u64(
-                start,
-                u64::try_from(
-                    index
-                        .checked_mul(width)
-                        .ok_or(DtaError::ArithmeticOverflow(context))?,
-                )
-                .map_err(|_| DtaError::ArithmeticOverflow(context))?,
-                context,
-            )
-        };
-        let type_bytes = read_exact_at(
-            reader,
-            field_offset(types_start, 2, "variable type offset")?,
-            2,
-            scratch,
-            "reading variable type",
-        )?;
-        let type_code = read_u16(&type_bytes, 0, header.byte_order, "variable type")?;
+        let type_code = type_codes[index];
         let (dta_type, byte_width) = resolve_type(type_code, header.format_version)?;
-        let mut decode_field = |start, width, context| {
-            decode_range(
-                reader,
-                field_offset(start, width, context)?,
-                width,
-                encoding,
-                true,
-                scratch,
-                &mut never_cancel,
-                context,
-            )
-            .map(|value| value.0)
-        };
-        let name = decode_field(varnames, widths.varname, "reading variable name")?;
-        let format = decode_field(formats, widths.format, "reading variable format")?;
-        let value_label_name = decode_field(
-            value_label_names,
-            widths.value_label_name,
-            "reading variable value-label name",
-        )?;
-        let label = decode_field(
-            variable_labels,
-            widths.variable_label,
-            "reading variable label",
-        )?;
         variables.push(VariableInfo {
-            name,
+            name: names[index].clone(),
             dta_type,
             type_code,
-            format,
-            label,
-            value_label_name,
+            format: formats[index].clone(),
+            label: variable_labels[index].clone(),
+            value_label_name: value_label_names[index].clone(),
             byte_width,
             byte_offset,
         });
@@ -2854,7 +3696,16 @@ impl<S: DtaSink> CellDecoder<'_, S> {
         variable: &VariableInfo,
     ) -> Result<(), DtaError> {
         if matches!(variable.dta_type, DtaType::FixedString(_)) {
-            let value = self.text_encoding.decode_cow(field_bytes(cell));
+            let field = field_bytes(cell);
+            if self.sink.try_push_fixed_string_bytes(
+                output_column,
+                output_row,
+                field,
+                self.text_encoding,
+            )? {
+                return Ok(());
+            }
+            let value = self.text_encoding.decode_cow(field);
             return self
                 .sink
                 .push_fixed_string(output_column, output_row, &value);

--- a/r-package/dtaparser/src/dta-parser/src/file.rs
+++ b/r-package/dtaparser/src/dta-parser/src/file.rs
@@ -121,6 +121,40 @@ struct ObservationPlan {
     columns: Vec<ObservationColumnPlan>,
 }
 
+trait InterruptChecks {
+    fn coarse(&mut self) -> bool;
+    fn frequent(&mut self) -> bool;
+}
+
+struct SharedInterrupt<F> {
+    callback: F,
+}
+
+impl<F: FnMut() -> bool> InterruptChecks for SharedInterrupt<F> {
+    fn coarse(&mut self) -> bool {
+        (self.callback)()
+    }
+
+    fn frequent(&mut self) -> bool {
+        (self.callback)()
+    }
+}
+
+struct SplitInterrupt<C, F> {
+    coarse: C,
+    frequent: F,
+}
+
+impl<C: FnMut() -> bool, F: FnMut() -> bool> InterruptChecks for SplitInterrupt<C, F> {
+    fn coarse(&mut self) -> bool {
+        (self.coarse)()
+    }
+
+    fn frequent(&mut self) -> bool {
+        (self.frequent)()
+    }
+}
+
 impl ObservationPlan {
     fn new(metadata: &DtaMetadata, indices: &[u32]) -> Result<Self, DtaError> {
         let row_width = usize::try_from(metadata.obs_length)
@@ -1046,6 +1080,32 @@ impl<R: Read + Seek> DtaFile<R> {
         )
     }
 
+    /// Read with separate callbacks for bounded work and high-frequency row
+    /// polling. This lets foreign-runtime adapters throttle only the latter;
+    /// the coarse callback remains responsive during large strings, `strL`
+    /// values, and value-label sections.
+    pub fn read_with_interrupts<C, F>(
+        &mut self,
+        options: &ReadOptions,
+        coarse_interrupt: C,
+        frequent_interrupt: F,
+    ) -> Result<DtaData, DtaError>
+    where
+        C: FnMut() -> bool,
+        F: FnMut() -> bool,
+    {
+        self.read_with_sink_and_interrupts(
+            options,
+            |metadata, _row_start, row_count, indices| {
+                let capacity = usize::try_from(row_count)
+                    .map_err(|_| DtaError::ArithmeticOverflow("projected row count"))?;
+                Ok(VecSink::new(metadata, indices, capacity))
+            },
+            coarse_interrupt,
+            frequent_interrupt,
+        )
+    }
+
     /// Resolve the worker count for the validated modern parallel path.
     ///
     /// A requested value of zero selects an automatic count. Unsupported
@@ -1358,14 +1418,59 @@ impl<R: Read + Seek> DtaFile<R> {
         &mut self,
         options: &ReadOptions,
         build_sink: B,
-        mut should_interrupt: F,
+        should_interrupt: F,
     ) -> Result<S::Output, DtaError>
     where
         S: DtaSink,
         B: FnOnce(&DtaMetadata, u64, u64, &[u32]) -> Result<S, DtaError>,
         F: FnMut() -> bool,
     {
-        check_cancel(&mut should_interrupt)?;
+        self.read_with_sink_and_interrupt_controller(
+            options,
+            build_sink,
+            SharedInterrupt {
+                callback: should_interrupt,
+            },
+        )
+    }
+
+    /// Decode through a typed output collector with separate coarse and
+    /// high-frequency interrupt callbacks.
+    pub fn read_with_sink_and_interrupts<S, B, C, F>(
+        &mut self,
+        options: &ReadOptions,
+        build_sink: B,
+        coarse_interrupt: C,
+        frequent_interrupt: F,
+    ) -> Result<S::Output, DtaError>
+    where
+        S: DtaSink,
+        B: FnOnce(&DtaMetadata, u64, u64, &[u32]) -> Result<S, DtaError>,
+        C: FnMut() -> bool,
+        F: FnMut() -> bool,
+    {
+        self.read_with_sink_and_interrupt_controller(
+            options,
+            build_sink,
+            SplitInterrupt {
+                coarse: coarse_interrupt,
+                frequent: frequent_interrupt,
+            },
+        )
+    }
+
+    fn read_with_sink_and_interrupt_controller<S, B, I>(
+        &mut self,
+        options: &ReadOptions,
+        build_sink: B,
+        mut interrupts: I,
+    ) -> Result<S::Output, DtaError>
+    where
+        S: DtaSink,
+        B: FnOnce(&DtaMetadata, u64, u64, &[u32]) -> Result<S, DtaError>,
+        I: InterruptChecks,
+    {
+        check_coarse_cancel(&mut interrupts)?;
         validate_layout(
             &mut self.reader,
             &self.metadata,
@@ -1409,7 +1514,7 @@ impl<R: Read + Seek> DtaFile<R> {
             let mut row = 0_u64;
             let mut observation_buffer = Vec::new();
             while row < row_count {
-                check_cancel(&mut should_interrupt)?;
+                check_coarse_cancel(&mut interrupts)?;
                 let chunk_rows = (row_count - row).min(rows_per_chunk);
                 let chunk_rows_usize = usize::try_from(chunk_rows)
                     .map_err(|_| DtaError::ArithmeticOverflow("chunk row count"))?;
@@ -1436,7 +1541,7 @@ impl<R: Read + Seek> DtaFile<R> {
                 )?;
                 let staged = &observation_buffer;
                 for local_row in 0..chunk_rows_usize {
-                    check_cancel(&mut should_interrupt)?;
+                    check_frequent_cancel(&mut interrupts)?;
                     let row_at = local_row
                         .checked_mul(obs_length)
                         .ok_or(DtaError::ArithmeticOverflow("staged row offset"))?;
@@ -1480,7 +1585,7 @@ impl<R: Read + Seek> DtaFile<R> {
             }
         } else if !plan.columns.is_empty() {
             for row in 0..row_count {
-                check_cancel(&mut should_interrupt)?;
+                check_frequent_cancel(&mut interrupts)?;
                 let output_row =
                     usize::try_from(row).map_err(|_| DtaError::ArithmeticOverflow("output row"))?;
                 let source_row = row_start
@@ -1497,6 +1602,7 @@ impl<R: Read + Seek> DtaFile<R> {
                         .ok_or(DtaError::ArithmeticOverflow("cell offset"))?;
                     let width = column.byte_width;
                     if matches!(variable.dta_type, DtaType::FixedString(_)) {
+                        let mut coarse_interrupt = || interrupts.coarse();
                         let (value, _) = decode_range(
                             &mut self.reader,
                             cell_offset,
@@ -1504,7 +1610,7 @@ impl<R: Read + Seek> DtaFile<R> {
                             self.text_encoding,
                             true,
                             &mut self.scratch,
-                            &mut should_interrupt,
+                            &mut coarse_interrupt,
                             "reading fixed-string observation",
                         )?;
                         cell_decoder.sink.push_fixed_string(
@@ -1531,17 +1637,23 @@ impl<R: Read + Seek> DtaFile<R> {
                 }
             }
         }
-        resolve_file_strls(
-            &mut self.reader,
-            &self.metadata,
-            &mut self.scratch,
-            &mut strl_pointers,
-            &mut sink,
-            &mut should_interrupt,
-            self.text_encoding,
-        )?;
-        check_cancel(&mut should_interrupt)?;
-        self.ensure_value_labels(&mut should_interrupt)?;
+        {
+            let mut coarse_interrupt = || interrupts.coarse();
+            resolve_file_strls(
+                &mut self.reader,
+                &self.metadata,
+                &mut self.scratch,
+                &mut strl_pointers,
+                &mut sink,
+                &mut coarse_interrupt,
+                self.text_encoding,
+            )?;
+        }
+        check_coarse_cancel(&mut interrupts)?;
+        {
+            let mut coarse_interrupt = || interrupts.coarse();
+            self.ensure_value_labels(&mut coarse_interrupt)?;
+        }
         let value_label_tables = self
             .value_label_tables
             .clone()
@@ -1582,6 +1694,22 @@ impl<R: Read + Seek> DtaFile<R> {
 
 fn check_cancel<F: FnMut() -> bool>(should_interrupt: &mut F) -> Result<(), DtaError> {
     if should_interrupt() {
+        Err(DtaError::Cancelled)
+    } else {
+        Ok(())
+    }
+}
+
+fn check_coarse_cancel<I: InterruptChecks>(interrupts: &mut I) -> Result<(), DtaError> {
+    if interrupts.coarse() {
+        Err(DtaError::Cancelled)
+    } else {
+        Ok(())
+    }
+}
+
+fn check_frequent_cancel<I: InterruptChecks>(interrupts: &mut I) -> Result<(), DtaError> {
+    if interrupts.frequent() {
         Err(DtaError::Cancelled)
     } else {
         Ok(())
@@ -2522,16 +2650,21 @@ fn read_modern_metadata<R: Read + Seek>(
 
     let mut byte_offset = 0_u64;
     let mut variables = Vec::with_capacity(nvar);
-    for index in 0..nvar {
-        let type_code = type_codes[index];
+    for ((((type_code, name), format), value_label_name), label) in type_codes
+        .into_iter()
+        .zip(names)
+        .zip(formats)
+        .zip(value_label_names)
+        .zip(variable_labels)
+    {
         let (dta_type, byte_width) = resolve_type(type_code, header.format_version)?;
         variables.push(VariableInfo {
-            name: names[index].clone(),
+            name,
             dta_type,
             type_code,
-            format: formats[index].clone(),
-            label: variable_labels[index].clone(),
-            value_label_name: value_label_names[index].clone(),
+            format,
+            label,
+            value_label_name,
             byte_width,
             byte_offset,
         });

--- a/r-package/dtaparser/src/dta-parser/src/file.rs
+++ b/r-package/dtaparser/src/dta-parser/src/file.rs
@@ -1332,10 +1332,11 @@ impl<R: Read + Seek> DtaFile<R> {
                             Ok(Err(error)) => errors.push((worker, error)),
                             Ok(Ok(())) => {}
                             Err(_) => {
-                                execution_error = Some(DtaError::Output(format!(
-                                    "parallel decoder worker {worker} stopped"
-                                )));
-                                break;
+                                if execution_error.is_none() {
+                                    execution_error = Some(DtaError::Output(format!(
+                                        "parallel decoder worker {worker} stopped"
+                                    )));
+                                }
                             }
                         }
                     }

--- a/r-package/dtaparser/src/dta-parser/src/lib.rs
+++ b/r-package/dtaparser/src/dta-parser/src/lib.rs
@@ -22,7 +22,7 @@ pub use data_reader::{
     read_dta, read_dta_with_encoding, read_dta_with_options, read_dta_with_options_and_encoding,
 };
 pub use error::DtaError;
-pub use file::{DtaFile, DtaSink, FileOptions};
+pub use file::{DtaColumnSink, DtaFile, DtaSink, FileOptions, ParallelDtaSink};
 pub use metadata::{parse_metadata, parse_metadata_with_encoding};
 pub use missing::{
     classify_byte_missing, classify_double_missing_bits, classify_float_missing_bits,

--- a/r-package/dtaparser/src/dta-parser/tests/file.rs
+++ b/r-package/dtaparser/src/dta-parser/tests/file.rs
@@ -354,6 +354,43 @@ fn stages_bounded_wide_rows_for_dense_and_sparse_projections() {
 }
 
 #[test]
+fn modern_parallel_vectors_match_serial_and_gate_unsupported_layouts() {
+    let bytes = fixture("auto_v118.dta");
+    let read_options = options(3, Some(41), vec![11, 0, 7, 2]);
+    let mut serial_file = DtaFile::from_reader(Cursor::new(bytes.clone())).unwrap();
+    let serial = serial_file.read_with_options(&read_options).unwrap();
+
+    let mut parallel_file = DtaFile::from_reader(Cursor::new(bytes)).unwrap();
+    let threads = parallel_file
+        .parallel_thread_count(&read_options, 4)
+        .unwrap();
+    if threads > 1 {
+        let parallel = parallel_file
+            .read_with_parallel_interrupt(&read_options, threads, || false)
+            .unwrap();
+        assert_eq!(parallel, serial);
+    }
+
+    let legacy = fixture("auto_v117.dta");
+    let legacy_file = DtaFile::from_reader(Cursor::new(legacy)).unwrap();
+    assert_eq!(
+        legacy_file
+            .parallel_thread_count(&ReadOptions::default(), 4)
+            .unwrap(),
+        1
+    );
+
+    let strl = fixture("strl_test_v118.dta");
+    let strl_file = DtaFile::from_reader(Cursor::new(strl)).unwrap();
+    assert_eq!(
+        strl_file
+            .parallel_thread_count(&ReadOptions::default(), 4)
+            .unwrap(),
+        1
+    );
+}
+
+#[test]
 fn file_and_slice_reject_invalid_signatures_identically() {
     for bytes in [b"xot a dta".as_slice(), b"<stata_dat>".as_slice()] {
         assert_eq!(

--- a/r-package/dtaparser/src/dta-parser/tests/file.rs
+++ b/r-package/dtaparser/src/dta-parser/tests/file.rs
@@ -555,6 +555,27 @@ fn labels_are_lazy_and_cancellation_never_returns_partial_data() {
 }
 
 #[test]
+fn split_interrupt_callbacks_keep_row_polling_separate() {
+    let mut file = DtaFile::from_reader(Cursor::new(fixture("auto_v118.dta"))).unwrap();
+    let mut coarse_checks = 0_usize;
+    let mut frequent_checks = 0_usize;
+    let result = file.read_with_interrupts(
+        &ReadOptions::default(),
+        || {
+            coarse_checks += 1;
+            false
+        },
+        || {
+            frequent_checks += 1;
+            true
+        },
+    );
+    assert_eq!(result, Err(DtaError::Cancelled));
+    assert!(coarse_checks >= 2);
+    assert_eq!(frequent_checks, 1);
+}
+
+#[test]
 fn cancels_between_large_gso_chunks_without_returning_partial_data() {
     let (bytes, content_start) = large_first_gso(fixture("strl_test_v118.dta"), 4096);
     let (reader, trace) = TracedReader::new(bytes);
@@ -566,13 +587,17 @@ fn cancels_between_large_gso_chunks_without_returning_partial_data() {
     )
     .unwrap();
     trace.borrow_mut().reads.clear();
-    let result = file.read_with_interrupt(&options(0, Some(1), vec![0]), || {
-        trace
-            .borrow()
-            .reads
-            .iter()
-            .any(|(offset, length)| *offset == content_start && *length == 1024)
-    });
+    let result = file.read_with_interrupts(
+        &options(0, Some(1), vec![0]),
+        || {
+            trace
+                .borrow()
+                .reads
+                .iter()
+                .any(|(offset, length)| *offset == content_start && *length == 1024)
+        },
+        || false,
+    );
     assert_eq!(result, Err(DtaError::Cancelled));
     assert!(!trace
         .borrow()
@@ -594,13 +619,17 @@ fn cancels_between_large_label_chunks_and_leaves_cache_uninitialized() {
     )
     .unwrap();
     trace.borrow_mut().reads.clear();
-    let result = file.read_with_interrupt(&options(0, Some(0), vec![]), || {
-        trace
-            .borrow()
-            .reads
-            .iter()
-            .any(|(offset, length)| *offset == label_start && *length == 1024)
-    });
+    let result = file.read_with_interrupts(
+        &options(0, Some(0), vec![]),
+        || {
+            trace
+                .borrow()
+                .reads
+                .iter()
+                .any(|(offset, length)| *offset == label_start && *length == 1024)
+        },
+        || false,
+    );
     assert_eq!(result, Err(DtaError::Cancelled));
     assert!(!trace
         .borrow()

--- a/r-package/dtaparser/src/init.c
+++ b/r-package/dtaparser/src/init.c
@@ -12,8 +12,8 @@ extern SEXP dtaparser_metadata_rust(
     const char *, uint32_t, uint32_t, const char *, char **
 );
 extern SEXP dtaparser_read_rust(
-    const char *, const int *, size_t, int, double, double, int, const char *,
-    char **
+    const char *, const int *, size_t, int, double, double, int, int,
+    const char *, char **
 );
 extern void dtaparser_free_error(char *);
 extern void dtaparser_dictstring_free(void *);
@@ -324,7 +324,7 @@ SEXP C_dtaparser_metadata(
 
 SEXP C_dtaparser_read(
     SEXP path, SEXP columns, SEXP skip, SEXP n_max, SEXP direct_to_r,
-    SEXP encoding
+    SEXP threads, SEXP encoding
 ) {
     if (TYPEOF(path) != STRSXP || XLENGTH(path) != 1 || STRING_ELT(path, 0) == NA_STRING) {
         Rf_error("`file` must be one non-missing path");
@@ -341,6 +341,10 @@ SEXP C_dtaparser_read(
         LOGICAL(direct_to_r)[0] == NA_LOGICAL) {
         Rf_error("internal materialization selector must be logical");
     }
+    if (TYPEOF(threads) != INTSXP || XLENGTH(threads) != 1 ||
+        INTEGER(threads)[0] < 0) {
+        Rf_error("internal thread count must be one non-negative integer");
+    }
     char *error = NULL;
     SEXP result = dtaparser_read_rust(
         Rf_translateCharUTF8(STRING_ELT(path, 0)),
@@ -350,6 +354,7 @@ SEXP C_dtaparser_read(
         REAL(skip)[0],
         REAL(n_max)[0],
         LOGICAL(direct_to_r)[0],
+        INTEGER(threads)[0],
         optional_encoding(encoding),
         &error
     );
@@ -359,7 +364,7 @@ SEXP C_dtaparser_read(
 
 static const R_CallMethodDef CallEntries[] = {
     {"C_dtaparser_metadata", (DL_FUNC) &C_dtaparser_metadata, 4},
-    {"C_dtaparser_read", (DL_FUNC) &C_dtaparser_read, 6},
+    {"C_dtaparser_read", (DL_FUNC) &C_dtaparser_read, 7},
     {NULL, NULL, 0}
 };
 

--- a/r-package/dtaparser/src/rust/src/lib.rs
+++ b/r-package/dtaparser/src/rust/src/lib.rs
@@ -178,7 +178,11 @@ fn poll_interrupt(index: usize) -> Result<(), String> {
     Ok(())
 }
 
-fn interrupt_poller() -> impl FnMut() -> bool {
+fn coarse_interrupt() -> bool {
+    unsafe { dtaparser_check_interrupt() != 0 }
+}
+
+fn frequent_interrupt_poller() -> impl FnMut() -> bool {
     let mut calls = 0_usize;
     move || {
         let poll = calls.is_multiple_of(INTERRUPT_STRIDE);
@@ -1124,22 +1128,27 @@ unsafe fn read_impl(
                 |metadata, _row_start, row_count, indices| unsafe {
                     RDataFrameSink::new(metadata, row_count, indices)
                 },
-                || unsafe { dtaparser_check_interrupt() != 0 },
+                coarse_interrupt,
             )
             .map_err(|error| error.to_string())
         } else {
-            file.read_with_sink_and_interrupt(
+            file.read_with_sink_and_interrupts(
                 &options,
                 |metadata, _row_start, row_count, indices| unsafe {
                     RDataFrameSink::new(metadata, row_count, indices)
                 },
-                interrupt_poller(),
+                coarse_interrupt,
+                frequent_interrupt_poller(),
             )
             .map_err(|error| error.to_string())
         }
     } else {
         let data = file
-            .read_with_interrupt(&options, interrupt_poller())
+            .read_with_interrupts(
+                &options,
+                coarse_interrupt,
+                frequent_interrupt_poller(),
+            )
             .map_err(|error| error.to_string())?;
         build_data_frame(&data)
     }

--- a/r-package/dtaparser/src/rust/src/lib.rs
+++ b/r-package/dtaparser/src/rust/src/lib.rs
@@ -5,8 +5,8 @@ use std::ptr;
 
 use ahash::AHashMap;
 use dta_parser::{
-    ColumnValues, DtaData, DtaError, DtaFile, DtaMetadata, DtaSink, DtaType, MissingTag,
-    ReadOptions, TextEncoding, ValueLabelTable, VariableInfo,
+    ColumnValues, DtaColumnSink, DtaData, DtaError, DtaFile, DtaMetadata, DtaSink, DtaType,
+    MissingTag, ParallelDtaSink, ReadOptions, TextEncoding, ValueLabelTable, VariableInfo,
 };
 
 type Sexp = *mut c_void;
@@ -178,6 +178,15 @@ fn poll_interrupt(index: usize) -> Result<(), String> {
     Ok(())
 }
 
+fn interrupt_poller() -> impl FnMut() -> bool {
+    let mut calls = 0_usize;
+    move || {
+        let poll = calls.is_multiple_of(INTERRUPT_STRIDE);
+        calls = calls.wrapping_add(1);
+        poll && unsafe { dtaparser_check_interrupt() != 0 }
+    }
+}
+
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum TemporalKind {
     None,
@@ -203,12 +212,16 @@ fn observed_value(value: f64, temporal: TemporalKind) -> f64 {
     }
 }
 
-fn r_missing(tag: MissingTag) -> f64 {
+fn r_missing_with_system(tag: MissingTag, system_missing: f64) -> f64 {
     if tag == MissingTag::System {
-        return unsafe { R_NaReal };
+        return system_missing;
     }
     let letter = u64::from(b'a' + tag.offset() - 1);
     f64::from_bits(0x7ff0_0000_0000_07a2_u64 | (letter << 32))
+}
+
+fn r_missing(tag: MissingTag) -> f64 {
+    r_missing_with_system(tag, unsafe { R_NaReal })
 }
 
 unsafe fn r_char(value: &str) -> Result<Sexp, String> {
@@ -532,6 +545,31 @@ impl RStringData {
         }
         self.push_id(id)
     }
+
+    fn push_utf8_bytes(&mut self, row: usize, value: &[u8]) -> Result<(), DtaError> {
+        if self.value_ids.len() != row {
+            return Err(DtaError::Output(format!(
+                "string output row mismatch: expected {}, got {row}",
+                self.value_ids.len()
+            )));
+        }
+        if let Some(period) = self.cycle_period {
+            let id = self.value_ids[row % period];
+            let Some(&(cached, length)) = self.value_views.get(id as usize) else {
+                return Err(DtaError::Output("invalid R string index".to_owned()));
+            };
+            // Valid UTF-8 is stored byte-for-byte in the canonical dictionary.
+            // Checking it before UTF-8 validation makes repeated modern string
+            // cycles a raw-byte operation. Malformed input falls through to
+            // the ordinary replacement decoder, preserving exact semantics.
+            let cached = unsafe { std::slice::from_raw_parts(cached, length) };
+            if cached == value {
+                return self.push_id(id);
+            }
+        }
+        let decoded = String::from_utf8_lossy(value);
+        self.push(row, &decoded)
+    }
 }
 
 enum RColumn {
@@ -539,12 +577,18 @@ enum RColumn {
         vector: Sexp,
         output: *mut f64,
         temporal: TemporalKind,
+        system_missing: f64,
     },
     String {
         vector: Sexp,
         data: RStringData,
     },
 }
+
+// Parallel workers receive disjoint columns. Numeric workers only write to
+// non-overlapping memory obtained before the threads start; string workers
+// mutate Rust-owned dictionaries. They never invoke the R API.
+unsafe impl Send for RColumn {}
 
 struct RDataFrameSink {
     result: Sexp,
@@ -594,6 +638,7 @@ impl RDataFrameSink {
                         vector,
                         output: REAL(vector),
                         temporal: temporal_kind(&variable.format),
+                        system_missing: R_NaReal,
                     }
                 }
             };
@@ -621,11 +666,17 @@ impl RDataFrameSink {
     }
 
     #[inline(always)]
-    fn numeric_column(&self, column: usize) -> Result<(*mut f64, TemporalKind), DtaError> {
+    fn numeric_column(
+        &self,
+        column: usize,
+    ) -> Result<(*mut f64, TemporalKind, f64), DtaError> {
         match self.columns.get(column) {
             Some(RColumn::Numeric {
-                output, temporal, ..
-            }) => Ok((*output, *temporal)),
+                output,
+                temporal,
+                system_missing,
+                ..
+            }) => Ok((*output, *temporal, *system_missing)),
             _ => Err(DtaError::Output(
                 "numeric output column mismatch".to_owned(),
             )),
@@ -640,10 +691,10 @@ impl RDataFrameSink {
         value: f64,
         missing: Option<MissingTag>,
     ) -> Result<(), DtaError> {
-        let (output, temporal) = self.numeric_column(column)?;
+        let (output, temporal, system_missing) = self.numeric_column(column)?;
         unsafe {
             *output.add(row) = missing
-                .map(r_missing)
+                .map(|tag| r_missing_with_system(tag, system_missing))
                 .unwrap_or_else(|| observed_value(value, temporal));
         }
         Ok(())
@@ -660,6 +711,104 @@ impl RDataFrameSink {
             Some(RColumn::String { data, .. }) => data.push(row, value),
             _ => Err(DtaError::Output("string output column mismatch".to_owned())),
         }
+    }
+}
+
+impl RColumn {
+    #[inline(always)]
+    fn write_numeric_value(
+        &mut self,
+        row: usize,
+        value: f64,
+        missing: Option<MissingTag>,
+    ) -> Result<(), DtaError> {
+        let Self::Numeric {
+            output,
+            temporal,
+            system_missing,
+            ..
+        } = self
+        else {
+            return Err(DtaError::Output(
+                "numeric output column mismatch".to_owned(),
+            ));
+        };
+        unsafe {
+            *output.add(row) = missing
+                .map(|tag| r_missing_with_system(tag, *system_missing))
+                .unwrap_or_else(|| observed_value(value, *temporal));
+        }
+        Ok(())
+    }
+}
+
+impl DtaColumnSink for RColumn {
+    fn push_byte(
+        &mut self,
+        row: usize,
+        value: i8,
+        missing: Option<MissingTag>,
+    ) -> Result<(), DtaError> {
+        self.write_numeric_value(row, f64::from(value), missing)
+    }
+
+    fn push_int(
+        &mut self,
+        row: usize,
+        value: i16,
+        missing: Option<MissingTag>,
+    ) -> Result<(), DtaError> {
+        self.write_numeric_value(row, f64::from(value), missing)
+    }
+
+    fn push_long(
+        &mut self,
+        row: usize,
+        value: i32,
+        missing: Option<MissingTag>,
+    ) -> Result<(), DtaError> {
+        self.write_numeric_value(row, f64::from(value), missing)
+    }
+
+    fn push_float(
+        &mut self,
+        row: usize,
+        value: f32,
+        missing: Option<MissingTag>,
+    ) -> Result<(), DtaError> {
+        self.write_numeric_value(row, f64::from(value), missing)
+    }
+
+    fn push_double(
+        &mut self,
+        row: usize,
+        value: f64,
+        missing: Option<MissingTag>,
+    ) -> Result<(), DtaError> {
+        self.write_numeric_value(row, value, missing)
+    }
+
+    fn push_fixed_string(&mut self, row: usize, value: &str) -> Result<(), DtaError> {
+        let Self::String { data, .. } = self else {
+            return Err(DtaError::Output("string output column mismatch".to_owned()));
+        };
+        data.push(row, value)
+    }
+
+    fn try_push_fixed_string_bytes(
+        &mut self,
+        row: usize,
+        value: &[u8],
+        encoding: TextEncoding,
+    ) -> Result<bool, DtaError> {
+        if encoding != TextEncoding::Utf8 {
+            return Ok(false);
+        }
+        let Self::String { data, .. } = self else {
+            return Err(DtaError::Output("string output column mismatch".to_owned()));
+        };
+        data.push_utf8_bytes(row, value)?;
+        Ok(true)
     }
 }
 
@@ -729,6 +878,25 @@ impl DtaSink for RDataFrameSink {
         value: &str,
     ) -> Result<(), DtaError> {
         self.push_string_value(column, row, value)
+    }
+
+    fn try_push_fixed_string_bytes(
+        &mut self,
+        column: usize,
+        row: usize,
+        value: &[u8],
+        encoding: TextEncoding,
+    ) -> Result<bool, DtaError> {
+        if encoding != TextEncoding::Utf8 {
+            return Ok(false);
+        }
+        match self.columns.get_mut(column) {
+            Some(RColumn::String { data, .. }) => {
+                data.push_utf8_bytes(row, value)?;
+                Ok(true)
+            }
+            _ => Err(DtaError::Output("string output column mismatch".to_owned())),
+        }
     }
 
     #[inline(always)]
@@ -809,6 +977,51 @@ impl DtaSink for RDataFrameSink {
     }
 }
 
+struct RParallelState {
+    result: Sexp,
+    source_indices: Vec<u32>,
+    guard: ProtectGuard,
+}
+
+impl ParallelDtaSink for RDataFrameSink {
+    type Output = Sexp;
+    type Column = RColumn;
+    type State = RParallelState;
+
+    fn split(self) -> (Self::State, Vec<Self::Column>) {
+        (
+            RParallelState {
+                result: self.result,
+                source_indices: self.source_indices,
+                guard: self._guard,
+            },
+            self.columns,
+        )
+    }
+
+    fn finish_parallel(
+        state: Self::State,
+        columns: Vec<Self::Column>,
+        metadata: DtaMetadata,
+        row_start: u64,
+        row_count: u64,
+        value_label_tables: Vec<ValueLabelTable>,
+    ) -> Result<Self::Output, DtaError> {
+        DtaSink::finish(
+            RDataFrameSink {
+                result: state.result,
+                columns,
+                source_indices: state.source_indices,
+                _guard: state.guard,
+            },
+            metadata,
+            row_start,
+            row_count,
+            value_label_tables,
+        )
+    }
+}
+
 unsafe fn metadata_impl(
     path: &str,
     encoding: TextEncoding,
@@ -872,6 +1085,7 @@ unsafe fn read_impl(
     n_max: f64,
     direct_to_r: bool,
     encoding: TextEncoding,
+    requested_threads: usize,
 ) -> Result<Sexp, String> {
     // Public semantics are normalized once by the R wrapper. These checks are
     // only a defensive ABI guard for exact representability and +Inf as the
@@ -900,17 +1114,32 @@ unsafe fn read_impl(
         column_indices: columns,
     };
     if direct_to_r {
-        file.read_with_sink_and_interrupt(
-            &options,
-            |metadata, _row_start, row_count, indices| unsafe {
-                RDataFrameSink::new(metadata, row_count, indices)
-            },
-            || unsafe { dtaparser_check_interrupt() != 0 },
-        )
-        .map_err(|error| error.to_string())
+        let threads = file
+            .parallel_thread_count(&options, requested_threads)
+            .map_err(|error| error.to_string())?;
+        if threads > 1 {
+            file.read_with_parallel_sink_and_interrupt(
+                &options,
+                threads,
+                |metadata, _row_start, row_count, indices| unsafe {
+                    RDataFrameSink::new(metadata, row_count, indices)
+                },
+                || unsafe { dtaparser_check_interrupt() != 0 },
+            )
+            .map_err(|error| error.to_string())
+        } else {
+            file.read_with_sink_and_interrupt(
+                &options,
+                |metadata, _row_start, row_count, indices| unsafe {
+                    RDataFrameSink::new(metadata, row_count, indices)
+                },
+                interrupt_poller(),
+            )
+            .map_err(|error| error.to_string())
+        }
     } else {
         let data = file
-            .read_with_interrupt(&options, || unsafe { dtaparser_check_interrupt() != 0 })
+            .read_with_interrupt(&options, interrupt_poller())
             .map_err(|error| error.to_string())?;
         build_data_frame(&data)
     }
@@ -1018,6 +1247,7 @@ pub unsafe extern "C" fn dtaparser_read_rust(
     skip: f64,
     n_max: f64,
     direct_to_r: c_int,
+    requested_threads: c_int,
     encoding: *const c_char,
     error: *mut *mut c_char,
 ) -> Sexp {
@@ -1028,6 +1258,8 @@ pub unsafe extern "C" fn dtaparser_read_rust(
         let path = CStr::from_ptr(path)
             .to_str()
             .map_err(|_| "file path is not valid UTF-8".to_owned())?;
+        let requested_threads = usize::try_from(requested_threads)
+            .map_err(|_| "thread count must be non-negative".to_owned())?;
         let projection = if all_columns != 0 {
             None
         } else {
@@ -1055,6 +1287,7 @@ pub unsafe extern "C" fn dtaparser_read_rust(
             n_max,
             direct_to_r != 0,
             text_encoding(encoding)?,
+            requested_threads,
         )
     })
 }

--- a/r-package/dtaparser/tests/testthat/test-read-dta.R
+++ b/r-package/dtaparser/tests/testthat/test-read-dta.R
@@ -13,14 +13,50 @@ replace_first_byte <- function(bytes, text, replacement) {
     bytes
 }
 
-test_that("read_dta has the haven-compatible public signature", {
-    expected <- c("file", "encoding", "col_select", "skip", "n_max", ".name_repair")
+test_that("read_dta extends the haven-compatible public signature", {
+    expected <- c(
+        "file", "encoding", "col_select", "skip", "n_max", ".name_repair",
+        "threads"
+    )
     expect_identical(names(formals(read_dta)), expected)
     expect_null(formals(read_dta)$encoding)
     expect_null(formals(read_dta)$col_select)
     expect_identical(formals(read_dta)$skip, 0)
     expect_identical(formals(read_dta)$n_max, Inf)
     expect_identical(formals(read_dta)$.name_repair, "unique")
+    expect_identical(
+        formals(read_dta)$threads,
+        quote(getOption("dtaparser.threads", 0L))
+    )
+})
+
+test_that("modern parallel decoding is identical and older formats fall back", {
+    modern <- fixture("auto_v118.dta")
+    serial <- read_dta(modern, threads = 1L)
+    parallel <- read_dta(modern, threads = 4L)
+    projected <- read_dta(
+        modern,
+        col_select = c(text = make, number = price),
+        threads = 4L
+    )
+    expect_identical(parallel, serial)
+    expect_identical(
+        projected,
+        read_dta(
+            modern,
+            col_select = c(text = make, number = price),
+            threads = 1L
+        )
+    )
+
+    expect_identical(
+        read_dta(fixture("all_types_v117.dta"), threads = 4L),
+        read_dta(fixture("all_types_v117.dta"), threads = 1L)
+    )
+    expect_identical(
+        read_dta(fixture("strl_test_v118.dta"), threads = 4L),
+        read_dta(fixture("strl_test_v118.dta"), threads = 1L)
+    )
 })
 
 test_that("internal metadata projection is bounded and preserves attributes", {
@@ -546,6 +582,9 @@ test_that("argument and native parse failures are ordinary R errors", {
     expect_error(read_dta(path, encoding = c("UTF-8", "latin1")),
                  "one non-missing")
     expect_error(read_dta(path, encoding = 1), "one non-missing")
+    for (threads in list(-1, 1.5, NA_real_, Inf, c(1, 2), "2")) {
+        expect_error(read_dta(path, threads = threads), "threads.*non-negative")
+    }
     expect_error(read_dta(path, col_select = absent), "absent")
 
     corrupt <- tempfile(fileext = ".dta")


### PR DESCRIPTION
## Summary

- add a bounded, column-partitioned multicore decoder for sufficiently large Stata 118/119 reads, with automatic thread selection and serial fallback for earlier formats and selected strL columns
- accelerate modern UTF-8 string and metadata handling while preserving R object semantics, user interrupts, and bounded I/O
- address review findings by keeping coarse interrupt checkpoints unthrottled, moving batched metadata strings into `VariableInfo`, and draining all worker acknowledgements before joining workers
- disaggregate DHS, MICS, and NSFG benchmark reporting by the stored DTA release, retain all-release subtotals, and test the aggregation contract in CI

## Benchmark

The multicore refresh at commit `5245856` is authoritative. Fresh dta-parser-only measurements used automatic multicore decoding on the same modern files as the archived comparison. Haven and Stata were not rerun; their matched values are retained. Both synthetic files are DTA release 119, and all 515 DHS/MICS/NSFG modern corpus files are release 118.

Synthetic release-119 medians (seven measured iterations):

- 100 MB full: 0.073 s, 14.42x haven, 0.151x Stata
- 100 MB projected: 0.034 s, 7.97x haven, 0.412x Stata
- 1 GB full: 0.254 s, 43.14x haven, 0.398x Stata
- 1 GB projected: 0.130 s, 24.00x haven, 1.077x Stata

Aggregate release-118 corpus time:

- DHS: 0.330 s to 0.189 s (42.7% lower)
- MICS: 16.716 s to 15.588 s (6.7% lower)
- NSFG: 9.644 s to 4.875 s (49.5% lower)

Every refreshed corpus read succeeded and returned the same dimensions as the archived oracle run.

## Validation

- `DTA_REQUIRE_R_CONFORMANCE=1 scripts/conformance.sh` (TypeScript/native oracle gates, R archive, R CMD check Status OK, R/haven equivalence)
- `cargo test --workspace --all-targets --locked`
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `RUSTDOCFLAGS=-D warnings cargo doc --workspace --locked --no-deps`
- `cargo package -p dta-parser --locked --offline`
- `Rscript --vanilla benchmarks/r-corpus-performance/test-framework.R`
- Rust source-hash and R Cargo vendor integrity checks
- mixed-release end-to-end corpus benchmark smoke with Stata 117 and 118 fixtures
- fresh dta-parser-only refresh of all release-118 corpus files and both release-119 synthetic files, with dimension validation and fresh-process RSS collection

## Review

CodeRabbit's worker-acknowledgement finding was valid as a channel-liveness invariant. The coordinator now records the first worker failure while continuing to receive every remaining acknowledgement before joining workers. The full Rust workspace test suite, formatting, clippy, source-hash, and vendor checks passed after the fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional multithreaded reading for large modern Stata 118–119 files through the `threads` argument and `dtaparser.threads` option.
  - Preserved serial behavior for older formats, smaller files, and `strL` data.
  - Improved read performance while maintaining equivalent serial and parallel results.

- **Documentation**
  - Expanded usage guidance, limitations, and release-specific benchmark reporting.

- **Tests**
  - Added coverage for threading, fallbacks, interruptions, file-release detection, and benchmark aggregation.
  - Benchmark summaries now report results by corpus and stored-file release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
