### PR TITLE
Fix format 119 strL pointer decoding

### DIFF
--- a/r-package/dtaparser/src/dta-parser/src/endian.rs
+++ b/r-package/dtaparser/src/dta-parser/src/endian.rs
@@ -85,6 +85,33 @@ pub(crate) fn read_i8(bytes: &[u8], offset: usize, context: &'static str) -> Res
     Ok(i8::from_ne_bytes([read_u8(bytes, offset, context)?]))
 }
 
+pub(crate) fn read_uint(
+    bytes: &[u8],
+    offset: usize,
+    width: usize,
+    byte_order: ByteOrder,
+    context: &'static str,
+) -> Result<u64, DtaError> {
+    if width > std::mem::size_of::<u64>() {
+        return Err(DtaError::ArithmeticOverflow(context));
+    }
+    let field = slice_at(bytes, offset, width, context)?;
+    let mut value = 0_u64;
+    match byte_order {
+        ByteOrder::Lsf => {
+            for (shift, byte) in field.iter().enumerate() {
+                value |= u64::from(*byte) << (shift * 8);
+            }
+        }
+        ByteOrder::Msf => {
+            for byte in field {
+                value = (value << 8) | u64::from(*byte);
+            }
+        }
+    }
+    Ok(value)
+}
+
 pub(crate) fn read_u16(
     bytes: &[u8],
     offset: usize,
@@ -160,6 +187,14 @@ mod tests {
         assert_eq!(read_u16(&bytes, 0, ByteOrder::Msf, "test").unwrap(), 0x0102);
         assert_eq!(read_u16(&bytes, 0, ByteOrder::Lsf, "test").unwrap(), 0x0201);
         assert_eq!(
+            read_uint(&bytes, 0, 3, ByteOrder::Msf, "test").unwrap(),
+            0x01_0203
+        );
+        assert_eq!(
+            read_uint(&bytes, 0, 5, ByteOrder::Lsf, "test").unwrap(),
+            0x05_0403_0201
+        );
+        assert_eq!(
             read_u32(&bytes, 0, ByteOrder::Msf, "test").unwrap(),
             0x0102_0304
         );
@@ -184,6 +219,10 @@ mod tests {
             read_u64(&[0; 7], 0, ByteOrder::Lsf, "u64"),
             Err(DtaError::Truncated { context: "u64", .. })
         ));
+        assert_eq!(
+            read_uint(&[0; 9], 0, 9, ByteOrder::Lsf, "uint"),
+            Err(DtaError::ArithmeticOverflow("uint"))
+        );
         assert_eq!(
             checked_add(usize::MAX, 1, "offset"),
             Err(DtaError::ArithmeticOverflow("offset"))

--- a/r-package/dtaparser/src/dta-parser/src/file.rs
+++ b/r-package/dtaparser/src/dta-parser/src/file.rs
@@ -7,7 +7,7 @@ use std::thread;
 
 use encoding_rs::CoderResult;
 
-use crate::endian::{read_i16, read_i32, read_i8, read_u16, read_u32, read_u64};
+use crate::endian::{read_i16, read_i32, read_i8, read_u16, read_u32, read_u64, read_uint};
 use crate::legacy::{legacy_fixed_offsets, legacy_type, LegacyLayout, LegacyValueLabelLayout};
 use crate::metadata::{field_widths, resolve_type};
 use crate::selection::{resolve_columns, row_window};
@@ -4007,27 +4007,21 @@ fn parse_pointer(
                 "strL observation pointer",
             )?),
         )
+    } else if metadata.format_version == FormatVersion::V118 {
+        (
+            u32::from(read_u16(
+                bytes,
+                0,
+                metadata.byte_order,
+                "strL variable pointer",
+            )?),
+            read_uint(bytes, 2, 6, metadata.byte_order, "strL observation pointer")?,
+        )
     } else {
-        let variable = u32::from(read_u16(
-            bytes,
-            0,
-            metadata.byte_order,
-            "strL variable pointer",
-        )?);
-        let mut observation = 0_u64;
-        match metadata.byte_order {
-            ByteOrder::Lsf => {
-                for (shift, byte) in bytes[2..8].iter().enumerate() {
-                    observation |= u64::from(*byte) << (shift * 8);
-                }
-            }
-            ByteOrder::Msf => {
-                for byte in &bytes[2..8] {
-                    observation = (observation << 8) | u64::from(*byte);
-                }
-            }
-        }
-        (variable, observation)
+        (
+            read_uint(bytes, 0, 3, metadata.byte_order, "strL variable pointer")? as u32,
+            read_uint(bytes, 3, 5, metadata.byte_order, "strL observation pointer")?,
+        )
     };
     if variable == 0 && observation == 0 {
         return Ok(None);
@@ -4594,49 +4588,53 @@ mod tests {
     }
 
     #[test]
-    fn column_kernel_collects_big_endian_modern_strl_pointers() {
-        let mut metadata = kernel_metadata(ByteOrder::Msf);
-        metadata.format_version = FormatVersion::V119;
-        metadata.nvar = 1;
-        metadata.nobs = 42;
-        metadata.obs_length = 8;
-        metadata.variables = vec![VariableInfo {
-            name: "text".to_owned(),
-            dta_type: DtaType::StrL,
-            type_code: 32_768,
-            format: "%9s".to_owned(),
-            label: String::new(),
-            value_label_name: String::new(),
-            byte_width: 8,
-            byte_offset: 0,
-        }];
-        let mut bytes = Vec::new();
-        bytes.extend_from_slice(&1_u16.to_be_bytes());
-        bytes.extend_from_slice(&42_u64.to_be_bytes()[2..]);
-        bytes.extend_from_slice(&[0; 8]);
-        let mut columns = vec![kernel_column(ObservationKind::StrL, 0, 8)];
-        let block = ObservationBlock {
-            bytes,
-            source_offset: 512,
-            output_row_start: 0,
-            row_count: 2,
-        };
+    fn column_kernel_collects_v119_strl_pointers_in_both_byte_orders() {
+        for (byte_order, pointer) in [
+            (ByteOrder::Lsf, [1, 0, 0, 42, 0, 0, 0, 0]),
+            (ByteOrder::Msf, [0, 0, 1, 0, 0, 0, 0, 42]),
+        ] {
+            let mut metadata = kernel_metadata(byte_order);
+            metadata.format_version = FormatVersion::V119;
+            metadata.nvar = 1;
+            metadata.nobs = 42;
+            metadata.obs_length = 8;
+            metadata.variables = vec![VariableInfo {
+                name: "text".to_owned(),
+                dta_type: DtaType::StrL,
+                type_code: 32_768,
+                format: "%9s".to_owned(),
+                label: String::new(),
+                value_label_name: String::new(),
+                byte_width: 8,
+                byte_offset: 0,
+            }];
+            let mut bytes = Vec::from(pointer);
+            bytes.extend_from_slice(&[0; 8]);
+            let mut columns = vec![kernel_column(ObservationKind::StrL, 0, 8)];
+            let block = ObservationBlock {
+                bytes,
+                source_offset: 512,
+                output_row_start: 0,
+                row_count: 2,
+            };
 
-        decode_worker_block(&mut columns, &block, 8, &metadata, TextEncoding::Utf8, None).unwrap();
+            decode_worker_block(&mut columns, &block, 8, &metadata, TextEncoding::Utf8, None)
+                .unwrap();
 
-        assert_eq!(
-            columns[0].strl_pointers.as_deref(),
-            Some(
-                [
-                    Some(FileGsoKey {
-                        variable: 1,
-                        observation: 42,
-                    }),
-                    None,
-                ]
-                .as_slice()
-            )
-        );
+            assert_eq!(
+                columns[0].strl_pointers.as_deref(),
+                Some(
+                    [
+                        Some(FileGsoKey {
+                            variable: 1,
+                            observation: 42,
+                        }),
+                        None,
+                    ]
+                    .as_slice()
+                )
+            );
+        }
     }
 
     #[test]

--- a/r-package/dtaparser/src/dta-parser/src/strl.rs
+++ b/r-package/dtaparser/src/dta-parser/src/strl.rs
@@ -1,7 +1,8 @@
 use std::collections::HashMap;
 
 use crate::endian::{
-    checked_add, checked_sub, expect_at, offset_to_usize, read_u16, read_u32, read_u64, slice_at,
+    checked_add, checked_sub, expect_at, offset_to_usize, read_u16, read_u32, read_u64, read_uint,
+    slice_at,
 };
 use crate::text::TextEncoding;
 use crate::{Column, ColumnValues, DtaError, DtaMetadata, DtaType, FormatVersion, VariableInfo};
@@ -33,24 +34,6 @@ fn checked_mul_u64(left: u64, right: u64, context: &'static str) -> Result<u64, 
         .ok_or(DtaError::ArithmeticOverflow(context))
 }
 
-fn read_u48(bytes: &[u8], offset: usize, metadata: &DtaMetadata) -> Result<u64, DtaError> {
-    let field = slice_at(bytes, offset, 6, "strL observation pointer")?;
-    let mut value = 0_u64;
-    match metadata.byte_order {
-        crate::ByteOrder::Lsf => {
-            for (shift, byte) in field.iter().enumerate() {
-                value |= u64::from(*byte) << (shift * 8);
-            }
-        }
-        crate::ByteOrder::Msf => {
-            for byte in field {
-                value = (value << 8) | u64::from(*byte);
-            }
-        }
-    }
-    Ok(value)
-}
-
 fn read_pointer(
     bytes: &[u8],
     offset: usize,
@@ -66,7 +49,7 @@ fn read_pointer(
                 "strL observation pointer",
             )?),
         )
-    } else {
+    } else if metadata.format_version == FormatVersion::V118 {
         (
             u32::from(read_u16(
                 bytes,
@@ -74,10 +57,29 @@ fn read_pointer(
                 metadata.byte_order,
                 "strL variable pointer",
             )?),
-            read_u48(
+            read_uint(
                 bytes,
                 checked_add(offset, 2, "strL observation pointer")?,
-                metadata,
+                6,
+                metadata.byte_order,
+                "strL observation pointer",
+            )?,
+        )
+    } else {
+        (
+            read_uint(
+                bytes,
+                offset,
+                3,
+                metadata.byte_order,
+                "strL variable pointer",
+            )? as u32,
+            read_uint(
+                bytes,
+                checked_add(offset, 3, "strL observation pointer")?,
+                5,
+                metadata.byte_order,
+                "strL observation pointer",
             )?,
         )
     };
@@ -374,6 +376,30 @@ mod tests {
         let mut big = [0_u8; 8];
         big[..2].copy_from_slice(&1_u16.to_be_bytes());
         big[2..].copy_from_slice(&[0x01, 0x02, 0x03, 0x04, 0x05, 0x06]);
+        let big_metadata = metadata(FormatVersion::V118, ByteOrder::Msf, observation);
+        assert_eq!(
+            read_pointer(&big, 0, &big_metadata).unwrap(),
+            Some(GsoKey {
+                variable: 1,
+                observation
+            })
+        );
+    }
+
+    #[test]
+    fn reads_v119_three_byte_variable_and_five_byte_observation_in_both_orders() {
+        let observation = 0x01_0203_0405_u64;
+        let little = [0x01, 0x00, 0x00, 0x05, 0x04, 0x03, 0x02, 0x01];
+        let little_metadata = metadata(FormatVersion::V119, ByteOrder::Lsf, observation);
+        assert_eq!(
+            read_pointer(&little, 0, &little_metadata).unwrap(),
+            Some(GsoKey {
+                variable: 1,
+                observation
+            })
+        );
+
+        let big = [0x00, 0x00, 0x01, 0x01, 0x02, 0x03, 0x04, 0x05];
         let big_metadata = metadata(FormatVersion::V119, ByteOrder::Msf, observation);
         assert_eq!(
             read_pointer(&big, 0, &big_metadata).unwrap(),


### PR DESCRIPTION
## Summary
- decode format 119 strL pointers using their 3-byte variable and 5-byte observation fields
- share variable-width unsigned decoding across file-backed and slice-backed parser paths
- cover both byte orders and reject unsupported integer widths

## Validation
- full Rust test suite
- `cargo fmt`
- `cargo clippy --all-targets -- -D warnings`
- `git diff --check`