### PR TITLE
Speed up direct R DTA loading

### DIFF
--- a/r-package/dtaparser/src/dta-parser/README.md
+++ b/r-package/dtaparser/src/dta-parser/README.md
@@ -105,8 +105,8 @@ the per-cell loop.
 The file reader builds one format-neutral observation plan for every release
 before decoding. `DtaFile::parallel_thread_count` gates the current multicore
 executor to sufficiently large projections in every supported release;
-oversized rows or small workloads return one and use the synchronous
-column-oriented executor.
+small eligible workloads use the synchronous column-oriented executor, while
+rows wider than the staging limit use the ordinary serial fallback.
 `DtaFile::read_with_parallel_interrupt` materializes the built-in Rust model,
 while `read_with_parallel_sink_and_interrupt` accepts a `ParallelDtaSink` that
 splits independently owned `DtaColumnSink` values across persistent workers.

--- a/r-package/dtaparser/src/dta-parser/README.md
+++ b/r-package/dtaparser/src/dta-parser/README.md
@@ -104,14 +104,16 @@ the per-cell loop.
 
 The file reader builds one format-neutral observation plan for every release
 before decoding. `DtaFile::parallel_thread_count` gates the current multicore
-executor to sufficiently large projections in every supported release whose
-selected columns do not include `strL`; unsupported or small workloads return
-one and continue through the serial executor.
+executor to sufficiently large projections in every supported release;
+oversized rows or small workloads return one and use the synchronous
+column-oriented executor.
 `DtaFile::read_with_parallel_interrupt` materializes the built-in Rust model,
 while `read_with_parallel_sink_and_interrupt` accepts a `ParallelDtaSink` that
 splits independently owned `DtaColumnSink` values across persistent workers.
 Workers share immutable bounded input blocks and retain the ordinary scalar
-decoding rules.
+decoding rules. For `strL` columns, workers collect observation pointers and
+the coordinator validates the GSO index, streams selected payloads, and writes
+the resolved strings after the workers join.
 
 `DtaMetadata` and its nested types implement `serde::Serialize` and
 `serde::Deserialize`; the observation and value-label models do as well. Their

--- a/r-package/dtaparser/src/dta-parser/src/file.rs
+++ b/r-package/dtaparser/src/dta-parser/src/file.rs
@@ -906,10 +906,10 @@ fn decode_worker_block<C: DtaColumnSink>(
     encoding: TextEncoding,
     mut should_interrupt: Option<&mut dyn FnMut() -> bool>,
 ) -> Result<(), DtaError> {
+    if block.row_count == 0 {
+        return Ok(());
+    }
     for (column_index, column) in columns.iter_mut().enumerate() {
-        if block.row_count == 0 {
-            continue;
-        }
         let last_row = block
             .row_count
             .checked_sub(1)
@@ -4365,45 +4365,75 @@ fn materialize_file_strls<R: Read + Seek, F: FnMut() -> bool, S: DtaSink>(
         let Some(column_pointers) = column_pointers else {
             continue;
         };
-        for (row_index, pointer) in column_pointers.iter().copied().enumerate() {
-            if pointer_count.is_multiple_of(STRL_CANCEL_CHECK_INTERVAL) {
-                check_cancel(should_interrupt)?;
-            }
-            pointer_count = pointer_count
-                .checked_add(1)
-                .ok_or(DtaError::ArithmeticOverflow("strL pointer count"))?;
-            let Some(key) = pointer else {
-                sink.push_strl(column_index, row_index, "")?;
-                continue;
-            };
-            if let Some(value) = decoded.get(&key) {
-                sink.push_strl(column_index, row_index, value)?;
-                continue;
-            }
-            let entry = entries.get(&key).ok_or(DtaError::DanglingStrlPointer {
-                variable: key.variable,
-                observation: key.observation,
-            })?;
+        materialize_file_strl_pointers(
+            reader,
+            scratch,
+            entries,
+            column_pointers,
+            &mut decoded,
+            &mut pointer_count,
+            should_interrupt,
+            encoding,
+            |row_index, value| sink.push_strl(column_index, row_index, value),
+        )?;
+    }
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn materialize_file_strl_pointers<
+    R: Read + Seek,
+    F: FnMut() -> bool,
+    P: FnMut(usize, &str) -> Result<(), DtaError>,
+>(
+    reader: &mut R,
+    scratch: &mut Scratch,
+    entries: &HashMap<FileGsoKey, FileGsoEntry>,
+    pointers: &[Option<FileGsoKey>],
+    decoded: &mut HashMap<FileGsoKey, String>,
+    pointer_count: &mut usize,
+    should_interrupt: &mut F,
+    encoding: TextEncoding,
+    mut push: P,
+) -> Result<(), DtaError> {
+    for (row_index, pointer) in pointers.iter().copied().enumerate() {
+        if pointer_count.is_multiple_of(STRL_CANCEL_CHECK_INTERVAL) {
             check_cancel(should_interrupt)?;
-            let decoded_length = if entry.gso_type == 130 {
-                entry.content_length - 1
-            } else {
-                entry.content_length
-            };
-            let value = decode_range(
-                reader,
-                entry.content_offset,
-                decoded_length,
-                encoding,
-                false,
-                scratch,
-                should_interrupt,
-                "reading selected GSO content",
-            )?
-            .0;
-            sink.push_strl(column_index, row_index, &value)?;
-            decoded.insert(key, value);
         }
+        *pointer_count = pointer_count
+            .checked_add(1)
+            .ok_or(DtaError::ArithmeticOverflow("strL pointer count"))?;
+        let Some(key) = pointer else {
+            push(row_index, "")?;
+            continue;
+        };
+        if let Some(value) = decoded.get(&key) {
+            push(row_index, value)?;
+            continue;
+        }
+        let entry = entries.get(&key).ok_or(DtaError::DanglingStrlPointer {
+            variable: key.variable,
+            observation: key.observation,
+        })?;
+        check_cancel(should_interrupt)?;
+        let decoded_length = if entry.gso_type == 130 {
+            entry.content_length - 1
+        } else {
+            entry.content_length
+        };
+        let value = decode_range(
+            reader,
+            entry.content_offset,
+            decoded_length,
+            encoding,
+            false,
+            scratch,
+            should_interrupt,
+            "reading selected GSO content",
+        )?
+        .0;
+        push(row_index, &value)?;
+        decoded.insert(key, value);
     }
     Ok(())
 }
@@ -4432,45 +4462,18 @@ fn resolve_parallel_file_strls<R: Read + Seek, F: FnMut() -> bool, C: DtaColumnS
         let Some(pointers) = column.strl_pointers.as_ref() else {
             continue;
         };
-        for (row_index, pointer) in pointers.iter().copied().enumerate() {
-            if pointer_count.is_multiple_of(STRL_CANCEL_CHECK_INTERVAL) {
-                check_cancel(should_interrupt)?;
-            }
-            pointer_count = pointer_count
-                .checked_add(1)
-                .ok_or(DtaError::ArithmeticOverflow("strL pointer count"))?;
-            let Some(key) = pointer else {
-                column.sink.push_strl(row_index, "")?;
-                continue;
-            };
-            if let Some(value) = decoded.get(&key) {
-                column.sink.push_strl(row_index, value)?;
-                continue;
-            }
-            let entry = entries.get(&key).ok_or(DtaError::DanglingStrlPointer {
-                variable: key.variable,
-                observation: key.observation,
-            })?;
-            check_cancel(should_interrupt)?;
-            let decoded_length = if entry.gso_type == 130 {
-                entry.content_length - 1
-            } else {
-                entry.content_length
-            };
-            let value = decode_range(
-                reader,
-                entry.content_offset,
-                decoded_length,
-                encoding,
-                false,
-                scratch,
-                should_interrupt,
-                "reading selected GSO content",
-            )?
-            .0;
-            column.sink.push_strl(row_index, &value)?;
-            decoded.insert(key, value);
-        }
+        let sink = &mut column.sink;
+        materialize_file_strl_pointers(
+            reader,
+            scratch,
+            &entries,
+            pointers,
+            &mut decoded,
+            &mut pointer_count,
+            should_interrupt,
+            encoding,
+            |row_index, value| sink.push_strl(row_index, value),
+        )?;
     }
     Ok(())
 }

--- a/r-package/dtaparser/src/dta-parser/src/file.rs
+++ b/r-package/dtaparser/src/dta-parser/src/file.rs
@@ -1449,97 +1449,120 @@ impl<R: Read + Seek> DtaFile<R> {
                         }));
                     }
 
-                    let mut row = 0_u64;
-                    let mut inflight_block: Option<Arc<ObservationBlock>> = None;
-                    while row < row_count {
-                        let ready = (|| -> Result<(u64, usize), DtaError> {
-                            check_cancel(&mut should_interrupt)?;
-                            let block_rows = (row_count - row).min(rows_per_block);
-                            let block_row_count = usize::try_from(block_rows).map_err(|_| {
-                                DtaError::ArithmeticOverflow("parallel block row count")
-                            })?;
-                            let block_length = plan
-                                .row_width
-                                .checked_mul(block_row_count)
-                                .ok_or(DtaError::ArithmeticOverflow("parallel block length"))?;
-                            let source_row = row_start
-                                .checked_add(row)
-                                .ok_or(DtaError::ArithmeticOverflow("parallel source row"))?;
-                            let block_offset = payload_start
-                                .checked_add(
-                                    source_row.checked_mul(self.metadata.obs_length).ok_or(
-                                        DtaError::ArithmeticOverflow("parallel row offset"),
-                                    )?,
-                                )
-                                .ok_or(DtaError::ArithmeticOverflow("parallel block offset"))?;
-                            read_exact_at_into(
-                                &mut self.reader,
-                                block_offset,
-                                block_length,
-                                &mut self.scratch,
-                                &mut observation_buffer,
-                                "reading observation rows",
-                            )?;
-                            Ok((block_rows, block_row_count))
-                        })();
-
-                        // The read above overlaps worker decoding of the
-                        // preceding block. Once those workers finish, recycle
-                        // its allocation as the buffer for the following read.
-                        let reusable_buffer = if let Some(block) = inflight_block.take() {
-                            receive_worker_acks(&ack_receivers)?;
-                            Arc::try_unwrap(block)
-                                .map_err(|_| {
-                                    DtaError::Output(
-                                        "parallel input block remained borrowed".to_owned(),
+                    let execution = (|| -> Result<(), DtaError> {
+                        let mut row = 0_u64;
+                        let mut inflight_block: Option<Arc<ObservationBlock>> = None;
+                        while row < row_count {
+                            let ready = (|| -> Result<(u64, usize), DtaError> {
+                                check_cancel(&mut should_interrupt)?;
+                                let block_rows = (row_count - row).min(rows_per_block);
+                                let block_row_count =
+                                    usize::try_from(block_rows).map_err(|_| {
+                                        DtaError::ArithmeticOverflow("parallel block row count")
+                                    })?;
+                                let block_length = plan
+                                    .row_width
+                                    .checked_mul(block_row_count)
+                                    .ok_or(DtaError::ArithmeticOverflow("parallel block length"))?;
+                                let source_row = row_start
+                                    .checked_add(row)
+                                    .ok_or(DtaError::ArithmeticOverflow("parallel source row"))?;
+                                let block_offset = payload_start
+                                    .checked_add(
+                                        source_row.checked_mul(self.metadata.obs_length).ok_or(
+                                            DtaError::ArithmeticOverflow("parallel row offset"),
+                                        )?,
                                     )
-                                })?
-                                .bytes
-                        } else {
-                            Vec::new()
-                        };
-                        // An error from the earlier block takes precedence
-                        // over a later read or cancellation error, matching
-                        // the non-pipelined executor's ordering.
-                        let (block_rows, block_row_count) = ready?;
-                        let ready_buffer =
-                            std::mem::replace(&mut observation_buffer, reusable_buffer);
-                        let block = Arc::new(ObservationBlock {
-                            bytes: ready_buffer,
-                            output_row_start: usize::try_from(row)
-                                .map_err(|_| DtaError::ArithmeticOverflow("parallel output row"))?,
-                            row_count: block_row_count,
-                        });
-                        for sender in &senders {
-                            sender
-                                .send(WorkerMessage::Block(Arc::clone(&block)))
-                                .map_err(|_| {
-                                    DtaError::Output("parallel decoder worker stopped".to_owned())
-                                })?;
-                        }
-                        inflight_block = Some(block);
-                        row = row
-                            .checked_add(block_rows)
-                            .ok_or(DtaError::ArithmeticOverflow("parallel projected row"))?;
-                    }
+                                    .ok_or(DtaError::ArithmeticOverflow("parallel block offset"))?;
+                                read_exact_at_into(
+                                    &mut self.reader,
+                                    block_offset,
+                                    block_length,
+                                    &mut self.scratch,
+                                    &mut observation_buffer,
+                                    "reading observation rows",
+                                )?;
+                                Ok((block_rows, block_row_count))
+                            })();
 
-                    if let Some(block) = inflight_block {
-                        receive_worker_acks(&ack_receivers)?;
-                        Arc::try_unwrap(block).map_err(|_| {
-                            DtaError::Output("parallel input block remained borrowed".to_owned())
-                        })?;
-                    }
-                    for sender in &senders {
-                        let _ = sender.send(WorkerMessage::Finish);
+                            // The read above overlaps worker decoding of the
+                            // preceding block. Once those workers finish,
+                            // recycle its allocation for the following read.
+                            let reusable_buffer = if let Some(block) = inflight_block.take() {
+                                receive_worker_acks(&ack_receivers)?;
+                                Arc::try_unwrap(block)
+                                    .map_err(|_| {
+                                        DtaError::Output(
+                                            "parallel input block remained borrowed".to_owned(),
+                                        )
+                                    })?
+                                    .bytes
+                            } else {
+                                Vec::new()
+                            };
+                            // An error from the earlier block takes precedence
+                            // over a later read or cancellation error, matching
+                            // the non-pipelined executor's ordering.
+                            let (block_rows, block_row_count) = ready?;
+                            // An interrupt can arrive while the speculative
+                            // read overlaps the earlier decode. Do not dispatch
+                            // that newly read block after such an interrupt.
+                            check_cancel(&mut should_interrupt)?;
+                            let ready_buffer =
+                                std::mem::replace(&mut observation_buffer, reusable_buffer);
+                            let block = Arc::new(ObservationBlock {
+                                bytes: ready_buffer,
+                                output_row_start: usize::try_from(row).map_err(|_| {
+                                    DtaError::ArithmeticOverflow("parallel output row")
+                                })?,
+                                row_count: block_row_count,
+                            });
+                            for sender in &senders {
+                                sender
+                                    .send(WorkerMessage::Block(Arc::clone(&block)))
+                                    .map_err(|_| {
+                                        DtaError::Output(
+                                            "parallel decoder worker stopped".to_owned(),
+                                        )
+                                    })?;
+                            }
+                            inflight_block = Some(block);
+                            row = row
+                                .checked_add(block_rows)
+                                .ok_or(DtaError::ArithmeticOverflow("parallel projected row"))?;
+                        }
+
+                        if let Some(block) = inflight_block {
+                            receive_worker_acks(&ack_receivers)?;
+                            Arc::try_unwrap(block).map_err(|_| {
+                                DtaError::Output(
+                                    "parallel input block remained borrowed".to_owned(),
+                                )
+                            })?;
+                        }
+                        Ok(())
+                    })();
+
+                    if execution.is_ok() {
+                        for sender in &senders {
+                            let _ = sender.send(WorkerMessage::Finish);
+                        }
                     }
                     drop(senders);
                     let mut completed = Vec::with_capacity(plan.columns.len());
+                    let mut worker_panicked = false;
                     for handle in handles {
-                        let shard = handle.join().map_err(|_| {
-                            DtaError::Output("parallel decoder worker panicked".to_owned())
-                        })?;
-                        completed.extend(shard);
+                        match handle.join() {
+                            Ok(shard) => completed.extend(shard),
+                            Err(_) => worker_panicked = true,
+                        }
                     }
+                    if worker_panicked {
+                        return Err(DtaError::Output(
+                            "parallel decoder worker panicked".to_owned(),
+                        ));
+                    }
+                    execution?;
                     Ok(completed)
                 },
             )?

--- a/r-package/dtaparser/src/dta-parser/src/file.rs
+++ b/r-package/dtaparser/src/dta-parser/src/file.rs
@@ -26,6 +26,7 @@ use crate::{
 const DEFAULT_MAX_BUFFER_BYTES: usize = 8 * 1024 * 1024;
 const MIN_MAX_BUFFER_BYTES: usize = 1024;
 const STRL_CANCEL_CHECK_INTERVAL: usize = 1024;
+const COLUMNAR_CANCEL_CHECK_INTERVAL: usize = 16_384;
 const MIN_PARALLEL_DATA_BYTES: u64 = 16 * 1024 * 1024;
 const MIN_PARALLEL_CELLS: u64 = 1_000_000;
 const MAX_AUTOMATIC_THREADS: usize = 8;
@@ -860,8 +861,9 @@ fn decode_worker_block<C: DtaColumnSink>(
     row_width: usize,
     metadata: &DtaMetadata,
     encoding: TextEncoding,
+    mut should_interrupt: Option<&mut dyn FnMut() -> bool>,
 ) -> Result<(), DtaError> {
-    for column in columns {
+    for (column_index, column) in columns.iter_mut().enumerate() {
         if block.row_count == 0 {
             continue;
         }
@@ -893,7 +895,15 @@ fn decode_worker_block<C: DtaColumnSink>(
         let mut output_row = block.output_row_start;
         macro_rules! decode_numeric_rows {
             ($body:expr) => {{
-                for _ in 0..block.row_count {
+                for local_row in 0..block.row_count {
+                    if column_index == 0 && local_row.is_multiple_of(COLUMNAR_CANCEL_CHECK_INTERVAL)
+                    {
+                        if let Some(callback) = should_interrupt.as_deref_mut() {
+                            if callback() {
+                                return Err(DtaError::Cancelled);
+                            }
+                        }
+                    }
                     $body(input_at, output_row)?;
                     input_at += row_width;
                     output_row += 1;
@@ -949,7 +959,15 @@ fn decode_worker_block<C: DtaColumnSink>(
                 )
             }),
             ObservationKind::FixedString => {
-                for _ in 0..block.row_count {
+                for local_row in 0..block.row_count {
+                    if column_index == 0 && local_row.is_multiple_of(COLUMNAR_CANCEL_CHECK_INTERVAL)
+                    {
+                        if let Some(callback) = should_interrupt.as_deref_mut() {
+                            if callback() {
+                                return Err(DtaError::Cancelled);
+                            }
+                        }
+                    }
                     // SAFETY: the complete strided column range was checked above.
                     let cell = unsafe {
                         std::slice::from_raw_parts(
@@ -1350,7 +1368,14 @@ impl<R: Read + Seek> DtaFile<R> {
                         .map_err(|_| DtaError::ArithmeticOverflow("columnar output row"))?,
                     row_count: block_row_count,
                 };
-                decode_worker_block(&mut shard, &block, plan.row_width, metadata, encoding)?;
+                decode_worker_block(
+                    &mut shard,
+                    &block,
+                    plan.row_width,
+                    metadata,
+                    encoding,
+                    Some(&mut should_interrupt),
+                )?;
                 observation_buffer = block.bytes;
                 row = row
                     .checked_add(block_rows)
@@ -1378,6 +1403,7 @@ impl<R: Read + Seek> DtaFile<R> {
                                             plan.row_width,
                                             metadata,
                                             encoding,
+                                            None,
                                         );
                                         drop(block);
                                         let failed = result.is_err();
@@ -4259,6 +4285,185 @@ fn materialize_file_strls<R: Read + Seek, F: FnMut() -> bool, S: DtaSink>(
 mod tests {
     use super::*;
     use std::io::Cursor;
+
+    fn kernel_metadata(byte_order: ByteOrder) -> DtaMetadata {
+        DtaMetadata {
+            format_version: FormatVersion::V119,
+            byte_order,
+            nvar: 0,
+            nobs: 0,
+            dataset_label: String::new(),
+            notes: Vec::new(),
+            variables: Vec::new(),
+            section_offsets: SectionOffsets::from_array([0; 14]),
+            obs_length: 0,
+        }
+    }
+
+    fn kernel_column(
+        kind: ObservationKind,
+        byte_offset: usize,
+        byte_width: usize,
+    ) -> ParallelColumn<ColumnBuilder> {
+        let sink = match kind {
+            ObservationKind::Byte => ColumnBuilder::Byte {
+                index: 0,
+                values: Vec::new(),
+                missing_tags: Vec::new(),
+            },
+            ObservationKind::Int => ColumnBuilder::Int {
+                index: 0,
+                values: Vec::new(),
+                missing_tags: Vec::new(),
+            },
+            ObservationKind::Long => ColumnBuilder::Long {
+                index: 0,
+                values: Vec::new(),
+                missing_tags: Vec::new(),
+            },
+            ObservationKind::Float => ColumnBuilder::Float {
+                index: 0,
+                values: Vec::new(),
+                missing_tags: Vec::new(),
+            },
+            ObservationKind::Double => ColumnBuilder::Double {
+                index: 0,
+                values: Vec::new(),
+                missing_tags: Vec::new(),
+            },
+            ObservationKind::FixedString => ColumnBuilder::FixedString {
+                index: 0,
+                values: Vec::new(),
+            },
+            ObservationKind::StrL => ColumnBuilder::StrL {
+                index: 0,
+                values: Vec::new(),
+            },
+        };
+        ParallelColumn {
+            plan: ObservationColumnPlan {
+                output_index: 0,
+                source_index: 0,
+                byte_offset,
+                byte_width,
+                kind,
+            },
+            sink,
+        }
+    }
+
+    #[test]
+    fn column_kernels_decode_big_endian_wide_numeric_values() {
+        let mut bytes = Vec::new();
+        for (long, float, double) in [(-2_i32, 1.5_f32, -3.25_f64), (42, -0.5, 9.75)] {
+            bytes.extend_from_slice(&long.to_be_bytes());
+            bytes.extend_from_slice(&float.to_bits().to_be_bytes());
+            bytes.extend_from_slice(&double.to_bits().to_be_bytes());
+        }
+        let mut columns = vec![
+            kernel_column(ObservationKind::Long, 0, 4),
+            kernel_column(ObservationKind::Float, 4, 4),
+            kernel_column(ObservationKind::Double, 8, 8),
+        ];
+        let block = ObservationBlock {
+            bytes,
+            output_row_start: 0,
+            row_count: 2,
+        };
+        decode_worker_block(
+            &mut columns,
+            &block,
+            16,
+            &kernel_metadata(ByteOrder::Msf),
+            TextEncoding::Utf8,
+            None,
+        )
+        .unwrap();
+
+        let ColumnBuilder::Long { values, .. } = &columns[0].sink else {
+            unreachable!()
+        };
+        assert_eq!(values, &[-2, 42]);
+        let ColumnBuilder::Float { values, .. } = &columns[1].sink else {
+            unreachable!()
+        };
+        assert_eq!(values, &[1.5, -0.5]);
+        let ColumnBuilder::Double { values, .. } = &columns[2].sink else {
+            unreachable!()
+        };
+        assert_eq!(values, &[-3.25, 9.75]);
+    }
+
+    #[test]
+    fn column_kernel_range_proof_rejects_truncation_and_output_overflow() {
+        let metadata = kernel_metadata(ByteOrder::Lsf);
+        let mut truncated = vec![kernel_column(ObservationKind::Double, 1, 8)];
+        let block = ObservationBlock {
+            bytes: vec![0; 17],
+            output_row_start: 0,
+            row_count: 2,
+        };
+        assert!(matches!(
+            decode_worker_block(
+                &mut truncated,
+                &block,
+                9,
+                &metadata,
+                TextEncoding::Utf8,
+                None,
+            ),
+            Err(DtaError::Truncated { .. })
+        ));
+
+        let mut overflowing = vec![kernel_column(ObservationKind::Byte, 0, 1)];
+        let block = ObservationBlock {
+            bytes: vec![0; 2],
+            output_row_start: usize::MAX,
+            row_count: 2,
+        };
+        assert_eq!(
+            decode_worker_block(
+                &mut overflowing,
+                &block,
+                1,
+                &metadata,
+                TextEncoding::Utf8,
+                None,
+            ),
+            Err(DtaError::ArithmeticOverflow("parallel output row"))
+        );
+    }
+
+    #[test]
+    fn synchronous_column_kernel_polls_between_long_row_runs() {
+        let row_count = COLUMNAR_CANCEL_CHECK_INTERVAL * 3;
+        let mut columns = vec![kernel_column(ObservationKind::Byte, 0, 1)];
+        let block = ObservationBlock {
+            bytes: vec![1; row_count],
+            output_row_start: 0,
+            row_count,
+        };
+        let mut checks = 0;
+        let mut interrupt = || {
+            checks += 1;
+            checks >= 2
+        };
+        assert_eq!(
+            decode_worker_block(
+                &mut columns,
+                &block,
+                1,
+                &kernel_metadata(ByteOrder::Lsf),
+                TextEncoding::Utf8,
+                Some(&mut interrupt),
+            ),
+            Err(DtaError::Cancelled)
+        );
+        let ColumnBuilder::Byte { values, .. } = &columns[0].sink else {
+            unreachable!()
+        };
+        assert_eq!(values.len(), COLUMNAR_CANCEL_CHECK_INTERVAL);
+    }
 
     #[test]
     fn automatic_parallelism_accepts_large_byte_or_cell_workloads() {

--- a/r-package/dtaparser/src/dta-parser/src/file.rs
+++ b/r-package/dtaparser/src/dta-parser/src/file.rs
@@ -31,6 +31,10 @@ const MIN_PARALLEL_CELLS: u64 = 1_000_000;
 const MAX_AUTOMATIC_THREADS: usize = 8;
 const MODERN_SIGNATURE: &[u8] = b"<stata_dta><header><release>";
 
+fn automatic_parallel_workload(data_bytes: u64, cells: u64) -> bool {
+    data_bytes >= MIN_PARALLEL_DATA_BYTES || cells >= MIN_PARALLEL_CELLS
+}
+
 /// Configuration for seekable file-backed reads.
 ///
 /// `max_buffer_bytes` bounds each temporary raw-byte staging allocation and
@@ -1131,7 +1135,7 @@ impl<R: Read + Seek> DtaFile<R> {
         }
         let data_bytes = row_count.saturating_mul(self.metadata.obs_length);
         let cells = row_count.saturating_mul(plan.columns.len() as u64);
-        if requested == 0 && (data_bytes < MIN_PARALLEL_DATA_BYTES || cells < MIN_PARALLEL_CELLS) {
+        if requested == 0 && !automatic_parallel_workload(data_bytes, cells) {
             return Ok(1);
         }
         let available = thread::available_parallelism().map_or(1, usize::from);
@@ -4137,6 +4141,22 @@ fn materialize_file_strls<R: Read + Seek, F: FnMut() -> bool, S: DtaSink>(
 mod tests {
     use super::*;
     use std::io::Cursor;
+
+    #[test]
+    fn automatic_parallelism_accepts_large_byte_or_cell_workloads() {
+        assert!(!automatic_parallel_workload(
+            MIN_PARALLEL_DATA_BYTES - 1,
+            MIN_PARALLEL_CELLS - 1,
+        ));
+        assert!(automatic_parallel_workload(
+            MIN_PARALLEL_DATA_BYTES,
+            MIN_PARALLEL_CELLS - 1,
+        ));
+        assert!(automatic_parallel_workload(
+            MIN_PARALLEL_DATA_BYTES - 1,
+            MIN_PARALLEL_CELLS,
+        ));
+    }
 
     #[test]
     fn short_strl_pointer_cells_return_a_truncation_error() {

--- a/r-package/dtaparser/src/dta-parser/src/file.rs
+++ b/r-package/dtaparser/src/dta-parser/src/file.rs
@@ -4591,6 +4591,52 @@ mod tests {
     }
 
     #[test]
+    fn column_kernel_collects_big_endian_modern_strl_pointers() {
+        let mut metadata = kernel_metadata(ByteOrder::Msf);
+        metadata.format_version = FormatVersion::V119;
+        metadata.nvar = 1;
+        metadata.nobs = 42;
+        metadata.obs_length = 8;
+        metadata.variables = vec![VariableInfo {
+            name: "text".to_owned(),
+            dta_type: DtaType::StrL,
+            type_code: 32_768,
+            format: "%9s".to_owned(),
+            label: String::new(),
+            value_label_name: String::new(),
+            byte_width: 8,
+            byte_offset: 0,
+        }];
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&1_u16.to_be_bytes());
+        bytes.extend_from_slice(&42_u64.to_be_bytes()[2..]);
+        bytes.extend_from_slice(&[0; 8]);
+        let mut columns = vec![kernel_column(ObservationKind::StrL, 0, 8)];
+        let block = ObservationBlock {
+            bytes,
+            source_offset: 512,
+            output_row_start: 0,
+            row_count: 2,
+        };
+
+        decode_worker_block(&mut columns, &block, 8, &metadata, TextEncoding::Utf8, None).unwrap();
+
+        assert_eq!(
+            columns[0].strl_pointers.as_deref(),
+            Some(
+                [
+                    Some(FileGsoKey {
+                        variable: 1,
+                        observation: 42,
+                    }),
+                    None,
+                ]
+                .as_slice()
+            )
+        );
+    }
+
+    #[test]
     fn column_kernel_range_proof_rejects_truncation_and_output_overflow() {
         let metadata = kernel_metadata(ByteOrder::Lsf);
         let mut truncated = vec![kernel_column(ObservationKind::Double, 1, 8)];

--- a/r-package/dtaparser/src/dta-parser/src/file.rs
+++ b/r-package/dtaparser/src/dta-parser/src/file.rs
@@ -828,6 +828,33 @@ enum WorkerMessage {
     Finish,
 }
 
+fn receive_worker_acks(
+    receivers: &[std::sync::mpsc::Receiver<Result<(), DtaError>>],
+) -> Result<(), DtaError> {
+    let mut stopped = None;
+    let mut errors = Vec::new();
+    for (worker, receiver) in receivers.iter().enumerate() {
+        match receiver.recv() {
+            Ok(Err(error)) => errors.push((worker, error)),
+            Ok(Ok(())) => {}
+            Err(_) if stopped.is_none() => {
+                stopped = Some(DtaError::Output(format!(
+                    "parallel decoder worker {worker} stopped"
+                )));
+            }
+            Err(_) => {}
+        }
+    }
+    if let Some(error) = stopped {
+        return Err(error);
+    }
+    errors.sort_by_key(|(worker, _)| *worker);
+    errors
+        .into_iter()
+        .next()
+        .map_or(Ok(()), |(_, error)| Err(error))
+}
+
 #[inline(always)]
 unsafe fn read_unaligned_u16(bytes: &[u8], offset: usize, byte_order: ByteOrder) -> u16 {
     let raw = unsafe { std::ptr::read_unaligned(bytes.as_ptr().add(offset).cast::<u16>()) };
@@ -1389,8 +1416,12 @@ impl<R: Read + Seek> DtaFile<R> {
                     let mut ack_receivers = Vec::with_capacity(worker_count);
                     let mut handles = Vec::with_capacity(worker_count);
                     for mut shard in shards {
-                        let (sender, receiver) = sync_channel::<WorkerMessage>(0);
-                        let (worker_ack, ack_receiver) = sync_channel::<Result<(), DtaError>>(0);
+                        // One buffered acknowledgement lets the coordinator
+                        // finish the next read while workers complete the
+                        // current block. It also lets workers unwind if that
+                        // read fails before acknowledgements are collected.
+                        let (sender, receiver) = sync_channel::<WorkerMessage>(1);
+                        let (worker_ack, ack_receiver) = sync_channel::<Result<(), DtaError>>(1);
                         senders.push(sender);
                         ack_receivers.push(ack_receiver);
                         handles.push(scope.spawn(move || {
@@ -1419,37 +1450,62 @@ impl<R: Read + Seek> DtaFile<R> {
                     }
 
                     let mut row = 0_u64;
-                    let mut execution_error = None;
+                    let mut inflight_block: Option<Arc<ObservationBlock>> = None;
                     while row < row_count {
-                        check_cancel(&mut should_interrupt)?;
-                        let block_rows = (row_count - row).min(rows_per_block);
-                        let block_row_count = usize::try_from(block_rows).map_err(|_| {
-                            DtaError::ArithmeticOverflow("parallel block row count")
-                        })?;
-                        let block_length = plan
-                            .row_width
-                            .checked_mul(block_row_count)
-                            .ok_or(DtaError::ArithmeticOverflow("parallel block length"))?;
-                        let source_row = row_start
-                            .checked_add(row)
-                            .ok_or(DtaError::ArithmeticOverflow("parallel source row"))?;
-                        let block_offset = payload_start
-                            .checked_add(
-                                source_row
-                                    .checked_mul(self.metadata.obs_length)
-                                    .ok_or(DtaError::ArithmeticOverflow("parallel row offset"))?,
-                            )
-                            .ok_or(DtaError::ArithmeticOverflow("parallel block offset"))?;
-                        read_exact_at_into(
-                            &mut self.reader,
-                            block_offset,
-                            block_length,
-                            &mut self.scratch,
-                            &mut observation_buffer,
-                            "reading observation rows",
-                        )?;
+                        let ready = (|| -> Result<(u64, usize), DtaError> {
+                            check_cancel(&mut should_interrupt)?;
+                            let block_rows = (row_count - row).min(rows_per_block);
+                            let block_row_count = usize::try_from(block_rows).map_err(|_| {
+                                DtaError::ArithmeticOverflow("parallel block row count")
+                            })?;
+                            let block_length = plan
+                                .row_width
+                                .checked_mul(block_row_count)
+                                .ok_or(DtaError::ArithmeticOverflow("parallel block length"))?;
+                            let source_row = row_start
+                                .checked_add(row)
+                                .ok_or(DtaError::ArithmeticOverflow("parallel source row"))?;
+                            let block_offset = payload_start
+                                .checked_add(
+                                    source_row.checked_mul(self.metadata.obs_length).ok_or(
+                                        DtaError::ArithmeticOverflow("parallel row offset"),
+                                    )?,
+                                )
+                                .ok_or(DtaError::ArithmeticOverflow("parallel block offset"))?;
+                            read_exact_at_into(
+                                &mut self.reader,
+                                block_offset,
+                                block_length,
+                                &mut self.scratch,
+                                &mut observation_buffer,
+                                "reading observation rows",
+                            )?;
+                            Ok((block_rows, block_row_count))
+                        })();
+
+                        // The read above overlaps worker decoding of the
+                        // preceding block. Once those workers finish, recycle
+                        // its allocation as the buffer for the following read.
+                        let reusable_buffer = if let Some(block) = inflight_block.take() {
+                            receive_worker_acks(&ack_receivers)?;
+                            Arc::try_unwrap(block)
+                                .map_err(|_| {
+                                    DtaError::Output(
+                                        "parallel input block remained borrowed".to_owned(),
+                                    )
+                                })?
+                                .bytes
+                        } else {
+                            Vec::new()
+                        };
+                        // An error from the earlier block takes precedence
+                        // over a later read or cancellation error, matching
+                        // the non-pipelined executor's ordering.
+                        let (block_rows, block_row_count) = ready?;
+                        let ready_buffer =
+                            std::mem::replace(&mut observation_buffer, reusable_buffer);
                         let block = Arc::new(ObservationBlock {
-                            bytes: std::mem::take(&mut observation_buffer),
+                            bytes: ready_buffer,
                             output_row_start: usize::try_from(row)
                                 .map_err(|_| DtaError::ArithmeticOverflow("parallel output row"))?,
                             row_count: block_row_count,
@@ -1461,44 +1517,20 @@ impl<R: Read + Seek> DtaFile<R> {
                                     DtaError::Output("parallel decoder worker stopped".to_owned())
                                 })?;
                         }
-                        let mut errors = Vec::new();
-                        for (worker, receiver) in ack_receivers.iter().enumerate() {
-                            match receiver.recv() {
-                                Ok(Err(error)) => errors.push((worker, error)),
-                                Ok(Ok(())) => {}
-                                Err(_) => {
-                                    if execution_error.is_none() {
-                                        execution_error = Some(DtaError::Output(format!(
-                                            "parallel decoder worker {worker} stopped"
-                                        )));
-                                    }
-                                }
-                            }
-                        }
-                        if execution_error.is_some() {
-                            break;
-                        }
-                        if !errors.is_empty() {
-                            errors.sort_by_key(|(worker, _)| *worker);
-                            execution_error = errors.into_iter().next().map(|(_, error)| error);
-                            break;
-                        }
-                        observation_buffer = Arc::try_unwrap(block)
-                            .map_err(|_| {
-                                DtaError::Output(
-                                    "parallel input block remained borrowed".to_owned(),
-                                )
-                            })?
-                            .bytes;
+                        inflight_block = Some(block);
                         row = row
                             .checked_add(block_rows)
                             .ok_or(DtaError::ArithmeticOverflow("parallel projected row"))?;
                     }
 
-                    if execution_error.is_none() {
-                        for sender in &senders {
-                            let _ = sender.send(WorkerMessage::Finish);
-                        }
+                    if let Some(block) = inflight_block {
+                        receive_worker_acks(&ack_receivers)?;
+                        Arc::try_unwrap(block).map_err(|_| {
+                            DtaError::Output("parallel input block remained borrowed".to_owned())
+                        })?;
+                    }
+                    for sender in &senders {
+                        let _ = sender.send(WorkerMessage::Finish);
                     }
                     drop(senders);
                     let mut completed = Vec::with_capacity(plan.columns.len());
@@ -1507,9 +1539,6 @@ impl<R: Read + Seek> DtaFile<R> {
                             DtaError::Output("parallel decoder worker panicked".to_owned())
                         })?;
                         completed.extend(shard);
-                    }
-                    if let Some(error) = execution_error {
-                        return Err(error);
                     }
                     Ok(completed)
                 },

--- a/r-package/dtaparser/src/dta-parser/src/file.rs
+++ b/r-package/dtaparser/src/dta-parser/src/file.rs
@@ -827,69 +827,30 @@ enum WorkerMessage {
     Finish,
 }
 
-fn decode_parallel_cell<C: DtaColumnSink>(
-    column: &mut ParallelColumn<C>,
-    row: usize,
-    cell: &[u8],
-    metadata: &DtaMetadata,
-    encoding: TextEncoding,
-) -> Result<(), DtaError> {
-    match column.plan.kind {
-        ObservationKind::Byte => {
-            let value = read_i8(cell, 0, "byte observation")?;
-            column.sink.push_byte(
-                row,
-                value,
-                classify_byte_missing_for_version(value, metadata.format_version),
-            )
-        }
-        ObservationKind::Int => {
-            let value = read_i16(cell, 0, metadata.byte_order, "int observation")?;
-            column.sink.push_int(
-                row,
-                value,
-                classify_int_missing_for_version(value, metadata.format_version),
-            )
-        }
-        ObservationKind::Long => {
-            let value = read_i32(cell, 0, metadata.byte_order, "long observation")?;
-            column.sink.push_long(
-                row,
-                value,
-                classify_long_missing_for_version(value, metadata.format_version),
-            )
-        }
-        ObservationKind::Float => {
-            let bits = read_u32(cell, 0, metadata.byte_order, "float observation")?;
-            column.sink.push_float(
-                row,
-                f32::from_bits(bits),
-                classify_float_missing_bits_for_version(bits, metadata.format_version),
-            )
-        }
-        ObservationKind::Double => {
-            let bits = read_u64(cell, 0, metadata.byte_order, "double observation")?;
-            column.sink.push_double(
-                row,
-                f64::from_bits(bits),
-                classify_double_missing_bits_for_version(bits, metadata.format_version),
-            )
-        }
-        ObservationKind::FixedString => {
-            let field = field_bytes(cell);
-            if column
-                .sink
-                .try_push_fixed_string_bytes(row, field, encoding)?
-            {
-                Ok(())
-            } else {
-                let value = encoding.decode_cow(field);
-                column.sink.push_fixed_string(row, &value)
-            }
-        }
-        ObservationKind::StrL => Err(DtaError::Output(
-            "parallel strL decoding is not enabled".to_owned(),
-        )),
+#[inline(always)]
+unsafe fn read_unaligned_u16(bytes: &[u8], offset: usize, byte_order: ByteOrder) -> u16 {
+    let raw = unsafe { std::ptr::read_unaligned(bytes.as_ptr().add(offset).cast::<u16>()) };
+    match byte_order {
+        ByteOrder::Lsf => u16::from_le(raw),
+        ByteOrder::Msf => u16::from_be(raw),
+    }
+}
+
+#[inline(always)]
+unsafe fn read_unaligned_u32(bytes: &[u8], offset: usize, byte_order: ByteOrder) -> u32 {
+    let raw = unsafe { std::ptr::read_unaligned(bytes.as_ptr().add(offset).cast::<u32>()) };
+    match byte_order {
+        ByteOrder::Lsf => u32::from_le(raw),
+        ByteOrder::Msf => u32::from_be(raw),
+    }
+}
+
+#[inline(always)]
+unsafe fn read_unaligned_u64(bytes: &[u8], offset: usize, byte_order: ByteOrder) -> u64 {
+    let raw = unsafe { std::ptr::read_unaligned(bytes.as_ptr().add(offset).cast::<u64>()) };
+    match byte_order {
+        ByteOrder::Lsf => u64::from_le(raw),
+        ByteOrder::Msf => u64::from_be(raw),
     }
 }
 
@@ -901,28 +862,118 @@ fn decode_worker_block<C: DtaColumnSink>(
     encoding: TextEncoding,
 ) -> Result<(), DtaError> {
     for column in columns {
-        for local_row in 0..block.row_count {
-            let row_at = local_row
-                .checked_mul(row_width)
-                .and_then(|value| value.checked_add(column.plan.byte_offset))
-                .ok_or(DtaError::ArithmeticOverflow("parallel cell offset"))?;
-            let cell_end = row_at
-                .checked_add(column.plan.byte_width)
-                .ok_or(DtaError::ArithmeticOverflow("parallel cell end"))?;
-            let cell = block
-                .bytes
-                .get(row_at..cell_end)
-                .ok_or(DtaError::Truncated {
-                    context: "observation cell",
-                    offset: row_at,
-                    needed: column.plan.byte_width,
-                    available: block.bytes.len().saturating_sub(row_at),
-                })?;
-            let output_row = block
-                .output_row_start
-                .checked_add(local_row)
-                .ok_or(DtaError::ArithmeticOverflow("parallel output row"))?;
-            decode_parallel_cell(column, output_row, cell, metadata, encoding)?;
+        if block.row_count == 0 {
+            continue;
+        }
+        let last_row = block
+            .row_count
+            .checked_sub(1)
+            .and_then(|row| row.checked_mul(row_width))
+            .ok_or(DtaError::ArithmeticOverflow("parallel cell offset"))?;
+        let last_cell = last_row
+            .checked_add(column.plan.byte_offset)
+            .ok_or(DtaError::ArithmeticOverflow("parallel cell offset"))?;
+        let input_end = last_cell
+            .checked_add(column.plan.byte_width)
+            .ok_or(DtaError::ArithmeticOverflow("parallel cell end"))?;
+        if input_end > block.bytes.len() {
+            return Err(DtaError::Truncated {
+                context: "observation cell",
+                offset: last_cell,
+                needed: column.plan.byte_width,
+                available: block.bytes.len().saturating_sub(last_cell),
+            });
+        }
+        block
+            .output_row_start
+            .checked_add(block.row_count)
+            .ok_or(DtaError::ArithmeticOverflow("parallel output row"))?;
+
+        let mut input_at = column.plan.byte_offset;
+        let mut output_row = block.output_row_start;
+        macro_rules! decode_numeric_rows {
+            ($body:expr) => {{
+                for _ in 0..block.row_count {
+                    $body(input_at, output_row)?;
+                    input_at += row_width;
+                    output_row += 1;
+                }
+            }};
+        }
+        match column.plan.kind {
+            ObservationKind::Byte => decode_numeric_rows!(|offset, row| {
+                // SAFETY: the complete strided column range was checked above.
+                let value = unsafe { *block.bytes.get_unchecked(offset) } as i8;
+                column.sink.push_byte(
+                    row,
+                    value,
+                    classify_byte_missing_for_version(value, metadata.format_version),
+                )
+            }),
+            ObservationKind::Int => decode_numeric_rows!(|offset, row| {
+                // SAFETY: the complete strided column range was checked above.
+                let value =
+                    unsafe { read_unaligned_u16(&block.bytes, offset, metadata.byte_order) } as i16;
+                column.sink.push_int(
+                    row,
+                    value,
+                    classify_int_missing_for_version(value, metadata.format_version),
+                )
+            }),
+            ObservationKind::Long => decode_numeric_rows!(|offset, row| {
+                // SAFETY: the complete strided column range was checked above.
+                let value =
+                    unsafe { read_unaligned_u32(&block.bytes, offset, metadata.byte_order) } as i32;
+                column.sink.push_long(
+                    row,
+                    value,
+                    classify_long_missing_for_version(value, metadata.format_version),
+                )
+            }),
+            ObservationKind::Float => decode_numeric_rows!(|offset, row| {
+                // SAFETY: the complete strided column range was checked above.
+                let bits = unsafe { read_unaligned_u32(&block.bytes, offset, metadata.byte_order) };
+                column.sink.push_float(
+                    row,
+                    f32::from_bits(bits),
+                    classify_float_missing_bits_for_version(bits, metadata.format_version),
+                )
+            }),
+            ObservationKind::Double => decode_numeric_rows!(|offset, row| {
+                // SAFETY: the complete strided column range was checked above.
+                let bits = unsafe { read_unaligned_u64(&block.bytes, offset, metadata.byte_order) };
+                column.sink.push_double(
+                    row,
+                    f64::from_bits(bits),
+                    classify_double_missing_bits_for_version(bits, metadata.format_version),
+                )
+            }),
+            ObservationKind::FixedString => {
+                for _ in 0..block.row_count {
+                    // SAFETY: the complete strided column range was checked above.
+                    let cell = unsafe {
+                        std::slice::from_raw_parts(
+                            block.bytes.as_ptr().add(input_at),
+                            column.plan.byte_width,
+                        )
+                    };
+                    let field = field_bytes(cell);
+                    if !column
+                        .sink
+                        .try_push_fixed_string_bytes(output_row, field, encoding)?
+                    {
+                        let value = encoding.decode_cow(field);
+                        column.sink.push_fixed_string(output_row, &value)?;
+                    }
+                    input_at += row_width;
+                    output_row += 1;
+                }
+            }
+            ObservationKind::StrL => {
+                return Err(DtaError::Output(
+                    "parallel strL decoding is not enabled".to_owned(),
+                ));
+            }
         }
     }
     Ok(())
@@ -1154,6 +1205,17 @@ impl<R: Read + Seek> DtaFile<R> {
         Ok(threads.min(plan.columns.len()).max(1))
     }
 
+    /// Return whether the selected observations can use the column-oriented
+    /// block decoder, including its single-worker path.
+    pub fn supports_columnar_sink(&self, options: &ReadOptions) -> Result<bool, DtaError> {
+        let indices = resolve_columns(&self.metadata, options)?;
+        let plan = ObservationPlan::new(&self.metadata, &indices)?;
+        Ok(!plan.columns.is_empty()
+            && plan.row_width > 0
+            && plan.row_width <= self.scratch.limit
+            && !plan.has_strls())
+    }
+
     /// Decode a projection into ordinary Rust vectors with the shared parallel
     /// block executor.
     pub fn read_with_parallel_interrupt<F>(
@@ -1179,10 +1241,9 @@ impl<R: Read + Seek> DtaFile<R> {
 
     /// Decode a projection through independently owned columns.
     ///
-    /// The shared scalar cell decoder is retained; workers only partition
-    /// columns and never call a foreign runtime. Use
-    /// [`DtaFile::parallel_thread_count`] before this method and fall back to
-    /// [`DtaFile::read_with_sink_and_interrupt`] when it returns one.
+    /// Each block is validated once before its type-specialized column kernels
+    /// run. Workers only partition columns and never call a foreign runtime.
+    /// A thread count of one executes the same kernels synchronously.
     pub fn read_with_parallel_sink_and_interrupt<S, B, F>(
         &mut self,
         options: &ReadOptions,
@@ -1205,8 +1266,8 @@ impl<R: Read + Seek> DtaFile<R> {
         let indices = resolve_columns(&self.metadata, options)?;
         let (row_start, row_count) = row_window(&self.metadata, options);
         let plan = ObservationPlan::new(&self.metadata, &indices)?;
-        if thread_count < 2
-            || plan.columns.len() < 2
+        if thread_count == 0
+            || plan.columns.is_empty()
             || plan.row_width == 0
             || plan.row_width > self.scratch.limit
             || plan.has_strls()
@@ -1251,133 +1312,183 @@ impl<R: Read + Seek> DtaFile<R> {
         let encoding = self.text_encoding;
         let mut observation_buffer = Vec::new();
 
-        let decoded_columns = thread::scope(
-            |scope| -> Result<Vec<ParallelColumn<S::Column>>, DtaError> {
-                let mut senders = Vec::with_capacity(worker_count);
-                let mut ack_receivers = Vec::with_capacity(worker_count);
-                let mut handles = Vec::with_capacity(worker_count);
-                for mut shard in shards {
-                    let (sender, receiver) = sync_channel::<WorkerMessage>(0);
-                    let (worker_ack, ack_receiver) = sync_channel::<Result<(), DtaError>>(0);
-                    senders.push(sender);
-                    ack_receivers.push(ack_receiver);
-                    handles.push(scope.spawn(move || {
-                        while let Ok(message) = receiver.recv() {
-                            match message {
-                                WorkerMessage::Block(block) => {
-                                    let result = decode_worker_block(
-                                        &mut shard,
-                                        &block,
-                                        plan.row_width,
-                                        metadata,
-                                        encoding,
-                                    );
-                                    drop(block);
-                                    let failed = result.is_err();
-                                    if worker_ack.send(result).is_err() || failed {
-                                        break;
+        let decoded_columns = if worker_count == 1 {
+            let mut shard = shards
+                .pop()
+                .expect("one worker has exactly one column shard");
+            let mut row = 0_u64;
+            while row < row_count {
+                check_cancel(&mut should_interrupt)?;
+                let block_rows = (row_count - row).min(rows_per_block);
+                let block_row_count = usize::try_from(block_rows)
+                    .map_err(|_| DtaError::ArithmeticOverflow("columnar block row count"))?;
+                let block_length = plan
+                    .row_width
+                    .checked_mul(block_row_count)
+                    .ok_or(DtaError::ArithmeticOverflow("columnar block length"))?;
+                let source_row = row_start
+                    .checked_add(row)
+                    .ok_or(DtaError::ArithmeticOverflow("columnar source row"))?;
+                let block_offset = payload_start
+                    .checked_add(
+                        source_row
+                            .checked_mul(self.metadata.obs_length)
+                            .ok_or(DtaError::ArithmeticOverflow("columnar row offset"))?,
+                    )
+                    .ok_or(DtaError::ArithmeticOverflow("columnar block offset"))?;
+                read_exact_at_into(
+                    &mut self.reader,
+                    block_offset,
+                    block_length,
+                    &mut self.scratch,
+                    &mut observation_buffer,
+                    "reading observation rows",
+                )?;
+                let block = ObservationBlock {
+                    bytes: std::mem::take(&mut observation_buffer),
+                    output_row_start: usize::try_from(row)
+                        .map_err(|_| DtaError::ArithmeticOverflow("columnar output row"))?,
+                    row_count: block_row_count,
+                };
+                decode_worker_block(&mut shard, &block, plan.row_width, metadata, encoding)?;
+                observation_buffer = block.bytes;
+                row = row
+                    .checked_add(block_rows)
+                    .ok_or(DtaError::ArithmeticOverflow("columnar projected row"))?;
+            }
+            shard
+        } else {
+            thread::scope(
+                |scope| -> Result<Vec<ParallelColumn<S::Column>>, DtaError> {
+                    let mut senders = Vec::with_capacity(worker_count);
+                    let mut ack_receivers = Vec::with_capacity(worker_count);
+                    let mut handles = Vec::with_capacity(worker_count);
+                    for mut shard in shards {
+                        let (sender, receiver) = sync_channel::<WorkerMessage>(0);
+                        let (worker_ack, ack_receiver) = sync_channel::<Result<(), DtaError>>(0);
+                        senders.push(sender);
+                        ack_receivers.push(ack_receiver);
+                        handles.push(scope.spawn(move || {
+                            while let Ok(message) = receiver.recv() {
+                                match message {
+                                    WorkerMessage::Block(block) => {
+                                        let result = decode_worker_block(
+                                            &mut shard,
+                                            &block,
+                                            plan.row_width,
+                                            metadata,
+                                            encoding,
+                                        );
+                                        drop(block);
+                                        let failed = result.is_err();
+                                        if worker_ack.send(result).is_err() || failed {
+                                            break;
+                                        }
+                                    }
+                                    WorkerMessage::Finish => break,
+                                }
+                            }
+                            shard
+                        }));
+                    }
+
+                    let mut row = 0_u64;
+                    let mut execution_error = None;
+                    while row < row_count {
+                        check_cancel(&mut should_interrupt)?;
+                        let block_rows = (row_count - row).min(rows_per_block);
+                        let block_row_count = usize::try_from(block_rows).map_err(|_| {
+                            DtaError::ArithmeticOverflow("parallel block row count")
+                        })?;
+                        let block_length = plan
+                            .row_width
+                            .checked_mul(block_row_count)
+                            .ok_or(DtaError::ArithmeticOverflow("parallel block length"))?;
+                        let source_row = row_start
+                            .checked_add(row)
+                            .ok_or(DtaError::ArithmeticOverflow("parallel source row"))?;
+                        let block_offset = payload_start
+                            .checked_add(
+                                source_row
+                                    .checked_mul(self.metadata.obs_length)
+                                    .ok_or(DtaError::ArithmeticOverflow("parallel row offset"))?,
+                            )
+                            .ok_or(DtaError::ArithmeticOverflow("parallel block offset"))?;
+                        read_exact_at_into(
+                            &mut self.reader,
+                            block_offset,
+                            block_length,
+                            &mut self.scratch,
+                            &mut observation_buffer,
+                            "reading observation rows",
+                        )?;
+                        let block = Arc::new(ObservationBlock {
+                            bytes: std::mem::take(&mut observation_buffer),
+                            output_row_start: usize::try_from(row)
+                                .map_err(|_| DtaError::ArithmeticOverflow("parallel output row"))?,
+                            row_count: block_row_count,
+                        });
+                        for sender in &senders {
+                            sender
+                                .send(WorkerMessage::Block(Arc::clone(&block)))
+                                .map_err(|_| {
+                                    DtaError::Output("parallel decoder worker stopped".to_owned())
+                                })?;
+                        }
+                        let mut errors = Vec::new();
+                        for (worker, receiver) in ack_receivers.iter().enumerate() {
+                            match receiver.recv() {
+                                Ok(Err(error)) => errors.push((worker, error)),
+                                Ok(Ok(())) => {}
+                                Err(_) => {
+                                    if execution_error.is_none() {
+                                        execution_error = Some(DtaError::Output(format!(
+                                            "parallel decoder worker {worker} stopped"
+                                        )));
                                     }
                                 }
-                                WorkerMessage::Finish => break,
                             }
                         }
-                        shard
-                    }));
-                }
-
-                let mut row = 0_u64;
-                let mut execution_error = None;
-                while row < row_count {
-                    check_cancel(&mut should_interrupt)?;
-                    let block_rows = (row_count - row).min(rows_per_block);
-                    let block_row_count = usize::try_from(block_rows)
-                        .map_err(|_| DtaError::ArithmeticOverflow("parallel block row count"))?;
-                    let block_length = plan
-                        .row_width
-                        .checked_mul(block_row_count)
-                        .ok_or(DtaError::ArithmeticOverflow("parallel block length"))?;
-                    let source_row = row_start
-                        .checked_add(row)
-                        .ok_or(DtaError::ArithmeticOverflow("parallel source row"))?;
-                    let block_offset = payload_start
-                        .checked_add(
-                            source_row
-                                .checked_mul(self.metadata.obs_length)
-                                .ok_or(DtaError::ArithmeticOverflow("parallel row offset"))?,
-                        )
-                        .ok_or(DtaError::ArithmeticOverflow("parallel block offset"))?;
-                    read_exact_at_into(
-                        &mut self.reader,
-                        block_offset,
-                        block_length,
-                        &mut self.scratch,
-                        &mut observation_buffer,
-                        "reading observation rows",
-                    )?;
-                    let block = Arc::new(ObservationBlock {
-                        bytes: std::mem::take(&mut observation_buffer),
-                        output_row_start: usize::try_from(row)
-                            .map_err(|_| DtaError::ArithmeticOverflow("parallel output row"))?,
-                        row_count: block_row_count,
-                    });
-                    for sender in &senders {
-                        sender
-                            .send(WorkerMessage::Block(Arc::clone(&block)))
+                        if execution_error.is_some() {
+                            break;
+                        }
+                        if !errors.is_empty() {
+                            errors.sort_by_key(|(worker, _)| *worker);
+                            execution_error = errors.into_iter().next().map(|(_, error)| error);
+                            break;
+                        }
+                        observation_buffer = Arc::try_unwrap(block)
                             .map_err(|_| {
-                                DtaError::Output("parallel decoder worker stopped".to_owned())
-                            })?;
+                                DtaError::Output(
+                                    "parallel input block remained borrowed".to_owned(),
+                                )
+                            })?
+                            .bytes;
+                        row = row
+                            .checked_add(block_rows)
+                            .ok_or(DtaError::ArithmeticOverflow("parallel projected row"))?;
                     }
-                    let mut errors = Vec::new();
-                    for (worker, receiver) in ack_receivers.iter().enumerate() {
-                        match receiver.recv() {
-                            Ok(Err(error)) => errors.push((worker, error)),
-                            Ok(Ok(())) => {}
-                            Err(_) => {
-                                if execution_error.is_none() {
-                                    execution_error = Some(DtaError::Output(format!(
-                                        "parallel decoder worker {worker} stopped"
-                                    )));
-                                }
-                            }
+
+                    if execution_error.is_none() {
+                        for sender in &senders {
+                            let _ = sender.send(WorkerMessage::Finish);
                         }
                     }
-                    if execution_error.is_some() {
-                        break;
+                    drop(senders);
+                    let mut completed = Vec::with_capacity(plan.columns.len());
+                    for handle in handles {
+                        let shard = handle.join().map_err(|_| {
+                            DtaError::Output("parallel decoder worker panicked".to_owned())
+                        })?;
+                        completed.extend(shard);
                     }
-                    if !errors.is_empty() {
-                        errors.sort_by_key(|(worker, _)| *worker);
-                        execution_error = errors.into_iter().next().map(|(_, error)| error);
-                        break;
+                    if let Some(error) = execution_error {
+                        return Err(error);
                     }
-                    observation_buffer = Arc::try_unwrap(block)
-                        .map_err(|_| {
-                            DtaError::Output("parallel input block remained borrowed".to_owned())
-                        })?
-                        .bytes;
-                    row = row
-                        .checked_add(block_rows)
-                        .ok_or(DtaError::ArithmeticOverflow("parallel projected row"))?;
-                }
-
-                if execution_error.is_none() {
-                    for sender in &senders {
-                        let _ = sender.send(WorkerMessage::Finish);
-                    }
-                }
-                drop(senders);
-                let mut completed = Vec::with_capacity(plan.columns.len());
-                for handle in handles {
-                    let shard = handle.join().map_err(|_| {
-                        DtaError::Output("parallel decoder worker panicked".to_owned())
-                    })?;
-                    completed.extend(shard);
-                }
-                if let Some(error) = execution_error {
-                    return Err(error);
-                }
-                Ok(completed)
-            },
-        )?;
+                    Ok(completed)
+                },
+            )?
+        };
 
         let mut ordered = (0..plan.columns.len())
             .map(|_| None)

--- a/r-package/dtaparser/src/dta-parser/src/file.rs
+++ b/r-package/dtaparser/src/dta-parser/src/file.rs
@@ -31,8 +31,8 @@ const MIN_PARALLEL_CELLS: u64 = 1_000_000;
 const MAX_AUTOMATIC_THREADS: usize = 8;
 const MODERN_SIGNATURE: &[u8] = b"<stata_dta><header><release>";
 
-fn automatic_parallel_workload(data_bytes: u64, cells: u64) -> bool {
-    data_bytes >= MIN_PARALLEL_DATA_BYTES || cells >= MIN_PARALLEL_CELLS
+fn automatic_parallel_workload(selected_bytes: u64, cells: u64) -> bool {
+    selected_bytes >= MIN_PARALLEL_DATA_BYTES || cells >= MIN_PARALLEL_CELLS
 }
 
 /// Configuration for seekable file-backed reads.
@@ -210,6 +210,13 @@ impl ObservationPlan {
         self.columns
             .iter()
             .any(|column| matches!(column.kind, ObservationKind::StrL))
+    }
+
+    fn selected_data_bytes(&self, row_count: u64) -> u64 {
+        let row_bytes = self.columns.iter().fold(0_u64, |total, column| {
+            total.saturating_add(column.byte_width as u64)
+        });
+        row_count.saturating_mul(row_bytes)
     }
 }
 
@@ -1133,7 +1140,7 @@ impl<R: Read + Seek> DtaFile<R> {
         {
             return Ok(1);
         }
-        let data_bytes = row_count.saturating_mul(self.metadata.obs_length);
+        let data_bytes = plan.selected_data_bytes(row_count);
         let cells = row_count.saturating_mul(plan.columns.len() as u64);
         if requested == 0 && !automatic_parallel_workload(data_bytes, cells) {
             return Ok(1);
@@ -4156,6 +4163,30 @@ mod tests {
             MIN_PARALLEL_DATA_BYTES - 1,
             MIN_PARALLEL_CELLS,
         ));
+
+        let narrow_projection = ObservationPlan {
+            row_width: 4096,
+            columns: vec![
+                ObservationColumnPlan {
+                    output_index: 0,
+                    source_index: 0,
+                    byte_offset: 0,
+                    byte_width: 8,
+                    kind: ObservationKind::Double,
+                },
+                ObservationColumnPlan {
+                    output_index: 1,
+                    source_index: 1,
+                    byte_offset: 4088,
+                    byte_width: 8,
+                    kind: ObservationKind::Double,
+                },
+            ],
+        };
+        let rows = 100_000;
+        let selected_bytes = narrow_projection.selected_data_bytes(rows);
+        assert_eq!(selected_bytes, 1_600_000);
+        assert!(!automatic_parallel_workload(selected_bytes, rows * 2));
     }
 
     #[test]

--- a/r-package/dtaparser/src/dta-parser/src/file.rs
+++ b/r-package/dtaparser/src/dta-parser/src/file.rs
@@ -376,6 +376,11 @@ pub trait DtaColumnSink: Send {
     ) -> Result<bool, DtaError> {
         Ok(false)
     }
+    fn push_strl(&mut self, _row: usize, _value: &str) -> Result<(), DtaError> {
+        Err(DtaError::Output(
+            "parallel output sink does not support strL values".to_owned(),
+        ))
+    }
 }
 
 /// Destination that can transfer independent columns to worker threads.
@@ -611,6 +616,14 @@ impl DtaColumnSink for ColumnBuilder {
         values.push(value.to_owned());
         Ok(())
     }
+
+    fn push_strl(&mut self, _row: usize, value: &str) -> Result<(), DtaError> {
+        let Self::StrL { values, .. } = self else {
+            return Err(DtaError::ArithmeticOverflow("output column type"));
+        };
+        values.push(value.to_owned());
+        Ok(())
+    }
 }
 
 impl VecSink {
@@ -815,10 +828,12 @@ impl ParallelDtaSink for VecSink {
 struct ParallelColumn<C> {
     plan: ObservationColumnPlan,
     sink: C,
+    strl_pointers: Option<Vec<Option<FileGsoKey>>>,
 }
 
 struct ObservationBlock {
     bytes: Vec<u8>,
+    source_offset: u64,
     output_row_start: usize,
     row_count: usize,
 }
@@ -1015,9 +1030,35 @@ fn decode_worker_block<C: DtaColumnSink>(
                 }
             }
             ObservationKind::StrL => {
-                return Err(DtaError::Output(
-                    "parallel strL decoding is not enabled".to_owned(),
-                ));
+                let pointers = column
+                    .strl_pointers
+                    .as_mut()
+                    .ok_or(DtaError::ArithmeticOverflow("parallel strL output column"))?;
+                for local_row in 0..block.row_count {
+                    if column_index == 0 && local_row.is_multiple_of(COLUMNAR_CANCEL_CHECK_INTERVAL)
+                    {
+                        if let Some(callback) = should_interrupt.as_deref_mut() {
+                            if callback() {
+                                return Err(DtaError::Cancelled);
+                            }
+                        }
+                    }
+                    // SAFETY: the complete strided column range was checked above.
+                    let cell = unsafe {
+                        std::slice::from_raw_parts(
+                            block.bytes.as_ptr().add(input_at),
+                            column.plan.byte_width,
+                        )
+                    };
+                    let absolute_offset = block
+                        .source_offset
+                        .checked_add(u64::try_from(input_at).map_err(|_| {
+                            DtaError::ArithmeticOverflow("parallel strL cell offset")
+                        })?)
+                        .ok_or(DtaError::ArithmeticOverflow("parallel strL cell offset"))?;
+                    pointers.push(parse_pointer(cell, absolute_offset, metadata)?);
+                    input_at += row_width;
+                }
             }
         }
     }
@@ -1215,9 +1256,9 @@ impl<R: Read + Seek> DtaFile<R> {
 
     /// Resolve the worker count for the validated parallel path.
     ///
-    /// A requested value of zero selects an automatic count. Unsupported
-    /// `strL` projections, oversized rows, and small automatic workloads
-    /// deliberately return one so callers can use the serial path.
+    /// A requested value of zero selects an automatic count. Oversized rows
+    /// and small automatic workloads deliberately return one so callers can
+    /// use the serial path.
     pub fn parallel_thread_count(
         &self,
         options: &ReadOptions,
@@ -1229,11 +1270,7 @@ impl<R: Read + Seek> DtaFile<R> {
         let indices = resolve_columns(&self.metadata, options)?;
         let plan = ObservationPlan::new(&self.metadata, &indices)?;
         let (_, row_count) = row_window(&self.metadata, options);
-        if plan.columns.len() < 2
-            || plan.row_width == 0
-            || plan.row_width > self.scratch.limit
-            || plan.has_strls()
-        {
+        if plan.columns.len() < 2 || plan.row_width == 0 || plan.row_width > self.scratch.limit {
             return Ok(1);
         }
         let data_bytes = plan.selected_data_bytes(row_count);
@@ -1255,10 +1292,7 @@ impl<R: Read + Seek> DtaFile<R> {
     pub fn supports_columnar_sink(&self, options: &ReadOptions) -> Result<bool, DtaError> {
         let indices = resolve_columns(&self.metadata, options)?;
         let plan = ObservationPlan::new(&self.metadata, &indices)?;
-        Ok(!plan.columns.is_empty()
-            && plan.row_width > 0
-            && plan.row_width <= self.scratch.limit
-            && !plan.has_strls())
+        Ok(!plan.columns.is_empty() && plan.row_width > 0 && plan.row_width <= self.scratch.limit)
     }
 
     /// Decode a projection into ordinary Rust vectors with the shared parallel
@@ -1315,7 +1349,6 @@ impl<R: Read + Seek> DtaFile<R> {
             || plan.columns.is_empty()
             || plan.row_width == 0
             || plan.row_width > self.scratch.limit
-            || plan.has_strls()
         {
             return Err(DtaError::Output(
                 "parallel decoder eligibility was not satisfied".to_owned(),
@@ -1334,6 +1367,8 @@ impl<R: Read + Seek> DtaFile<R> {
             .map(|_| Vec::<ParallelColumn<S::Column>>::new())
             .collect::<Vec<_>>();
         let mut shard_weights = vec![0_usize; worker_count];
+        let output_capacity = usize::try_from(row_count)
+            .map_err(|_| DtaError::ArithmeticOverflow("parallel output row count"))?;
         for (column_plan, column_sink) in plan.columns.iter().copied().zip(columns) {
             let worker = shard_weights
                 .iter()
@@ -1343,9 +1378,19 @@ impl<R: Read + Seek> DtaFile<R> {
                 .unwrap_or(0);
             shard_weights[worker] =
                 shard_weights[worker].saturating_add(column_plan.byte_width.max(8));
+            let strl_pointers = if matches!(column_plan.kind, ObservationKind::StrL) {
+                let mut pointers = Vec::new();
+                pointers
+                    .try_reserve_exact(output_capacity)
+                    .map_err(|_| DtaError::ArithmeticOverflow("parallel strL pointers"))?;
+                Some(pointers)
+            } else {
+                None
+            };
             shards[worker].push(ParallelColumn {
                 plan: column_plan,
                 sink: column_sink,
+                strl_pointers,
             });
         }
 
@@ -1391,6 +1436,7 @@ impl<R: Read + Seek> DtaFile<R> {
                 )?;
                 let block = ObservationBlock {
                     bytes: std::mem::take(&mut observation_buffer),
+                    source_offset: block_offset,
                     output_row_start: usize::try_from(row)
                         .map_err(|_| DtaError::ArithmeticOverflow("columnar output row"))?,
                     row_count: block_row_count,
@@ -1453,7 +1499,7 @@ impl<R: Read + Seek> DtaFile<R> {
                         let mut row = 0_u64;
                         let mut inflight_block: Option<Arc<ObservationBlock>> = None;
                         while row < row_count {
-                            let ready = (|| -> Result<(u64, usize), DtaError> {
+                            let ready = (|| -> Result<(u64, usize, u64), DtaError> {
                                 check_cancel(&mut should_interrupt)?;
                                 let block_rows = (row_count - row).min(rows_per_block);
                                 let block_row_count =
@@ -1482,7 +1528,7 @@ impl<R: Read + Seek> DtaFile<R> {
                                     &mut observation_buffer,
                                     "reading observation rows",
                                 )?;
-                                Ok((block_rows, block_row_count))
+                                Ok((block_rows, block_row_count, block_offset))
                             })();
 
                             // The read above overlaps worker decoding of the
@@ -1503,7 +1549,7 @@ impl<R: Read + Seek> DtaFile<R> {
                             // An error from the earlier block takes precedence
                             // over a later read or cancellation error, matching
                             // the non-pipelined executor's ordering.
-                            let (block_rows, block_row_count) = ready?;
+                            let (block_rows, block_row_count, block_offset) = ready?;
                             // An interrupt can arrive while the speculative
                             // read overlaps the earlier decode. Do not dispatch
                             // that newly read block after such an interrupt.
@@ -1512,6 +1558,7 @@ impl<R: Read + Seek> DtaFile<R> {
                                 std::mem::replace(&mut observation_buffer, reusable_buffer);
                             let block = Arc::new(ObservationBlock {
                                 bytes: ready_buffer,
+                                source_offset: block_offset,
                                 output_row_start: usize::try_from(row).map_err(|_| {
                                     DtaError::ArithmeticOverflow("parallel output row")
                                 })?,
@@ -1570,11 +1617,12 @@ impl<R: Read + Seek> DtaFile<R> {
 
         let mut ordered = (0..plan.columns.len())
             .map(|_| None)
-            .collect::<Vec<Option<S::Column>>>();
+            .collect::<Vec<Option<ParallelColumn<S::Column>>>>();
         for column in decoded_columns {
-            ordered[column.plan.output_index] = Some(column.sink);
+            let output_index = column.plan.output_index;
+            ordered[output_index] = Some(column);
         }
-        let columns = ordered
+        let mut ordered = ordered
             .into_iter()
             .map(|column| {
                 column.ok_or_else(|| {
@@ -1582,6 +1630,22 @@ impl<R: Read + Seek> DtaFile<R> {
                 })
             })
             .collect::<Result<Vec<_>, _>>()?;
+
+        if plan.has_strls() {
+            check_cancel(&mut should_interrupt)?;
+            resolve_parallel_file_strls(
+                &mut self.reader,
+                &self.metadata,
+                &mut self.scratch,
+                &mut ordered,
+                &mut should_interrupt,
+                self.text_encoding,
+            )?;
+        }
+        let columns = ordered
+            .into_iter()
+            .map(|column| column.sink)
+            .collect::<Vec<_>>();
 
         check_cancel(&mut should_interrupt)?;
         self.ensure_value_labels(&mut should_interrupt)?;
@@ -4136,6 +4200,25 @@ fn resolve_file_strls<R: Read + Seek, F: FnMut() -> bool, S: DtaSink>(
         .flat_map(|column| column.iter().flatten().copied())
         .collect::<HashSet<_>>();
 
+    let entries = index_file_strls(reader, metadata, scratch, &requested, should_interrupt)?;
+    materialize_file_strls(
+        reader,
+        scratch,
+        &entries,
+        pointers,
+        sink,
+        should_interrupt,
+        encoding,
+    )
+}
+
+fn index_file_strls<R: Read + Seek, F: FnMut() -> bool>(
+    reader: &mut R,
+    metadata: &DtaMetadata,
+    scratch: &mut Scratch,
+    requested: &HashSet<FileGsoKey>,
+    should_interrupt: &mut F,
+) -> Result<HashMap<FileGsoKey, FileGsoEntry>, DtaError> {
     let mut entries = HashMap::new();
     let mut seen = HashSet::new();
     let mut cursor = checked_add_u64(metadata.section_offsets.strls, 7, "GSO section start")?;
@@ -4263,16 +4346,7 @@ fn resolve_file_strls<R: Read + Seek, F: FnMut() -> bool, S: DtaSink>(
             offset: error_offset(cursor),
         });
     }
-
-    materialize_file_strls(
-        reader,
-        scratch,
-        &entries,
-        pointers,
-        sink,
-        should_interrupt,
-        encoding,
-    )
+    Ok(entries)
 }
 
 fn materialize_file_strls<R: Read + Seek, F: FnMut() -> bool, S: DtaSink>(
@@ -4327,6 +4401,73 @@ fn materialize_file_strls<R: Read + Seek, F: FnMut() -> bool, S: DtaSink>(
             )?
             .0;
             sink.push_strl(column_index, row_index, &value)?;
+            decoded.insert(key, value);
+        }
+    }
+    Ok(())
+}
+
+fn resolve_parallel_file_strls<R: Read + Seek, F: FnMut() -> bool, C: DtaColumnSink>(
+    reader: &mut R,
+    metadata: &DtaMetadata,
+    scratch: &mut Scratch,
+    columns: &mut [ParallelColumn<C>],
+    should_interrupt: &mut F,
+    encoding: TextEncoding,
+) -> Result<(), DtaError> {
+    if !columns.iter().any(|column| column.strl_pointers.is_some()) {
+        return Ok(());
+    }
+    let requested = columns
+        .iter()
+        .filter_map(|column| column.strl_pointers.as_ref())
+        .flat_map(|column| column.iter().flatten().copied())
+        .collect::<HashSet<_>>();
+    let entries = index_file_strls(reader, metadata, scratch, &requested, should_interrupt)?;
+
+    let mut decoded = HashMap::<FileGsoKey, String>::new();
+    let mut pointer_count = 0_usize;
+    for column in columns {
+        let Some(pointers) = column.strl_pointers.as_ref() else {
+            continue;
+        };
+        for (row_index, pointer) in pointers.iter().copied().enumerate() {
+            if pointer_count.is_multiple_of(STRL_CANCEL_CHECK_INTERVAL) {
+                check_cancel(should_interrupt)?;
+            }
+            pointer_count = pointer_count
+                .checked_add(1)
+                .ok_or(DtaError::ArithmeticOverflow("strL pointer count"))?;
+            let Some(key) = pointer else {
+                column.sink.push_strl(row_index, "")?;
+                continue;
+            };
+            if let Some(value) = decoded.get(&key) {
+                column.sink.push_strl(row_index, value)?;
+                continue;
+            }
+            let entry = entries.get(&key).ok_or(DtaError::DanglingStrlPointer {
+                variable: key.variable,
+                observation: key.observation,
+            })?;
+            check_cancel(should_interrupt)?;
+            let decoded_length = if entry.gso_type == 130 {
+                entry.content_length - 1
+            } else {
+                entry.content_length
+            };
+            let value = decode_range(
+                reader,
+                entry.content_offset,
+                decoded_length,
+                encoding,
+                false,
+                scratch,
+                should_interrupt,
+                "reading selected GSO content",
+            )?
+            .0;
+            column.sink.push_strl(row_index, &value)?;
             decoded.insert(key, value);
         }
     }
@@ -4401,6 +4542,7 @@ mod tests {
                 kind,
             },
             sink,
+            strl_pointers: matches!(kind, ObservationKind::StrL).then(Vec::new),
         }
     }
 
@@ -4419,6 +4561,7 @@ mod tests {
         ];
         let block = ObservationBlock {
             bytes,
+            source_offset: 0,
             output_row_start: 0,
             row_count: 2,
         };
@@ -4452,6 +4595,7 @@ mod tests {
         let mut truncated = vec![kernel_column(ObservationKind::Double, 1, 8)];
         let block = ObservationBlock {
             bytes: vec![0; 17],
+            source_offset: 0,
             output_row_start: 0,
             row_count: 2,
         };
@@ -4470,6 +4614,7 @@ mod tests {
         let mut overflowing = vec![kernel_column(ObservationKind::Byte, 0, 1)];
         let block = ObservationBlock {
             bytes: vec![0; 2],
+            source_offset: 0,
             output_row_start: usize::MAX,
             row_count: 2,
         };
@@ -4492,6 +4637,7 @@ mod tests {
         let mut columns = vec![kernel_column(ObservationKind::Byte, 0, 1)];
         let block = ObservationBlock {
             bytes: vec![1; row_count],
+            source_offset: 0,
             output_row_start: 0,
             row_count,
         };

--- a/r-package/dtaparser/src/dta-parser/src/file.rs
+++ b/r-package/dtaparser/src/dta-parser/src/file.rs
@@ -334,8 +334,9 @@ pub trait DtaSink: Sized {
 /// One independently owned output column used by the block executor.
 ///
 /// Implementations must not call a foreign runtime from these methods when
-/// they are used by the parallel executor. Each value is written by exactly
-/// one worker and rows ascend within a column.
+/// they are used by the parallel executor. Numeric and fixed-string values are
+/// written by exactly one worker; deferred `strL` values are written by the
+/// coordinator after workers join. Rows ascend within every column.
 pub trait DtaColumnSink: Send {
     fn push_byte(
         &mut self,

--- a/r-package/dtaparser/src/dta-parser/tests/file.rs
+++ b/r-package/dtaparser/src/dta-parser/tests/file.rs
@@ -133,6 +133,10 @@ impl DtaColumnSink for ProbeColumn {
     fn push_fixed_string(&mut self, _row: usize, _value: &str) -> Result<(), DtaError> {
         self.push()
     }
+
+    fn push_strl(&mut self, _row: usize, _value: &str) -> Result<(), DtaError> {
+        self.push()
+    }
 }
 
 struct ProbeSink {
@@ -481,7 +485,7 @@ fn stages_bounded_wide_rows_for_dense_and_sparse_projections() {
 }
 
 #[test]
-fn parallel_vectors_match_serial_across_supported_releases_and_gate_strls() {
+fn parallel_vectors_match_serial_across_supported_releases_and_strls() {
     for name in [
         "synthetic-v105.dta",
         "synthetic-v108.dta",
@@ -544,14 +548,25 @@ fn parallel_vectors_match_serial_across_supported_releases_and_gate_strls() {
     }
 
     let strl = fixture("strl_test_v118.dta");
-    let strl_file = DtaFile::from_reader(Cursor::new(strl)).unwrap();
+    let mut serial_file = DtaFile::from_reader(Cursor::new(strl.clone())).unwrap();
+    let serial = serial_file.read().unwrap();
+    let mut strl_file = DtaFile::from_reader(Cursor::new(strl)).unwrap();
+    let parallel = strl_file
+        .read_with_parallel_interrupt(&ReadOptions::default(), 4, || false)
+        .unwrap();
+    assert_eq!(parallel, serial);
+    let expected_threads = std::thread::available_parallelism()
+        .map_or(1, usize::from)
+        .min(4)
+        .min(strl_file.metadata().variables.len())
+        .max(1);
     assert_eq!(
         strl_file
             .parallel_thread_count(&ReadOptions::default(), 4)
             .unwrap(),
-        1
+        expected_threads
     );
-    assert!(!strl_file
+    assert!(strl_file
         .supports_columnar_sink(&ReadOptions::default())
         .unwrap());
 }
@@ -652,11 +667,16 @@ fn file_and_slice_reject_invalid_signatures_identically() {
 fn file_and_slice_report_the_same_overlong_gso_error() {
     let bytes = overlong_first_gso(fixture("strl_test_v118.dta"));
     let slice_error = read_dta(&bytes).unwrap_err();
-    let mut file = DtaFile::from_reader(Cursor::new(bytes)).unwrap();
+    let mut file = DtaFile::from_reader(Cursor::new(bytes.clone())).unwrap();
     let file_error = file
         .read_with_options(&options(0, Some(1), vec![0]))
         .unwrap_err();
     assert_eq!(file_error, slice_error);
+    let mut parallel_file = DtaFile::from_reader(Cursor::new(bytes)).unwrap();
+    let parallel_error = parallel_file
+        .read_with_parallel_interrupt(&options(0, Some(1), vec![0]), 1, || false)
+        .unwrap_err();
+    assert_eq!(parallel_error, slice_error);
     assert!(matches!(
         file_error,
         DtaError::Truncated {
@@ -670,11 +690,16 @@ fn file_and_slice_report_the_same_overlong_gso_error() {
 fn file_and_slice_report_the_same_beyond_eof_gso_error() {
     let bytes = beyond_eof_first_gso(fixture("strl_test_v118.dta"));
     let slice_error = read_dta(&bytes).unwrap_err();
-    let mut file = DtaFile::from_reader(Cursor::new(bytes)).unwrap();
+    let mut file = DtaFile::from_reader(Cursor::new(bytes.clone())).unwrap();
     let file_error = file
         .read_with_options(&options(0, Some(1), vec![0]))
         .unwrap_err();
     assert_eq!(file_error, slice_error);
+    let mut parallel_file = DtaFile::from_reader(Cursor::new(bytes)).unwrap();
+    let parallel_error = parallel_file
+        .read_with_parallel_interrupt(&options(0, Some(1), vec![0]), 1, || false)
+        .unwrap_err();
+    assert_eq!(parallel_error, slice_error);
     assert!(matches!(
         file_error,
         DtaError::Truncated {

--- a/r-package/dtaparser/src/dta-parser/tests/file.rs
+++ b/r-package/dtaparser/src/dta-parser/tests/file.rs
@@ -4,11 +4,15 @@ use std::cell::RefCell;
 use std::fs;
 use std::io::{Cursor, Read, Result as IoResult, Seek, SeekFrom};
 use std::rc::Rc;
+use std::sync::{
+    atomic::{AtomicBool, AtomicUsize, Ordering},
+    Arc,
+};
 use support::{fixture, parser_data_dir};
 
 use dta_parser::{
-    read_dta, read_dta_with_options, ColumnValues, DtaError, DtaFile, DtaType, FileOptions,
-    ReadOptions,
+    read_dta, read_dta_with_options, ColumnValues, DtaColumnSink, DtaError, DtaFile, DtaMetadata,
+    DtaType, FileOptions, MissingTag, ParallelDtaSink, ReadOptions, ValueLabelTable,
 };
 
 #[derive(Default)]
@@ -61,6 +65,128 @@ fn options(row_start: u64, row_count: Option<u64>, columns: Vec<u32>) -> ReadOpt
         row_count,
         column_indices: Some(columns),
     }
+}
+
+struct ProbeColumn {
+    panic_on_push: bool,
+    started: Arc<AtomicBool>,
+    pushes: Arc<AtomicUsize>,
+}
+
+impl ProbeColumn {
+    fn push(&self) -> Result<(), DtaError> {
+        if self.panic_on_push {
+            panic!("intentional column-sink panic");
+        }
+        self.pushes.fetch_add(1, Ordering::SeqCst);
+        self.started.store(true, Ordering::SeqCst);
+        Ok(())
+    }
+}
+
+impl DtaColumnSink for ProbeColumn {
+    fn push_byte(
+        &mut self,
+        _row: usize,
+        _value: i8,
+        _missing: Option<MissingTag>,
+    ) -> Result<(), DtaError> {
+        self.push()
+    }
+
+    fn push_int(
+        &mut self,
+        _row: usize,
+        _value: i16,
+        _missing: Option<MissingTag>,
+    ) -> Result<(), DtaError> {
+        self.push()
+    }
+
+    fn push_long(
+        &mut self,
+        _row: usize,
+        _value: i32,
+        _missing: Option<MissingTag>,
+    ) -> Result<(), DtaError> {
+        self.push()
+    }
+
+    fn push_float(
+        &mut self,
+        _row: usize,
+        _value: f32,
+        _missing: Option<MissingTag>,
+    ) -> Result<(), DtaError> {
+        self.push()
+    }
+
+    fn push_double(
+        &mut self,
+        _row: usize,
+        _value: f64,
+        _missing: Option<MissingTag>,
+    ) -> Result<(), DtaError> {
+        self.push()
+    }
+
+    fn push_fixed_string(&mut self, _row: usize, _value: &str) -> Result<(), DtaError> {
+        self.push()
+    }
+}
+
+struct ProbeSink {
+    columns: Vec<ProbeColumn>,
+}
+
+impl ProbeSink {
+    fn new(
+        column_count: usize,
+        panic_on_push: bool,
+        started: Arc<AtomicBool>,
+        pushes: Arc<AtomicUsize>,
+    ) -> Self {
+        let columns = (0..column_count)
+            .map(|_| ProbeColumn {
+                panic_on_push,
+                started: Arc::clone(&started),
+                pushes: Arc::clone(&pushes),
+            })
+            .collect();
+        Self { columns }
+    }
+}
+
+impl ParallelDtaSink for ProbeSink {
+    type Output = ();
+    type Column = ProbeColumn;
+    type State = ();
+
+    fn split(self) -> (Self::State, Vec<Self::Column>) {
+        ((), self.columns)
+    }
+
+    fn finish_parallel(
+        _state: Self::State,
+        _columns: Vec<Self::Column>,
+        _metadata: DtaMetadata,
+        _row_start: u64,
+        _row_count: u64,
+        _value_label_tables: Vec<ValueLabelTable>,
+    ) -> Result<Self::Output, DtaError> {
+        Ok(())
+    }
+}
+
+fn first_non_strl_columns(file: &DtaFile<Cursor<Vec<u8>>>, count: usize) -> Vec<u32> {
+    file.metadata()
+        .variables
+        .iter()
+        .enumerate()
+        .filter(|(_, variable)| variable.dta_type != DtaType::StrL)
+        .take(count)
+        .map(|(index, _)| u32::try_from(index).unwrap())
+        .collect()
 }
 
 fn file_and_slice_error(bytes: Vec<u8>) -> DtaError {
@@ -428,6 +554,84 @@ fn parallel_vectors_match_serial_across_supported_releases_and_gate_strls() {
     assert!(!strl_file
         .supports_columnar_sink(&ReadOptions::default())
         .unwrap());
+}
+
+#[test]
+fn parallel_sink_panics_are_returned_as_errors() {
+    let mut file = DtaFile::from_reader(Cursor::new(fixture("auto_v118.dta"))).unwrap();
+    let columns = first_non_strl_columns(&file, 2);
+    assert_eq!(columns.len(), 2);
+    let started = Arc::new(AtomicBool::new(false));
+    let pushes = Arc::new(AtomicUsize::new(0));
+
+    let result = file.read_with_parallel_sink_and_interrupt(
+        &options(0, None, columns),
+        2,
+        {
+            let started = Arc::clone(&started);
+            let pushes = Arc::clone(&pushes);
+            move |_metadata, _row_start, _row_count, indices| {
+                Ok(ProbeSink::new(
+                    indices.len(),
+                    true,
+                    Arc::clone(&started),
+                    Arc::clone(&pushes),
+                ))
+            }
+        },
+        || false,
+    );
+
+    assert_eq!(
+        result,
+        Err(DtaError::Output(
+            "parallel decoder worker panicked".to_owned()
+        ))
+    );
+}
+
+#[test]
+fn pipelined_cancellation_does_not_dispatch_the_ready_block() {
+    let buffer_limit = 1024;
+    let mut file = DtaFile::from_reader_with_options(
+        Cursor::new(fixture("auto_v118.dta")),
+        FileOptions {
+            max_buffer_bytes: buffer_limit,
+        },
+    )
+    .unwrap();
+    let columns = first_non_strl_columns(&file, 2);
+    assert_eq!(columns.len(), 2);
+    let rows_per_block =
+        buffer_limit / usize::try_from(file.metadata().obs_length).expect("row width fits usize");
+    assert!(rows_per_block > 0);
+    assert!(usize::try_from(file.metadata().nobs).unwrap() > rows_per_block);
+    let started = Arc::new(AtomicBool::new(false));
+    let pushes = Arc::new(AtomicUsize::new(0));
+
+    let result = file.read_with_parallel_sink_and_interrupt(
+        &options(0, None, columns),
+        2,
+        {
+            let started = Arc::clone(&started);
+            let pushes = Arc::clone(&pushes);
+            move |_metadata, _row_start, _row_count, indices| {
+                Ok(ProbeSink::new(
+                    indices.len(),
+                    false,
+                    Arc::clone(&started),
+                    Arc::clone(&pushes),
+                ))
+            }
+        },
+        {
+            let started = Arc::clone(&started);
+            move || started.load(Ordering::SeqCst)
+        },
+    );
+
+    assert_eq!(result, Err(DtaError::Cancelled));
+    assert_eq!(pushes.load(Ordering::SeqCst), rows_per_block * 2);
 }
 
 #[test]

--- a/r-package/dtaparser/src/dta-parser/tests/file.rs
+++ b/r-package/dtaparser/src/dta-parser/tests/file.rs
@@ -547,28 +547,34 @@ fn parallel_vectors_match_serial_across_supported_releases_and_strls() {
         );
     }
 
-    let strl = fixture("strl_test_v118.dta");
-    let mut serial_file = DtaFile::from_reader(Cursor::new(strl.clone())).unwrap();
-    let serial = serial_file.read().unwrap();
-    let mut strl_file = DtaFile::from_reader(Cursor::new(strl)).unwrap();
-    let parallel = strl_file
-        .read_with_parallel_interrupt(&ReadOptions::default(), 4, || false)
-        .unwrap();
-    assert_eq!(parallel, serial);
-    let expected_threads = std::thread::available_parallelism()
-        .map_or(1, usize::from)
-        .min(4)
-        .min(strl_file.metadata().variables.len())
-        .max(1);
-    assert_eq!(
-        strl_file
-            .parallel_thread_count(&ReadOptions::default(), 4)
-            .unwrap(),
-        expected_threads
-    );
-    assert!(strl_file
-        .supports_columnar_sink(&ReadOptions::default())
-        .unwrap());
+    for name in ["all_types_v117.dta", "strl_test_v118.dta"] {
+        let strl = fixture(name);
+        let mut serial_file = DtaFile::from_reader(Cursor::new(strl.clone())).unwrap();
+        let serial = serial_file.read().unwrap();
+        let mut strl_file = DtaFile::from_reader(Cursor::new(strl)).unwrap();
+        let parallel = strl_file
+            .read_with_parallel_interrupt(&ReadOptions::default(), 4, || false)
+            .unwrap();
+        assert_eq!(parallel, serial, "{name}");
+        let expected_threads = std::thread::available_parallelism()
+            .map_or(1, usize::from)
+            .min(4)
+            .min(strl_file.metadata().variables.len())
+            .max(1);
+        assert_eq!(
+            strl_file
+                .parallel_thread_count(&ReadOptions::default(), 4)
+                .unwrap(),
+            expected_threads,
+            "{name}"
+        );
+        assert!(
+            strl_file
+                .supports_columnar_sink(&ReadOptions::default())
+                .unwrap(),
+            "{name}"
+        );
+    }
 }
 
 #[test]

--- a/r-package/dtaparser/src/dta-parser/tests/file.rs
+++ b/r-package/dtaparser/src/dta-parser/tests/file.rs
@@ -379,15 +379,29 @@ fn parallel_vectors_match_serial_across_supported_releases_and_gate_strls() {
             .map(|(index, _)| u32::try_from(index).unwrap())
             .collect::<Vec<_>>();
         assert!(columns.len() >= 2, "{name}");
-        let read_options = options(0, None, columns);
+        let read_options = options(0, None, columns.clone());
 
         let mut serial_file = DtaFile::from_reader(Cursor::new(bytes.clone())).unwrap();
         let serial = serial_file.read_with_options(&read_options).unwrap();
-        let mut parallel_file = DtaFile::from_reader(Cursor::new(bytes)).unwrap();
+        let mut parallel_file = DtaFile::from_reader(Cursor::new(bytes.clone())).unwrap();
         let parallel = parallel_file
             .read_with_parallel_interrupt(&read_options, 2, || false)
             .unwrap();
         assert_eq!(parallel, serial, "{name}");
+
+        let single_options = options(0, None, vec![columns[0]]);
+        let mut single_serial_file = DtaFile::from_reader(Cursor::new(bytes.clone())).unwrap();
+        let single_serial = single_serial_file
+            .read_with_options(&single_options)
+            .unwrap();
+        let mut single_column_file = DtaFile::from_reader(Cursor::new(bytes)).unwrap();
+        assert!(single_column_file
+            .supports_columnar_sink(&single_options)
+            .unwrap());
+        let single_column = single_column_file
+            .read_with_parallel_interrupt(&single_options, 1, || false)
+            .unwrap();
+        assert_eq!(single_column, single_serial, "single column: {name}");
 
         let expected_threads = std::thread::available_parallelism()
             .map_or(1, usize::from)
@@ -411,6 +425,9 @@ fn parallel_vectors_match_serial_across_supported_releases_and_gate_strls() {
             .unwrap(),
         1
     );
+    assert!(!strl_file
+        .supports_columnar_sink(&ReadOptions::default())
+        .unwrap());
 }
 
 #[test]

--- a/r-package/dtaparser/src/init.c
+++ b/r-package/dtaparser/src/init.c
@@ -101,11 +101,15 @@ static SEXP dictstring_materialize(SEXP value) {
     dictstring_data *data = dictstring_storage(value);
     SEXP cache = dictstring_cache(value);
     R_xlen_t dictionary_length = XLENGTH(cache);
+    SEXP *dictionary_values = (SEXP *) R_alloc(
+        (R_SIZE_T) dictionary_length, (int) sizeof(SEXP)
+    );
     for (R_xlen_t id = 0; id < dictionary_length; id++) {
         if ((id & 16383) == 0) R_CheckUserInterrupt();
-        (void) dictstring_cached_value(data, cache, (uint32_t) id);
+        dictionary_values[id] = dictstring_cached_value(
+            data, cache, (uint32_t) id
+        );
     }
-    const SEXP *dictionary_values = VECTOR_PTR_RO(cache);
     materialized = PROTECT(Rf_allocVector(STRSXP, (R_xlen_t) data->length));
     for (size_t index = 0; index < data->length; index++) {
         if ((index & 16383) == 0) R_CheckUserInterrupt();

--- a/r-package/dtaparser/src/init.c
+++ b/r-package/dtaparser/src/init.c
@@ -17,6 +17,9 @@ extern SEXP dtaparser_read_rust(
 );
 extern void dtaparser_free_error(char *);
 extern void dtaparser_dictstring_free(void *);
+extern int dtaparser_dictstring_bytes(
+    void *, uint32_t, const char **, int *
+);
 
 typedef struct {
     uint32_t *value_ids;
@@ -41,12 +44,32 @@ static dictstring_data *dictstring_storage(SEXP value) {
     return data;
 }
 
-static SEXP dictstring_dictionary(SEXP value) {
-    SEXP dictionary = R_ExternalPtrProtected(R_altrep_data1(value));
-    if (TYPEOF(dictionary) != STRSXP) {
-        Rf_error("dtaparser string dictionary is no longer available");
+static SEXP dictstring_cache(SEXP value) {
+    SEXP cache = R_ExternalPtrProtected(R_altrep_data1(value));
+    if (TYPEOF(cache) != VECSXP) {
+        Rf_error("dtaparser string cache is no longer available");
     }
-    return dictionary;
+    return cache;
+}
+
+static SEXP dictstring_cached_value(
+    dictstring_data *data, SEXP cache, uint32_t id
+) {
+    if ((R_xlen_t) id >= XLENGTH(cache)) {
+        Rf_error("invalid dtaparser string-dictionary index");
+    }
+    SEXP cached = VECTOR_ELT(cache, (R_xlen_t) id);
+    if (cached != R_NilValue) return cached;
+
+    const char *bytes = NULL;
+    int length = 0;
+    if (!dtaparser_dictstring_bytes(data, id, &bytes, &length) ||
+        bytes == NULL || length < 0) {
+        Rf_error("invalid dtaparser string-dictionary value");
+    }
+    cached = Rf_mkCharLenCE(bytes, length, CE_UTF8);
+    SET_VECTOR_ELT(cache, (R_xlen_t) id, cached);
+    return cached;
 }
 
 static R_xlen_t dictstring_length(SEXP value) {
@@ -66,12 +89,9 @@ static SEXP dictstring_value(SEXP value, R_xlen_t index) {
     if (index < 0 || (size_t) index >= data->length) {
         Rf_error("invalid dtaparser string-vector index");
     }
-    SEXP dictionary = dictstring_dictionary(value);
+    SEXP cache = dictstring_cache(value);
     uint32_t id = data->value_ids[index];
-    if ((R_xlen_t) id >= XLENGTH(dictionary)) {
-        Rf_error("invalid dtaparser string-dictionary index");
-    }
-    return STRING_ELT(dictionary, (R_xlen_t) id);
+    return dictstring_cached_value(data, cache, id);
 }
 
 static SEXP dictstring_materialize(SEXP value) {
@@ -79,9 +99,13 @@ static SEXP dictstring_materialize(SEXP value) {
     if (materialized != R_NilValue) return materialized;
 
     dictstring_data *data = dictstring_storage(value);
-    SEXP dictionary = dictstring_dictionary(value);
-    R_xlen_t dictionary_length = XLENGTH(dictionary);
-    const SEXP *dictionary_values = STRING_PTR_RO(dictionary);
+    SEXP cache = dictstring_cache(value);
+    R_xlen_t dictionary_length = XLENGTH(cache);
+    for (R_xlen_t id = 0; id < dictionary_length; id++) {
+        if ((id & 16383) == 0) R_CheckUserInterrupt();
+        (void) dictstring_cached_value(data, cache, (uint32_t) id);
+    }
+    const SEXP *dictionary_values = VECTOR_PTR_RO(cache);
     materialized = PROTECT(Rf_allocVector(STRSXP, (R_xlen_t) data->length));
     for (size_t index = 0; index < data->length; index++) {
         if ((index & 16383) == 0) R_CheckUserInterrupt();
@@ -131,8 +155,6 @@ static int dictstring_no_na(SEXP value) {
 
 typedef struct {
     void *data;
-    const char *const *values;
-    const int *value_lengths;
     size_t value_count;
     int transferred;
     SEXP result;
@@ -140,17 +162,11 @@ typedef struct {
 
 static void make_dictstring_call(void *payload) {
     make_dictstring_context *context = (make_dictstring_context *) payload;
-    SEXP dictionary = PROTECT(Rf_allocVector(
-        STRSXP, (R_xlen_t) context->value_count
+    SEXP cache = PROTECT(Rf_allocVector(
+        VECSXP, (R_xlen_t) context->value_count
     ));
-    for (size_t index = 0; index < context->value_count; index++) {
-        if ((index & 16383) == 0) R_CheckUserInterrupt();
-        SET_STRING_ELT(dictionary, (R_xlen_t) index, Rf_mkCharLenCE(
-            context->values[index], context->value_lengths[index], CE_UTF8
-        ));
-    }
     SEXP external = PROTECT(R_MakeExternalPtr(
-        context->data, R_NilValue, dictionary
+        context->data, R_NilValue, cache
     ));
     R_RegisterCFinalizerEx(external, dictstring_finalize, TRUE);
     context->transferred = 1;
@@ -163,16 +179,14 @@ static void make_dictstring_call(void *payload) {
 }
 
 int dtaparser_make_dictstring(
-    void *data, const char *const *values, const int *value_lengths,
-    size_t value_count, int *transferred, SEXP *result
+    void *data, size_t value_count, int *transferred, SEXP *result
 ) {
     if (data == NULL || transferred == NULL || result == NULL ||
-        (value_count > 0 && (values == NULL || value_lengths == NULL)) ||
         value_count > (size_t) R_XLEN_T_MAX) {
         return 0;
     }
     make_dictstring_context context = {
-        data, values, value_lengths, value_count, 0, NULL
+        data, value_count, 0, NULL
     };
     int ok = R_ToplevelExec(make_dictstring_call, &context);
     *transferred = context.transferred;

--- a/r-package/dtaparser/src/rust/Cargo.toml
+++ b/r-package/dtaparser/src/rust/Cargo.toml
@@ -14,6 +14,7 @@ ahash = { version = "0.8", default-features = false, features = ["std"] }
 dta-parser = { path = "../dta-parser" }
 
 [profile.release]
+lto = "thin"
 panic = "unwind"
 strip = "debuginfo"
 

--- a/r-package/dtaparser/src/rust/src/lib.rs
+++ b/r-package/dtaparser/src/rust/src/lib.rs
@@ -1121,7 +1121,10 @@ unsafe fn read_impl(
         let threads = file
             .parallel_thread_count(&options, requested_threads)
             .map_err(|error| error.to_string())?;
-        if threads > 1 {
+        let columnar = file
+            .supports_columnar_sink(&options)
+            .map_err(|error| error.to_string())?;
+        if threads > 1 || columnar {
             file.read_with_parallel_sink_and_interrupt(
                 &options,
                 threads,

--- a/r-package/dtaparser/src/rust/src/lib.rs
+++ b/r-package/dtaparser/src/rust/src/lib.rs
@@ -57,6 +57,8 @@ extern "C" {
 struct DictStringData {
     value_ids: *mut u32,
     length: usize,
+    // Owns the string buffers referenced by `value_views` and must outlive
+    // every raw-pointer view.
     _values: AHashMap<String, u32>,
     value_views: Vec<(*const u8, usize)>,
 }

--- a/r-package/dtaparser/src/rust/src/lib.rs
+++ b/r-package/dtaparser/src/rust/src/lib.rs
@@ -841,6 +841,13 @@ impl DtaColumnSink for RColumn {
         data.push_utf8_bytes(row, value)?;
         Ok(true)
     }
+
+    fn push_strl(&mut self, row: usize, value: &str) -> Result<(), DtaError> {
+        let Self::String { data, .. } = self else {
+            return Err(DtaError::Output("string output column mismatch".to_owned()));
+        };
+        data.push(row, value)
+    }
 }
 
 impl DtaSink for RDataFrameSink {

--- a/r-package/dtaparser/src/rust/src/lib.rs
+++ b/r-package/dtaparser/src/rust/src/lib.rs
@@ -45,8 +45,6 @@ extern "C" {
     ) -> c_int;
     fn dtaparser_make_dictstring(
         data: *mut c_void,
-        values: *const *const c_char,
-        value_lengths: *const c_int,
         value_count: usize,
         transferred: *mut c_int,
         result: *mut Sexp,
@@ -59,15 +57,55 @@ extern "C" {
 struct DictStringData {
     value_ids: *mut u32,
     length: usize,
+    _values: AHashMap<String, u32>,
+    value_views: Vec<(*const u8, usize)>,
 }
 
 impl DictStringData {
-    fn new(value_ids: Vec<u32>) -> Self {
-        let values = value_ids.into_boxed_slice();
-        let length = values.len();
-        let value_ids = Box::into_raw(values).cast::<u32>();
-        Self { value_ids, length }
+    fn new(
+        value_ids: Vec<u32>,
+        values: AHashMap<String, u32>,
+        value_views: Vec<(*const u8, usize)>,
+    ) -> Self {
+        let ids = value_ids.into_boxed_slice();
+        let length = ids.len();
+        let value_ids = Box::into_raw(ids).cast::<u32>();
+        Self {
+            value_ids,
+            length,
+            _values: values,
+            value_views,
+        }
     }
+}
+
+#[no_mangle]
+/// Borrow UTF-8 bytes from a live dictionary-string ALTREP payload.
+///
+/// # Safety
+///
+/// `data` must point to a live `DictStringData`. `value` and `length` must
+/// point to writable output storage. The returned byte pointer remains valid
+/// until `data` is released.
+pub unsafe extern "C" fn dtaparser_dictstring_bytes(
+    data: *mut c_void,
+    id: u32,
+    value: *mut *const c_char,
+    length: *mut c_int,
+) -> c_int {
+    if data.is_null() || value.is_null() || length.is_null() {
+        return 0;
+    }
+    let data = &*data.cast::<DictStringData>();
+    let Some(&(bytes, byte_length)) = data.value_views.get(id as usize) else {
+        return 0;
+    };
+    let Ok(byte_length) = c_int::try_from(byte_length) else {
+        return 0;
+    };
+    *value = bytes.cast::<c_char>();
+    *length = byte_length;
+    1
 }
 
 #[no_mangle]
@@ -84,6 +122,7 @@ pub unsafe extern "C" fn dtaparser_dictstring_free(data: *mut c_void) {
     let data = Box::from_raw(data.cast::<DictStringData>());
     let values = ptr::slice_from_raw_parts_mut(data.value_ids, data.length);
     drop(Box::from_raw(values));
+    drop(data);
 }
 
 struct ProtectGuard {
@@ -113,34 +152,22 @@ impl ProtectGuard {
         self.objects
             .try_reserve(1)
             .map_err(|_| "R could not track a preserved native vector".to_owned())?;
-        let mut value_pointers = Vec::new();
-        value_pointers
-            .try_reserve_exact(data.values.len())
-            .map_err(|_| "could not prepare R string pointers".to_owned())?;
-        value_pointers.resize(data.values.len(), ptr::null());
-        let mut value_lengths = Vec::new();
-        value_lengths
-            .try_reserve_exact(data.values.len())
-            .map_err(|_| "could not prepare R string lengths".to_owned())?;
-        value_lengths.resize(data.values.len(), 0);
-        for (value, &id) in &data.values {
-            let index = usize::try_from(id).map_err(|_| "invalid R string index".to_owned())?;
-            value_pointers[index] = value.as_ptr().cast::<c_char>();
-            value_lengths[index] =
-                c_int::try_from(value.len()).map_err(|_| "R string is too long".to_owned())?;
+        for &(_, length) in &data.value_views {
+            c_int::try_from(length).map_err(|_| "R string is too long".to_owned())?;
         }
 
-        let storage = Box::into_raw(Box::new(DictStringData::new(std::mem::take(
-            &mut data.value_ids,
-        ))))
+        let value_count = data.values.len();
+        let storage = Box::into_raw(Box::new(DictStringData::new(
+            std::mem::take(&mut data.value_ids),
+            std::mem::replace(&mut data.values, AHashMap::new()),
+            std::mem::take(&mut data.value_views),
+        )))
         .cast::<c_void>();
         let mut transferred = 0;
         let mut result = ptr::null_mut();
         let ok = dtaparser_make_dictstring(
             storage,
-            value_pointers.as_ptr(),
-            value_lengths.as_ptr(),
-            value_pointers.len(),
+            value_count,
             &mut transferred,
             &mut result,
         );


### PR DESCRIPTION
## Summary

This stacks six independently reviewed performance stages for the R loader, excluding numeric ALTREP:

1. Tune automatic parallel scheduling using selected bytes and cell count.
2. Add specialized column-oriented decode kernels.
3. Defer R string dictionary materialization with ALTREP.
4. Pipeline bounded observation reads with parallel decode.
5. Decode mixed strL observation pointers in workers and resolve GSOs afterward.
6. Enable thin LTO for the Rust release static library.

Each stage lives on its own pushed branch, perf/r-loader-01-scheduler through perf/r-loader-06-release-profile, and was reviewed before integration.

## Synthetic benchmark results

Direct-R medians, baseline to aggregate:

| Workload | Baseline | Aggregate | Improvement |
| --- | ---: | ---: | ---: |
| 100 MB, 40 columns | 0.072 s | 0.025 s | 65% |
| 100 MB, 8 projected | 0.035 s | 0.014 s | 60% |
| 1 GB, 40 columns | 0.229 s | 0.123 s | 46% |
| 1 GB, 8 projected | 0.131 s | 0.072 s | 45% |

Incremental evidence:

- Scheduler: 0.020 to 0.014 s, 30%, on the synthetic 1M-cell threshold workload.
- Kernels: 31.6% full, 21.6% projected, and 10.6% single-numeric-column gains in targeted single-thread synthetic runs; 1 GB standard full improved 6.1%.
- Lazy strings: 26.6% dimensions, 30.0% sparse-string subset, and 28.5% numeric scan gains on a synthetic 1 GB string workload; a forced full string scan remained effectively flat.
- Read/decode pipeline: 1 GB full improved 23% and projected improved 34% versus the preceding stage.
- Mixed strL: 0.097 to 0.032 s, 67%, on a synthetic 1M-row mixed numeric/fixed-string/strL file; standard non-strL timings stayed flat.
- Thin LTO: 1 GB full improved another 6.8%, projected 2.7%, and mixed-strL 6.25%; codegen-units=1 was tested and rejected due to an 8-10% Rust-vector regression.

Only generated synthetic data was used for performance measurement. Benchmark validation checked result parity.

## Verification

- cargo test -p dta-parser
- cargo clippy --manifest-path r-package/dtaparser/src/rust/Cargo.toml --all-targets -- -D warnings
- R CMD check --no-manual --no-build-vignettes: tests OK; one pre-existing compiled-code warning for the Rust abort symbol
- git diff --check

Numeric ALTREP is intentionally excluded and will follow as a stacked draft PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Parallel column decoding now supports larger projections and selected `strL` columns across supported file versions.
  * Dictionary-backed strings are decoded and cached lazily for improved access and materialization.
  * Added cancellation handling and clearer reporting for workloads eligible for parallel processing.

* **Bug Fixes**
  * Improved validation and error reporting for invalid indexes, truncated data, worker failures, and beyond-end-of-file reads.
  * Prevented unnecessary work after cancellation and ensured consistent results across decoding modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->