### PR TITLE
Harden dictionary string drop order

### DIFF
--- a/r-package/dtaparser/src/rust/src/lib.rs
+++ b/r-package/dtaparser/src/rust/src/lib.rs
@@ -57,10 +57,10 @@ extern "C" {
 struct DictStringData {
     value_ids: *mut u32,
     length: usize,
-    // Owns the string buffers referenced by `value_views` and must outlive
-    // every raw-pointer view.
-    _values: AHashMap<String, u32>,
     value_views: Vec<(*const u8, usize)>,
+    // Owns the string buffers referenced by `value_views`. Declared after the
+    // views so it is dropped after them.
+    _values: AHashMap<String, u32>,
 }
 
 impl DictStringData {
@@ -75,8 +75,8 @@ impl DictStringData {
         Self {
             value_ids,
             length,
-            _values: values,
             value_views,
+            _values: values,
         }
     }
 }


### PR DESCRIPTION
## Summary

- declare dictionary string byte views before their backing map so Rust drops the views first
- document the field-order lifetime invariant
- preserve the two leading `repr(C)` fields used by the C boundary

## Testing

- `cargo test --manifest-path r-package/dtaparser/src/rust/Cargo.toml`