### PR TITLE
Optimize numeric columns with source-width ALTREP

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,7 +140,7 @@ jobs:
           rustup default "$RUSTUP_TOOLCHAIN"
       - name: Install R dependencies
         shell: Rscript {0}
-        run: install.packages(c("readr", "rlang", "tibble", "tidyselect", "testthat", "haven", "callr", "httpuv"))
+        run: install.packages(c("readr", "rlang", "tibble", "tidyselect", "testthat", "haven", "dplyr", "callr", "httpuv"))
       - name: Test Rust source hash validation
         if: runner.os == 'Linux'
         shell: bash

--- a/README.md
+++ b/README.md
@@ -49,20 +49,20 @@ including the synthetic, DHS, MICS, and NSFG results.
 
 ## Compatibility
 
-All three libraries read Stata releases 105, 108, 110--111, 113--115, and 117--119:
+All three libraries read DTA formats used by Stata 5 through 19:
 
-| Release | Stata generation |
+| DTA format code | Stata versions |
 | ---: | --- |
 | 105 | Stata 5 |
 | 108 | Stata 6 |
 | 110 | Stata 7 |
-| 111 | Stata/SE 7 |
-| 113 | Stata 8 |
-| 114 | Stata 10 |
+| 111 | Stata 7/SE |
+| 113 | Stata 8–9 |
+| 114 | Stata 10–11 |
 | 115 | Stata 12 |
 | 117 | Stata 13 |
-| 118 | Stata 14--19 |
-| 119 | Stata 15--19 files with more than 32,767 variables |
+| 118 | Stata 14–19 |
+| 119 | Stata 15–19 files with more than 32,767 variables |
 
 Releases 105, 108, and 110 use pre-111 storage codes. Release 105 has a compact
 60-byte header, 32-byte labels, 9-byte names, and 16-bit expansion lengths;

--- a/benchmarks/large-scale/README.md
+++ b/benchmarks/large-scale/README.md
@@ -88,10 +88,12 @@ in the numerator.
 
 The public reader interns each distinct character value once per column and
 returns a dictionary-backed ALTREP vector with compact row-to-dictionary
-indices. Timed reads therefore measure dataset loading and tibble construction;
-the dimension check does not allocate the full row-level string-pointer vector. The exact
+indices. Numeric columns also retain their source storage width behind ALTREP
+until R requests a double data pointer. Timed reads therefore measure dataset
+loading and tibble construction; the dimension check materializes neither the
+full row-level string-pointer vector nor widened numeric vectors. The exact
 dta-parser/Rust-vector comparison and the haven window comparisons before timing
-do access character values, so laziness cannot hide correctness differences.
+do access values, so laziness cannot hide correctness differences.
 Use the separate `benchmarks/r-materialization/string-workloads.R` and
 `benchmarks/r-materialization/memory-worker.R` harnesses for matched string-access and
 fresh-process peak-memory measurements, including workloads that force the

--- a/benchmarks/large-scale/README.md
+++ b/benchmarks/large-scale/README.md
@@ -90,7 +90,10 @@ The public reader interns each distinct character value once per column and
 returns a dictionary-backed ALTREP vector with compact row-to-dictionary
 indices. Byte, int, long, and float columns also retain their source storage
 width behind ALTREP until R requests a double data pointer; source doubles are
-eager because ALTREP would not reduce their storage. Timed reads therefore
+eager because ALTREP would not reduce their storage. Workloads that immediately
+require contiguous double vectors can set `use_numeric_altrep = FALSE` (or option
+`dtaparser.numeric_altrep = FALSE`) to widen numeric values during decoding.
+Timed reads therefore
 measure dataset loading and tibble construction; the dimension check
 materializes neither the full row-level string-pointer vector nor widened
 numeric vectors. The exact

--- a/benchmarks/large-scale/README.md
+++ b/benchmarks/large-scale/README.md
@@ -88,10 +88,12 @@ in the numerator.
 
 The public reader interns each distinct character value once per column and
 returns a dictionary-backed ALTREP vector with compact row-to-dictionary
-indices. Numeric columns also retain their source storage width behind ALTREP
-until R requests a double data pointer. Timed reads therefore measure dataset
-loading and tibble construction; the dimension check materializes neither the
-full row-level string-pointer vector nor widened numeric vectors. The exact
+indices. Byte, int, long, and float columns also retain their source storage
+width behind ALTREP until R requests a double data pointer; source doubles are
+eager because ALTREP would not reduce their storage. Timed reads therefore
+measure dataset loading and tibble construction; the dimension check
+materializes neither the full row-level string-pointer vector nor widened
+numeric vectors. The exact
 dta-parser/Rust-vector comparison and the haven window comparisons before timing
 do access values, so laziness cannot hide correctness differences.
 Use the separate `benchmarks/r-materialization/string-workloads.R` and

--- a/benchmarks/r-corpus-performance/README.md
+++ b/benchmarks/r-corpus-performance/README.md
@@ -20,8 +20,9 @@ per-file peak RSS observed for each reader. Unrecognized or
 unreadable signatures remain accounted for as `unknown` inventory groups. The
 report never publishes private paths or data values.
 
-See the [2026-08-24 aggregate report](results-2026-08-24.md) for the complete
-1,823-file run used in the R package README.
+See the [detailed corpus report](results-2026-08-24.md) for the complete
+1,823-file run and the current numeric ALTREP spot check used in the R package
+README.
 
 On macOS, run the complete suite from the checkout root:
 

--- a/benchmarks/r-corpus-performance/results-2026-08-24.md
+++ b/benchmarks/r-corpus-performance/results-2026-08-24.md
@@ -1,9 +1,37 @@
-# DHS, MICS, and NSFG reader results (2026-08-24)
+# Detailed DHS, MICS, and NSFG reader results
+
+Full corpus run: 2026-08-24. Numeric ALTREP spot check: 2026-08-25.
 
 Environment: Apple M4 Max, 128 GB RAM, macOS 26.5.2, R 4.6.1,
 dtaparser 0.5.0 built with Rust 1.98.0, haven 2.5.5, and Stata/MP 18.
 This report is aggregate-only: it does not publish private paths or data
 values from `/opt/aww_cache`.
+
+## Current numeric ALTREP spot check
+
+The two representative dta-parser cells below were rerun from PR #48 at
+implementation commit `1006ae4`. Haven and Stata were not rerun; their cells
+retain the matched measurements on the identical files from the full corpus
+run. Both refreshed reads returned the same row and column dimensions. The
+dta-parser reads used `threads = 0`, its automatic multicore mode.
+
+The Stata version descriptions identify the generation in which each on-disk
+format was introduced. They do not identify the Stata application version that
+created a particular survey file.
+
+Peak RSS means peak resident set size: the greatest amount of physical memory
+attributed to the reader process during the run. It includes the R or Stata
+runtime and loaded result, but not other processes or the operating system's
+file cache outside that process. Values use decimal GB (`GB = 10^9 bytes`).
+
+| Dataset | Input | dta-parser time | haven time | Stata time | dta-parser / haven time | dta-parser / Stata time | dta-parser peak RSS | haven peak RSS | Stata peak RSS |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| India DHS 2021 women (format introduced with Stata 8; 724,115 × 5,972) | 5.196 GB | 1.896 s | 437.088 s | 0.718 s | 0.004x | 2.641x | 5.218 GB | 35.103 GB | 5.256 GB |
+| NSFG 2017–2019 women (format introduced with Stata 14; 6,141 × 2,610) | 0.020 GB | 0.068 s | 1.002 s | 0.003 s | 0.068x | 22.667x | 0.142 GB | 0.308 GB | 0.051 GB |
+
+These spot checks show the current numeric ALTREP behavior without rerunning
+all 1,823 files. The full-corpus sections below retain the detailed coverage
+and matched comparator results from before numeric ALTREP.
 
 The resumable suite inventoried every regular, non-symlink DTA file beneath the
 DHS, MICS, and NSFG cache directories, then invoked dta-parser, haven, and
@@ -21,28 +49,28 @@ the successful result until exit. Reader order rotates between inputs.
 | NSFG | 229 | 5.777 GB | 222 | 7 |
 | Total | 1,823 | 56.430 GB | 1,812 | 11 |
 
-The harness derives the stored release from the DTA signature. The same
+The harness derives the Stata file format from the DTA signature. The same
 inventory and common-readable sets disaggregate as follows; `unknown` is the
 one MICS input without a recognized DTA signature.
 
-| Corpus | Stored release | Inventoried files | Common files | Excluded |
-| --- | ---: | ---: | ---: | ---: |
-| DHS | 111 | 130 | 129 | 1 |
-| DHS | 113 | 485 | 484 | 1 |
-| DHS | 114 | 24 | 24 | 0 |
-| DHS | 117 | 1 | 1 | 0 |
-| DHS | 118 | 3 | 3 | 0 |
-| MICS | 117 | 495 | 494 | 1 |
-| MICS | 118 | 455 | 455 | 0 |
+| Corpus | Stata file format | Inventoried files | Common files | Excluded |
+| --- | --- | ---: | ---: | ---: |
+| DHS | Introduced with Stata 7/SE | 130 | 129 | 1 |
+| DHS | Introduced with Stata 8 | 485 | 484 | 1 |
+| DHS | Introduced with Stata 10 | 24 | 24 | 0 |
+| DHS | Introduced with Stata 13 | 1 | 1 | 0 |
+| DHS | Introduced with Stata 14 | 3 | 3 | 0 |
+| MICS | Introduced with Stata 13 | 495 | 494 | 1 |
+| MICS | Introduced with Stata 14 | 455 | 455 | 0 |
 | MICS | unknown | 1 | 0 | 1 |
-| NSFG | 105 | 10 | 4 | 6 |
-| NSFG | 108 | 5 | 4 | 1 |
-| NSFG | 110 | 7 | 7 | 0 |
-| NSFG | 113 | 28 | 28 | 0 |
-| NSFG | 114 | 44 | 44 | 0 |
-| NSFG | 115 | 9 | 9 | 0 |
-| NSFG | 117 | 69 | 69 | 0 |
-| NSFG | 118 | 57 | 57 | 0 |
+| NSFG | Introduced with Stata 5 | 10 | 4 | 6 |
+| NSFG | Introduced with Stata 6 | 5 | 4 | 1 |
+| NSFG | Introduced with Stata 7 | 7 | 7 | 0 |
+| NSFG | Introduced with Stata 8 | 28 | 28 | 0 |
+| NSFG | Introduced with Stata 10 | 44 | 44 | 0 |
+| NSFG | Introduced with Stata 12 | 9 | 9 | 0 |
+| NSFG | Introduced with Stata 13 | 69 | 69 | 0 |
+| NSFG | Introduced with Stata 14 | 57 | 57 | 0 |
 
 The comparison uses only successful reads with identical row and column
 counts across all three readers. Both MICS exclusions were rejected by every
@@ -56,32 +84,32 @@ to 7,053 columns.
 
 Times are sums over each common file set. Peak RSS is the largest fresh-process
 value observed within that same set, not a sum. Dta-parser was rerun for all
-1,822 files with recognized releases after the multicore implementation was
-extended across releases, using its default automatic thread count at commit
-`2d09478`. Every refreshed read returned the same status and dimensions as the
-archived run. Haven and Stata were not rerun, so all comparator values are
-unchanged.
+1,822 files with recognized Stata formats after the multicore implementation
+was extended across file formats, using its default automatic thread count at
+commit `2d09478`. Every refreshed read returned the same status and dimensions
+as the original matched run. Haven and Stata were not rerun, so all comparator
+values are unchanged.
 
 | Corpus | Files | Input | dta-parser time | haven time | Stata time | dta-parser / haven time | dta-parser / Stata time | dta-parser peak RSS | haven peak RSS | Stata peak RSS |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
-| DHS — release 111 | 129 | 8.320 GB | 18.254 s | 435.302 s | 63.506 s | 0.042x | 0.287x | 4.526 GB | 4.526 GB | 0.725 GB |
-| DHS — release 113 | 484 | 37.343 GB | 71.413 s | 2,226.568 s | 5.124 s | 0.032x | 13.937x | 35.127 GB | 35.103 GB | 5.256 GB |
-| DHS — release 114 | 24 | 1.162 GB | 3.210 s | 61.036 s | 0.163 s | 0.053x | 19.693x | 0.898 GB | 0.914 GB | 0.149 GB |
-| DHS — release 117 | 1 | 0.028 GB | 0.090 s | 1.505 s | 0.004 s | 0.060x | 22.500x | 0.325 GB | 0.344 GB | 0.056 GB |
-| DHS — release 118 | 3 | 0.050 GB | 0.185 s | 2.640 s | 0.009 s | 0.070x | 20.556x | 0.411 GB | 0.430 GB | 0.077 GB |
-| DHS — all releases | 641 | 46.903 GB | 93.152 s | 2,727.051 s | 68.806 s | 0.034x | 1.354x | 35.127 GB | 35.103 GB | 5.256 GB |
-| MICS — release 117 | 494 | 1.634 GB | 14.708 s | 98.402 s | 0.567 s | 0.149x | 25.940x | 0.304 GB | 0.367 GB | 0.073 GB |
-| MICS — release 118 | 455 | 2.056 GB | 14.633 s | 118.330 s | 0.588 s | 0.124x | 24.886x | 0.651 GB | 0.669 GB | 0.100 GB |
-| MICS — all releases | 949 | 3.690 GB | 29.341 s | 216.732 s | 1.155 s | 0.135x | 25.403x | 0.651 GB | 0.669 GB | 0.100 GB |
-| NSFG — release 105 | 4 | 0.005 GB | 0.083 s | 0.196 s | 0.028 s | 0.423x | 2.964x | 0.125 GB | 0.121 GB | 0.054 GB |
-| NSFG — release 108 | 4 | 0.001 GB | 0.066 s | 0.097 s | 0.006 s | 0.680x | 11.000x | 0.106 GB | 0.104 GB | 0.030 GB |
-| NSFG — release 110 | 7 | 0.015 GB | 0.164 s | 0.497 s | 0.106 s | 0.330x | 1.547x | 0.128 GB | 0.123 GB | 0.041 GB |
-| NSFG — release 113 | 28 | 0.673 GB | 1.232 s | 7.389 s | 0.079 s | 0.167x | 15.595x | 0.525 GB | 0.543 GB | 0.435 GB |
-| NSFG — release 114 | 44 | 1.171 GB | 4.819 s | 47.892 s | 0.156 s | 0.101x | 30.891x | 0.751 GB | 0.765 GB | 0.208 GB |
-| NSFG — release 115 | 9 | 0.100 GB | 0.514 s | 3.512 s | 0.015 s | 0.146x | 34.267x | 0.392 GB | 0.414 GB | 0.068 GB |
-| NSFG — release 117 | 69 | 2.180 GB | 7.565 s | 107.544 s | 0.288 s | 0.070x | 26.267x | 1.318 GB | 1.330 GB | 0.201 GB |
-| NSFG — release 118 | 57 | 1.626 GB | 4.687 s | 67.461 s | 0.207 s | 0.069x | 22.643x | 2.460 GB | 2.470 GB | 0.375 GB |
-| NSFG — all releases | 222 | 5.772 GB | 19.130 s | 234.588 s | 0.885 s | 0.082x | 21.616x | 2.460 GB | 2.470 GB | 0.435 GB |
+| DHS — format introduced with Stata 7/SE | 129 | 8.320 GB | 18.254 s | 435.302 s | 63.506 s | 0.042x | 0.287x | 4.526 GB | 4.526 GB | 0.725 GB |
+| DHS — format introduced with Stata 8 | 484 | 37.343 GB | 71.413 s | 2,226.568 s | 5.124 s | 0.032x | 13.937x | 35.127 GB | 35.103 GB | 5.256 GB |
+| DHS — format introduced with Stata 10 | 24 | 1.162 GB | 3.210 s | 61.036 s | 0.163 s | 0.053x | 19.693x | 0.898 GB | 0.914 GB | 0.149 GB |
+| DHS — format introduced with Stata 13 | 1 | 0.028 GB | 0.090 s | 1.505 s | 0.004 s | 0.060x | 22.500x | 0.325 GB | 0.344 GB | 0.056 GB |
+| DHS — format introduced with Stata 14 | 3 | 0.050 GB | 0.185 s | 2.640 s | 0.009 s | 0.070x | 20.556x | 0.411 GB | 0.430 GB | 0.077 GB |
+| DHS — all formats | 641 | 46.903 GB | 93.152 s | 2,727.051 s | 68.806 s | 0.034x | 1.354x | 35.127 GB | 35.103 GB | 5.256 GB |
+| MICS — format introduced with Stata 13 | 494 | 1.634 GB | 14.708 s | 98.402 s | 0.567 s | 0.149x | 25.940x | 0.304 GB | 0.367 GB | 0.073 GB |
+| MICS — format introduced with Stata 14 | 455 | 2.056 GB | 14.633 s | 118.330 s | 0.588 s | 0.124x | 24.886x | 0.651 GB | 0.669 GB | 0.100 GB |
+| MICS — all formats | 949 | 3.690 GB | 29.341 s | 216.732 s | 1.155 s | 0.135x | 25.403x | 0.651 GB | 0.669 GB | 0.100 GB |
+| NSFG — format introduced with Stata 5 | 4 | 0.005 GB | 0.083 s | 0.196 s | 0.028 s | 0.423x | 2.964x | 0.125 GB | 0.121 GB | 0.054 GB |
+| NSFG — format introduced with Stata 6 | 4 | 0.001 GB | 0.066 s | 0.097 s | 0.006 s | 0.680x | 11.000x | 0.106 GB | 0.104 GB | 0.030 GB |
+| NSFG — format introduced with Stata 7 | 7 | 0.015 GB | 0.164 s | 0.497 s | 0.106 s | 0.330x | 1.547x | 0.128 GB | 0.123 GB | 0.041 GB |
+| NSFG — format introduced with Stata 8 | 28 | 0.673 GB | 1.232 s | 7.389 s | 0.079 s | 0.167x | 15.595x | 0.525 GB | 0.543 GB | 0.435 GB |
+| NSFG — format introduced with Stata 10 | 44 | 1.171 GB | 4.819 s | 47.892 s | 0.156 s | 0.101x | 30.891x | 0.751 GB | 0.765 GB | 0.208 GB |
+| NSFG — format introduced with Stata 12 | 9 | 0.100 GB | 0.514 s | 3.512 s | 0.015 s | 0.146x | 34.267x | 0.392 GB | 0.414 GB | 0.068 GB |
+| NSFG — format introduced with Stata 13 | 69 | 2.180 GB | 7.565 s | 107.544 s | 0.288 s | 0.070x | 26.267x | 1.318 GB | 1.330 GB | 0.201 GB |
+| NSFG — format introduced with Stata 14 | 57 | 1.626 GB | 4.687 s | 67.461 s | 0.207 s | 0.069x | 22.643x | 2.460 GB | 2.470 GB | 0.375 GB |
+| NSFG — all formats | 222 | 5.772 GB | 19.130 s | 234.588 s | 0.885 s | 0.082x | 21.616x | 2.460 GB | 2.470 GB | 0.435 GB |
 
 Both comparison ratios are dta-parser time divided by comparator time, the
 reciprocals of the previously reported ratios. Values below 1x favor
@@ -95,25 +123,26 @@ R reader must construct R-compatible vectors, so the Stata result is best read
 as an eager native-format reference rather than a directly attainable R-object
 floor.
 
-Across stored-release strata, dta-parser was 2.36--31.18 times as fast as haven.
-It was 3.48 times as fast as Stata on DHS release 111; Stata was 1.55--34.27
-times as fast on every other stratum. At the all-release corpus level,
-dta-parser was 29.28 times as fast as haven on DHS, 7.39 times on MICS, and
-12.26 times on NSFG. Its peak RSS was 0.1% higher than haven on DHS, 2.7% lower
-on MICS, and 0.4% lower on NSFG. Stata was 1.35, 25.40, and 21.62 times as fast
-as dta-parser respectively, and its maximum peak RSS was 82.3--85.0% lower.
+Across Stata-format strata, dta-parser was 2.36--31.18 times as fast as haven.
+It was 3.48 times as fast as Stata on DHS files in the format introduced with
+Stata 7/SE; Stata was 1.55--34.27 times as fast on every other stratum. At the
+all-format corpus level, dta-parser was 29.28 times as fast as haven on DHS,
+7.39 times on MICS, and 12.26 times on NSFG. Its peak RSS was 0.1% higher than
+haven on DHS, 2.7% lower on MICS, and 0.4% lower on NSFG. Stata was 1.35, 25.40,
+and 21.62 times as fast as dta-parser respectively, and its maximum peak RSS was
+82.3--85.0% lower.
 
-Compared with the archived dta-parser run, the all-release refresh reduced
+Compared with the original dta-parser run, the all-format refresh reduced
 aggregate time from 297.669 to 93.152 seconds on DHS (68.7%), from 30.687 to
 29.341 seconds on MICS (4.4%), and from 29.865 to 19.130 seconds on NSFG
-(35.9%). The DHS release-111, release-113, release-114, and release-117 strata
+(35.9%). The DHS strata for formats introduced with Stata 7/SE, 8, 10, and 13
 fell by 57.6--70.3%; the smaller or already-modern strata include ordinary
 fresh-process timing noise.
 
 These are warm-cache, machine- and corpus-specific measurements rather than
 performance guarantees. The dta-parser-only refresh artifacts are in
-`target/r-corpus-performance/pr46-legacy-refresh-2d09478`; the archived matched
-run remains in `target/r-corpus-performance/20260824T142432Z`. Together they
+`target/r-corpus-performance/pr46-legacy-refresh-2d09478`; the matched run is
+in `target/r-corpus-performance/20260824T142432Z`. Together they
 contain the stable inventory, append-only per-reader measurements, package
 build, installed library, and generated summary. The public harness can
 reproduce the suite without publishing any path:

--- a/r-package/dtaparser/DESCRIPTION
+++ b/r-package/dtaparser/DESCRIPTION
@@ -17,6 +17,7 @@ Imports:
     tidyselect
 Suggests:
     callr,
+    dplyr (>= 1.1.0),
     haven,
     httpuv,
     testthat (>= 3.1.7)

--- a/r-package/dtaparser/R/read-dta.R
+++ b/r-package/dtaparser/R/read-dta.R
@@ -1,11 +1,11 @@
 #' Read a Stata DTA file
 #'
 #' Reads releases 105, 108, 110--111, 113--115, and 117--119 through the native Rust parser.
-#' Numeric and character columns are created directly by native code. Numeric
-#' columns retain their compact Stata storage width until R requests a
-#' materialized double vector. Dataset and variable labels, dataset notes,
-#' Stata display formats, value labels, `strL` content, and Stata
-#' system/extended missing values are retained.
+#' Numeric and character columns are created directly by native code. Byte,
+#' int, long, and float columns retain their compact Stata storage width until
+#' R requests a materialized double vector; source doubles are created eagerly.
+#' Dataset and variable labels, dataset notes, Stata display formats, value
+#' labels, `strL` content, and Stata system/extended missing values are retained.
 #'
 #' @param file A path, URL, raw vector, or binary connection. Local and remote
 #'   gzip files and local bzip2, xz, and zip files are decompressed

--- a/r-package/dtaparser/R/read-dta.R
+++ b/r-package/dtaparser/R/read-dta.R
@@ -1,9 +1,11 @@
 #' Read a Stata DTA file
 #'
 #' Reads releases 105, 108, 110--111, 113--115, and 117--119 through the native Rust parser.
-#' Numeric and character columns are created directly by native code. Dataset
-#' and variable labels, dataset notes, Stata display formats, value labels,
-#' `strL` content, and Stata system/extended missing values are retained.
+#' Numeric and character columns are created directly by native code. Numeric
+#' columns retain their compact Stata storage width until R requests a
+#' materialized double vector. Dataset and variable labels, dataset notes,
+#' Stata display formats, value labels, `strL` content, and Stata
+#' system/extended missing values are retained.
 #'
 #' @param file A path, URL, raw vector, or binary connection. Local and remote
 #'   gzip files and local bzip2, xz, and zip files are decompressed
@@ -57,6 +59,11 @@ read_dta <- function(file, encoding = NULL, col_select = NULL, skip = 0,
         file, encoding, rlang::enquo(col_select), skip, n_max, .name_repair,
         materialization = "rust-vectors", threads = 1L
     )
+}
+
+# Internal invariant probe used by the native-materialization tests.
+.is_numeric_altrep <- function(value) {
+    .Call(C_dtaparser_is_numeric_altrep, value)
 }
 
 .read_dta_impl <- function(file, encoding, selection, skip, n_max,

--- a/r-package/dtaparser/R/read-dta.R
+++ b/r-package/dtaparser/R/read-dta.R
@@ -16,6 +16,37 @@
 #' create them. Use ordinary `NA_real_`, rather than a tagged value, to create
 #' Stata system missing. Missing tags are part of the numeric values and are
 #' distinct from Stata value labels stored in a column's `labels` attribute.
+#' For example:
+#' ```
+#' x <- c(1, NA_real_, haven::tagged_na("a"), haven::tagged_na("z"))
+#' is.na(x)
+#' haven::na_tag(x)
+#' haven::is_tagged_na(x)
+#' haven::is_tagged_na(x, "a")
+#' haven::na_tag(x) %in% c("a", "f")
+#'
+#' x[1] <- NA_real_                 # Stata .
+#' x[2] <- haven::tagged_na("a")    # Stata .a
+#' x[3] <- haven::tagged_na("f")    # Stata .f
+#' ```
+#' `haven::is_tagged_na()` accepts only one specific tag at a time; extract
+#' tags with `haven::na_tag()` and use `%in%` to match several tags.
+#'
+#' Base subassignment and [replace()] retain unselected tags when their index
+#' contains no missing values; use `!is.na(x) & x == value` when recoding an
+#' observed value. Avoid `ifelse(x == value, replacement, x)`, whose missing
+#' condition entries become ordinary `NA` and lose their tags.
+#'
+#' When recoding, `dplyr::case_when()` preserves values returned by its default
+#' branch. `dplyr::if_else()` preserves unselected tags when its condition is
+#' complete; if the condition can be `NA`, also supply `missing = x`. On bare
+#' numeric columns, legacy `dplyr::recode()` normalizes unmatched tagged
+#' missings to ordinary `NA`; it does not support classed `haven_labelled`,
+#' `Date`, or `POSIXct` columns. Missing-value replacement helpers match all 27
+#' codes; select a particular code with
+#' `haven::is_tagged_na(x, tag)` instead. A transformation may materialize an
+#' ALTREP column and may drop Stata metadata attributes when it constructs a
+#' new vector, following the same behavior as haven-compatible vectors.
 #'
 #' @param file A path, URL, raw vector, or binary connection. Local and remote
 #'   gzip files and local bzip2, xz, and zip files are decompressed

--- a/r-package/dtaparser/R/read-dta.R
+++ b/r-package/dtaparser/R/read-dta.R
@@ -35,6 +35,11 @@
 #' @param threads Number of decoder threads. Zero selects an automatic count
 #'   for sufficiently large files in any supported Stata release. One always
 #'   uses the serial decoder. Projections containing `strL` remain serial.
+#' @param use_numeric_altrep Whether byte, int, long, and float columns should retain
+#'   their compact Stata storage through ALTREP. Set to `FALSE` to create eager
+#'   R double vectors during decoding, which uses more memory but avoids later
+#'   widening when a workload requires a contiguous double data pointer.
+#'   Character-column ALTREP is unaffected.
 #' @param .name_repair Name repair passed to [tibble::as_tibble()].
 #' @return A tibble. `%td` columns and legacy or custom formats beginning `%d`
 #'   have class `Date`; `%tc` and `%tC` columns have classes `POSIXct` and
@@ -43,10 +48,14 @@
 #' @export
 read_dta <- function(file, encoding = NULL, col_select = NULL, skip = 0,
                      n_max = Inf, .name_repair = "unique",
-                     threads = getOption("dtaparser.threads", 0L)) {
+                     threads = getOption("dtaparser.threads", 0L),
+                     use_numeric_altrep = getOption(
+                         "dtaparser.numeric_altrep", TRUE
+                     )) {
     .read_dta_impl(
         file, encoding, rlang::enquo(col_select), skip, n_max, .name_repair,
-        materialization = "direct", threads = threads
+        materialization = "direct", threads = threads,
+        use_numeric_altrep = use_numeric_altrep
     )
 }
 
@@ -57,7 +66,8 @@ read_dta <- function(file, encoding = NULL, col_select = NULL, skip = 0,
                                    .name_repair = "unique") {
     .read_dta_impl(
         file, encoding, rlang::enquo(col_select), skip, n_max, .name_repair,
-        materialization = "rust-vectors", threads = 1L
+        materialization = "rust-vectors", threads = 1L,
+        use_numeric_altrep = FALSE
     )
 }
 
@@ -67,10 +77,12 @@ read_dta <- function(file, encoding = NULL, col_select = NULL, skip = 0,
 }
 
 .read_dta_impl <- function(file, encoding, selection, skip, n_max,
-                           .name_repair, materialization, threads) {
+                           .name_repair, materialization, threads,
+                           use_numeric_altrep) {
     encoding <- .validate_dta_encoding(encoding)
     row_window <- .normalize_row_window(skip, n_max)
     threads <- .normalize_threads(threads)
+    use_numeric_altrep <- .normalize_use_numeric_altrep(use_numeric_altrep)
 
     source <- .resolve_dta_source(file)
     on.exit(.cleanup_dta_source(source), add = TRUE)
@@ -100,6 +112,7 @@ read_dta <- function(file, encoding = NULL, col_select = NULL, skip = 0,
         row_window$n_max,
         identical(materialization, "direct"),
         threads,
+        use_numeric_altrep,
         encoding
     )
     if (!is.null(column_indices)) {
@@ -112,6 +125,14 @@ read_dta <- function(file, encoding = NULL, col_select = NULL, skip = 0,
     if (!is.null(dataset_label)) attr(result, "label") <- dataset_label
     if (!is.null(dataset_notes)) attr(result, "notes") <- dataset_notes
     result
+}
+
+.normalize_use_numeric_altrep <- function(value) {
+    if (!is.logical(value) || length(value) != 1L || is.na(value)) {
+        stop("`use_numeric_altrep` must be one non-missing logical value",
+             call. = FALSE)
+    }
+    value
 }
 
 .normalize_threads <- function(value) {

--- a/r-package/dtaparser/R/read-dta.R
+++ b/r-package/dtaparser/R/read-dta.R
@@ -7,6 +7,16 @@
 #' Dataset and variable labels, dataset notes, Stata display formats, value
 #' labels, `strL` content, and Stata system/extended missing values are retained.
 #'
+#' @section Stata missing values:
+#' Stata system missing (`.`) is returned as `NA_real_`; in releases supporting
+#' extended missings (113 and newer), `.a` through `.z` use haven-compatible
+#' tagged-NA payloads. Base [is.na()] therefore identifies every code present.
+#' Use `haven::na_tag()` to recover their letters,
+#' `haven::is_tagged_na()` to select tagged values, and `haven::tagged_na()` to
+#' create them. Use ordinary `NA_real_`, rather than a tagged value, to create
+#' Stata system missing. Missing tags are part of the numeric values and are
+#' distinct from Stata value labels stored in a column's `labels` attribute.
+#'
 #' @param file A path, URL, raw vector, or binary connection. Local and remote
 #'   gzip files and local bzip2, xz, and zip files are decompressed
 #'   automatically. Character vectors containing literal data are not handled,

--- a/r-package/dtaparser/README.md
+++ b/r-package/dtaparser/README.md
@@ -105,23 +105,43 @@ releases 105 through 111 encode only system missing.
 release supports them, but returns normal R-compatible numeric vectors. System
 missing `.` becomes `NA_real_`; `.a` through `.z` become the tagged-NA payloads
 used by haven. Base R therefore recognizes every Stata missing code without a
-package-specific method:
+package-specific method.
+
+### Using missing values in R
 
 ```r
-x <- c(1, NA_real_, haven::tagged_na(c("a", "f", "z")))
-haven::print_tagged_na(x)        # "1", "NA", "NA(a)", "NA(f)", "NA(z)"
-is.na(x)                         # TRUE for ., .a, ..., .z
-anyNA(x)
+x <- c(
+  1,
+  NA_real_,                   # Stata .
+  haven::tagged_na("a"),      # Stata .a
+  haven::tagged_na("z")       # Stata .z
+)
+
+is.na(x)
+#> [1] FALSE  TRUE  TRUE  TRUE
+
+haven::na_tag(x)
+#> [1] NA  NA  "a" "z"
+
+haven::is_tagged_na(x)
+#> [1] FALSE FALSE  TRUE  TRUE
+
+haven::is_tagged_na(x, "a")
+#> [1] FALSE FALSE  TRUE FALSE
+
+haven::na_tag(x) %in% c("a", "f")
+#> [1] FALSE FALSE  TRUE FALSE
 ```
 
-The haven package exposes the tag when that distinction matters:
+`haven::is_tagged_na()` accepts only one specific tag at a time, so use
+`haven::na_tag(x) %in% tags` to match several tags. These functions are
+exported by haven; the explicit `haven::` prefix means haven does not need to
+be attached with `library(haven)`.
+
+To identify system missing specifically, while excluding tagged missings and
+ordinary `NaN`, use:
 
 ```r
-tags <- haven::na_tag(x)         # "a" ... "z"; NA for system/non-missing
-haven::is_tagged_na(x)           # elementwise TRUE for .a-.z
-haven::is_tagged_na(x, "a")      # .a only
-tags %in% c("a", "f")           # several selected tags
-
 system_missing <- is.na(x) & !is.nan(x) &
   !haven::is_tagged_na(x)
 ```
@@ -134,9 +154,64 @@ as any writable mutation must.
 ```r
 x[1] <- NA_real_                 # Stata .
 x[2] <- haven::tagged_na("a")    # Stata .a
-x[3:4] <- haven::tagged_na(c("f", "z"))
-haven::print_tagged_na(x)        # displays NA, NA(a), NA(f), ...
+x[3] <- haven::tagged_na("f")    # Stata .f
 ```
+
+### Recoding without losing missing tags
+
+With base R, direct assignment and `replace()` preserve every unselected tag.
+Make an observed-value predicate non-missing before using it as an assignment
+index:
+
+```r
+x <- c(1, NA_real_, haven::tagged_na(c("a", "f", "z")))
+selected <- !is.na(x) & x == 1
+x[selected] <- 10
+x <- replace(x, selected, 10)
+
+x[haven::is_tagged_na(x, "a")] <- -1
+```
+
+Avoid `ifelse(x == 1, 10, x)`: `x == 1` is `NA` at every missing position, so
+`ifelse()` writes ordinary `NA` there and loses extended tags. Adding
+`!is.na(x) &` makes the test complete and preserves the payloads, but
+`ifelse()` still drops attributes. Direct assignment is therefore the safer
+base-R pattern for an existing column. `transform()` and `within()` inherit the
+behavior of the expression used on their right-hand side.
+
+Tidyverse operations similarly preserve tagged missings when the recoding
+expression carries unmatched values forward from the original column. For
+example, this replaces only `.a` and leaves `.`, `.b` through `.z`, and
+observed values unchanged:
+
+```r
+data <- dplyr::mutate(
+  data,
+  status = dplyr::case_when(
+    haven::is_tagged_na(status, "a") ~ -1,
+    .default = status
+  )
+)
+```
+
+`dplyr::if_else()` preserves tags when its condition contains no `NA` and its
+unselected branch returns the original values. If its condition can be `NA`,
+also pass `missing = x`; otherwise those positions become ordinary `NA`. In
+contrast, legacy `dplyr::recode()` rebuilds unmatched missing values in bare
+numeric columns as ordinary `NA` and therefore loses their tags, even when
+recoding only an observed number. It does not support classed
+`haven_labelled`, `Date`, or `POSIXct` columns. Prefer `case_when()` or a
+correctly specified `if_else()` for tagged columns. Operations intended to
+replace missing values, such as
+`dplyr::coalesce()`, `tidyr::replace_na()`, or a branch selected by `is.na()`,
+match all 27 codes by design; use `haven::is_tagged_na(x, tag)` when only one
+extended code should change.
+
+These transformations may materialize a compact ALTREP column. Operations
+that construct a new vector can also drop Stata metadata attributes such as
+`label`, `format.stata`, or `labels`, just as they can for a vector read by
+haven. Missing tags are numeric payloads rather than metadata attributes, so
+the two concerns are separate.
 
 Do not use `haven::tagged_na(".")` for system missing; canonical system missing
 is `NA_real_`. R comparisons deliberately follow R missing-value semantics, so

--- a/r-package/dtaparser/README.md
+++ b/r-package/dtaparser/README.md
@@ -245,113 +245,61 @@ have identical R missing-value semantics.
 
 ## Performance compared with haven and Stata
 
-The dta-parser cells for synthetic release-119 inputs and every recognized
-corpus release were refreshed with the automatic multicore executor at commit
-`2d09478`. Haven and Stata were not rerun: their cells retain the archived
-matched comparison on the identical files.
+The dta-parser cells below were rerun from PR #48 at implementation commit
+`1006ae4`. Haven 2.5.5 and Stata/MP 18 were not rerun: their cells retain the
+archived matched measurements on the identical files. Restricting the refresh
+to four deterministic synthetic workloads and one recent file from each survey
+family keeps the comparison economical while covering both controlled and
+real-world inputs.
 
-On an Apple M4 Max with 128 GB RAM, the new dictionary-backed implementation
-was benchmarked against haven 2.5.5 and Stata/MP 18. The synthetic files are
-deterministic mixed-type Stata 15 datasets with 40 columns; their time cells are
-seven-run warm-cache medians. The DHS, MICS, and NSFG suite visited all 1,823
-regular DTA files under the local corpus cache in fresh processes. Its time
-cells are sums and its memory cells are the largest per-file peak RSS on the
-common set that all three readers loaded with identical dimensions. Corpus
-rows are disaggregated by the release stored in each DTA signature. Comparator
-values are unchanged in both the release-specific and `all releases` rows.
+Measurements used an Apple M4 Max with 128 GB RAM, macOS 26.5.2, R 4.6.1, and
+Rust 1.98.0. Synthetic inputs are mixed-type, 40-column Stata 15 files. Their
+elapsed times are seven-run warm-cache medians and their peak RSS values are
+three-run fresh-process medians. The India DHS and NSFG rows each use one
+fresh-process read, matching the archived corpus methodology. All refreshed
+reads returned the archived row and column dimensions.
 
-| Dataset/workload | Common files | Input | dta-parser time | haven time | Stata time | dta-parser / haven time | dta-parser / Stata time | dta-parser peak RSS | haven peak RSS | Stata peak RSS |
-| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
-| Synthetic 100 MB, full 40 columns (release 119) | 1 | 0.100 GB | 0.073 s | 1.053 s | 0.011 s | 0.069x | 6.636x | 0.276 GB | 0.253 GB | 0.143 GB |
-| Synthetic 100 MB, projected 8 columns (release 119) | 1 | 0.100 GB | 0.035 s | 0.271 s | 0.014 s | 0.129x | 2.500x | 0.201 GB | 0.168 GB | 0.058 GB |
-| Synthetic 1 GB, full 40 columns (release 119) | 1 | 1.000 GB | 0.258 s | 10.958 s | 0.101 s | 0.024x | 2.554x | 0.839 GB | 0.888 GB | 1.133 GB |
-| Synthetic 1 GB, projected 8 columns (release 119) | 1 | 1.000 GB | 0.130 s | 3.120 s | 0.140 s | 0.042x | 0.929x | 0.302 GB | 0.292 GB | 0.365 GB |
-| DHS — release 111 | 129 | 8.320 GB | 18.254 s | 435.302 s | 63.506 s | 0.042x | 0.287x | 4.526 GB | 4.526 GB | 0.725 GB |
-| DHS — release 113 | 484 | 37.343 GB | 71.413 s | 2,226.568 s | 5.124 s | 0.032x | 13.937x | 35.127 GB | 35.103 GB | 5.256 GB |
-| DHS — release 114 | 24 | 1.162 GB | 3.210 s | 61.036 s | 0.163 s | 0.053x | 19.693x | 0.898 GB | 0.914 GB | 0.149 GB |
-| DHS — release 117 | 1 | 0.028 GB | 0.090 s | 1.505 s | 0.004 s | 0.060x | 22.500x | 0.325 GB | 0.344 GB | 0.056 GB |
-| DHS — release 118 | 3 | 0.050 GB | 0.185 s | 2.640 s | 0.009 s | 0.070x | 20.556x | 0.411 GB | 0.430 GB | 0.077 GB |
-| DHS — all releases | 641 | 46.903 GB | 93.152 s | 2,727.051 s | 68.806 s | 0.034x | 1.354x | 35.127 GB | 35.103 GB | 5.256 GB |
-| MICS — release 117 | 494 | 1.634 GB | 14.708 s | 98.402 s | 0.567 s | 0.149x | 25.940x | 0.304 GB | 0.367 GB | 0.073 GB |
-| MICS — release 118 | 455 | 2.056 GB | 14.633 s | 118.330 s | 0.588 s | 0.124x | 24.886x | 0.651 GB | 0.669 GB | 0.100 GB |
-| MICS — all releases | 949 | 3.690 GB | 29.341 s | 216.732 s | 1.155 s | 0.135x | 25.403x | 0.651 GB | 0.669 GB | 0.100 GB |
-| NSFG — release 105 | 4 | 0.005 GB | 0.083 s | 0.196 s | 0.028 s | 0.423x | 2.964x | 0.125 GB | 0.121 GB | 0.054 GB |
-| NSFG — release 108 | 4 | 0.001 GB | 0.066 s | 0.097 s | 0.006 s | 0.680x | 11.000x | 0.106 GB | 0.104 GB | 0.030 GB |
-| NSFG — release 110 | 7 | 0.015 GB | 0.164 s | 0.497 s | 0.106 s | 0.330x | 1.547x | 0.128 GB | 0.123 GB | 0.041 GB |
-| NSFG — release 113 | 28 | 0.673 GB | 1.232 s | 7.389 s | 0.079 s | 0.167x | 15.595x | 0.525 GB | 0.543 GB | 0.435 GB |
-| NSFG — release 114 | 44 | 1.171 GB | 4.819 s | 47.892 s | 0.156 s | 0.101x | 30.891x | 0.751 GB | 0.765 GB | 0.208 GB |
-| NSFG — release 115 | 9 | 0.100 GB | 0.514 s | 3.512 s | 0.015 s | 0.146x | 34.267x | 0.392 GB | 0.414 GB | 0.068 GB |
-| NSFG — release 117 | 69 | 2.180 GB | 7.565 s | 107.544 s | 0.288 s | 0.070x | 26.267x | 1.318 GB | 1.330 GB | 0.201 GB |
-| NSFG — release 118 | 57 | 1.626 GB | 4.687 s | 67.461 s | 0.207 s | 0.069x | 22.643x | 2.460 GB | 2.470 GB | 0.375 GB |
-| NSFG — all releases | 222 | 5.772 GB | 19.130 s | 234.588 s | 0.885 s | 0.082x | 21.616x | 2.460 GB | 2.470 GB | 0.435 GB |
+| Dataset/workload | Input | dta-parser time | haven time | Stata time | dta-parser / haven time | dta-parser / Stata time | dta-parser peak RSS | haven peak RSS | Stata peak RSS |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| Synthetic 100 MB, full 40 columns (release 119) | 0.100 GB | 0.025 s | 1.053 s | 0.011 s | 0.024x | 2.273x | 0.223 GB | 0.253 GB | 0.143 GB |
+| Synthetic 100 MB, projected 8 columns (release 119) | 0.100 GB | 0.014 s | 0.271 s | 0.014 s | 0.052x | 1.000x | 0.182 GB | 0.168 GB | 0.058 GB |
+| Synthetic 1 GB, full 40 columns (release 119) | 1.000 GB | 0.143 s | 10.958 s | 0.101 s | 0.013x | 1.416x | 0.663 GB | 0.888 GB | 1.133 GB |
+| Synthetic 1 GB, projected 8 columns (release 119) | 1.000 GB | 0.073 s | 3.120 s | 0.140 s | 0.023x | 0.521x | 0.269 GB | 0.292 GB | 0.365 GB |
+| India DHS 2021 women (release 113; 724,115 × 5,972) | 5.196 GB | 1.896 s | 437.088 s | 0.718 s | 0.004x | 2.641x | 5.218 GB | 35.103 GB | 5.256 GB |
+| NSFG 2017–2019 women (release 118; 6,141 × 2,610) | 0.020 GB | 0.068 s | 1.002 s | 0.003 s | 0.068x | 22.667x | 0.142 GB | 0.308 GB | 0.051 GB |
 
-Both ratio columns are dta-parser time divided by comparator time, the
-reciprocals of the previously reported ratios. Values below 1x mean dta-parser
-was faster; values above 1x mean the comparator was faster.
+Both ratio columns are dta-parser time divided by comparator time. Values below
+1x favor dta-parser. Across these rows, dta-parser was 14.7–230.5 times as fast
+as haven. It matched Stata on the projected 100 MB file and was faster on the
+projected 1 GB file; Stata remained faster on the other four workloads.
 
-Stata's result is not a metadata-only or lazy `use`. The official
-[`use` manual](https://www.stata.com/manuals/duse.pdf) says that `use` loads a
-Stata-format dataset into memory, and the
-[User's Guide](https://www.stata.com/manuals/u.pdf) says Stata works with a copy
-of the data loaded into memory and stores data in memory. The measured RSS also
-supports a real load: the 1 GB full synthetic file produced a 1.133 GB Stata
-process, and the largest DHS read produced 5.256 GB. Stata's exact loader is
-closed source, but its advantage plausibly comes from reading its native format
-into compact native storage widths, plus mature implementation work and the
-warm operating-system page cache. Dta-parser must additionally construct R
-objects; in particular, its numeric result vectors use R's eight-byte doubles.
-Matching Stata while returning ordinary R-compatible objects is therefore a
-different engineering target, but the Stata time is still a valid eager-load
-reference rather than an unattainable lazy-open measurement.
+Numeric ALTREP materially changes both load time and memory. Relative to the
+previous dta-parser cells at `2d09478`, the four synthetic medians fell by
+43.8–65.8%, India DHS fell from 35.030 to 1.896 seconds (94.6%), and NSFG fell
+from 0.188 to 0.068 seconds (63.8%). Peak RSS fell by 9.3–21.0% on the
+synthetic workloads, by 85.2% on India DHS, and by 49.8% on NSFG. On the
+5.196 GB India file, dta-parser used 5.218 GB peak RSS versus haven's
+35.103 GB and Stata's 5.256 GB.
 
-For the synthetic release-119 loads, dta-parser was 7.74--42.47 times as fast
-as haven. The stored-release strata make the corpus spread explicit:
-dta-parser was 2.36--31.18 times as fast as haven, while the all-release corpus
-subtotals were 7.39--29.28 times as fast. Dta-parser was 3.48 times as fast as
-Stata on the DHS release-111 stratum and took 0.929 times Stata's time on the
-projected 1 GB synthetic workload; Stata was 1.55--34.27 times as fast on the
-remaining corpus strata. At corpus level Stata was 1.35, 25.40, and 21.62 times
-as fast as dta-parser on DHS, MICS, and NSFG. Dta-parser peak RSS was 2.7% lower
-on MICS, 0.4% lower on NSFG, and 0.1% higher on the largest DHS file; Stata used
-82.3--85.0% less peak RSS on those corpus maxima. On the 1 GB full synthetic
-load, however, dta-parser used 26.0% less peak RSS than Stata. These are
-workload- and machine-specific observations, not guarantees.
+These are load-and-return measurements. The result remains reachable through
+process exit, but the dimensions check does not request contiguous vectors, so
+dictionary-backed strings and narrow numeric ALTREP columns can remain compact.
+A later operation that requires a writable or contiguous double vector pays
+the deferred conversion cost then. That is expected deferral rather than
+duplicate loading; use `use_numeric_altrep = FALSE` when eager widening better
+matches the downstream workload.
 
-Compared with the archived dta-parser corpus run, the all-release refresh
-reduced aggregate time from 297.669 to 93.152 seconds on DHS (68.7%), from
-30.687 to 29.341 seconds on MICS (4.4%), and from 29.865 to 19.130 seconds on
-NSFG (35.9%).
+R elapsed time covers only the reader call. Stata elapsed time covers its
+`use` command. Application startup is excluded from elapsed time and included
+in fresh-process peak RSS. Stata's official
+[`use` manual](https://www.stata.com/manuals/duse.pdf) describes a real
+in-memory load, so it remains a useful eager native-format reference even
+though dta-parser must additionally construct R-compatible objects.
 
-The corpus comparison is deliberately paired. Two MICS files were rejected by
-all three readers. Nine additional files (two DHS and seven NSFG) were read with
-matching dimensions by dta-parser and Stata but did not yield a comparable
-haven result, so they are excluded from every aggregate rather than giving one
-reader a different input set. Private paths and values are not published.
-
-R elapsed time covers the reader call, while Stata elapsed time covers its
-`use` command; application startup is excluded from both. Peak RSS comes from a
-fresh process and includes the complete runtime. The archived synthetic
-comparison alternated reader order after warmup; the current refresh reran only
-dta-parser on the same generated files. Exact dta-parser collector identity
-and sampled haven parity were checked for the archived comparison. The corpus
-suite originally rotated reader order between files and retained only
-successful, dimension-identical triples; the current refresh reran dta-parser
-only for all recognized releases and verified status and dimensions against
-that archive.
-
-Compared with the old eager collector rebuilt under Rust 1.98.0, the new 1 GB
-full-load median fell from 2.354 s to 0.911 s (61.3%) and dimensions-only peak
-RSS fell from 2.184 GB to 0.834 GB (61.8%). Forcing every character vector with
-`object.size()` still completes in 1.722 s versus 2.256 s for the eager
-collector and uses 0.975 GB peak RSS versus haven's 1.313 GB. Thus the deferred
-dictionary representation keeps its partial-access benefit without imposing
-the earlier raw-deferral prototype's forcing cliff.
-
-See the [synthetic benchmark report](../../benchmarks/large-scale/results-2026-08-24.md)
-and [DHS/MICS/NSFG report](../../benchmarks/r-corpus-performance/results-2026-08-24.md)
-for exact methodology, provenance, validation, and reproduction commands. The
-benchmark harnesses and raw private outputs are report-only evidence, not CI
-performance thresholds.
+The archived [synthetic report](../../benchmarks/large-scale/results-2026-08-24.md)
+and [corpus report](../../benchmarks/r-corpus-performance/results-2026-08-24.md)
+provide comparator provenance and the full older corpus run. Benchmark
+artifacts are report-only evidence, not CI performance thresholds.
 
 ## Scope and limitations
 

--- a/r-package/dtaparser/README.md
+++ b/r-package/dtaparser/README.md
@@ -259,6 +259,12 @@ three-run fresh-process medians. The India DHS and NSFG rows each use one
 fresh-process read, matching the archived corpus methodology. All refreshed
 reads returned the archived row and column dimensions.
 
+Peak RSS means peak resident set size: the greatest amount of physical memory
+attributed to the reader process during the run. It includes the R or Stata
+runtime and the loaded result, but not memory used by other processes or the
+operating system's file cache outside that process. Values below use decimal GB
+(`GB = 10^9 bytes`).
+
 | Dataset/workload | Input | dta-parser time | haven time | Stata time | dta-parser / haven time | dta-parser / Stata time | dta-parser peak RSS | haven peak RSS | Stata peak RSS |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
 | Synthetic 100 MB, full 40 columns (release 119) | 0.100 GB | 0.025 s | 1.053 s | 0.011 s | 0.024x | 2.273x | 0.223 GB | 0.253 GB | 0.143 GB |

--- a/r-package/dtaparser/README.md
+++ b/r-package/dtaparser/README.md
@@ -2,9 +2,10 @@
 
 `dtaparser` is the R interface to this repository's bounded Rust DTA
 reader. Its exported `read_dta()` function follows `haven::read_dta()` and adds
-an optional `threads` execution control, while observation storage is decoded by Rust
-and materialized through an R-specific collector. Numeric values are written
-into their final R vectors during decoding. Each character column interns its
+optional `threads` and `use_numeric_altrep` controls, while observation storage is
+decoded by Rust and materialized through an R-specific collector. Byte, int,
+long, and float values retain their compact source widths through ALTREP by
+default; source doubles are written eagerly. Each character column interns its
 distinct normalized UTF-8 values once and keeps compact row-to-dictionary
 indices behind an ordinary R character vector through ALTREP. Element access
 resolves the dictionary immediately; allocation of the complete row-level
@@ -216,6 +217,10 @@ performance thresholds.
   supported release without selected `strL` columns. Use `threads = 1` for
   deterministic single-thread benchmarking. Option `dtaparser.threads`
   controls the default.
+- `use_numeric_altrep = TRUE` retains byte, int, long, and float source widths until
+  R needs a contiguous double data pointer. Set it to `FALSE`, or set option
+  `dtaparser.numeric_altrep = FALSE`, to create eager double vectors during
+  decoding for workloads that immediately materialize every numeric column.
 - Character columns use dictionary-backed ALTREP vectors. Loading does not
   depend on the source path after `read_dta()` returns. Distinct R strings are
   created once during the load; operations that request a contiguous pointer

--- a/r-package/dtaparser/README.md
+++ b/r-package/dtaparser/README.md
@@ -90,6 +90,84 @@ With an explicit UTF-8 override, malformed input sequences are replaced
 deterministically with U+FFFD. Haven 2.5.5 may instead omit or empty an affected
 label.
 
+## Stata missing values and labels
+
+In releases that support extended missings (113 and newer), Stata reserves 27
+numeric codes for missing values: system missing `.`, followed by `.a` through
+`.z`. They occupy the top of each supported numeric storage range. For example,
+byte storage uses 101 through 127, int uses 32,741 through 32,767, and long uses
+2,147,483,621 through 2,147,483,647. Float and double storage use corresponding
+reserved high-value bit patterns. In Stata, every missing code compares greater
+than every observed number, with `. < .a < ... < .z`. Earlier supported
+releases 105 through 111 encode only system missing.
+
+`dtaparser` preserves which code was stored, including all 27 where the source
+release supports them, but returns normal R-compatible numeric vectors. System
+missing `.` becomes `NA_real_`; `.a` through `.z` become the tagged-NA payloads
+used by haven. Base R therefore recognizes every Stata missing code without a
+package-specific method:
+
+```r
+x <- c(1, NA_real_, haven::tagged_na(c("a", "f", "z")))
+haven::print_tagged_na(x)        # "1", "NA", "NA(a)", "NA(f)", "NA(z)"
+is.na(x)                         # TRUE for ., .a, ..., .z
+anyNA(x)
+```
+
+The haven package exposes the tag when that distinction matters:
+
+```r
+tags <- haven::na_tag(x)         # "a" ... "z"; NA for system/non-missing
+haven::is_tagged_na(x)           # elementwise TRUE for .a-.z
+haven::is_tagged_na(x, "a")      # .a only
+tags %in% c("a", "f")           # several selected tags
+
+system_missing <- is.na(x) & !is.nan(x) &
+  !haven::is_tagged_na(x)
+```
+
+Use ordinary `NA_real_` to create Stata system missing and
+`haven::tagged_na()` for an extended missing value. Assignment to a compact
+numeric ALTREP column materializes that column as an ordinary R double vector,
+as any writable mutation must.
+
+```r
+x[1] <- NA_real_                 # Stata .
+x[2] <- haven::tagged_na("a")    # Stata .a
+x[3:4] <- haven::tagged_na(c("f", "z"))
+haven::print_tagged_na(x)        # displays NA, NA(a), NA(f), ...
+```
+
+Do not use `haven::tagged_na(".")` for system missing; canonical system missing
+is `NA_real_`. R comparisons deliberately follow R missing-value semantics, so
+`x > 100` returns `NA` at every missing position rather than reproducing
+Stata's high-value comparison ordering. Use `haven::na_tag()` and an explicit
+factor/order when the order among missing tags matters.
+
+Missing tags are encoded in the numeric values themselves, not in the value
+label attribute. Stata metadata are exposed separately:
+
+```r
+attr(cars, "label")              # dataset label
+attr(cars, "notes")              # dataset notes
+attr(cars$foreign, "label")      # variable label
+attr(cars$foreign, "format.stata")
+attr(cars$foreign, "labels")     # named numeric vector: text -> code
+```
+
+A non-temporal numeric column with a Stata value-label table has classes
+`haven_labelled`, `vctrs_vctr`, and `double`. Its `labels` attribute is a named
+numeric vector whose names are display text and whose values are the associated
+codes. If Stata labels a missing code, that attribute value uses the same
+tagged-NA representation and can also be inspected with `haven::na_tag()`.
+
+Narrow numeric ALTREP columns keep the original Stata sentinels in compact
+backing storage until values are requested. Conversion to R system/tagged NAs
+happens during element or region access, summary kernels, or materialization.
+Source doubles, and all numeric columns read with
+`use_numeric_altrep = FALSE`, are converted during decoding instead. Both paths
+have identical R missing-value semantics.
+
 ## Performance compared with haven and Stata
 
 The dta-parser cells for synthetic release-119 inputs and every recognized

--- a/r-package/dtaparser/README.md
+++ b/r-package/dtaparser/README.md
@@ -15,8 +15,10 @@ Large reads from every supported Stata release use a shared block decoder
 across multiple cores by default. `threads = 0` selects an automatic count,
 `threads = 1` forces the serial executor, and a positive larger value requests
 an explicit count capped by available parallelism and selected columns. Small
-inputs and projections containing `strL` remain serial. Both executors use the
-same validated observation plan and scalar value-decoding semantics.
+inputs remain serial. For selected `strL` columns, workers decode observation
+references in parallel; the coordinator then validates the shared object table
+and resolves the referenced payloads. Both executors use the same validated
+observation plan and scalar value-decoding semantics.
 
 ## Installation
 
@@ -65,7 +67,7 @@ URLs use temporary files that are removed when the read succeeds, errors, or
 is interrupted. This keeps network and decompression dependencies out of the
 reusable Rust parser.
 
-The reader supports Stata releases 105, 108, 110--111, 113--115, and 117--119. It retains dataset
+The reader supports Stata 5–19 file formats. It retains dataset
 and variable labels, dataset notes, display formats, value-label tables,
 `strL` values, and system missing values plus `.a`--`.z` tags where the release
 supports them. `%td` and legacy or
@@ -247,17 +249,24 @@ have identical R missing-value semantics.
 
 The dta-parser cells below were rerun from PR #48 at implementation commit
 `1006ae4`. Haven 2.5.5 and Stata/MP 18 were not rerun: their cells retain the
-archived matched measurements on the identical files. Restricting the refresh
+saved matched measurements on the identical files. Restricting the refresh
 to four deterministic synthetic workloads and one recent file from each survey
 family keeps the comparison economical while covering both controlled and
 real-world inputs.
 
 Measurements used an Apple M4 Max with 128 GB RAM, macOS 26.5.2, R 4.6.1, and
-Rust 1.98.0. Synthetic inputs are mixed-type, 40-column Stata 15 files. Their
-elapsed times are seven-run warm-cache medians and their peak RSS values are
-three-run fresh-process medians. The India DHS and NSFG rows each use one
-fresh-process read, matching the archived corpus methodology. All refreshed
-reads returned the archived row and column dimensions.
+Rust 1.98.0. Every dta-parser measurement used `threads = 0`, its default
+automatic multicore mode, which uses up to eight workers for eligible reads.
+Synthetic inputs are mixed-type, 40-column files in the wide-file DTA format
+introduced with Stata 15. Their elapsed times are seven-run warm-cache medians
+and their peak RSS values are three-run fresh-process medians. The India DHS
+and NSFG rows each use one fresh-process read, matching the detailed corpus
+methodology. All refreshed reads returned the previously recorded row and
+column dimensions.
+
+The Stata version descriptions below identify the generation in which each
+on-disk format was introduced. A DTA header does not identify which version of
+the Stata application created a particular file.
 
 Peak RSS means peak resident set size: the greatest amount of physical memory
 attributed to the reader process during the run. It includes the R or Stata
@@ -267,12 +276,12 @@ operating system's file cache outside that process. Values below use decimal GB
 
 | Dataset/workload | Input | dta-parser time | haven time | Stata time | dta-parser / haven time | dta-parser / Stata time | dta-parser peak RSS | haven peak RSS | Stata peak RSS |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
-| Synthetic 100 MB, full 40 columns (release 119) | 0.100 GB | 0.025 s | 1.053 s | 0.011 s | 0.024x | 2.273x | 0.223 GB | 0.253 GB | 0.143 GB |
-| Synthetic 100 MB, projected 8 columns (release 119) | 0.100 GB | 0.014 s | 0.271 s | 0.014 s | 0.052x | 1.000x | 0.182 GB | 0.168 GB | 0.058 GB |
-| Synthetic 1 GB, full 40 columns (release 119) | 1.000 GB | 0.143 s | 10.958 s | 0.101 s | 0.013x | 1.416x | 0.663 GB | 0.888 GB | 1.133 GB |
-| Synthetic 1 GB, projected 8 columns (release 119) | 1.000 GB | 0.073 s | 3.120 s | 0.140 s | 0.023x | 0.521x | 0.269 GB | 0.292 GB | 0.365 GB |
-| India DHS 2021 women (release 113; 724,115 × 5,972) | 5.196 GB | 1.896 s | 437.088 s | 0.718 s | 0.004x | 2.641x | 5.218 GB | 35.103 GB | 5.256 GB |
-| NSFG 2017–2019 women (release 118; 6,141 × 2,610) | 0.020 GB | 0.068 s | 1.002 s | 0.003 s | 0.068x | 22.667x | 0.142 GB | 0.308 GB | 0.051 GB |
+| Synthetic 100 MB, full 40 columns (wide-file format introduced with Stata 15) | 0.100 GB | 0.025 s | 1.053 s | 0.011 s | 0.024x | 2.273x | 0.223 GB | 0.253 GB | 0.143 GB |
+| Synthetic 100 MB, projected 8 columns (wide-file format introduced with Stata 15) | 0.100 GB | 0.014 s | 0.271 s | 0.014 s | 0.052x | 1.000x | 0.182 GB | 0.168 GB | 0.058 GB |
+| Synthetic 1 GB, full 40 columns (wide-file format introduced with Stata 15) | 1.000 GB | 0.143 s | 10.958 s | 0.101 s | 0.013x | 1.416x | 0.663 GB | 0.888 GB | 1.133 GB |
+| Synthetic 1 GB, projected 8 columns (wide-file format introduced with Stata 15) | 1.000 GB | 0.073 s | 3.120 s | 0.140 s | 0.023x | 0.521x | 0.269 GB | 0.292 GB | 0.365 GB |
+| India DHS 2021 women (format introduced with Stata 8; 724,115 × 5,972) | 5.196 GB | 1.896 s | 437.088 s | 0.718 s | 0.004x | 2.641x | 5.218 GB | 35.103 GB | 5.256 GB |
+| NSFG 2017–2019 women (format introduced with Stata 14; 6,141 × 2,610) | 0.020 GB | 0.068 s | 1.002 s | 0.003 s | 0.068x | 22.667x | 0.142 GB | 0.308 GB | 0.051 GB |
 
 Both ratio columns are dta-parser time divided by comparator time. Values below
 1x favor dta-parser. Across these rows, dta-parser was 14.7–230.5 times as fast
@@ -302,10 +311,10 @@ in fresh-process peak RSS. Stata's official
 in-memory load, so it remains a useful eager native-format reference even
 though dta-parser must additionally construct R-compatible objects.
 
-The archived [synthetic report](../../benchmarks/large-scale/results-2026-08-24.md)
-and [corpus report](../../benchmarks/r-corpus-performance/results-2026-08-24.md)
-provide comparator provenance and the full older corpus run. Benchmark
-artifacts are report-only evidence, not CI performance thresholds.
+The [detailed synthetic report](../../benchmarks/large-scale/results-2026-08-24.md)
+and [detailed corpus report](../../benchmarks/r-corpus-performance/results-2026-08-24.md)
+provide comparator provenance and broader results. Benchmark artifacts are
+report-only evidence, not CI performance thresholds.
 
 ## Scope and limitations
 
@@ -321,9 +330,10 @@ artifacts are report-only evidence, not CI performance thresholds.
   are applied.
 - Reads are synchronous. Long reads cooperatively check for R user interrupts.
 - `threads = 0` automatically parallelizes sufficiently large reads from any
-  supported release without selected `strL` columns. Use `threads = 1` for
-  deterministic single-thread benchmarking. Option `dtaparser.threads`
-  controls the default.
+  supported release. With selected `strL` columns, observation references are
+  decoded across workers before the coordinator resolves their shared
+  payloads. Use `threads = 1` to force the serial executor. Option
+  `dtaparser.threads` controls the default.
 - `use_numeric_altrep = TRUE` retains byte, int, long, and float source widths until
   R needs a contiguous double data pointer. Set it to `FALSE`, or set option
   `dtaparser.numeric_altrep = FALSE`, to create eager double vectors during

--- a/r-package/dtaparser/man/read_dta.Rd
+++ b/r-package/dtaparser/man/read_dta.Rd
@@ -35,10 +35,10 @@ convention. Non-negative values must be whole numbers no larger than
 sufficiently large files in any supported Stata release. One always uses the
 serial decoder. Projections containing \code{strL} remain serial.}
 }
-\value{A tibble containing native numeric and character vectors. Numeric
-columns retain their compact Stata storage width until R requests a
-materialized double vector. \code{\%td} columns and legacy or custom formats
-beginning \code{\%d} have class
+\value{A tibble containing native numeric and character vectors. Byte, int,
+long, and float columns retain their compact Stata storage width until R
+requests a materialized double vector; source doubles are created eagerly.
+\code{\%td} columns and legacy or custom formats beginning \code{\%d} have class
 \code{Date}; \code{\%tc} and \code{\%tC} columns have classes \code{POSIXct}
 and \code{POSIXt} in UTC. Other Stata temporal formats remain numeric with
 their \code{format.stata} attribute.}

--- a/r-package/dtaparser/man/read_dta.Rd
+++ b/r-package/dtaparser/man/read_dta.Rd
@@ -53,3 +53,14 @@ Reads Stata releases 105, 108, 110--111, 113--115, and 117--119 through the nati
 retaining dataset and variable labels, dataset notes, formats, value labels,
 long strings, temporal classes, and Stata tagged missing values.
 }
+\section{Stata missing values}{
+Stata system missing (\code{.}) is returned as \code{NA_real_}; in releases
+supporting extended missings (113 and newer), \code{.a} through \code{.z} use
+haven-compatible tagged-NA payloads. Base \code{is.na()} therefore identifies
+every code present. Use \code{haven::na_tag()} to recover their letters,
+\code{haven::is_tagged_na()} to select tagged values, and
+\code{haven::tagged_na()} to create them. Use ordinary \code{NA_real_}, rather
+than a tagged value, to create Stata system missing. Missing tags are part of
+the numeric values and are distinct from Stata value labels stored in a
+column's \code{labels} attribute.
+}

--- a/r-package/dtaparser/man/read_dta.Rd
+++ b/r-package/dtaparser/man/read_dta.Rd
@@ -4,7 +4,8 @@
 \usage{
 read_dta(file, encoding = NULL, col_select = NULL, skip = 0,
   n_max = Inf, .name_repair = "unique",
-  threads = getOption("dtaparser.threads", 0L))
+  threads = getOption("dtaparser.threads", 0L),
+  use_numeric_altrep = getOption("dtaparser.numeric_altrep", TRUE))
 }
 \arguments{
 \item{file}{A path, URL, raw vector, or binary connection. Local and remote
@@ -34,6 +35,11 @@ convention. Non-negative values must be whole numbers no larger than
 \item{threads}{Number of decoder threads. Zero selects an automatic count for
 sufficiently large files in any supported Stata release. One always uses the
 serial decoder. Projections containing \code{strL} remain serial.}
+\item{use_numeric_altrep}{Whether byte, int, long, and float columns should retain
+their compact Stata storage through ALTREP. Set to \code{FALSE} to create eager
+R double vectors during decoding, which uses more memory but avoids later
+widening when a workload requires a contiguous double data pointer.
+Character-column ALTREP is unaffected.}
 }
 \value{A tibble containing native numeric and character vectors. Byte, int,
 long, and float columns retain their compact Stata storage width until R

--- a/r-package/dtaparser/man/read_dta.Rd
+++ b/r-package/dtaparser/man/read_dta.Rd
@@ -35,8 +35,10 @@ convention. Non-negative values must be whole numbers no larger than
 sufficiently large files in any supported Stata release. One always uses the
 serial decoder. Projections containing \code{strL} remain serial.}
 }
-\value{A tibble containing native numeric and character vectors. \code{\%td}
-columns and legacy or custom formats beginning \code{\%d} have class
+\value{A tibble containing native numeric and character vectors. Numeric
+columns retain their compact Stata storage width until R requests a
+materialized double vector. \code{\%td} columns and legacy or custom formats
+beginning \code{\%d} have class
 \code{Date}; \code{\%tc} and \code{\%tC} columns have classes \code{POSIXct}
 and \code{POSIXt} in UTC. Other Stata temporal formats remain numeric with
 their \code{format.stata} attribute.}

--- a/r-package/dtaparser/man/read_dta.Rd
+++ b/r-package/dtaparser/man/read_dta.Rd
@@ -63,4 +63,35 @@ every code present. Use \code{haven::na_tag()} to recover their letters,
 than a tagged value, to create Stata system missing. Missing tags are part of
 the numeric values and are distinct from Stata value labels stored in a
 column's \code{labels} attribute.
+For example:
+\preformatted{x <- c(1, NA_real_, haven::tagged_na("a"), haven::tagged_na("z"))
+is.na(x)
+haven::na_tag(x)
+haven::is_tagged_na(x)
+haven::is_tagged_na(x, "a")
+haven::na_tag(x) \%in\% c("a", "f")
+
+x[1] <- NA_real_                 # Stata .
+x[2] <- haven::tagged_na("a")    # Stata .a
+x[3] <- haven::tagged_na("f")    # Stata .f
+}
+\code{haven::is_tagged_na()} accepts only one specific tag at a time; extract
+tags with \code{haven::na_tag()} and use \code{\%in\%} to match several tags.
+
+Base subassignment and \code{replace()} retain unselected tags when their index
+contains no missing values; use \code{!is.na(x) & x == value} when recoding an
+observed value. Avoid \code{ifelse(x == value, replacement, x)}, whose missing
+condition entries become ordinary \code{NA} and lose their tags.
+
+When recoding, \code{dplyr::case_when()} preserves values returned by its
+default branch. \code{dplyr::if_else()} preserves unselected tags when its
+condition is complete; if the condition can be \code{NA}, also supply
+\code{missing = x}. On bare numeric columns, legacy \code{dplyr::recode()}
+normalizes unmatched tagged missings to ordinary \code{NA}; it does not support
+classed \code{haven_labelled}, \code{Date}, or \code{POSIXct} columns.
+Missing-value replacement helpers match all 27 codes; select a particular code
+with \code{haven::is_tagged_na(x, tag)} instead. A transformation may
+materialize an ALTREP column and may drop Stata metadata attributes when it
+constructs a new vector, following the same behavior as haven-compatible
+vectors.
 }

--- a/r-package/dtaparser/src/init.c
+++ b/r-package/dtaparser/src/init.c
@@ -5,6 +5,7 @@
 #include <R_ext/Altrep.h>
 #include <R_ext/Utils.h>
 #include <R_ext/Visibility.h>
+#include <float.h>
 #include <stdint.h>
 #include <string.h>
 
@@ -269,6 +270,20 @@ static int numeric_no_na(SEXP value) {
         return 1;
     }
     return numeric_storage(value)->no_na;
+}
+
+static SEXP numeric_sum(SEXP value, Rboolean na_rm) {
+    if (R_altrep_data2(value) != R_NilValue) return NULL;
+    numeric_data *data = numeric_storage(value);
+    long double sum = 0.0;
+    for (size_t index = 0; index < data->length; index++) {
+        if ((index & 16383) == 0) R_CheckUserInterrupt();
+        double element = numeric_value_at(data, index);
+        if (!na_rm || !ISNAN(element)) sum += element;
+    }
+    if (sum > DBL_MAX) return Rf_ScalarReal(R_PosInf);
+    if (sum < -DBL_MAX) return Rf_ScalarReal(R_NegInf);
+    return Rf_ScalarReal((double) sum);
 }
 
 typedef struct {
@@ -681,6 +696,7 @@ void attribute_visible R_init_dtaparser(DllInfo *dll) {
     R_set_altreal_Elt_method(dtaparser_numeric_class, numeric_value);
     R_set_altreal_Get_region_method(dtaparser_numeric_class, numeric_region);
     R_set_altreal_No_NA_method(dtaparser_numeric_class, numeric_no_na);
+    R_set_altreal_Sum_method(dtaparser_numeric_class, numeric_sum);
     dtaparser_dictstring_class = R_make_altstring_class(
         "dtaparser_dictstring", "dtaparser", dll
     );

--- a/r-package/dtaparser/src/init.c
+++ b/r-package/dtaparser/src/init.c
@@ -13,7 +13,7 @@ extern SEXP dtaparser_metadata_rust(
     const char *, uint32_t, uint32_t, const char *, char **
 );
 extern SEXP dtaparser_read_rust(
-    const char *, const int *, size_t, int, double, double, int, int,
+    const char *, const int *, size_t, int, double, double, int, int, int,
     const char *, char **
 );
 extern void dtaparser_free_error(char *);
@@ -751,7 +751,7 @@ SEXP C_dtaparser_metadata(
 
 SEXP C_dtaparser_read(
     SEXP path, SEXP columns, SEXP skip, SEXP n_max, SEXP direct_to_r,
-    SEXP threads, SEXP encoding
+    SEXP threads, SEXP numeric_altrep, SEXP encoding
 ) {
     if (TYPEOF(path) != STRSXP || XLENGTH(path) != 1 || STRING_ELT(path, 0) == NA_STRING) {
         Rf_error("`file` must be one non-missing path");
@@ -772,6 +772,10 @@ SEXP C_dtaparser_read(
         INTEGER(threads)[0] < 0) {
         Rf_error("internal thread count must be one non-negative integer");
     }
+    if (TYPEOF(numeric_altrep) != LGLSXP || XLENGTH(numeric_altrep) != 1 ||
+        LOGICAL(numeric_altrep)[0] == NA_LOGICAL) {
+        Rf_error("internal numeric ALTREP selector must be logical");
+    }
     char *error = NULL;
     SEXP result = dtaparser_read_rust(
         Rf_translateCharUTF8(STRING_ELT(path, 0)),
@@ -782,6 +786,7 @@ SEXP C_dtaparser_read(
         REAL(n_max)[0],
         LOGICAL(direct_to_r)[0],
         INTEGER(threads)[0],
+        LOGICAL(numeric_altrep)[0],
         optional_encoding(encoding),
         &error
     );
@@ -795,7 +800,7 @@ SEXP C_dtaparser_is_numeric_altrep(SEXP value) {
 
 static const R_CallMethodDef CallEntries[] = {
     {"C_dtaparser_metadata", (DL_FUNC) &C_dtaparser_metadata, 4},
-    {"C_dtaparser_read", (DL_FUNC) &C_dtaparser_read, 7},
+    {"C_dtaparser_read", (DL_FUNC) &C_dtaparser_read, 8},
     {"C_dtaparser_is_numeric_altrep",
      (DL_FUNC) &C_dtaparser_is_numeric_altrep, 1},
     {NULL, NULL, 0}

--- a/r-package/dtaparser/src/init.c
+++ b/r-package/dtaparser/src/init.c
@@ -44,8 +44,7 @@ enum {
     NUMERIC_BYTE = 0,
     NUMERIC_INT = 1,
     NUMERIC_LONG = 2,
-    NUMERIC_FLOAT = 3,
-    NUMERIC_DOUBLE = 4
+    NUMERIC_FLOAT = 3
 };
 
 static void numeric_finalize(SEXP external) {
@@ -106,27 +105,6 @@ static int float_missing_offset(float value, int format_version) {
         ? (int) (delta / UINT32_C(0x00000800)) : -1;
 }
 
-static int double_missing_offset(double value, int format_version) {
-    uint64_t bits;
-    memcpy(&bits, &value, sizeof(bits));
-    if (format_version == 105) {
-        return bits == UINT64_C(0x54c0000000000000) ||
-               (bits >= UINT64_C(0x7fe0000000000000) &&
-                bits < UINT64_C(0x8000000000000000)) ? 0 : -1;
-    }
-    if (format_version <= 111) {
-        return bits >= UINT64_C(0x7fe0000000000000) &&
-               bits < UINT64_C(0x8000000000000000) ? 0 : -1;
-    }
-    if (bits < UINT64_C(0x7fe0000000000000) ||
-        bits > UINT64_C(0x7fe01a0000000000)) {
-        return -1;
-    }
-    uint64_t delta = bits - UINT64_C(0x7fe0000000000000);
-    return delta % UINT64_C(0x0000010000000000) == 0
-        ? (int) (delta / UINT64_C(0x0000010000000000)) : -1;
-}
-
 static double numeric_missing_value(int offset) {
     if (offset == 0) return NA_REAL;
     uint64_t letter = (uint64_t) ('a' + offset - 1);
@@ -142,55 +120,184 @@ static double numeric_observed_value(double value, int temporal) {
     return value;
 }
 
-static double numeric_value_at(numeric_data *data, size_t index) {
-    double value;
-    int missing;
+#define DEFINE_NUMERIC_KERNELS(NAME, TYPE, MISSING_OFFSET)                    \
+    static TYPE numeric_##NAME##_raw_at(                                     \
+        const numeric_data *data, size_t index                               \
+    ) {                                                                       \
+        TYPE raw;                                                             \
+        memcpy(&raw, (const char *) data->values + index * sizeof(raw),       \
+               sizeof(raw));                                                  \
+        return raw;                                                           \
+    }                                                                         \
+                                                                              \
+    static double numeric_##NAME##_value_at(                                  \
+        const numeric_data *data, size_t index                                \
+    ) {                                                                       \
+        TYPE raw = numeric_##NAME##_raw_at(data, index);                      \
+        int missing = MISSING_OFFSET(raw, data->format_version);              \
+        return missing >= 0                                                   \
+            ? numeric_missing_value(missing)                                  \
+            : numeric_observed_value((double) raw, data->temporal);           \
+    }                                                                         \
+                                                                              \
+    static void numeric_##NAME##_region(                                      \
+        const numeric_data *data, size_t index, size_t length, double *output \
+    ) {                                                                       \
+        if (data->no_na) {                                                     \
+            for (size_t offset = 0; offset < length; offset++) {              \
+                if ((offset & 16383) == 0) R_CheckUserInterrupt();            \
+                TYPE raw = numeric_##NAME##_raw_at(data, index + offset);     \
+                output[offset] = numeric_observed_value(                      \
+                    (double) raw, data->temporal                              \
+                );                                                            \
+            }                                                                 \
+        } else {                                                              \
+            for (size_t offset = 0; offset < length; offset++) {              \
+                if ((offset & 16383) == 0) R_CheckUserInterrupt();            \
+                output[offset] = numeric_##NAME##_value_at(                   \
+                    data, index + offset                                      \
+                );                                                            \
+            }                                                                 \
+        }                                                                     \
+    }                                                                         \
+                                                                              \
+    static long double numeric_##NAME##_sum(                                  \
+        const numeric_data *data, Rboolean na_rm                              \
+    ) {                                                                       \
+        long double sum = 0.0;                                                \
+        if (data->no_na) {                                                     \
+            for (size_t index = 0; index < data->length; index++) {           \
+                if ((index & 16383) == 0) R_CheckUserInterrupt();             \
+                TYPE raw = numeric_##NAME##_raw_at(data, index);              \
+                sum += numeric_observed_value((double) raw, data->temporal);  \
+            }                                                                 \
+        } else {                                                              \
+            for (size_t index = 0; index < data->length; index++) {           \
+                if ((index & 16383) == 0) R_CheckUserInterrupt();             \
+                double element = numeric_##NAME##_value_at(data, index);      \
+                if (!na_rm || !ISNAN(element)) sum += element;                \
+            }                                                                 \
+        }                                                                     \
+        return sum;                                                           \
+    }                                                                         \
+                                                                              \
+    static int numeric_##NAME##_extreme(                                      \
+        const numeric_data *data, Rboolean na_rm, int minimum, double *result \
+    ) {                                                                       \
+        double current = 0.0;                                                 \
+        int updated = 0;                                                      \
+        if (data->no_na) {                                                     \
+            if (data->length == 0) return 0;                                  \
+            TYPE raw = numeric_##NAME##_raw_at(data, 0);                     \
+            current = numeric_observed_value(                                \
+                (double) raw, data->temporal                                  \
+            );                                                                \
+            updated = 1;                                                      \
+            for (size_t index = 1; index < data->length; index++) {           \
+                if ((index & 16383) == 0) R_CheckUserInterrupt();             \
+                raw = numeric_##NAME##_raw_at(data, index);                   \
+                double element = numeric_observed_value(                     \
+                    (double) raw, data->temporal                              \
+                );                                                            \
+                if (minimum ? element < current : element > current) {        \
+                    current = element;                                        \
+                }                                                             \
+            }                                                                 \
+        } else {                                                              \
+            for (size_t index = 0; index < data->length; index++) {           \
+                if ((index & 16383) == 0) R_CheckUserInterrupt();             \
+                double element = numeric_##NAME##_value_at(data, index);      \
+                if (ISNAN(element)) {                                         \
+                    if (!na_rm) {                                             \
+                        if (!ISNA(current)) current = element;                \
+                        updated = 1;                                          \
+                    }                                                         \
+                } else if (!updated ||                                        \
+                           (minimum ? element < current : element > current)) {\
+                    current = element;                                        \
+                    updated = 1;                                              \
+                }                                                             \
+            }                                                                 \
+        }                                                                     \
+        if (updated) *result = current;                                       \
+        return updated;                                                       \
+    }
+
+DEFINE_NUMERIC_KERNELS(byte, int8_t, byte_missing_offset)
+DEFINE_NUMERIC_KERNELS(int, int16_t, int_missing_offset)
+DEFINE_NUMERIC_KERNELS(long, int32_t, long_missing_offset)
+DEFINE_NUMERIC_KERNELS(float, float, float_missing_offset)
+
+#undef DEFINE_NUMERIC_KERNELS
+
+static double numeric_value_at(const numeric_data *data, size_t index) {
     switch (data->kind) {
-    case NUMERIC_BYTE: {
-        int8_t raw;
-        memcpy(&raw, (const char *) data->values + index, sizeof(raw));
-        value = (double) raw;
-        missing = byte_missing_offset(raw, data->format_version);
-        break;
-    }
-    case NUMERIC_INT: {
-        int16_t raw;
-        memcpy(&raw, (const char *) data->values + index * sizeof(raw),
-               sizeof(raw));
-        value = (double) raw;
-        missing = int_missing_offset(raw, data->format_version);
-        break;
-    }
-    case NUMERIC_LONG: {
-        int32_t raw;
-        memcpy(&raw, (const char *) data->values + index * sizeof(raw),
-               sizeof(raw));
-        value = (double) raw;
-        missing = long_missing_offset(raw, data->format_version);
-        break;
-    }
-    case NUMERIC_FLOAT: {
-        float raw;
-        memcpy(&raw, (const char *) data->values + index * sizeof(raw),
-               sizeof(raw));
-        value = (double) raw;
-        missing = float_missing_offset(raw, data->format_version);
-        break;
-    }
-    case NUMERIC_DOUBLE: {
-        double raw;
-        memcpy(&raw, (const char *) data->values + index * sizeof(raw),
-               sizeof(raw));
-        value = raw;
-        missing = double_missing_offset(raw, data->format_version);
-        break;
-    }
+    case NUMERIC_BYTE:
+        return numeric_byte_value_at(data, index);
+    case NUMERIC_INT:
+        return numeric_int_value_at(data, index);
+    case NUMERIC_LONG:
+        return numeric_long_value_at(data, index);
+    case NUMERIC_FLOAT:
+        return numeric_float_value_at(data, index);
     default:
         Rf_error("invalid dtaparser numeric storage kind");
     }
-    return missing >= 0
-        ? numeric_missing_value(missing)
-        : numeric_observed_value(value, data->temporal);
+}
+
+static void numeric_fill_region(
+    const numeric_data *data, size_t index, size_t length, double *output
+) {
+    switch (data->kind) {
+    case NUMERIC_BYTE:
+        numeric_byte_region(data, index, length, output);
+        return;
+    case NUMERIC_INT:
+        numeric_int_region(data, index, length, output);
+        return;
+    case NUMERIC_LONG:
+        numeric_long_region(data, index, length, output);
+        return;
+    case NUMERIC_FLOAT:
+        numeric_float_region(data, index, length, output);
+        return;
+    default:
+        Rf_error("invalid dtaparser numeric storage kind");
+    }
+}
+
+static long double numeric_sum_storage(
+    const numeric_data *data, Rboolean na_rm
+) {
+    switch (data->kind) {
+    case NUMERIC_BYTE:
+        return numeric_byte_sum(data, na_rm);
+    case NUMERIC_INT:
+        return numeric_int_sum(data, na_rm);
+    case NUMERIC_LONG:
+        return numeric_long_sum(data, na_rm);
+    case NUMERIC_FLOAT:
+        return numeric_float_sum(data, na_rm);
+    default:
+        Rf_error("invalid dtaparser numeric storage kind");
+    }
+}
+
+static int numeric_extreme_storage(
+    const numeric_data *data, Rboolean na_rm, int minimum, double *result
+) {
+    switch (data->kind) {
+    case NUMERIC_BYTE:
+        return numeric_byte_extreme(data, na_rm, minimum, result);
+    case NUMERIC_INT:
+        return numeric_int_extreme(data, na_rm, minimum, result);
+    case NUMERIC_LONG:
+        return numeric_long_extreme(data, na_rm, minimum, result);
+    case NUMERIC_FLOAT:
+        return numeric_float_extreme(data, na_rm, minimum, result);
+    default:
+        Rf_error("invalid dtaparser numeric storage kind");
+    }
 }
 
 static double numeric_value(SEXP value, R_xlen_t index) {
@@ -221,10 +328,7 @@ static R_xlen_t numeric_region(
     size_t available = data->length - (size_t) index;
     size_t requested = (size_t) count;
     size_t length = requested < available ? requested : available;
-    for (size_t offset = 0; offset < length; offset++) {
-        if ((offset & 16383) == 0) R_CheckUserInterrupt();
-        output[offset] = numeric_value_at(data, (size_t) index + offset);
-    }
+    numeric_fill_region(data, (size_t) index, length, output);
     return (R_xlen_t) length;
 }
 
@@ -234,10 +338,7 @@ static SEXP numeric_materialize(SEXP value) {
     numeric_data *data = numeric_storage(value);
     materialized = PROTECT(Rf_allocVector(REALSXP, (R_xlen_t) data->length));
     double *output = REAL(materialized);
-    for (size_t index = 0; index < data->length; index++) {
-        if ((index & 16383) == 0) R_CheckUserInterrupt();
-        output[index] = numeric_value_at(data, index);
-    }
+    numeric_fill_region(data, 0, data->length, output);
     R_set_altrep_data2(value, materialized);
     numeric_finalize(R_altrep_data1(value));
     UNPROTECT(1);
@@ -275,15 +376,31 @@ static int numeric_no_na(SEXP value) {
 static SEXP numeric_sum(SEXP value, Rboolean na_rm) {
     if (R_altrep_data2(value) != R_NilValue) return NULL;
     numeric_data *data = numeric_storage(value);
-    long double sum = 0.0;
-    for (size_t index = 0; index < data->length; index++) {
-        if ((index & 16383) == 0) R_CheckUserInterrupt();
-        double element = numeric_value_at(data, index);
-        if (!na_rm || !ISNAN(element)) sum += element;
-    }
+    long double sum = numeric_sum_storage(data, na_rm);
     if (sum > DBL_MAX) return Rf_ScalarReal(R_PosInf);
     if (sum < -DBL_MAX) return Rf_ScalarReal(R_NegInf);
     return Rf_ScalarReal((double) sum);
+}
+
+static SEXP numeric_extreme(
+    SEXP value, Rboolean na_rm, int minimum
+) {
+    if (R_altrep_data2(value) != R_NilValue) return NULL;
+    double result;
+    if (!numeric_extreme_storage(
+            numeric_storage(value), na_rm, minimum, &result
+        )) {
+        return NULL;
+    }
+    return Rf_ScalarReal(result);
+}
+
+static SEXP numeric_min(SEXP value, Rboolean na_rm) {
+    return numeric_extreme(value, na_rm, 1);
+}
+
+static SEXP numeric_max(SEXP value, Rboolean na_rm) {
+    return numeric_extreme(value, na_rm, 0);
 }
 
 typedef struct {
@@ -697,6 +814,8 @@ void attribute_visible R_init_dtaparser(DllInfo *dll) {
     R_set_altreal_Get_region_method(dtaparser_numeric_class, numeric_region);
     R_set_altreal_No_NA_method(dtaparser_numeric_class, numeric_no_na);
     R_set_altreal_Sum_method(dtaparser_numeric_class, numeric_sum);
+    R_set_altreal_Min_method(dtaparser_numeric_class, numeric_min);
+    R_set_altreal_Max_method(dtaparser_numeric_class, numeric_max);
     dtaparser_dictstring_class = R_make_altstring_class(
         "dtaparser_dictstring", "dtaparser", dll
     );

--- a/r-package/dtaparser/src/init.c
+++ b/r-package/dtaparser/src/init.c
@@ -16,6 +16,7 @@ extern SEXP dtaparser_read_rust(
     const char *, char **
 );
 extern void dtaparser_free_error(char *);
+extern void dtaparser_numeric_free(void *);
 extern void dtaparser_dictstring_free(void *);
 extern int dtaparser_dictstring_bytes(
     void *, uint32_t, const char **, int *
@@ -27,6 +28,282 @@ typedef struct {
 } dictstring_data;
 
 static R_altrep_class_t dtaparser_dictstring_class;
+static R_altrep_class_t dtaparser_numeric_class;
+
+typedef struct {
+    void *values;
+    size_t length;
+    int kind;
+    int temporal;
+    int format_version;
+    int no_na;
+} numeric_data;
+
+enum {
+    NUMERIC_BYTE = 0,
+    NUMERIC_INT = 1,
+    NUMERIC_LONG = 2,
+    NUMERIC_FLOAT = 3,
+    NUMERIC_DOUBLE = 4
+};
+
+static void numeric_finalize(SEXP external) {
+    void *data = R_ExternalPtrAddr(external);
+    if (data != NULL) {
+        R_ClearExternalPtr(external);
+        dtaparser_numeric_free(data);
+    }
+    R_SetExternalPtrProtected(external, R_NilValue);
+}
+
+static numeric_data *numeric_storage(SEXP value) {
+    numeric_data *data = (numeric_data *) R_ExternalPtrAddr(
+        R_altrep_data1(value)
+    );
+    if (data == NULL) Rf_error("dtaparser numeric data are no longer available");
+    return data;
+}
+
+static R_xlen_t numeric_length(SEXP value) {
+    SEXP materialized = R_altrep_data2(value);
+    if (materialized != R_NilValue) return XLENGTH(materialized);
+    size_t length = numeric_storage(value)->length;
+    if (length > (size_t) R_XLEN_T_MAX) {
+        Rf_error("dtaparser numeric vector is too long");
+    }
+    return (R_xlen_t) length;
+}
+
+static int byte_missing_offset(int8_t value, int format_version) {
+    if (format_version <= 111) return value == 127 ? 0 : -1;
+    return value >= 101 && value <= 127 ? value - 101 : -1;
+}
+
+static int int_missing_offset(int16_t value, int format_version) {
+    if (format_version <= 111) return value == 32767 ? 0 : -1;
+    return value >= 32741 && value <= 32767 ? value - 32741 : -1;
+}
+
+static int long_missing_offset(int32_t value, int format_version) {
+    if (format_version <= 111) return value == INT32_MAX ? 0 : -1;
+    return value >= INT32_C(2147483621) && value <= INT32_MAX
+        ? (int) (value - INT32_C(2147483621)) : -1;
+}
+
+static int float_missing_offset(float value, int format_version) {
+    uint32_t bits;
+    memcpy(&bits, &value, sizeof(bits));
+    if (format_version <= 111) {
+        return bits >= UINT32_C(0x7f000000) && bits < UINT32_C(0x80000000)
+            ? 0 : -1;
+    }
+    if (bits < UINT32_C(0x7f000000) || bits > UINT32_C(0x7f00d000)) {
+        return -1;
+    }
+    uint32_t delta = bits - UINT32_C(0x7f000000);
+    return delta % UINT32_C(0x00000800) == 0
+        ? (int) (delta / UINT32_C(0x00000800)) : -1;
+}
+
+static int double_missing_offset(double value, int format_version) {
+    uint64_t bits;
+    memcpy(&bits, &value, sizeof(bits));
+    if (format_version == 105) {
+        return bits == UINT64_C(0x54c0000000000000) ||
+               (bits >= UINT64_C(0x7fe0000000000000) &&
+                bits < UINT64_C(0x8000000000000000)) ? 0 : -1;
+    }
+    if (format_version <= 111) {
+        return bits >= UINT64_C(0x7fe0000000000000) &&
+               bits < UINT64_C(0x8000000000000000) ? 0 : -1;
+    }
+    if (bits < UINT64_C(0x7fe0000000000000) ||
+        bits > UINT64_C(0x7fe01a0000000000)) {
+        return -1;
+    }
+    uint64_t delta = bits - UINT64_C(0x7fe0000000000000);
+    return delta % UINT64_C(0x0000010000000000) == 0
+        ? (int) (delta / UINT64_C(0x0000010000000000)) : -1;
+}
+
+static double numeric_missing_value(int offset) {
+    if (offset == 0) return NA_REAL;
+    uint64_t letter = (uint64_t) ('a' + offset - 1);
+    uint64_t bits = UINT64_C(0x7ff00000000007a2) | (letter << 32);
+    double value;
+    memcpy(&value, &bits, sizeof(value));
+    return value;
+}
+
+static double numeric_observed_value(double value, int temporal) {
+    if (temporal == 1) return value - 3653.0;
+    if (temporal == 2) return value / 1000.0 - 315619200.0;
+    return value;
+}
+
+static double numeric_value_at(numeric_data *data, size_t index) {
+    double value;
+    int missing;
+    switch (data->kind) {
+    case NUMERIC_BYTE: {
+        int8_t raw;
+        memcpy(&raw, (const char *) data->values + index, sizeof(raw));
+        value = (double) raw;
+        missing = byte_missing_offset(raw, data->format_version);
+        break;
+    }
+    case NUMERIC_INT: {
+        int16_t raw;
+        memcpy(&raw, (const char *) data->values + index * sizeof(raw),
+               sizeof(raw));
+        value = (double) raw;
+        missing = int_missing_offset(raw, data->format_version);
+        break;
+    }
+    case NUMERIC_LONG: {
+        int32_t raw;
+        memcpy(&raw, (const char *) data->values + index * sizeof(raw),
+               sizeof(raw));
+        value = (double) raw;
+        missing = long_missing_offset(raw, data->format_version);
+        break;
+    }
+    case NUMERIC_FLOAT: {
+        float raw;
+        memcpy(&raw, (const char *) data->values + index * sizeof(raw),
+               sizeof(raw));
+        value = (double) raw;
+        missing = float_missing_offset(raw, data->format_version);
+        break;
+    }
+    case NUMERIC_DOUBLE: {
+        double raw;
+        memcpy(&raw, (const char *) data->values + index * sizeof(raw),
+               sizeof(raw));
+        value = raw;
+        missing = double_missing_offset(raw, data->format_version);
+        break;
+    }
+    default:
+        Rf_error("invalid dtaparser numeric storage kind");
+    }
+    return missing >= 0
+        ? numeric_missing_value(missing)
+        : numeric_observed_value(value, data->temporal);
+}
+
+static double numeric_value(SEXP value, R_xlen_t index) {
+    SEXP materialized = R_altrep_data2(value);
+    if (materialized != R_NilValue) return REAL_ELT(materialized, index);
+    numeric_data *data = numeric_storage(value);
+    if (index < 0 || (size_t) index >= data->length) {
+        Rf_error("invalid dtaparser numeric-vector index");
+    }
+    return numeric_value_at(data, (size_t) index);
+}
+
+static R_xlen_t numeric_region(
+    SEXP value, R_xlen_t index, R_xlen_t count, double *output
+) {
+    SEXP materialized = R_altrep_data2(value);
+    if (materialized != R_NilValue) {
+        R_xlen_t length = XLENGTH(materialized);
+        if (index < 0 || count < 0 || index >= length) return 0;
+        R_xlen_t available = length - index;
+        R_xlen_t copied = count < available ? count : available;
+        memcpy(output, REAL(materialized) + index,
+               (size_t) copied * sizeof(double));
+        return copied;
+    }
+    numeric_data *data = numeric_storage(value);
+    if (index < 0 || count < 0 || (size_t) index >= data->length) return 0;
+    size_t available = data->length - (size_t) index;
+    size_t requested = (size_t) count;
+    size_t length = requested < available ? requested : available;
+    for (size_t offset = 0; offset < length; offset++) {
+        if ((offset & 16383) == 0) R_CheckUserInterrupt();
+        output[offset] = numeric_value_at(data, (size_t) index + offset);
+    }
+    return (R_xlen_t) length;
+}
+
+static SEXP numeric_materialize(SEXP value) {
+    SEXP materialized = R_altrep_data2(value);
+    if (materialized != R_NilValue) return materialized;
+    numeric_data *data = numeric_storage(value);
+    materialized = PROTECT(Rf_allocVector(REALSXP, (R_xlen_t) data->length));
+    double *output = REAL(materialized);
+    for (size_t index = 0; index < data->length; index++) {
+        if ((index & 16383) == 0) R_CheckUserInterrupt();
+        output[index] = numeric_value_at(data, index);
+    }
+    R_set_altrep_data2(value, materialized);
+    numeric_finalize(R_altrep_data1(value));
+    UNPROTECT(1);
+    return materialized;
+}
+
+static void *numeric_dataptr(SEXP value, Rboolean writeable) {
+    SEXP materialized = numeric_materialize(value);
+#if R_VERSION >= R_Version(4, 6, 0)
+    return writeable ? DATAPTR_RW(materialized) : (void *) DATAPTR_RO(materialized);
+#else
+    (void) writeable;
+    return DATAPTR(materialized);
+#endif
+}
+
+static const void *numeric_dataptr_or_null(SEXP value) {
+    SEXP materialized = R_altrep_data2(value);
+    return materialized == R_NilValue ? NULL : DATAPTR_OR_NULL(materialized);
+}
+
+static int numeric_no_na(SEXP value) {
+    SEXP materialized = R_altrep_data2(value);
+    if (materialized != R_NilValue) {
+        R_xlen_t length = XLENGTH(materialized);
+        for (R_xlen_t index = 0; index < length; index++) {
+            if ((index & 16383) == 0) R_CheckUserInterrupt();
+            if (ISNAN(REAL_ELT(materialized, index))) return 0;
+        }
+        return 1;
+    }
+    return numeric_storage(value)->no_na;
+}
+
+typedef struct {
+    void *data;
+    SEXP backing;
+    int transferred;
+    SEXP result;
+} make_numeric_context;
+
+static void make_numeric_call(void *payload) {
+    make_numeric_context *context = (make_numeric_context *) payload;
+    SEXP external = PROTECT(R_MakeExternalPtr(
+        context->data, R_NilValue, context->backing
+    ));
+    R_RegisterCFinalizerEx(external, numeric_finalize, TRUE);
+    context->transferred = 1;
+    SEXP result = PROTECT(R_new_altrep(
+        dtaparser_numeric_class, external, R_NilValue
+    ));
+    R_PreserveObject(result);
+    context->result = result;
+    UNPROTECT(2);
+}
+
+int dtaparser_make_numeric(
+    void *data, SEXP backing, int *transferred, SEXP *result
+) {
+    if (data == NULL || transferred == NULL || result == NULL) return 0;
+    if (TYPEOF(backing) != RAWSXP) return 0;
+    make_numeric_context context = {data, backing, 0, NULL};
+    int ok = R_ToplevelExec(make_numeric_call, &context);
+    *transferred = context.transferred;
+    if (ok) *result = context.result;
+    return ok;
+}
 
 static void dictstring_finalize(SEXP external) {
     void *data = R_ExternalPtrAddr(external);
@@ -380,13 +657,30 @@ SEXP C_dtaparser_read(
     return result;
 }
 
+SEXP C_dtaparser_is_numeric_altrep(SEXP value) {
+    return Rf_ScalarLogical(R_altrep_inherits(value, dtaparser_numeric_class));
+}
+
 static const R_CallMethodDef CallEntries[] = {
     {"C_dtaparser_metadata", (DL_FUNC) &C_dtaparser_metadata, 4},
     {"C_dtaparser_read", (DL_FUNC) &C_dtaparser_read, 7},
+    {"C_dtaparser_is_numeric_altrep",
+     (DL_FUNC) &C_dtaparser_is_numeric_altrep, 1},
     {NULL, NULL, 0}
 };
 
 void attribute_visible R_init_dtaparser(DllInfo *dll) {
+    dtaparser_numeric_class = R_make_altreal_class(
+        "dtaparser_numeric", "dtaparser", dll
+    );
+    R_set_altrep_Length_method(dtaparser_numeric_class, numeric_length);
+    R_set_altvec_Dataptr_method(dtaparser_numeric_class, numeric_dataptr);
+    R_set_altvec_Dataptr_or_null_method(
+        dtaparser_numeric_class, numeric_dataptr_or_null
+    );
+    R_set_altreal_Elt_method(dtaparser_numeric_class, numeric_value);
+    R_set_altreal_Get_region_method(dtaparser_numeric_class, numeric_region);
+    R_set_altreal_No_NA_method(dtaparser_numeric_class, numeric_no_na);
     dtaparser_dictstring_class = R_make_altstring_class(
         "dtaparser_dictstring", "dtaparser", dll
     );

--- a/r-package/dtaparser/src/rust/src/lib.rs
+++ b/r-package/dtaparser/src/rust/src/lib.rs
@@ -94,6 +94,15 @@ enum NumericKind {
     Float = 3,
 }
 
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum EagerNumericKind {
+    Byte,
+    Int,
+    Long,
+    Float,
+    Double,
+}
+
 struct RNumericData {
     backing: Sexp,
     values: *mut u8,
@@ -694,6 +703,7 @@ enum RColumn {
         vector: Sexp,
         output: *mut f64,
         length: usize,
+        source_kind: EagerNumericKind,
         temporal: TemporalKind,
         system_missing: f64,
     },
@@ -760,6 +770,7 @@ impl RDataFrameSink {
         metadata: &DtaMetadata,
         row_count: u64,
         source_indices: &[u32],
+        numeric_altrep: bool,
     ) -> Result<Self, DtaError> {
         let length = RLen::try_from(row_count)
             .map_err(|_| DtaError::Output("R vector is too long".to_owned()))?;
@@ -792,12 +803,21 @@ impl RDataFrameSink {
                             .map_err(|_| DtaError::Output("R vector is too long".to_owned()))?,
                     )?,
                 },
-                DtaType::Double => {
+                _ if !numeric_altrep || matches!(variable.dta_type, DtaType::Double) => {
                     let vector = guard.alloc(REALSXP, length).map_err(DtaError::Output)?;
+                    let source_kind = match variable.dta_type {
+                        DtaType::Byte => EagerNumericKind::Byte,
+                        DtaType::Int => EagerNumericKind::Int,
+                        DtaType::Long => EagerNumericKind::Long,
+                        DtaType::Float => EagerNumericKind::Float,
+                        DtaType::Double => EagerNumericKind::Double,
+                        DtaType::FixedString(_) | DtaType::StrL => unreachable!(),
+                    };
                     RColumn::NumericEager {
                         vector,
                         output: REAL(vector),
                         length: native_length,
+                        source_kind,
                         temporal: temporal_kind(&variable.format),
                         system_missing: R_NaReal,
                     }
@@ -839,28 +859,14 @@ impl RDataFrameSink {
     }
 
     #[inline(always)]
-    fn numeric_column_mut(&mut self, column: usize) -> Result<&mut RNumericData, DtaError> {
+    fn numeric_column_mut(&mut self, column: usize) -> Result<&mut RColumn, DtaError> {
         match self.columns.get_mut(column) {
-            Some(RColumn::NumericAltRep { data, .. }) => Ok(data),
+            Some(column @ (RColumn::NumericAltRep { .. } | RColumn::NumericEager { .. })) => {
+                Ok(column)
+            }
             _ => Err(DtaError::Output(
                 "numeric output column mismatch".to_owned(),
             )),
-        }
-    }
-
-    #[inline(always)]
-    fn write_eager_double(
-        &mut self,
-        column: usize,
-        row: usize,
-        value: f64,
-        missing: Option<MissingTag>,
-    ) -> Result<(), DtaError> {
-        match self.columns.get_mut(column) {
-            Some(column @ RColumn::NumericEager { .. }) => {
-                column.write_eager_double(row, value, missing)
-            }
-            _ => Err(DtaError::Output("double output column mismatch".to_owned())),
         }
     }
 
@@ -971,32 +977,32 @@ impl RNumericData {
 }
 
 impl RColumn {
-    fn numeric_mut(&mut self) -> Result<&mut RNumericData, DtaError> {
-        let Self::NumericAltRep { data, .. } = self else {
-            return Err(DtaError::Output(
-                "numeric output column mismatch".to_owned(),
-            ));
-        };
-        Ok(data)
-    }
-
     #[inline(always)]
-    fn write_eager_double(
+    fn write_eager_numeric(
         &mut self,
         row: usize,
         value: f64,
         missing: Option<MissingTag>,
+        expected_kind: EagerNumericKind,
     ) -> Result<(), DtaError> {
         let Self::NumericEager {
             output,
             length,
+            source_kind,
             temporal,
             system_missing,
             ..
         } = self
         else {
-            return Err(DtaError::Output("double output column mismatch".to_owned()));
+            return Err(DtaError::Output(
+                "numeric output column mismatch".to_owned(),
+            ));
         };
+        if *source_kind != expected_kind {
+            return Err(DtaError::Output(
+                "value used for another numeric storage type".to_owned(),
+            ));
+        }
         if row >= *length {
             return Err(RNumericData::row_error(row, *length));
         }
@@ -1007,6 +1013,88 @@ impl RColumn {
         }
         Ok(())
     }
+
+    #[inline(always)]
+    fn store_byte(
+        &mut self,
+        row: usize,
+        value: i8,
+        missing: Option<MissingTag>,
+    ) -> Result<(), DtaError> {
+        match self {
+            Self::NumericAltRep { data, .. } => data.write_byte(row, value, missing),
+            Self::NumericEager { .. } => {
+                self.write_eager_numeric(row, f64::from(value), missing, EagerNumericKind::Byte)
+            }
+            Self::String { .. } => Err(DtaError::Output(
+                "numeric output column mismatch".to_owned(),
+            )),
+        }
+    }
+
+    #[inline(always)]
+    fn store_int(
+        &mut self,
+        row: usize,
+        value: i16,
+        missing: Option<MissingTag>,
+    ) -> Result<(), DtaError> {
+        match self {
+            Self::NumericAltRep { data, .. } => data.write_int(row, value, missing),
+            Self::NumericEager { .. } => {
+                self.write_eager_numeric(row, f64::from(value), missing, EagerNumericKind::Int)
+            }
+            Self::String { .. } => Err(DtaError::Output(
+                "numeric output column mismatch".to_owned(),
+            )),
+        }
+    }
+
+    #[inline(always)]
+    fn store_long(
+        &mut self,
+        row: usize,
+        value: i32,
+        missing: Option<MissingTag>,
+    ) -> Result<(), DtaError> {
+        match self {
+            Self::NumericAltRep { data, .. } => data.write_long(row, value, missing),
+            Self::NumericEager { .. } => {
+                self.write_eager_numeric(row, f64::from(value), missing, EagerNumericKind::Long)
+            }
+            Self::String { .. } => Err(DtaError::Output(
+                "numeric output column mismatch".to_owned(),
+            )),
+        }
+    }
+
+    #[inline(always)]
+    fn store_float(
+        &mut self,
+        row: usize,
+        value: f32,
+        missing: Option<MissingTag>,
+    ) -> Result<(), DtaError> {
+        match self {
+            Self::NumericAltRep { data, .. } => data.write_float(row, value, missing),
+            Self::NumericEager { .. } => {
+                self.write_eager_numeric(row, f64::from(value), missing, EagerNumericKind::Float)
+            }
+            Self::String { .. } => Err(DtaError::Output(
+                "numeric output column mismatch".to_owned(),
+            )),
+        }
+    }
+
+    #[inline(always)]
+    fn store_double(
+        &mut self,
+        row: usize,
+        value: f64,
+        missing: Option<MissingTag>,
+    ) -> Result<(), DtaError> {
+        self.write_eager_numeric(row, value, missing, EagerNumericKind::Double)
+    }
 }
 
 impl DtaColumnSink for RColumn {
@@ -1016,7 +1104,7 @@ impl DtaColumnSink for RColumn {
         value: i8,
         missing: Option<MissingTag>,
     ) -> Result<(), DtaError> {
-        self.numeric_mut()?.write_byte(row, value, missing)
+        self.store_byte(row, value, missing)
     }
 
     fn push_int(
@@ -1025,7 +1113,7 @@ impl DtaColumnSink for RColumn {
         value: i16,
         missing: Option<MissingTag>,
     ) -> Result<(), DtaError> {
-        self.numeric_mut()?.write_int(row, value, missing)
+        self.store_int(row, value, missing)
     }
 
     fn push_long(
@@ -1034,7 +1122,7 @@ impl DtaColumnSink for RColumn {
         value: i32,
         missing: Option<MissingTag>,
     ) -> Result<(), DtaError> {
-        self.numeric_mut()?.write_long(row, value, missing)
+        self.store_long(row, value, missing)
     }
 
     fn push_float(
@@ -1043,7 +1131,7 @@ impl DtaColumnSink for RColumn {
         value: f32,
         missing: Option<MissingTag>,
     ) -> Result<(), DtaError> {
-        self.numeric_mut()?.write_float(row, value, missing)
+        self.store_float(row, value, missing)
     }
 
     fn push_double(
@@ -1052,7 +1140,7 @@ impl DtaColumnSink for RColumn {
         value: f64,
         missing: Option<MissingTag>,
     ) -> Result<(), DtaError> {
-        self.write_eager_double(row, value, missing)
+        self.store_double(row, value, missing)
     }
 
     fn push_fixed_string(&mut self, row: usize, value: &str) -> Result<(), DtaError> {
@@ -1098,7 +1186,7 @@ impl DtaSink for RDataFrameSink {
         missing: Option<MissingTag>,
     ) -> Result<(), DtaError> {
         self.numeric_column_mut(column)?
-            .write_byte(row, value, missing)
+            .store_byte(row, value, missing)
     }
 
     #[inline(always)]
@@ -1110,7 +1198,7 @@ impl DtaSink for RDataFrameSink {
         missing: Option<MissingTag>,
     ) -> Result<(), DtaError> {
         self.numeric_column_mut(column)?
-            .write_int(row, value, missing)
+            .store_int(row, value, missing)
     }
 
     #[inline(always)]
@@ -1122,7 +1210,7 @@ impl DtaSink for RDataFrameSink {
         missing: Option<MissingTag>,
     ) -> Result<(), DtaError> {
         self.numeric_column_mut(column)?
-            .write_long(row, value, missing)
+            .store_long(row, value, missing)
     }
 
     #[inline(always)]
@@ -1134,7 +1222,7 @@ impl DtaSink for RDataFrameSink {
         missing: Option<MissingTag>,
     ) -> Result<(), DtaError> {
         self.numeric_column_mut(column)?
-            .write_float(row, value, missing)
+            .store_float(row, value, missing)
     }
 
     #[inline(always)]
@@ -1145,7 +1233,8 @@ impl DtaSink for RDataFrameSink {
         value: f64,
         missing: Option<MissingTag>,
     ) -> Result<(), DtaError> {
-        self.write_eager_double(column, row, value, missing)
+        self.numeric_column_mut(column)?
+            .store_double(row, value, missing)
     }
 
     #[inline(always)]
@@ -1365,14 +1454,19 @@ fn validate_r_row_count(nobs: u64, row_start: u64, row_count: Option<u64>) -> Re
     Ok(output_rows)
 }
 
+struct RReadConfig {
+    direct_to_r: bool,
+    numeric_altrep: bool,
+    encoding: TextEncoding,
+    requested_threads: usize,
+}
+
 unsafe fn read_impl(
     path: &str,
     columns: Option<Vec<u32>>,
     skip: f64,
     n_max: f64,
-    direct_to_r: bool,
-    encoding: TextEncoding,
-    requested_threads: usize,
+    config: RReadConfig,
 ) -> Result<Sexp, String> {
     // Public semantics are normalized once by the R wrapper. These checks are
     // only a defensive ABI guard for exact representability and +Inf as the
@@ -1393,16 +1487,16 @@ unsafe fn read_impl(
         Some(n_max as u64)
     };
     let mut file =
-        DtaFile::open_with_encoding(path, encoding).map_err(|error| error.to_string())?;
+        DtaFile::open_with_encoding(path, config.encoding).map_err(|error| error.to_string())?;
     validate_r_row_count(file.metadata().nobs, row_start, row_count)?;
     let options = ReadOptions {
         row_start,
         row_count,
         column_indices: columns,
     };
-    if direct_to_r {
+    if config.direct_to_r {
         let threads = file
-            .parallel_thread_count(&options, requested_threads)
+            .parallel_thread_count(&options, config.requested_threads)
             .map_err(|error| error.to_string())?;
         let columnar = file
             .supports_columnar_sink(&options)
@@ -1412,7 +1506,7 @@ unsafe fn read_impl(
                 &options,
                 threads,
                 |metadata, _row_start, row_count, indices| unsafe {
-                    RDataFrameSink::new(metadata, row_count, indices)
+                    RDataFrameSink::new(metadata, row_count, indices, config.numeric_altrep)
                 },
                 coarse_interrupt,
             )
@@ -1421,7 +1515,7 @@ unsafe fn read_impl(
             file.read_with_sink_and_interrupts(
                 &options,
                 |metadata, _row_start, row_count, indices| unsafe {
-                    RDataFrameSink::new(metadata, row_count, indices)
+                    RDataFrameSink::new(metadata, row_count, indices, config.numeric_altrep)
                 },
                 coarse_interrupt,
                 frequent_interrupt_poller(),
@@ -1539,6 +1633,7 @@ pub unsafe extern "C" fn dtaparser_read_rust(
     n_max: f64,
     direct_to_r: c_int,
     requested_threads: c_int,
+    numeric_altrep: c_int,
     encoding: *const c_char,
     error: *mut *mut c_char,
 ) -> Sexp {
@@ -1576,9 +1671,12 @@ pub unsafe extern "C" fn dtaparser_read_rust(
             projection,
             skip,
             n_max,
-            direct_to_r != 0,
-            text_encoding(encoding)?,
-            requested_threads,
+            RReadConfig {
+                direct_to_r: direct_to_r != 0,
+                numeric_altrep: numeric_altrep != 0,
+                encoding: text_encoding(encoding)?,
+                requested_threads,
+            },
         )
     })
 }

--- a/r-package/dtaparser/src/rust/src/lib.rs
+++ b/r-package/dtaparser/src/rust/src/lib.rs
@@ -6,7 +6,8 @@ use std::ptr;
 use ahash::AHashMap;
 use dta_parser::{
     ColumnValues, DtaColumnSink, DtaData, DtaError, DtaFile, DtaMetadata, DtaSink, DtaType,
-    MissingTag, ParallelDtaSink, ReadOptions, TextEncoding, ValueLabelTable, VariableInfo,
+    FormatVersion, MissingTag, ParallelDtaSink, ReadOptions, TextEncoding, ValueLabelTable,
+    VariableInfo,
 };
 
 type Sexp = *mut c_void;
@@ -16,6 +17,7 @@ const INTSXP: c_int = 13;
 const REALSXP: c_int = 14;
 const STRSXP: c_int = 16;
 const VECSXP: c_int = 19;
+const RAWSXP: c_int = 24;
 const CE_UTF8: c_int = 1;
 const INTERRUPT_STRIDE: usize = 16_384;
 const R_DATA_FRAME_MAX_ROWS: u64 = c_int::MAX as u64;
@@ -27,6 +29,7 @@ extern "C" {
     fn SET_VECTOR_ELT(vector: Sexp, index: RLen, value: Sexp) -> Sexp;
     fn INTEGER(vector: Sexp) -> *mut c_int;
     fn REAL(vector: Sexp) -> *mut f64;
+    fn RAW(vector: Sexp) -> *mut u8;
 
     static mut R_NamesSymbol: Sexp;
     static mut R_ClassSymbol: Sexp;
@@ -49,8 +52,71 @@ extern "C" {
         transferred: *mut c_int,
         result: *mut Sexp,
     ) -> c_int;
+    fn dtaparser_make_numeric(
+        data: *mut c_void,
+        backing: Sexp,
+        transferred: *mut c_int,
+        result: *mut Sexp,
+    ) -> c_int;
     fn dtaparser_install(name: *const c_char, result: *mut Sexp) -> c_int;
     fn dtaparser_set_attrib(object: Sexp, name: Sexp, value: Sexp) -> c_int;
+}
+
+#[repr(C)]
+struct NumericData {
+    values: *mut c_void,
+    length: usize,
+    kind: c_int,
+    temporal: c_int,
+    format_version: c_int,
+    no_na: c_int,
+}
+
+impl NumericData {
+    fn new(data: RNumericData) -> Self {
+        Self {
+            values: data.values.cast::<c_void>(),
+            length: data.length,
+            kind: data.kind as c_int,
+            temporal: data.temporal as c_int,
+            format_version: c_int::from(data.format_version.as_u16()),
+            no_na: c_int::from(data.no_na),
+        }
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+#[repr(i32)]
+enum NumericKind {
+    Byte = 0,
+    Int = 1,
+    Long = 2,
+    Float = 3,
+    Double = 4,
+}
+
+struct RNumericData {
+    backing: Sexp,
+    values: *mut u8,
+    length: usize,
+    kind: NumericKind,
+    temporal: TemporalKind,
+    format_version: FormatVersion,
+    no_na: bool,
+}
+
+#[no_mangle]
+/// Release numeric storage previously transferred to an R ALTREP vector.
+///
+/// # Safety
+///
+/// `data` must be null or a live pointer created by `ProtectGuard::numeric`,
+/// and it must not have been freed previously.
+pub unsafe extern "C" fn dtaparser_numeric_free(data: *mut c_void) {
+    if data.is_null() {
+        return;
+    }
+    drop(Box::from_raw(data.cast::<NumericData>()));
 }
 
 #[repr(C)]
@@ -167,17 +233,31 @@ impl ProtectGuard {
         .cast::<c_void>();
         let mut transferred = 0;
         let mut result = ptr::null_mut();
-        let ok = dtaparser_make_dictstring(
-            storage,
-            value_count,
-            &mut transferred,
-            &mut result,
-        );
+        let ok = dtaparser_make_dictstring(storage, value_count, &mut transferred, &mut result);
         if ok == 0 || result.is_null() {
             if transferred == 0 {
                 dtaparser_dictstring_free(storage);
             }
             return Err("R could not allocate a dictionary string vector".to_owned());
+        }
+        self.objects.push(result);
+        Ok(result)
+    }
+
+    unsafe fn numeric(&mut self, data: RNumericData) -> Result<Sexp, String> {
+        self.objects
+            .try_reserve(1)
+            .map_err(|_| "R could not track a preserved native vector".to_owned())?;
+        let backing = data.backing;
+        let storage = Box::into_raw(Box::new(NumericData::new(data))).cast::<c_void>();
+        let mut transferred = 0;
+        let mut result = ptr::null_mut();
+        let ok = dtaparser_make_numeric(storage, backing, &mut transferred, &mut result);
+        if ok == 0 || result.is_null() {
+            if transferred == 0 {
+                dtaparser_numeric_free(storage);
+            }
+            return Err("R could not allocate a numeric ALTREP vector".to_owned());
         }
         self.objects.push(result);
         Ok(result)
@@ -221,10 +301,11 @@ fn frequent_interrupt_poller() -> impl FnMut() -> bool {
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]
+#[repr(i32)]
 enum TemporalKind {
-    None,
-    Date,
-    Datetime,
+    None = 0,
+    Date = 1,
+    Datetime = 2,
 }
 
 fn temporal_kind(format: &str) -> TemporalKind {
@@ -606,22 +687,50 @@ impl RStringData {
 }
 
 enum RColumn {
-    Numeric {
-        vector: Sexp,
-        output: *mut f64,
-        temporal: TemporalKind,
-        system_missing: f64,
-    },
-    String {
-        vector: Sexp,
-        data: RStringData,
-    },
+    Numeric { vector: Sexp, data: RNumericData },
+    String { vector: Sexp, data: RStringData },
 }
 
-// Parallel workers receive disjoint columns. Numeric workers only write to
-// non-overlapping memory obtained before the threads start; string workers
-// mutate Rust-owned dictionaries. They never invoke the R API.
+// Parallel workers receive disjoint columns. Numeric workers write to compact
+// R-owned raw vectors allocated before threads start, while string workers
+// mutate Rust-owned dictionaries. Workers never invoke the R API.
 unsafe impl Send for RColumn {}
+
+unsafe fn numeric_storage(
+    dta_type: DtaType,
+    length: usize,
+    temporal: TemporalKind,
+    format_version: FormatVersion,
+    guard: &mut ProtectGuard,
+) -> Result<RNumericData, DtaError> {
+    let (kind, width) = match dta_type {
+        DtaType::Byte => (NumericKind::Byte, std::mem::size_of::<i8>()),
+        DtaType::Int => (NumericKind::Int, std::mem::size_of::<i16>()),
+        DtaType::Long => (NumericKind::Long, std::mem::size_of::<i32>()),
+        DtaType::Float => (NumericKind::Float, std::mem::size_of::<f32>()),
+        DtaType::Double => (NumericKind::Double, std::mem::size_of::<f64>()),
+        DtaType::FixedString(_) | DtaType::StrL => {
+            return Err(DtaError::Output(
+                "string type used for numeric output".to_owned(),
+            ));
+        }
+    };
+    let byte_length = length
+        .checked_mul(width)
+        .ok_or(DtaError::ArithmeticOverflow("numeric output bytes"))?;
+    let byte_length = RLen::try_from(byte_length)
+        .map_err(|_| DtaError::Output("R vector is too long".to_owned()))?;
+    let backing = guard.alloc(RAWSXP, byte_length).map_err(DtaError::Output)?;
+    Ok(RNumericData {
+        backing,
+        values: RAW(backing),
+        length,
+        kind,
+        temporal,
+        format_version,
+        no_na: true,
+    })
+}
 
 struct RDataFrameSink {
     result: Sexp,
@@ -637,6 +746,8 @@ impl RDataFrameSink {
         source_indices: &[u32],
     ) -> Result<Self, DtaError> {
         let length = RLen::try_from(row_count)
+            .map_err(|_| DtaError::Output("R vector is too long".to_owned()))?;
+        let native_length = usize::try_from(length)
             .map_err(|_| DtaError::Output("R vector is too long".to_owned()))?;
         let column_count = RLen::try_from(source_indices.len())
             .map_err(|_| DtaError::Output("too many columns".to_owned()))?;
@@ -665,15 +776,16 @@ impl RDataFrameSink {
                             .map_err(|_| DtaError::Output("R vector is too long".to_owned()))?,
                     )?,
                 },
-                _ => {
-                    let vector = guard.alloc(REALSXP, length).map_err(DtaError::Output)?;
-                    RColumn::Numeric {
-                        vector,
-                        output: REAL(vector),
-                        temporal: temporal_kind(&variable.format),
-                        system_missing: R_NaReal,
-                    }
-                }
+                _ => RColumn::Numeric {
+                    vector: ptr::null_mut(),
+                    data: numeric_storage(
+                        variable.dta_type.clone(),
+                        native_length,
+                        temporal_kind(&variable.format),
+                        metadata.format_version,
+                        &mut guard,
+                    )?,
+                },
             };
             let vector = match &column {
                 RColumn::Numeric { vector, .. } | RColumn::String { vector, .. } => *vector,
@@ -699,38 +811,13 @@ impl RDataFrameSink {
     }
 
     #[inline(always)]
-    fn numeric_column(
-        &self,
-        column: usize,
-    ) -> Result<(*mut f64, TemporalKind, f64), DtaError> {
-        match self.columns.get(column) {
-            Some(RColumn::Numeric {
-                output,
-                temporal,
-                system_missing,
-                ..
-            }) => Ok((*output, *temporal, *system_missing)),
+    fn numeric_column_mut(&mut self, column: usize) -> Result<&mut RNumericData, DtaError> {
+        match self.columns.get_mut(column) {
+            Some(RColumn::Numeric { data, .. }) => Ok(data),
             _ => Err(DtaError::Output(
                 "numeric output column mismatch".to_owned(),
             )),
         }
-    }
-
-    #[inline(always)]
-    fn write_numeric(
-        &mut self,
-        column: usize,
-        row: usize,
-        value: f64,
-        missing: Option<MissingTag>,
-    ) -> Result<(), DtaError> {
-        let (output, temporal, system_missing) = self.numeric_column(column)?;
-        unsafe {
-            *output.add(row) = missing
-                .map(|tag| r_missing_with_system(tag, system_missing))
-                .unwrap_or_else(|| observed_value(value, temporal));
-        }
-        Ok(())
     }
 
     #[inline(always)]
@@ -747,31 +834,121 @@ impl RDataFrameSink {
     }
 }
 
-impl RColumn {
+impl RNumericData {
+    fn take(&mut self) -> Self {
+        let replacement = Self {
+            backing: ptr::null_mut(),
+            values: ptr::null_mut(),
+            length: 0,
+            kind: self.kind,
+            temporal: self.temporal,
+            format_version: self.format_version,
+            no_na: true,
+        };
+        std::mem::replace(self, replacement)
+    }
+
     #[inline(always)]
-    fn write_numeric_value(
+    fn write_value<T: Copy>(
+        &mut self,
+        row: usize,
+        value: T,
+        kind: NumericKind,
+        no_na: bool,
+    ) -> Result<(), DtaError> {
+        if self.kind != kind {
+            return Err(DtaError::Output(
+                "value used for another numeric storage type".to_owned(),
+            ));
+        }
+        if row >= self.length {
+            return Err(Self::row_error(row, self.length));
+        }
+        self.no_na &= no_na;
+        unsafe {
+            self.values
+                .add(row * std::mem::size_of::<T>())
+                .cast::<T>()
+                .write_unaligned(value);
+        }
+        Ok(())
+    }
+
+    fn row_error(row: usize, length: usize) -> DtaError {
+        DtaError::Output(format!(
+            "numeric output row {row} is out of bounds for length {length}"
+        ))
+    }
+
+    #[inline(always)]
+    fn write_byte(
+        &mut self,
+        row: usize,
+        value: i8,
+        missing: Option<MissingTag>,
+    ) -> Result<(), DtaError> {
+        self.write_value(row, value, NumericKind::Byte, missing.is_none())
+    }
+
+    #[inline(always)]
+    fn write_int(
+        &mut self,
+        row: usize,
+        value: i16,
+        missing: Option<MissingTag>,
+    ) -> Result<(), DtaError> {
+        self.write_value(row, value, NumericKind::Int, missing.is_none())
+    }
+
+    #[inline(always)]
+    fn write_long(
+        &mut self,
+        row: usize,
+        value: i32,
+        missing: Option<MissingTag>,
+    ) -> Result<(), DtaError> {
+        self.write_value(row, value, NumericKind::Long, missing.is_none())
+    }
+
+    #[inline(always)]
+    fn write_float(
+        &mut self,
+        row: usize,
+        value: f32,
+        missing: Option<MissingTag>,
+    ) -> Result<(), DtaError> {
+        self.write_value(
+            row,
+            value,
+            NumericKind::Float,
+            missing.is_none() && !value.is_nan(),
+        )
+    }
+
+    #[inline(always)]
+    fn write_double(
         &mut self,
         row: usize,
         value: f64,
         missing: Option<MissingTag>,
     ) -> Result<(), DtaError> {
-        let Self::Numeric {
-            output,
-            temporal,
-            system_missing,
-            ..
-        } = self
-        else {
+        self.write_value(
+            row,
+            value,
+            NumericKind::Double,
+            missing.is_none() && !value.is_nan(),
+        )
+    }
+}
+
+impl RColumn {
+    fn numeric_mut(&mut self) -> Result<&mut RNumericData, DtaError> {
+        let Self::Numeric { data, .. } = self else {
             return Err(DtaError::Output(
                 "numeric output column mismatch".to_owned(),
             ));
         };
-        unsafe {
-            *output.add(row) = missing
-                .map(|tag| r_missing_with_system(tag, *system_missing))
-                .unwrap_or_else(|| observed_value(value, *temporal));
-        }
-        Ok(())
+        Ok(data)
     }
 }
 
@@ -782,7 +959,7 @@ impl DtaColumnSink for RColumn {
         value: i8,
         missing: Option<MissingTag>,
     ) -> Result<(), DtaError> {
-        self.write_numeric_value(row, f64::from(value), missing)
+        self.numeric_mut()?.write_byte(row, value, missing)
     }
 
     fn push_int(
@@ -791,7 +968,7 @@ impl DtaColumnSink for RColumn {
         value: i16,
         missing: Option<MissingTag>,
     ) -> Result<(), DtaError> {
-        self.write_numeric_value(row, f64::from(value), missing)
+        self.numeric_mut()?.write_int(row, value, missing)
     }
 
     fn push_long(
@@ -800,7 +977,7 @@ impl DtaColumnSink for RColumn {
         value: i32,
         missing: Option<MissingTag>,
     ) -> Result<(), DtaError> {
-        self.write_numeric_value(row, f64::from(value), missing)
+        self.numeric_mut()?.write_long(row, value, missing)
     }
 
     fn push_float(
@@ -809,7 +986,7 @@ impl DtaColumnSink for RColumn {
         value: f32,
         missing: Option<MissingTag>,
     ) -> Result<(), DtaError> {
-        self.write_numeric_value(row, f64::from(value), missing)
+        self.numeric_mut()?.write_float(row, value, missing)
     }
 
     fn push_double(
@@ -818,7 +995,7 @@ impl DtaColumnSink for RColumn {
         value: f64,
         missing: Option<MissingTag>,
     ) -> Result<(), DtaError> {
-        self.write_numeric_value(row, value, missing)
+        self.numeric_mut()?.write_double(row, value, missing)
     }
 
     fn push_fixed_string(&mut self, row: usize, value: &str) -> Result<(), DtaError> {
@@ -863,7 +1040,8 @@ impl DtaSink for RDataFrameSink {
         value: i8,
         missing: Option<MissingTag>,
     ) -> Result<(), DtaError> {
-        self.write_numeric(column, row, f64::from(value), missing)
+        self.numeric_column_mut(column)?
+            .write_byte(row, value, missing)
     }
 
     #[inline(always)]
@@ -874,7 +1052,8 @@ impl DtaSink for RDataFrameSink {
         value: i16,
         missing: Option<MissingTag>,
     ) -> Result<(), DtaError> {
-        self.write_numeric(column, row, f64::from(value), missing)
+        self.numeric_column_mut(column)?
+            .write_int(row, value, missing)
     }
 
     #[inline(always)]
@@ -885,7 +1064,8 @@ impl DtaSink for RDataFrameSink {
         value: i32,
         missing: Option<MissingTag>,
     ) -> Result<(), DtaError> {
-        self.write_numeric(column, row, f64::from(value), missing)
+        self.numeric_column_mut(column)?
+            .write_long(row, value, missing)
     }
 
     #[inline(always)]
@@ -896,7 +1076,8 @@ impl DtaSink for RDataFrameSink {
         value: f32,
         missing: Option<MissingTag>,
     ) -> Result<(), DtaError> {
-        self.write_numeric(column, row, f64::from(value), missing)
+        self.numeric_column_mut(column)?
+            .write_float(row, value, missing)
     }
 
     #[inline(always)]
@@ -907,7 +1088,8 @@ impl DtaSink for RDataFrameSink {
         value: f64,
         missing: Option<MissingTag>,
     ) -> Result<(), DtaError> {
-        self.write_numeric(column, row, value, missing)
+        self.numeric_column_mut(column)?
+            .write_double(row, value, missing)
     }
 
     #[inline(always)]
@@ -955,18 +1137,24 @@ impl DtaSink for RDataFrameSink {
             .map_err(|_| DtaError::Output("R vector is too long".to_owned()))?;
         unsafe {
             for (output_index, column) in self.columns.iter_mut().enumerate() {
-                let RColumn::String { vector, data } = column else {
-                    continue;
-                };
-                if data.value_ids.len() != expected_string_rows {
-                    return Err(DtaError::Output(format!(
-                        "string output row count mismatch: expected {expected_string_rows}, got {}",
-                        data.value_ids.len()
-                    )));
+                match column {
+                    RColumn::Numeric { vector, data } => {
+                        let data = data.take();
+                        *vector = self._guard.numeric(data).map_err(DtaError::Output)?;
+                        SET_VECTOR_ELT(self.result, output_index as RLen, *vector);
+                    }
+                    RColumn::String { vector, data } => {
+                        if data.value_ids.len() != expected_string_rows {
+                            return Err(DtaError::Output(format!(
+                                "string output row count mismatch: expected {expected_string_rows}, got {}",
+                                data.value_ids.len()
+                            )));
+                        }
+                        let data = std::mem::replace(data, RStringData::new(0)?);
+                        *vector = self._guard.dictstring(data).map_err(DtaError::Output)?;
+                        SET_VECTOR_ELT(self.result, output_index as RLen, *vector);
+                    }
                 }
-                let data = std::mem::replace(data, RStringData::new(0)?);
-                *vector = self._guard.dictstring(data).map_err(DtaError::Output)?;
-                SET_VECTOR_ELT(self.result, output_index as RLen, *vector);
             }
 
             for (output_index, &source_index) in self.source_indices.iter().enumerate() {
@@ -1183,11 +1371,7 @@ unsafe fn read_impl(
         }
     } else {
         let data = file
-            .read_with_interrupts(
-                &options,
-                coarse_interrupt,
-                frequent_interrupt_poller(),
-            )
+            .read_with_interrupts(&options, coarse_interrupt, frequent_interrupt_poller())
             .map_err(|error| error.to_string())?;
         build_data_frame(&data)
     }

--- a/r-package/dtaparser/src/rust/src/lib.rs
+++ b/r-package/dtaparser/src/rust/src/lib.rs
@@ -92,7 +92,6 @@ enum NumericKind {
     Int = 1,
     Long = 2,
     Float = 3,
-    Double = 4,
 }
 
 struct RNumericData {
@@ -687,16 +686,29 @@ impl RStringData {
 }
 
 enum RColumn {
-    Numeric { vector: Sexp, data: RNumericData },
-    String { vector: Sexp, data: RStringData },
+    NumericAltRep {
+        vector: Sexp,
+        data: RNumericData,
+    },
+    NumericEager {
+        vector: Sexp,
+        output: *mut f64,
+        length: usize,
+        temporal: TemporalKind,
+        system_missing: f64,
+    },
+    String {
+        vector: Sexp,
+        data: RStringData,
+    },
 }
 
 // Parallel workers receive disjoint columns. Numeric workers write to compact
-// R-owned raw vectors allocated before threads start, while string workers
-// mutate Rust-owned dictionaries. Workers never invoke the R API.
+// raw or eager double vectors allocated before threads start, while string
+// workers mutate Rust-owned dictionaries. Workers never invoke the R API.
 unsafe impl Send for RColumn {}
 
-unsafe fn numeric_storage(
+unsafe fn numeric_altrep_storage(
     dta_type: DtaType,
     length: usize,
     temporal: TemporalKind,
@@ -708,7 +720,11 @@ unsafe fn numeric_storage(
         DtaType::Int => (NumericKind::Int, std::mem::size_of::<i16>()),
         DtaType::Long => (NumericKind::Long, std::mem::size_of::<i32>()),
         DtaType::Float => (NumericKind::Float, std::mem::size_of::<f32>()),
-        DtaType::Double => (NumericKind::Double, std::mem::size_of::<f64>()),
+        DtaType::Double => {
+            return Err(DtaError::Output(
+                "double storage used for a narrow numeric ALTREP".to_owned(),
+            ));
+        }
         DtaType::FixedString(_) | DtaType::StrL => {
             return Err(DtaError::Output(
                 "string type used for numeric output".to_owned(),
@@ -776,9 +792,19 @@ impl RDataFrameSink {
                             .map_err(|_| DtaError::Output("R vector is too long".to_owned()))?,
                     )?,
                 },
-                _ => RColumn::Numeric {
+                DtaType::Double => {
+                    let vector = guard.alloc(REALSXP, length).map_err(DtaError::Output)?;
+                    RColumn::NumericEager {
+                        vector,
+                        output: REAL(vector),
+                        length: native_length,
+                        temporal: temporal_kind(&variable.format),
+                        system_missing: R_NaReal,
+                    }
+                }
+                _ => RColumn::NumericAltRep {
                     vector: ptr::null_mut(),
-                    data: numeric_storage(
+                    data: numeric_altrep_storage(
                         variable.dta_type.clone(),
                         native_length,
                         temporal_kind(&variable.format),
@@ -788,7 +814,9 @@ impl RDataFrameSink {
                 },
             };
             let vector = match &column {
-                RColumn::Numeric { vector, .. } | RColumn::String { vector, .. } => *vector,
+                RColumn::NumericAltRep { vector, .. }
+                | RColumn::NumericEager { vector, .. }
+                | RColumn::String { vector, .. } => *vector,
             };
             if !vector.is_null() {
                 SET_VECTOR_ELT(result, output_index as RLen, vector);
@@ -813,10 +841,26 @@ impl RDataFrameSink {
     #[inline(always)]
     fn numeric_column_mut(&mut self, column: usize) -> Result<&mut RNumericData, DtaError> {
         match self.columns.get_mut(column) {
-            Some(RColumn::Numeric { data, .. }) => Ok(data),
+            Some(RColumn::NumericAltRep { data, .. }) => Ok(data),
             _ => Err(DtaError::Output(
                 "numeric output column mismatch".to_owned(),
             )),
+        }
+    }
+
+    #[inline(always)]
+    fn write_eager_double(
+        &mut self,
+        column: usize,
+        row: usize,
+        value: f64,
+        missing: Option<MissingTag>,
+    ) -> Result<(), DtaError> {
+        match self.columns.get_mut(column) {
+            Some(column @ RColumn::NumericEager { .. }) => {
+                column.write_eager_double(row, value, missing)
+            }
+            _ => Err(DtaError::Output("double output column mismatch".to_owned())),
         }
     }
 
@@ -924,31 +968,44 @@ impl RNumericData {
             missing.is_none() && !value.is_nan(),
         )
     }
-
-    #[inline(always)]
-    fn write_double(
-        &mut self,
-        row: usize,
-        value: f64,
-        missing: Option<MissingTag>,
-    ) -> Result<(), DtaError> {
-        self.write_value(
-            row,
-            value,
-            NumericKind::Double,
-            missing.is_none() && !value.is_nan(),
-        )
-    }
 }
 
 impl RColumn {
     fn numeric_mut(&mut self) -> Result<&mut RNumericData, DtaError> {
-        let Self::Numeric { data, .. } = self else {
+        let Self::NumericAltRep { data, .. } = self else {
             return Err(DtaError::Output(
                 "numeric output column mismatch".to_owned(),
             ));
         };
         Ok(data)
+    }
+
+    #[inline(always)]
+    fn write_eager_double(
+        &mut self,
+        row: usize,
+        value: f64,
+        missing: Option<MissingTag>,
+    ) -> Result<(), DtaError> {
+        let Self::NumericEager {
+            output,
+            length,
+            temporal,
+            system_missing,
+            ..
+        } = self
+        else {
+            return Err(DtaError::Output("double output column mismatch".to_owned()));
+        };
+        if row >= *length {
+            return Err(RNumericData::row_error(row, *length));
+        }
+        unsafe {
+            *output.add(row) = missing
+                .map(|tag| r_missing_with_system(tag, *system_missing))
+                .unwrap_or_else(|| observed_value(value, *temporal));
+        }
+        Ok(())
     }
 }
 
@@ -995,7 +1052,7 @@ impl DtaColumnSink for RColumn {
         value: f64,
         missing: Option<MissingTag>,
     ) -> Result<(), DtaError> {
-        self.numeric_mut()?.write_double(row, value, missing)
+        self.write_eager_double(row, value, missing)
     }
 
     fn push_fixed_string(&mut self, row: usize, value: &str) -> Result<(), DtaError> {
@@ -1088,8 +1145,7 @@ impl DtaSink for RDataFrameSink {
         value: f64,
         missing: Option<MissingTag>,
     ) -> Result<(), DtaError> {
-        self.numeric_column_mut(column)?
-            .write_double(row, value, missing)
+        self.write_eager_double(column, row, value, missing)
     }
 
     #[inline(always)]
@@ -1138,11 +1194,12 @@ impl DtaSink for RDataFrameSink {
         unsafe {
             for (output_index, column) in self.columns.iter_mut().enumerate() {
                 match column {
-                    RColumn::Numeric { vector, data } => {
+                    RColumn::NumericAltRep { vector, data } => {
                         let data = data.take();
                         *vector = self._guard.numeric(data).map_err(DtaError::Output)?;
                         SET_VECTOR_ELT(self.result, output_index as RLen, *vector);
                     }
+                    RColumn::NumericEager { .. } => {}
                     RColumn::String { vector, data } => {
                         if data.value_ids.len() != expected_string_rows {
                             return Err(DtaError::Output(format!(
@@ -1171,7 +1228,9 @@ impl DtaSink for RDataFrameSink {
                         .find(|table| table.name == variable.value_label_name)
                 };
                 let vector = match &self.columns[output_index] {
-                    RColumn::Numeric { vector, .. } | RColumn::String { vector, .. } => *vector,
+                    RColumn::NumericAltRep { vector, .. }
+                    | RColumn::NumericEager { vector, .. }
+                    | RColumn::String { vector, .. } => *vector,
                 };
                 let mut attribute_guard = ProtectGuard::new();
                 attach_variable_attributes(vector, variable, table, &mut attribute_guard)

--- a/r-package/dtaparser/tests/testthat/test-read-dta.R
+++ b/r-package/dtaparser/tests/testthat/test-read-dta.R
@@ -120,6 +120,65 @@ test_that("numeric ALTREP can be disabled explicitly or by option", {
     )))
 })
 
+test_that("R and haven recognize every Stata numeric missing code", {
+    skip_if_not_installed("haven")
+    expected_tags <- c(NA_character_, letters)
+    expected_tagged <- c(FALSE, rep(TRUE, 26L))
+    expected_system <- c(TRUE, rep(FALSE, 26L))
+
+    for (name in c("missing_values_v115.dta", "missing_values_v118.dta")) {
+        path <- fixture_with_all_numeric_missing_codes(name)
+        on.exit(unlink(path), add = TRUE)
+        storage <- attr(dtaparser:::.dta_metadata(path), "dta_storage")
+        numeric_indices <- which(storage != "character")
+
+        for (use_numeric_altrep in c(TRUE, FALSE)) {
+            actual <- read_dta(
+                path,
+                n_max = 27,
+                use_numeric_altrep = use_numeric_altrep
+            )
+            mode <- if (use_numeric_altrep) "default" else "eager"
+            for (index in numeric_indices) {
+                values <- unclass(actual[[index]])
+                info <- paste(name, storage[[index]], mode)
+
+                expect_identical(
+                    dtaparser:::.is_numeric_altrep(values),
+                    use_numeric_altrep && storage[[index]] != "double",
+                    info = paste(info, "representation")
+                )
+                expect_true(all(is.na(values)), info = paste(info, "is.na"))
+                expect_identical(
+                    haven::na_tag(values),
+                    expected_tags,
+                    info = paste(info, "na_tag")
+                )
+                expect_identical(
+                    haven::is_tagged_na(values),
+                    expected_tagged,
+                    info = paste(info, "is_tagged_na")
+                )
+                expect_identical(
+                    is.na(values) & !is.nan(values) &
+                        !haven::is_tagged_na(values),
+                    expected_system,
+                    info = paste(info, "system missing")
+                )
+                for (tag in letters) {
+                    expected_match <- seq_along(expected_tags) ==
+                        match(tag, letters) + 1L
+                    expect_identical(
+                        haven::is_tagged_na(values, tag),
+                        expected_match,
+                        info = paste(info, "tag", tag)
+                    )
+                }
+            }
+        }
+    }
+})
+
 test_that("parallel decoding is identical across supported releases", {
     modern <- fixture("auto_v118.dta")
     serial <- read_dta(modern, threads = 1L)

--- a/r-package/dtaparser/tests/testthat/test-read-dta.R
+++ b/r-package/dtaparser/tests/testthat/test-read-dta.R
@@ -179,6 +179,414 @@ test_that("R and haven recognize every Stata numeric missing code", {
     }
 })
 
+test_that("base R recoding preserves tags with complete predicates", {
+    skip_if_not_installed("haven")
+    expected_tags <- c(NA_character_, letters)
+
+    for (name in c("missing_values_v115.dta", "missing_values_v118.dta")) {
+        path <- fixture_with_all_numeric_missing_codes(name)
+        on.exit(unlink(path), add = TRUE)
+        storage <- attr(dtaparser:::.dta_metadata(path), "dta_storage")
+
+        for (use_numeric_altrep in c(TRUE, FALSE)) {
+            actual <- read_dta(
+                path,
+                n_max = 30,
+                use_numeric_altrep = use_numeric_altrep
+            )
+            mode <- if (use_numeric_altrep) "default" else "eager"
+
+            for (index in seq_along(actual)) {
+                original <- actual[[index]]
+                selected <- !is.na(original) & original == original[[28L]]
+                info <- paste(name, storage[[index]], mode)
+                expect_false(anyNA(selected), info = paste(info, "predicate"))
+
+                assigned <- original
+                assigned[selected] <- -1
+                expect_identical(
+                    haven::na_tag(assigned[seq_len(27L)]),
+                    expected_tags,
+                    info = paste(info, "subassignment tags")
+                )
+                expect_identical(
+                    attributes(assigned),
+                    attributes(original),
+                    info = paste(info, "subassignment attributes")
+                )
+
+                replaced <- replace(original, selected, -1)
+                expect_identical(
+                    haven::na_tag(replaced[seq_len(27L)]),
+                    expected_tags,
+                    info = paste(info, "replace tags")
+                )
+                expect_identical(
+                    attributes(replaced),
+                    attributes(original),
+                    info = paste(info, "replace attributes")
+                )
+
+                tag_assigned <- original
+                tag_assigned[haven::is_tagged_na(tag_assigned, "a")] <- -2
+                remaining_tags <- expected_tags
+                remaining_tags[[2L]] <- NA_character_
+                expect_identical(
+                    haven::na_tag(tag_assigned[seq_len(27L)]),
+                    remaining_tags,
+                    info = paste(info, "tag-specific assignment")
+                )
+
+                safe_ifelse <- ifelse(selected, -1, original)
+                expect_identical(
+                    haven::na_tag(safe_ifelse[seq_len(27L)]),
+                    expected_tags,
+                    info = paste(info, "complete ifelse predicate")
+                )
+                expect_null(
+                    attributes(safe_ifelse),
+                    info = paste(info, "ifelse attributes")
+                )
+
+                unsafe_ifelse <- ifelse(
+                    original == original[[28L]], -1, original
+                )
+                expect_identical(
+                    haven::na_tag(unsafe_ifelse[seq_len(27L)]),
+                    rep(NA_character_, 27L),
+                    info = paste(info, "incomplete ifelse predicate")
+                )
+            }
+        }
+    }
+})
+
+test_that("dplyr recoding preserves unselected Stata missing codes", {
+    skip_if_not_installed("dplyr")
+    skip_if_not_installed("haven")
+    expected_tags <- c(NA_character_, letters)
+    recoded_tags <- expected_tags
+    recoded_tags[c(2L, 7L)] <- NA_character_
+    recoded_missing <- rep(TRUE, 27L)
+    recoded_missing[c(2L, 7L)] <- FALSE
+
+    recode_tags <- function(data) {
+        dplyr::mutate(
+            data,
+            dplyr::across(
+                dplyr::everything(),
+                function(values) {
+                    dplyr::case_when(
+                        haven::is_tagged_na(values, "a") ~ -1,
+                        haven::is_tagged_na(values, "f") ~ -6,
+                        .default = values
+                    )
+                }
+            )
+        )
+    }
+    recode_observed <- function(data) {
+        dplyr::mutate(
+            data,
+            dplyr::across(
+                dplyr::everything(),
+                function(values) {
+                    dplyr::if_else(is.na(values), values, values + 1)
+                }
+            )
+        )
+    }
+
+    for (name in c("missing_values_v115.dta", "missing_values_v118.dta")) {
+        path <- fixture_with_all_numeric_missing_codes(name)
+        on.exit(unlink(path), add = TRUE)
+        storage <- attr(dtaparser:::.dta_metadata(path), "dta_storage")
+        reference_tags <- recode_tags(haven::read_dta(path, n_max = 27))
+        reference_observed <- recode_observed(
+            haven::read_dta(path, n_max = 30)
+        )
+
+        for (use_numeric_altrep in c(TRUE, FALSE)) {
+            tagged <- recode_tags(read_dta(
+                path,
+                n_max = 27,
+                use_numeric_altrep = use_numeric_altrep
+            ))
+            source <- read_dta(
+                path,
+                n_max = 30,
+                use_numeric_altrep = use_numeric_altrep
+            )
+            observed <- recode_observed(source)
+            mode <- if (use_numeric_altrep) "default" else "eager"
+
+            for (index in seq_along(tagged)) {
+                info <- paste(name, storage[[index]], mode)
+                expect_identical(
+                    tagged[[index]],
+                    reference_tags[[index]],
+                    info = paste(info, "selective recode matches haven")
+                )
+                expect_identical(
+                    haven::na_tag(tagged[[index]]),
+                    recoded_tags,
+                    info = paste(info, "unselected tags")
+                )
+                expect_identical(
+                    is.na(tagged[[index]]),
+                    recoded_missing,
+                    info = paste(info, "missing positions")
+                )
+                expect_identical(
+                    unname(tagged[[index]][c(2L, 7L)]),
+                    c(-1, -6),
+                    info = paste(info, "selected replacements")
+                )
+                expect_identical(
+                    observed[[index]],
+                    reference_observed[[index]],
+                    info = paste(info, "observed recode matches haven")
+                )
+                expect_identical(
+                    haven::na_tag(observed[[index]][seq_len(27L)]),
+                    expected_tags,
+                    info = paste(info, "observed recode tags")
+                )
+
+                condition <- source[[index]] == source[[index]][[28L]]
+                unsafe_if_else <- dplyr::if_else(
+                    condition, -1, source[[index]]
+                )
+                expect_identical(
+                    haven::na_tag(unsafe_if_else[seq_len(27L)]),
+                    rep(NA_character_, 27L),
+                    info = paste(info, "if_else missing condition")
+                )
+                safe_if_else <- dplyr::if_else(
+                    condition, -1, source[[index]], missing = source[[index]]
+                )
+                expect_identical(
+                    haven::na_tag(safe_if_else[seq_len(27L)]),
+                    expected_tags,
+                    info = paste(info, "if_else missing branch")
+                )
+
+                legacy_recode <- rlang::exec(
+                    dplyr::recode,
+                    source[[index]],
+                    !!!stats::setNames(
+                        list(-1), as.character(source[[index]][[28L]])
+                    )
+                )
+                expect_identical(
+                    haven::na_tag(legacy_recode[seq_len(27L)]),
+                    rep(NA_character_, 27L),
+                    info = paste(info, "legacy recode")
+                )
+            }
+        }
+    }
+})
+
+test_that("dplyr manipulation matches haven for every storage type", {
+    skip_if_not_installed("dplyr")
+    skip_if_not_installed("haven")
+
+    manipulate <- function(data) {
+        dplyr::mutate(
+            data,
+            dplyr::across(
+                dplyr::everything(),
+                function(values) {
+                    if (is.character(values)) {
+                        dplyr::if_else(
+                            is.na(values), values, paste0(values, "-recoded")
+                        )
+                    } else {
+                        dplyr::if_else(is.na(values), values, values + 1)
+                    }
+                }
+            )
+        )
+    }
+
+    for (name in c("all_types_v115.dta", "all_types_v118.dta")) {
+        path <- fixture(name)
+        expected <- manipulate(haven::read_dta(path))
+        storage <- attr(dtaparser:::.dta_metadata(path), "dta_storage")
+
+        for (use_numeric_altrep in c(TRUE, FALSE)) {
+            actual <- manipulate(read_dta(
+                path,
+                use_numeric_altrep = use_numeric_altrep
+            ))
+            mode <- if (use_numeric_altrep) "default" else "eager"
+            expect_identical(names(actual), names(expected))
+            for (index in seq_along(actual)) {
+                expect_identical(
+                    actual[[index]],
+                    expected[[index]],
+                    info = paste(name, storage[[index]], mode)
+                )
+            }
+        }
+    }
+})
+
+test_that("dplyr manipulation matches haven for labelled and temporal data", {
+    skip_if_not_installed("dplyr")
+    skip_if_not_installed("haven")
+    path <- tempfile(fileext = ".dta")
+    on.exit(unlink(path), add = TRUE)
+
+    tagged_date <- structure(
+        c(0, unclass(haven::tagged_na("a")), NA_real_),
+        class = "Date"
+    )
+    tagged_instant <- structure(
+        c(0, unclass(haven::tagged_na("b")), NA_real_),
+        class = c("POSIXct", "POSIXt"),
+        tzone = "UTC"
+    )
+    input <- tibble::tibble(
+        labelled = haven::labelled(
+            c(1, haven::tagged_na("c"), NA_real_),
+            labels = c(one = 1)
+        ),
+        date = tagged_date,
+        instant = tagged_instant,
+        text = c("alpha", "", "omega")
+    )
+    haven::write_dta(input, path, version = 15)
+
+    manipulate <- function(data) {
+        dplyr::mutate(
+            data,
+            labelled = dplyr::case_when(
+                labelled == 1 ~ 2,
+                .default = labelled
+            ),
+            date = dplyr::if_else(is.na(date), date, date + 1),
+            instant = dplyr::if_else(
+                is.na(instant), instant, instant + 1
+            ),
+            text = dplyr::if_else(text == "alpha", "recoded", text)
+        )
+    }
+    expected <- manipulate(haven::read_dta(path))
+    unmanipulated <- read_dta(path)
+
+    expect_error(
+        dplyr::recode(unmanipulated$labelled, `1` = 2),
+        "no applicable method"
+    )
+    expect_error(
+        dplyr::recode(unmanipulated$date, `0` = 1),
+        "no applicable method"
+    )
+    expect_error(
+        dplyr::recode(unmanipulated$instant, `0` = 1),
+        "no applicable method"
+    )
+
+    for (use_numeric_altrep in c(TRUE, FALSE)) {
+        actual <- manipulate(read_dta(
+            path,
+            use_numeric_altrep = use_numeric_altrep
+        ))
+        mode <- if (use_numeric_altrep) "default" else "eager"
+        expect_identical(actual, expected, info = mode)
+        expect_s3_class(actual$labelled, "haven_labelled")
+        expect_s3_class(actual$date, "Date")
+        expect_s3_class(actual$instant, "POSIXct")
+        expect_identical(
+            haven::na_tag(unclass(actual$labelled)),
+            c(NA_character_, "c", NA_character_),
+            info = paste(mode, "labelled tag")
+        )
+        expect_identical(
+            haven::na_tag(unclass(actual$date)),
+            c(NA_character_, "a", NA_character_),
+            info = paste(mode, "Date tag")
+        )
+        expect_identical(
+            haven::na_tag(unclass(actual$instant)),
+            c(NA_character_, "b", NA_character_),
+            info = paste(mode, "POSIXct tag")
+        )
+    }
+
+    source <- fixture("auto_v118.dta")
+    bytes <- readBin(source, "raw", n = file.info(source)[["size"]])
+    data_tag <- charToRaw("<data>")
+    data_start <- grepRaw(data_tag, bytes, fixed = TRUE)[[1L]] +
+        length(data_tag)
+    closing_start <- grepRaw(
+        charToRaw("</data>"), bytes, fixed = TRUE
+    )[[1L]]
+    row_width <- as.integer((closing_start - data_start) / 74L)
+    expect_identical(row_width, 43L)
+
+    # `foreign` is the final one-byte field; make its first value `.a` while
+    # retaining its value-label table and haven_labelled class.
+    bytes[[data_start + row_width - 1L]] <- as.raw(102L)
+
+    # `price` follows the 18-byte `make` field and is a two-byte int. Change
+    # its first value to `.a` and its display format to `%td`, making it an
+    # integer-backed Date. The second format match is `price`; the first occurs
+    # outside its fixed-width format entry in this fixture.
+    bytes[data_start + 18L + 0:1] <- writeBin(
+        as.integer(32742L), raw(), size = 2L, endian = "little"
+    )
+    old_format <- charToRaw("%8.0gc")
+    format_matches <- grepRaw(old_format, bytes, fixed = TRUE, all = TRUE)
+    expect_gte(length(format_matches), 2L)
+    price_format <- format_matches[[2L]]
+    bytes[price_format + seq_along(old_format) - 1L] <- c(
+        charToRaw("%td"), raw(length(old_format) - 3L)
+    )
+
+    narrow_path <- tempfile(fileext = ".dta")
+    on.exit(unlink(narrow_path), add = TRUE)
+    writeBin(bytes, narrow_path)
+    narrow <- read_dta(narrow_path)
+    narrow_reference <- haven::read_dta(narrow_path)
+    expect_true(dtaparser:::.is_numeric_altrep(narrow$foreign))
+    expect_true(dtaparser:::.is_numeric_altrep(narrow$price))
+    expect_s3_class(narrow$foreign, "haven_labelled")
+    expect_s3_class(narrow$price, "Date")
+    expect_identical(haven::na_tag(unclass(narrow$foreign))[[1L]], "a")
+    expect_identical(haven::na_tag(unclass(narrow$price))[[1L]], "a")
+
+    manipulate_narrow <- function(data) {
+        dplyr::mutate(
+            data,
+            foreign = dplyr::case_when(
+                foreign == 0 ~ 2,
+                .default = foreign
+            ),
+            price = dplyr::if_else(is.na(price), price, price + 1)
+        )
+    }
+    narrow_input <- read_dta(narrow_path)
+    expect_true(dtaparser:::.is_numeric_altrep(narrow_input$foreign))
+    expect_true(dtaparser:::.is_numeric_altrep(narrow_input$price))
+    narrow_transformed <- manipulate_narrow(narrow_input)
+    narrow_expected <- manipulate_narrow(narrow_reference)
+    expect_identical(
+        narrow_transformed,
+        narrow_expected
+    )
+    expect_identical(
+        haven::na_tag(unclass(narrow_transformed$foreign))[[1L]],
+        "a"
+    )
+    expect_identical(
+        haven::na_tag(unclass(narrow_transformed$price))[[1L]],
+        "a"
+    )
+})
+
 test_that("parallel decoding is identical across supported releases", {
     modern <- fixture("auto_v118.dta")
     serial <- read_dta(modern, threads = 1L)

--- a/r-package/dtaparser/tests/testthat/test-read-dta.R
+++ b/r-package/dtaparser/tests/testthat/test-read-dta.R
@@ -528,6 +528,42 @@ test_that("native numerics use width-aware storage with R value semantics", {
                     )
                 )
             }
+            for (code in seq_along(expected_tags)) {
+                tagged <- read_dta(path, skip = code - 1L, n_max = 1L)
+                tagged_eager <- read_dta(
+                    path,
+                    skip = code - 1L,
+                    n_max = 1L,
+                    use_numeric_altrep = FALSE
+                )
+                for (index in numeric_indices) {
+                    for (summary_name in c("min", "max")) {
+                        summary_function <- match.fun(summary_name)
+                        actual_tag <- haven::na_tag(summary_function(
+                            unclass(tagged[[index]])
+                        ))
+                        eager_tag <- haven::na_tag(summary_function(
+                            unclass(tagged_eager[[index]])
+                        ))
+                        expect_identical(
+                            actual_tag,
+                            expected_tags[[code]],
+                            info = paste(
+                                name, storage[[index]], summary_name,
+                                "single missing code", code - 1L
+                            )
+                        )
+                        expect_identical(
+                            actual_tag,
+                            eager_tag,
+                            info = paste(
+                                name, storage[[index]], summary_name,
+                                "eager missing code", code - 1L
+                            )
+                        )
+                    }
+                }
+            }
         }
         altrep_indices <- which(storage %in% c("byte", "int", "long", "float"))
         eager_indices <- which(storage == "double")

--- a/r-package/dtaparser/tests/testthat/test-read-dta.R
+++ b/r-package/dtaparser/tests/testthat/test-read-dta.R
@@ -428,6 +428,14 @@ test_that("native numerics use width-aware storage with R value semantics", {
     expect_true(dtaparser:::.is_numeric_altrep(empty))
     expect_length(empty, 0L)
     expect_false(anyNA(empty))
+    expect_warning(
+        expect_identical(min(empty), Inf),
+        "no non-missing arguments to min"
+    )
+    expect_warning(
+        expect_identical(max(empty), -Inf),
+        "no non-missing arguments to max"
+    )
 
     fixture_names <- c(
         "all_types_v115.dta", "all_types_v118.dta",
@@ -480,6 +488,25 @@ test_that("native numerics use width-aware storage with R value semantics", {
             dtaparser:::.is_numeric_altrep,
             logical(1)
         )), info = name)
+        if (startsWith(name, "missing_values_")) {
+            missing_only <- read_dta(path, n_max = 27)
+            for (index in altrep_indices) {
+                expect_warning(
+                    expect_identical(
+                        min(unclass(missing_only[[index]]), na.rm = TRUE),
+                        Inf
+                    ),
+                    "no non-missing arguments to min"
+                )
+                expect_warning(
+                    expect_identical(
+                        max(unclass(missing_only[[index]]), na.rm = TRUE),
+                        -Inf
+                    ),
+                    "no non-missing arguments to max"
+                )
+            }
+        }
         for (index in numeric_indices) {
             actual_column <- unclass(actual[[index]])
             reference_column <- unclass(reference[[index]])
@@ -493,6 +520,16 @@ test_that("native numerics use width-aware storage with R value semantics", {
                     sum(reference_column, na.rm = na_rm),
                     info = paste(name, storage[[index]], "sum", na_rm)
                 )
+                for (summary_name in c("min", "max")) {
+                    summary_function <- match.fun(summary_name)
+                    expect_identical(
+                        summary_function(actual_column, na.rm = na_rm),
+                        summary_function(reference_column, na.rm = na_rm),
+                        info = paste(
+                            name, storage[[index]], summary_name, na_rm
+                        )
+                    )
+                }
             }
             expect_identical(actual[[index]][], reference[[index]][],
                              info = paste(name, storage[[index]]))

--- a/r-package/dtaparser/tests/testthat/test-read-dta.R
+++ b/r-package/dtaparser/tests/testthat/test-read-dta.R
@@ -396,7 +396,7 @@ test_that("native strings serialize and preserve copy-on-modify semantics", {
     expect_identical(retained[[2L]], reference$make[[2L]])
 })
 
-test_that("native numerics use ALTREP with ordinary R value semantics", {
+test_that("native numerics use width-aware storage with R value semantics", {
     skip_if_not_installed("haven")
     path <- normalizePath(fixture("auto_v118.dta"))
     reference <- dtaparser:::.read_dta_rust_vectors(path)
@@ -463,20 +463,30 @@ test_that("native numerics use ALTREP with ordinary R value semantics", {
                     haven::na_tag(actual[[index]][seq_along(expected_tags)]),
                     expected_tags,
                     info = paste(
-                        name, storage[[index]], "ALTREP missing codes"
+                        name, storage[[index]], "native missing codes"
                     )
                 )
             }
         }
+        altrep_indices <- which(storage %in% c("byte", "int", "long", "float"))
+        eager_indices <- which(storage == "double")
         expect_true(all(vapply(
-            actual[numeric_indices],
+            actual[altrep_indices],
+            dtaparser:::.is_numeric_altrep,
+            logical(1)
+        )), info = name)
+        expect_false(any(vapply(
+            actual[eager_indices],
             dtaparser:::.is_numeric_altrep,
             logical(1)
         )), info = name)
         for (index in numeric_indices) {
             actual_column <- unclass(actual[[index]])
             reference_column <- unclass(reference[[index]])
-            expect_true(dtaparser:::.is_numeric_altrep(actual_column))
+            expect_identical(
+                dtaparser:::.is_numeric_altrep(actual_column),
+                storage[[index]] != "double"
+            )
             for (na_rm in c(FALSE, TRUE)) {
                 expect_identical(
                     sum(actual_column, na.rm = na_rm),

--- a/r-package/dtaparser/tests/testthat/test-read-dta.R
+++ b/r-package/dtaparser/tests/testthat/test-read-dta.R
@@ -2,6 +2,52 @@ fixture <- function(name) {
     system.file("extdata", name, package = "dtaparser", mustWork = TRUE)
 }
 
+fixture_with_all_numeric_missing_codes <- function(name) {
+    input <- fixture(name)
+    bytes <- readBin(input, "raw", n = file.info(input)[["size"]])
+    row_width <- 19L
+    row_count <- 30L
+    if (identical(name, "missing_values_v115.dta")) {
+        data_start <- length(bytes) - row_width * row_count + 1L
+    } else {
+        data_tag <- charToRaw("<data>")
+        matches <- grepRaw(data_tag, bytes, fixed = TRUE, all = TRUE)
+        stopifnot(length(matches) == 1L)
+        data_start <- matches[[1L]] + length(data_tag)
+        closing_tag <- charToRaw("</data>")
+        closing_start <- data_start + row_width * row_count
+        stopifnot(identical(
+            bytes[closing_start + seq_along(closing_tag) - 1L],
+            closing_tag
+        ))
+    }
+
+    raw_integer <- function(value, size) {
+        writeBin(as.integer(value), raw(), size = size, endian = "little")
+    }
+    assign_raw <- function(row, offset, value) {
+        start <- data_start + row * row_width + offset
+        bytes[start + seq_along(value) - 1L] <<- value
+    }
+    for (code in 0:26) {
+        assign_raw(
+            code, 0L,
+            c(raw(4L), raw_integer(0x7fe00000 + code * 0x100, 4L))
+        )
+        assign_raw(code, 8L, as.raw(101L + code))
+        assign_raw(code, 9L, raw_integer(32741L + code, 2L))
+        assign_raw(code, 11L, raw_integer(2147483621 + code, 4L))
+        assign_raw(
+            code, 15L,
+            raw_integer(0x7f000000 + code * 0x800, 4L)
+        )
+    }
+
+    output <- tempfile(fileext = ".dta")
+    writeBin(bytes, output)
+    output
+}
+
 replace_first_byte <- function(bytes, text, replacement) {
     needle <- charToRaw(text)
     starts <- seq_len(length(bytes) - length(needle) + 1L)
@@ -351,6 +397,7 @@ test_that("native strings serialize and preserve copy-on-modify semantics", {
 })
 
 test_that("native numerics use ALTREP with ordinary R value semantics", {
+    skip_if_not_installed("haven")
     path <- normalizePath(fixture("auto_v118.dta"))
     reference <- dtaparser:::.read_dta_rust_vectors(path)
     actual <- read_dta(path)
@@ -382,18 +429,61 @@ test_that("native numerics use ALTREP with ordinary R value semantics", {
     expect_length(empty, 0L)
     expect_false(anyNA(empty))
 
-    for (name in c("all_types_v115.dta", "all_types_v118.dta")) {
-        path <- normalizePath(fixture(name))
+    fixture_names <- c(
+        "all_types_v115.dta", "all_types_v118.dta",
+        "missing_values_v115.dta", "missing_values_v118.dta"
+    )
+    paths <- vapply(fixture_names, function(name) {
+        if (startsWith(name, "missing_values_")) {
+            fixture_with_all_numeric_missing_codes(name)
+        } else {
+            fixture(name)
+        }
+    }, character(1))
+    on.exit(
+        unlink(paths[startsWith(fixture_names, "missing_values_")]),
+        add = TRUE
+    )
+    for (case in seq_along(paths)) {
+        name <- fixture_names[[case]]
+        path <- normalizePath(paths[[case]])
         actual <- read_dta(path)
         reference <- dtaparser:::.read_dta_rust_vectors(path)
         storage <- attr(dtaparser:::.dta_metadata(path), "dta_storage")
         numeric_indices <- which(storage != "character")
+        if (startsWith(name, "missing_values_")) {
+            expected_tags <- c(NA_character_, letters)
+            for (index in numeric_indices) {
+                expect_identical(
+                    haven::na_tag(reference[[index]][seq_along(expected_tags)]),
+                    expected_tags,
+                    info = paste(name, storage[[index]], "missing codes")
+                )
+                expect_identical(
+                    haven::na_tag(actual[[index]][seq_along(expected_tags)]),
+                    expected_tags,
+                    info = paste(
+                        name, storage[[index]], "ALTREP missing codes"
+                    )
+                )
+            }
+        }
         expect_true(all(vapply(
             actual[numeric_indices],
             dtaparser:::.is_numeric_altrep,
             logical(1)
         )), info = name)
         for (index in numeric_indices) {
+            actual_column <- unclass(actual[[index]])
+            reference_column <- unclass(reference[[index]])
+            expect_true(dtaparser:::.is_numeric_altrep(actual_column))
+            for (na_rm in c(FALSE, TRUE)) {
+                expect_identical(
+                    sum(actual_column, na.rm = na_rm),
+                    sum(reference_column, na.rm = na_rm),
+                    info = paste(name, storage[[index]], "sum", na_rm)
+                )
+            }
             expect_identical(actual[[index]][], reference[[index]][],
                              info = paste(name, storage[[index]]))
             expect_identical(anyNA(actual[[index]]),

--- a/r-package/dtaparser/tests/testthat/test-read-dta.R
+++ b/r-package/dtaparser/tests/testthat/test-read-dta.R
@@ -318,9 +318,11 @@ test_that("native materialization survives forced garbage collection", {
     gctorture(TRUE)
     on.exit(gctorture(FALSE), add = TRUE)
 
-    result <- read_dta(path, col_select = make, n_max = 1)
-    expect_identical(dim(result), c(1L, 1L))
-    expect_identical(result[[1L]][[1L]], "AMC Concord")
+    result <- read_dta(path, col_select = c(make, price), n_max = 1)
+    expect_identical(dim(result), c(1L, 2L))
+    expect_identical(result$make[[1L]], "AMC Concord")
+    expect_true(dtaparser:::.is_numeric_altrep(result$price))
+    expect_identical(result$price[[1L]], 4099)
 })
 
 test_that("native strings serialize and preserve copy-on-modify semantics", {
@@ -346,6 +348,59 @@ test_that("native strings serialize and preserve copy-on-modify semantics", {
     retained <- read_dta(path)$make
     invisible(gc())
     expect_identical(retained[[2L]], reference$make[[2L]])
+})
+
+test_that("native numerics use ALTREP with ordinary R value semantics", {
+    path <- normalizePath(fixture("auto_v118.dta"))
+    reference <- dtaparser:::.read_dta_rust_vectors(path)
+    actual <- read_dta(path)
+
+    numeric_columns <- vapply(reference, is.numeric, logical(1))
+    expect_true(all(vapply(
+        actual[numeric_columns], dtaparser:::.is_numeric_altrep, logical(1)
+    )))
+    expect_false(dtaparser:::.is_numeric_altrep(actual$make))
+
+    encoded <- serialize(actual$price, NULL)
+    invisible(gc())
+    expect_identical(unserialize(encoded), reference$price)
+
+    original <- actual$price
+    modified <- original
+    modified[[1L]] <- NA_real_
+    expect_identical(original[[1L]], reference$price[[1L]])
+    expect_false(anyNA(original))
+    expect_true(anyNA(modified))
+    expect_identical(modified[[1L]], NA_real_)
+
+    retained <- read_dta(path)$price
+    invisible(gc())
+    expect_identical(retained[[2L]], reference$price[[2L]])
+
+    empty <- read_dta(path, col_select = price, n_max = 0)$price
+    expect_true(dtaparser:::.is_numeric_altrep(empty))
+    expect_length(empty, 0L)
+    expect_false(anyNA(empty))
+
+    for (name in c("all_types_v115.dta", "all_types_v118.dta")) {
+        path <- normalizePath(fixture(name))
+        actual <- read_dta(path)
+        reference <- dtaparser:::.read_dta_rust_vectors(path)
+        storage <- attr(dtaparser:::.dta_metadata(path), "dta_storage")
+        numeric_indices <- which(storage != "character")
+        expect_true(all(vapply(
+            actual[numeric_indices],
+            dtaparser:::.is_numeric_altrep,
+            logical(1)
+        )), info = name)
+        for (index in numeric_indices) {
+            expect_identical(actual[[index]][], reference[[index]][],
+                             info = paste(name, storage[[index]]))
+            expect_identical(anyNA(actual[[index]]),
+                             anyNA(reference[[index]]),
+                             info = paste(name, storage[[index]], "missing"))
+        }
+    }
 })
 
 test_that("repeated string patterns can diverge without changing values", {

--- a/r-package/dtaparser/tests/testthat/test-read-dta.R
+++ b/r-package/dtaparser/tests/testthat/test-read-dta.R
@@ -126,9 +126,11 @@ test_that("R and haven recognize every Stata numeric missing code", {
     expected_tagged <- c(FALSE, rep(TRUE, 26L))
     expected_system <- c(TRUE, rep(FALSE, 26L))
 
+    paths <- character()
+    on.exit(unlink(paths), add = TRUE)
     for (name in c("missing_values_v115.dta", "missing_values_v118.dta")) {
         path <- fixture_with_all_numeric_missing_codes(name)
-        on.exit(unlink(path), add = TRUE)
+        paths <- c(paths, path)
         storage <- attr(dtaparser:::.dta_metadata(path), "dta_storage")
         numeric_indices <- which(storage != "character")
 
@@ -183,9 +185,11 @@ test_that("base R recoding preserves tags with complete predicates", {
     skip_if_not_installed("haven")
     expected_tags <- c(NA_character_, letters)
 
+    paths <- character()
+    on.exit(unlink(paths), add = TRUE)
     for (name in c("missing_values_v115.dta", "missing_values_v118.dta")) {
         path <- fixture_with_all_numeric_missing_codes(name)
-        on.exit(unlink(path), add = TRUE)
+        paths <- c(paths, path)
         storage <- attr(dtaparser:::.dta_metadata(path), "dta_storage")
 
         for (use_numeric_altrep in c(TRUE, FALSE)) {
@@ -297,9 +301,11 @@ test_that("dplyr recoding preserves unselected Stata missing codes", {
         )
     }
 
+    paths <- character()
+    on.exit(unlink(paths), add = TRUE)
     for (name in c("missing_values_v115.dta", "missing_values_v118.dta")) {
         path <- fixture_with_all_numeric_missing_codes(name)
-        on.exit(unlink(path), add = TRUE)
+        paths <- c(paths, path)
         storage <- attr(dtaparser:::.dta_metadata(path), "dta_storage")
         reference_tags <- recode_tags(haven::read_dta(path, n_max = 27))
         reference_observed <- recode_observed(

--- a/r-package/dtaparser/tests/testthat/test-read-dta.R
+++ b/r-package/dtaparser/tests/testthat/test-read-dta.R
@@ -62,7 +62,7 @@ replace_first_byte <- function(bytes, text, replacement) {
 test_that("read_dta extends the haven-compatible public signature", {
     expected <- c(
         "file", "encoding", "col_select", "skip", "n_max", ".name_repair",
-        "threads"
+        "threads", "use_numeric_altrep"
     )
     expect_identical(names(formals(read_dta)), expected)
     expect_null(formals(read_dta)$encoding)
@@ -74,6 +74,50 @@ test_that("read_dta extends the haven-compatible public signature", {
         formals(read_dta)$threads,
         quote(getOption("dtaparser.threads", 0L))
     )
+    expect_identical(
+        formals(read_dta)$use_numeric_altrep,
+        quote(getOption("dtaparser.numeric_altrep", TRUE))
+    )
+    expect_identical(nrow(read_dta(fixture("auto_v118.dta"), n = 2)), 2L)
+})
+
+test_that("numeric ALTREP can be disabled explicitly or by option", {
+    path <- fixture("all_types_v118.dta")
+    reference <- dtaparser:::.read_dta_rust_vectors(path)
+    explicit <- read_dta(path, use_numeric_altrep = FALSE, threads = 1L)
+    parallel <- read_dta(path, use_numeric_altrep = FALSE, threads = 4L)
+
+    expect_identical(explicit, reference)
+    expect_identical(parallel, explicit)
+    numeric_columns <- vapply(explicit, is.numeric, logical(1))
+    expect_false(any(vapply(
+        explicit[numeric_columns],
+        dtaparser:::.is_numeric_altrep,
+        logical(1)
+    )))
+
+    previous <- options(dtaparser.numeric_altrep = FALSE)
+    on.exit(options(previous), add = TRUE)
+    from_option <- read_dta(path)
+    expect_identical(from_option, explicit)
+    expect_false(any(vapply(
+        from_option[numeric_columns],
+        dtaparser:::.is_numeric_altrep,
+        logical(1)
+    )))
+
+    empty <- read_dta(
+        path,
+        col_select = c(v_byte, v_double),
+        n_max = 0,
+        use_numeric_altrep = FALSE
+    )
+    expect_identical(empty, dtaparser:::.read_dta_rust_vectors(
+        path, col_select = c(v_byte, v_double), n_max = 0
+    ))
+    expect_false(any(vapply(
+        empty, dtaparser:::.is_numeric_altrep, logical(1)
+    )))
 })
 
 test_that("parallel decoding is identical across supported releases", {
@@ -456,7 +500,9 @@ test_that("native numerics use width-aware storage with R value semantics", {
         name <- fixture_names[[case]]
         path <- normalizePath(paths[[case]])
         actual <- read_dta(path)
+        eager <- read_dta(path, use_numeric_altrep = FALSE)
         reference <- dtaparser:::.read_dta_rust_vectors(path)
+        expect_identical(eager, reference, info = paste(name, "eager"))
         storage <- attr(dtaparser:::.dta_metadata(path), "dta_storage")
         numeric_indices <- which(storage != "character")
         if (startsWith(name, "missing_values_")) {
@@ -474,6 +520,13 @@ test_that("native numerics use width-aware storage with R value semantics", {
                         name, storage[[index]], "native missing codes"
                     )
                 )
+                expect_identical(
+                    haven::na_tag(eager[[index]][seq_along(expected_tags)]),
+                    expected_tags,
+                    info = paste(
+                        name, storage[[index]], "eager missing codes"
+                    )
+                )
             }
         }
         altrep_indices <- which(storage %in% c("byte", "int", "long", "float"))
@@ -488,6 +541,11 @@ test_that("native numerics use width-aware storage with R value semantics", {
             dtaparser:::.is_numeric_altrep,
             logical(1)
         )), info = name)
+        expect_false(any(vapply(
+            eager[numeric_indices],
+            dtaparser:::.is_numeric_altrep,
+            logical(1)
+        )), info = paste(name, "eager"))
         if (startsWith(name, "missing_values_")) {
             missing_only <- read_dta(path, n_max = 27)
             for (index in altrep_indices) {
@@ -582,12 +640,17 @@ test_that("date and datetime storage become native R temporal vectors", {
     haven::write_dta(input, path, version = 15)
 
     actual <- read_dta(path)
+    eager <- read_dta(path, use_numeric_altrep = FALSE)
     expected <- haven::read_dta(path)
     expect_equal(actual$date, expected$date)
     expect_s3_class(actual$date, "Date")
     expect_equal(actual$instant, expected$instant)
     expect_s3_class(actual$instant, "POSIXct")
     expect_identical(attr(actual$instant, "tzone"), "UTC")
+    expect_identical(eager, actual)
+    expect_false(any(vapply(
+        eager, dtaparser:::.is_numeric_altrep, logical(1)
+    )))
 })
 
 test_that("legacy and custom daily-date formats match haven", {
@@ -779,6 +842,14 @@ test_that("argument and native parse failures are ordinary R errors", {
     expect_error(read_dta(path, encoding = 1), "one non-missing")
     for (threads in list(-1, 1.5, NA_real_, Inf, c(1, 2), "2")) {
         expect_error(read_dta(path, threads = threads), "threads.*non-negative")
+    }
+    for (use_numeric_altrep in list(
+        NULL, NA, logical(), c(TRUE, FALSE), 1, "TRUE"
+    )) {
+        expect_error(
+            read_dta(path, use_numeric_altrep = use_numeric_altrep),
+            "use_numeric_altrep.*non-missing logical"
+        )
     }
     expect_error(read_dta(path, col_select = absent), "absent")
 


### PR DESCRIPTION
## Stack

Follow-up to #47, rebased onto current `main`, including the dictionary-string drop-order hardening merged in #49.

## What changed

- Keep Stata byte, int, long, and float columns at their compact source widths in R-accounted backing buffers and expose them as ALTREAL vectors.
- Keep source doubles eager because ALTREP cannot reduce their storage.
- Specialize element, region/materialization, Sum, Min, and Max kernels by source width, with separate no-missing fast paths and bounded interrupt polling.
- Preserve system missing plus `.a` through `.z`, ordinary NaN behavior, temporal conversion, overflow behavior, serialization, and copy-on-modify semantics.
- Document Stata missing storage, R/haven inspection and assignment, ordering differences, and returned label attributes with copy-paste examples.
- Add `use_numeric_altrep = getOption("dtaparser.numeric_altrep", TRUE)`. Setting it to `FALSE` widens all numeric columns during decoding for workloads dominated by non-kernel operations that require ordinary double vectors. Character ALTREP is unaffected.

## Synthetic evidence

Only generated synthetic inputs were used.

Focused 1 GB numeric benchmarks show the progression:

| Stage | Median |
|---|---:|
| Eager numeric baseline, aggregate scan | 0.068 s |
| Original numeric ALTREP prototype | 0.138 s |
| Custom Sum kernel | 0.084 s |
| Keep source doubles eager | 0.079 s |
| Per-width/no-missing specialized Sum kernels | 0.056 s |

The final specialized Sum path is 17.6% faster than the eager baseline. Combined Min plus Max is 0.224 s, versus 0.332 s eager and 0.407 s through the unspecialized ALTREP fallback: 32.5% faster than eager.

Fresh-process peak RSS for the generated 1 GB, 40-column file is 649.8 MB in the default mode versus 784.5 MB with eager numeric materialization, a 17.2% reduction. Load-only timing is neutral on the projected narrow-column workload (0.043 s default, 0.044 s eager).

The eager opt-out helps operations without custom kernels on the same synthetic projection:

| Load plus operation | Default ALTREP | Eager opt-out |
|---|---:|---:|
| `mean()` | 0.068 s | 0.062 s |
| serialization | 0.059 s | 0.052 s |
| partial sort | 0.062 s | 0.052 s |
| forced `column[]` copy | 0.047 s | 0.047 s |
| custom-kernel `sum()` | 0.045 s | 0.047 s |

The final seven-run standard synthetic harness passed every exact-identity precheck. Medians were:

| Input/workload | Direct R | Rust-vector reference | haven |
|---|---:|---:|---:|
| 100 MB full | 0.025 s | 0.255 s | 1.065 s |
| 100 MB projected | 0.014 s | 0.069 s | 0.274 s |
| 1 GB full | 0.131 s | 2.094 s | 10.608 s |
| 1 GB projected | 0.073 s | 0.697 s | 2.902 s |

## Validation

- Full oracle/equivalence suite: 22 immutable TypeScript fixtures, 10 deterministic native cases, one canonical fixture oracle, package archive validation, and R/haven conformance
- Full Rust suite with `cargo test --locked`
- Strict Clippy with warnings denied and formatting/diff checks
- Full R package check and testthat suite
- Explicit all-27-code coverage (`.`, `.a` through `.z`) for byte, int, long, float, and double across releases 115 and 118, on the eager reference, default ALTREP path, and eager opt-out path
- Both `na.rm` modes plus empty/all-missing behavior for Sum, Min, and Max
- Serial/parallel eager parity, zero-row projections, temporal classes, attributes, serialization, copy-on-modify, gctorture, and post-GC access
- Two independent reviews at each final stage; all findings addressed and both reviewers approved

`R CMD check` retains the existing Rust `_abort` compiled-code warning and adds no new warning.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional numeric ALTREP decoding for more compact numeric storage.
  * Added the `use_numeric_altrep` setting and package option to control this behavior.
  * Preserved Stata missing-value handling, including tagged missing values and temporal data.
  * Added lazy materialization and support for standard numeric operations.

* **Documentation**
  * Expanded guidance on ALTREP behavior, missing values, inspection, recoding, and materialization.
  * Clarified benchmark storage and materialization checks.

* **Tests**
  * Added comprehensive coverage for configuration, missing values, serialization, copying, aggregation, and common R workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->