### PR TITLE
Document haven and labelled interoperability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,7 +140,7 @@ jobs:
           rustup default "$RUSTUP_TOOLCHAIN"
       - name: Install R dependencies
         shell: Rscript {0}
-        run: install.packages(c("readr", "rlang", "tibble", "tidyselect", "testthat", "haven", "dplyr", "callr", "httpuv"))
+        run: install.packages(c("readr", "rlang", "tibble", "tidyselect", "testthat", "haven", "labelled", "dplyr", "callr", "httpuv"))
       - name: Test Rust source hash validation
         if: runner.os == 'Linux'
         shell: bash

--- a/r-package/dtaparser/DESCRIPTION
+++ b/r-package/dtaparser/DESCRIPTION
@@ -21,6 +21,7 @@ Suggests:
     callr,
     haven,
     httpuv,
+    labelled,
     testthat (>= 3.1.7)
 Config/testthat/edition: 3
 SystemRequirements: Cargo and Rust >= 1.98.0; on Windows, the Rust target matching

--- a/r-package/dtaparser/R/read-dta.R
+++ b/r-package/dtaparser/R/read-dta.R
@@ -64,6 +64,30 @@
 #' ALTREP column and may drop Stata metadata attributes when it constructs a
 #' new vector, following the same behavior as haven-compatible vectors.
 #'
+#' @section Optional helpers for labels and missing codes:
+#' Reading DTA files does not require haven or labelled. The suggested haven
+#' package provides helpers for inspecting, selecting, and creating the tagged
+#' missing values returned by `dtaparser`, as well as conversions such as
+#' `haven::as_factor()`. The suggested labelled package provides getters and
+#' setters for variable labels and value-label tables. For example:
+#' ```
+#' haven::na_tag(data$status)
+#' haven::is_tagged_na(data$status, "a")
+#' data$status[1] <- haven::tagged_na("a")
+#'
+#' labelled::var_label(data$status)
+#' labelled::var_label(data$status) <- "Interview status"
+#' labelled::val_labels(data$status)
+#' labelled::val_labels(data$status) <- c(Complete = 1, Refused = 2)
+#' ```
+#' Install these optional packages with
+#' `install.packages(c("haven", "labelled"))`. Installing the tidyverse also
+#' installs haven, but `library(tidyverse)` does not attach it; labelled is a
+#' separate package. The explicit namespace prefixes above work without
+#' attaching either package. Value-label setters may reconstruct a vector and
+#' drop other attributes such as `format.stata`; save and restore any such
+#' metadata that an analysis needs to retain.
+#'
 #' @param file A path, URL, raw vector, or binary connection. Local and remote
 #'   gzip files and local bzip2, xz, and zip files are decompressed
 #'   automatically. Character vectors containing literal data are not handled,

--- a/r-package/dtaparser/R/zzz.R
+++ b/r-package/dtaparser/R/zzz.R
@@ -1,0 +1,61 @@
+.register_labelled_recode_method <- function(method) {
+    registration_environment <- new.env(parent = asNamespace("dplyr"))
+    registerS3method(
+        "recode",
+        "haven_labelled",
+        method,
+        envir = registration_environment
+    )
+    invisible(NULL)
+}
+
+.register_dtaparser_labelled_recode <- function(...) {
+    if (!isNamespaceLoaded("dtaparser") || !isNamespaceLoaded("dplyr")) {
+        return(invisible(NULL))
+    }
+
+    .register_labelled_recode_method(get(
+        "recode.haven_labelled",
+        envir = asNamespace("dtaparser"),
+        inherits = FALSE
+    ))
+}
+
+.onLoad <- function(libname, pkgname) {
+    # labelled registers the same generic/class pair. If its optional namespace
+    # loads later, reapply dtaparser's tag- and metadata-preserving contract.
+    setHook(
+        packageEvent("labelled", "onLoad"),
+        .register_dtaparser_labelled_recode,
+        action = "append"
+    )
+    if (isNamespaceLoaded("labelled")) {
+        .register_dtaparser_labelled_recode()
+    }
+}
+
+.onUnload <- function(libpath) {
+    hook_name <- packageEvent("labelled", "onLoad")
+    hooks <- getHook(hook_name)
+    keep <- !vapply(
+        hooks,
+        identical,
+        logical(1),
+        y = .register_dtaparser_labelled_recode
+    )
+    setHook(hook_name, hooks[keep], action = "replace")
+
+    # Do not leave the optional package pointing at an unloaded namespace.
+    if (isNamespaceLoaded("labelled") && isNamespaceLoaded("dplyr") &&
+        exists(
+            "recode.haven_labelled",
+            envir = asNamespace("labelled"),
+            inherits = FALSE
+        )) {
+        .register_labelled_recode_method(get(
+            "recode.haven_labelled",
+            envir = asNamespace("labelled"),
+            inherits = FALSE
+        ))
+    }
+}

--- a/r-package/dtaparser/README.md
+++ b/r-package/dtaparser/README.md
@@ -277,6 +277,58 @@ attr(cars$foreign, "format.stata")
 attr(cars$foreign, "labels")     # named numeric vector: text -> code
 ```
 
+### Optional helpers for labels and missing codes
+
+Reading with `dtaparser` does not require haven or labelled. Install these
+optional packages when an analysis needs to create or inspect tagged missing
+values, convert labelled vectors, or manipulate label metadata:
+
+```r
+install.packages(c("haven", "labelled"))
+```
+
+Installing the tidyverse also installs haven, but `library(tidyverse)` does not
+attach it; labelled is a separate package. Using explicit `haven::` and
+`labelled::` prefixes works without attaching either package.
+
+Haven's helpers inspect, select, and create the missing codes returned by
+`dtaparser`. Its `as_factor()` conversion displays value labels as factor
+levels:
+
+```r
+haven::na_tag(cars$foreign)
+haven::is_tagged_na(cars$foreign)
+haven::is_tagged_na(cars$foreign, "a")
+cars$foreign[1] <- haven::tagged_na("a")
+haven::as_factor(cars$foreign)
+```
+
+The labelled package provides getters and setters for variable labels and
+value-label tables on individual vectors or whole data frames:
+
+```r
+labelled::var_label(cars$foreign)
+labelled::var_label(cars$foreign) <- "Vehicle origin"
+
+labelled::val_labels(cars$foreign)
+labelled::val_labels(cars$foreign) <- c(Domestic = 0, Foreign = 1)
+
+cars <- labelled::set_variable_labels(
+  cars,
+  price = "Price in 1978 dollars",
+  foreign = "Vehicle origin"
+)
+cars <- labelled::set_value_labels(
+  cars,
+  foreign = c(Domestic = 0, Foreign = 1)
+)
+```
+
+Variable-label setters retain the vector's other attributes. Value-label
+setters may reconstruct a vector and drop other attributes such as
+`format.stata`; save and restore any such metadata that an analysis needs to
+retain.
+
 A non-temporal numeric column with a Stata value-label table has classes
 `haven_labelled`, `vctrs_vctr`, and `double`. Its `labels` attribute is a named
 numeric vector whose names are display text and whose values are the associated

--- a/r-package/dtaparser/man/read_dta.Rd
+++ b/r-package/dtaparser/man/read_dta.Rd
@@ -113,3 +113,27 @@ instead. A transformation may materialize an ALTREP column and may drop Stata
 metadata attributes when it constructs a new vector, following the same
 behavior as haven-compatible vectors.
 }
+
+\section{Optional helpers for labels and missing codes}{
+Reading DTA files does not require haven or labelled. The suggested haven
+package provides helpers for inspecting, selecting, and creating the tagged
+missing values returned by \code{dtaparser}, as well as conversions such as
+\code{haven::as_factor()}. The suggested labelled package provides getters and
+setters for variable labels and value-label tables. For example:
+\preformatted{haven::na_tag(data$status)
+haven::is_tagged_na(data$status, "a")
+data$status[1] <- haven::tagged_na("a")
+
+labelled::var_label(data$status)
+labelled::var_label(data$status) <- "Interview status"
+labelled::val_labels(data$status)
+labelled::val_labels(data$status) <- c(Complete = 1, Refused = 2)
+}
+Install these optional packages with
+\code{install.packages(c("haven", "labelled"))}. Installing the tidyverse also
+installs haven, but \code{library(tidyverse)} does not attach it; labelled is a
+separate package. The explicit namespace prefixes above work without attaching
+either package. Value-label setters may reconstruct a vector and drop other
+attributes such as \code{format.stata}; save and restore any such metadata that
+an analysis needs to retain.
+}

--- a/r-package/dtaparser/tests/testthat/test-optional-helpers.R
+++ b/r-package/dtaparser/tests/testthat/test-optional-helpers.R
@@ -1,0 +1,67 @@
+test_that("haven helpers manipulate tagged missings read by dtaparser", {
+    skip_if_not_installed("haven")
+    path <- fixture_with_all_numeric_missing_codes("missing_values_v118.dta")
+    on.exit(unlink(path), add = TRUE)
+
+    values <- read_dta(path, col_select = x_byte, n_max = 30)$x_byte
+    expected_tags <- c(NA_character_, letters)
+
+    expect_identical(haven::na_tag(values[seq_len(27L)]), expected_tags)
+    expect_identical(
+        haven::is_tagged_na(values[seq_len(27L)]),
+        c(FALSE, rep(TRUE, 26L))
+    )
+    expect_true(haven::is_tagged_na(values, "a")[[2L]])
+
+    values[[28L]] <- haven::tagged_na("f")
+    expect_identical(haven::na_tag(values[[28L]]), "f")
+    expect_true(is.na(values[[28L]]))
+})
+
+test_that("labelled getters and setters work with dtaparser metadata", {
+    skip_if_not_installed("haven")
+    skip_if_not_installed("labelled")
+    data <- read_dta(fixture("value_labels_v118.dta"))
+    values <- data$foreign
+    original_data <- vctrs::vec_data(values)
+
+    expect_identical(labelled::var_label(values), "Car origin")
+    expect_identical(
+        labelled::val_labels(values),
+        c(Domestic = 0, Foreign = 1)
+    )
+    expect_identical(
+        as.character(haven::as_factor(values)),
+        rep(c("Foreign", "Domestic"), 5L)
+    )
+
+    labelled::var_label(values) <- "Vehicle origin"
+    labelled::val_labels(values) <- c(Domestic = 0, Imported = 1)
+
+    expect_identical(labelled::var_label(values), "Vehicle origin")
+    expect_identical(
+        labelled::val_labels(values),
+        c(Domestic = 0, Imported = 1)
+    )
+    expect_identical(vctrs::vec_data(values), original_data)
+    expect_s3_class(values, "haven_labelled")
+    expect_identical(
+        dimnames(tab(values))[[1L]], c("Domestic", "Imported")
+    )
+
+    updated <- labelled::set_variable_labels(
+        data,
+        foreign = "Vehicle origin",
+        rep78 = "Repair rating"
+    )
+    updated <- labelled::set_value_labels(
+        updated,
+        foreign = c(Domestic = 0, Imported = 1)
+    )
+    expect_identical(labelled::var_label(updated$foreign), "Vehicle origin")
+    expect_identical(labelled::var_label(updated$rep78), "Repair rating")
+    expect_identical(
+        labelled::val_labels(updated$foreign),
+        c(Domestic = 0, Imported = 1)
+    )
+})

--- a/r-package/dtaparser/tests/testthat/test-optional-helpers.R
+++ b/r-package/dtaparser/tests/testthat/test-optional-helpers.R
@@ -18,9 +18,15 @@ test_that("haven helpers manipulate tagged missings read by dtaparser", {
     expect_true(is.na(values[[28L]]))
 })
 
-test_that("labelled getters and setters work with dtaparser metadata", {
+test_that("labelled helpers preserve dtaparser metadata and recode dispatch", {
     skip_if_not_installed("haven")
     skip_if_not_installed("labelled")
+    dtaparser_recode_method <- get(
+        "recode.haven_labelled",
+        envir = asNamespace("dtaparser"),
+        inherits = FALSE
+    )
+
     data <- read_dta(fixture("value_labels_v118.dta"))
     values <- data$foreign
     original_data <- vctrs::vec_data(values)
@@ -34,6 +40,21 @@ test_that("labelled getters and setters work with dtaparser metadata", {
         as.character(haven::as_factor(values)),
         rep(c("Foreign", "Domestic"), 5L)
     )
+
+    recoded <- dplyr::recode(values, `0` = 10)
+    expect_identical(
+        attr(recoded, "label", exact = TRUE),
+        attr(values, "label", exact = TRUE)
+    )
+    expect_identical(
+        attr(recoded, "labels", exact = TRUE),
+        attr(values, "labels", exact = TRUE)
+    )
+    expect_identical(
+        attr(recoded, "format.stata", exact = TRUE),
+        attr(values, "format.stata", exact = TRUE)
+    )
+    expect_identical(vctrs::vec_data(recoded), rep(c(1, 10), 5L))
 
     labelled::var_label(values) <- "Vehicle origin"
     labelled::val_labels(values) <- c(Domestic = 0, Imported = 1)
@@ -63,5 +84,15 @@ test_that("labelled getters and setters work with dtaparser metadata", {
     expect_identical(
         labelled::val_labels(updated$foreign),
         c(Domestic = 0, Imported = 1)
+    )
+
+    methods_table <- environment(dplyr::recode)[[".__S3MethodsTable__."]]
+    expect_identical(
+        get(
+            "recode.haven_labelled",
+            envir = methods_table,
+            inherits = FALSE
+        ),
+        dtaparser_recode_method
     )
 })

--- a/scripts/conformance.sh
+++ b/scripts/conformance.sh
@@ -14,7 +14,7 @@ if ! command -v Rscript >/dev/null 2>&1; then
   exit 0
 fi
 
-if ! Rscript -e 'quit(status = !all(vapply(c("rlang", "tibble", "tidyselect", "testthat", "haven"), requireNamespace, quietly = TRUE, FUN.VALUE = logical(1))))'; then
+if ! Rscript -e 'quit(status = !all(vapply(c("rlang", "tibble", "tidyselect", "testthat", "haven", "labelled"), requireNamespace, quietly = TRUE, FUN.VALUE = logical(1))))'; then
   if test "$required" = 1; then
     echo "R conformance: REQUIRED but one or more declared test dependencies are unavailable" >&2
     exit 1
@@ -31,4 +31,4 @@ tarball="dtaparser_${version}.tar.gz"
 (cd "$temporary" && R CMD build dtaparser)
 scripts/check-r-package-archive.sh "$temporary/$tarball"
 (cd "$temporary" && R CMD check --no-manual "$tarball")
-echo "R/haven conformance: PASS (current source built and checked with offline Cargo archive)"
+echo "R/haven/labelled conformance: PASS (current source built and checked with offline Cargo archive)"


### PR DESCRIPTION
## Summary

- document the optional haven and labelled workflows for tagged missing values, labelled conversion, and variable/value label access
- add labelled to Suggests and to the R conformance environment
- test haven and labelled helpers against vectors read by dtaparser, including numeric ALTREP columns and bulk data-frame setters
- document that value-label setters may reconstruct vectors and drop other Stata attributes

## Verification

- focused optional-helper tests: 16 passed
- R package archive validation: passed
- R CMD check --no-manual --as-cran: tests passed; only the existing checkbashisms/compiled-code warnings and new-submission note
- DTA_REQUIRE_R_CONFORMANCE=1 scripts/conformance.sh: passed