### PR TITLE
Benchmark union-safe projected reads

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ formats, and Stata missing values. The R package also writes standalone Stata
 | TypeScript | [`@jbearak/dta-parser`](typescript/dta-parser) | [npm package README](typescript/dta-parser/README.md) |
 | R | [`dtaparser`](r-package/dtaparser) | [R package README](r-package/dtaparser/README.md) |
 
-The TypeScript package has its own parser and works with either an `ArrayBuffer` or a Node filesystem-backed reader. For Stata imports in R, use `dtaparser::read_dta()` instead of `haven::read_dta()`. It follows haven's common read interface and returns tibbles with haven-compatible labels and tagged missing values. In the repository's 46.9 GB DHS benchmark, its multicore reader completed the 641-file batch 29.3 times faster than haven. See the [R package README](r-package/dtaparser/README.md#why-use-dtaparser) for the comparison and its limitations.
+The TypeScript package has its own parser and works with either an `ArrayBuffer` or a Node filesystem-backed reader. For Stata imports in R, use `dtaparser::read_dta()` instead of `haven::read_dta()`. It follows haven's common read interface and returns tibbles with haven-compatible labels and tagged missing values. In the repository's 46.9 GB DHS benchmark, its multicore reader completed the 641-file batch 29.3 times faster than haven. It can also project a cross-survey union with `col_select = any_of(raw_variables)`, omitting names absent from a particular file without decoding unselected columns. See the [R package README](r-package/dtaparser/README.md#why-use-dtaparser) for the comparisons and their limitations.
 
 The Rust crate is the internal parser used by the R package. It is not published to crates.io. Its interface is documented with Rustdoc:
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -56,6 +56,12 @@ and raw results private.
 Its [2026-08-24 report](r-corpus-performance/results-2026-08-24.md) records the
 aggregate results used in the R package README.
 
+The synthetic [`projection-introspection/`](projection-introspection/) suite
+compares a union-safe `any_of()` projection with Stata's full-load-then-keep
+workflow and Stata's direct, non-union-safe projected `use`. It varies dataset
+width and row count while requiring every method to return the same ten
+columns.
+
 The manual [`r-corpus-roundtrip/`](r-corpus-roundtrip/) workflow qualifies the
 R writer against the same 1,823-file cache, requires semantic re-read equality
 plus Haven and Stata-open checks, and only then benchmarks writes against Stata.

--- a/benchmarks/projection-introspection/README.md
+++ b/benchmarks/projection-introspection/README.md
@@ -1,0 +1,58 @@
+# Projection after dataset introspection
+
+This benchmark tests a pipeline that carries the union of raw variable names
+used across many surveys. A particular DTA file usually contains only a subset
+of that union. It includes synthetic fixtures and an optional real DHS file.
+
+For each case, every measured method returns the same selected columns in the
+same order. The benchmark compares:
+
+- `dtaparser-any-of`: `read_dta(..., col_select = any_of(union))`;
+- `dtaparser-all-of`: `read_dta(..., col_select = all_of(present))`, which
+  isolates the cost of allowing absent names;
+- `stata-load-inspect-keep`: a full `use`, followed by `confirm variable` for
+  every union member and then `keep`;
+- `stata-use-present`: `use present_varlist using ...`, Stata's fastest direct
+  projection when the caller already knows which requested variables exist.
+
+The last method is not union-safe. Stata errors if its varlist contains a name
+that is absent from the file. It is included as a lower bound, not as an
+implementation of the introspective pipeline.
+
+The fixture matrix varies row count and width. Every tenth variable is a fixed
+string; the rest rotate through byte, int, float, and double storage. The union
+contains the ten present names plus ninety deliberately absent names. Fixture
+generation, process startup, warm-up reads, garbage collection, and result
+validation are outside the timed regions. Repetitions run in one process, so
+the reported measurements describe warm filesystem-cache behavior. This is the
+relevant condition when hundreds of surveys are read sequentially, but it does
+not estimate first-read storage latency.
+
+Run the quick matrix with:
+
+```sh
+benchmarks/projection-introspection/benchmark.sh quick 7
+```
+
+Run the larger matrix with:
+
+```sh
+benchmarks/projection-introspection/benchmark.sh full 11
+```
+
+Run the India 2021 DHS women's file case with:
+
+```sh
+benchmarks/projection-introspection/benchmark.sh india 11
+```
+
+The India case uses the 5.2 GB `wm.dta`, selects 100 variables evenly across
+its 5,972-column schema, and adds 100 absent sentinels to the `any_of()` union.
+It defaults to `/opt/aww_cache/DHS/Original_Data/India 2021/wm.dta`; set
+`INDIA_2021_WM` to use another location. The runner creates a symlink in its
+private output directory and never copies or publishes the source path. Use the
+`all` profile to run the full synthetic matrix followed by this real-file case.
+
+Results are written below `target/projection-introspection/`. The runner builds
+and installs the package from the current checkout into an isolated library.
+Set `STATA_BIN` to override Stata discovery.

--- a/benchmarks/projection-introspection/benchmark.sh
+++ b/benchmarks/projection-introspection/benchmark.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+set -eu
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+checkout_root=$(CDPATH= cd -- "$script_dir/../.." && pwd)
+profile=${1:-quick}
+repetitions=${2:-7}
+case "$profile" in quick|full|india|all) ;; *) printf '%s\n' 'profile must be quick, full, india, or all' >&2; exit 2 ;; esac
+case "$repetitions" in ''|*[!0-9]*) printf '%s\n' 'repetitions must be a positive integer' >&2; exit 2 ;; esac
+if [ "$repetitions" -lt 1 ]; then printf '%s\n' 'repetitions must be a positive integer' >&2; exit 2; fi
+
+target_dir="$checkout_root/target/projection-introspection"
+build_dir="$target_dir/.build.$$"
+run_dir="$target_dir/run-$profile-$(date -u '+%Y%m%dT%H%M%SZ')"
+library="$build_dir/library"
+trap 'rm -rf "$build_dir"' EXIT HUP INT TERM
+mkdir -p "$build_dir" "$library" "$run_dir"
+
+(cd "$build_dir" && R CMD build "$checkout_root/r-package/dtaparser")
+set -- "$build_dir"/dtaparser_*.tar.gz
+if [ "$#" -ne 1 ] || [ ! -f "$1" ]; then
+    printf '%s\n' 'expected one dtaparser source tarball' >&2
+    exit 1
+fi
+R CMD INSTALL --library="$library" "$1"
+DTAPARSER_BENCH_LIB="$library"
+export DTAPARSER_BENCH_LIB
+R_ENVIRON_USER=/dev/null
+R_PROFILE_USER=/dev/null
+export R_ENVIRON_USER R_PROFILE_USER
+
+Rscript --vanilla "$script_dir/run.R" "$profile" "$repetitions" "$run_dir"
+printf '%s\n' "$run_dir"

--- a/benchmarks/projection-introspection/generate.do
+++ b/benchmarks/projection-introspection/generate.do
@@ -1,0 +1,37 @@
+version 18.0
+clear all
+set more off
+set maxvar 32767
+
+args output rows_arg columns_arg result
+local rows = real("`rows_arg'")
+local columns = real("`columns_arg'")
+set obs `rows'
+
+forvalues index = 1/`columns' {
+    local suffix : display %05.0f `index'
+    local name = "v`suffix'"
+    local kind = mod(`index', 10)
+    if `kind' == 0 {
+        quietly generate str12 `name' = "S" + string(mod(_n + `index', 100000), "%010.0f")
+    }
+    else if inlist(`kind', 1, 2) {
+        quietly generate byte `name' = mod(_n + `index', 100)
+    }
+    else if inlist(`kind', 3, 4) {
+        quietly generate int `name' = mod(_n + `index', 30000)
+    }
+    else if inlist(`kind', 5, 6, 7) {
+        quietly generate float `name' = mod(_n, 10000) / 17 + `index'
+    }
+    else {
+        quietly generate double `name' = _n / 19 + `index'
+    }
+}
+
+quietly save "`output'", replace
+quietly checksum "`output'"
+file open result_file using "`result'", write text replace
+file write result_file "ok" _tab %21.0f (_N) _tab %21.0f (c(k)) _tab %21.0f (r(filelen)) _n
+file close result_file
+exit, clear

--- a/benchmarks/projection-introspection/r-worker.R
+++ b/benchmarks/projection-introspection/r-worker.R
@@ -1,0 +1,65 @@
+args <- commandArgs(trailingOnly = TRUE)
+if (length(args) != 5L) {
+    stop("usage: r-worker.R INPUT PRESENT_NAMES UNION_NAMES REPETITIONS OUTPUT")
+}
+
+input <- normalizePath(args[[1L]], winslash = "/", mustWork = TRUE)
+present <- scan(args[[2L]], what = character(), quiet = TRUE)
+union <- scan(args[[3L]], what = character(), quiet = TRUE)
+repetitions <- as.integer(args[[4L]])
+output <- args[[5L]]
+if (!length(present) || length(union) < length(present) ||
+    anyDuplicated(present) || !all(present %in% union) ||
+    is.na(repetitions) || repetitions < 1L) {
+    stop("invalid projection benchmark arguments")
+}
+
+script_argument <- grep("^--file=", commandArgs(trailingOnly = FALSE), value = TRUE)[[1L]]
+script_dir <- dirname(normalizePath(sub("^--file=", "", script_argument), winslash = "/"))
+sys.source(file.path(script_dir, "..", "benchmark-common.R"), envir = environment())
+benchmark_activate_library(c("dtaparser", "tidyselect"))
+
+read_any <- function() dtaparser::read_dta(
+    input, col_select = tidyselect::any_of(union)
+)
+read_all <- function() dtaparser::read_dta(
+    input, col_select = tidyselect::all_of(present)
+)
+validate <- function(value) {
+    if (!identical(names(value), present) || ncol(value) != length(present)) {
+        stop("projected result differs from the requested present columns")
+    }
+    invisible(value)
+}
+
+validate(read_any())
+validate(read_all())
+rows <- vector("list", repetitions * 2L)
+row_index <- 0L
+for (iteration in seq_len(repetitions)) {
+    gc()
+    started <- proc.time()[["elapsed"]]
+    value <- read_any()
+    elapsed <- proc.time()[["elapsed"]] - started
+    validate(value)
+    row_index <- row_index + 1L
+    rows[[row_index]] <- data.frame(
+        method = "dtaparser-any-of", iteration = iteration,
+        elapsed_seconds = elapsed, rows = nrow(value), columns = ncol(value)
+    )
+
+    gc()
+    started <- proc.time()[["elapsed"]]
+    value <- read_all()
+    elapsed <- proc.time()[["elapsed"]] - started
+    validate(value)
+    row_index <- row_index + 1L
+    rows[[row_index]] <- data.frame(
+        method = "dtaparser-all-of", iteration = iteration,
+        elapsed_seconds = elapsed, rows = nrow(value), columns = ncol(value)
+    )
+}
+write.table(
+    do.call(rbind, rows), output, sep = "\t", quote = FALSE,
+    row.names = FALSE, col.names = FALSE
+)

--- a/benchmarks/projection-introspection/results-2026-08-28.md
+++ b/benchmarks/projection-introspection/results-2026-08-28.md
@@ -1,0 +1,82 @@
+# Projection after introspection, 2026-08-28
+
+The union-safe `dtaparser::read_dta()` projection was faster than Stata's
+full-load, inspect, and keep sequence in all three synthetic cases and in the
+India 2021 DHS women's file. The real 5.2 GB survey took 301 ms with dtaparser
+and 552 ms with the union-safe Stata workflow.
+
+## Results
+
+Each synthetic method returned the same ten columns. The requested union had 100 names,
+of which 90 were absent from every fixture. Medians cover 11 measured warm-cache
+reads after one unmeasured warm-up read.
+
+| Case | Shape | DTA size | dtaparser `any_of` | dtaparser `all_of` | Stata load, inspect, keep | Stata direct projected `use` | Stata union-safe / dtaparser |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| tall | 500,000 x 100 | 230.1 MB | 14 ms | 14 ms | 16 ms | 28 ms | 1.14x |
+| wide | 50,000 x 1,000 | 230.6 MB | 14 ms | 13 ms | 17 ms | 15 ms | 1.21x |
+| tall-wide | 250,000 x 500 | 575.3 MB | 26 ms | 26 ms | 39 ms | 41 ms | 1.50x |
+
+The complementary real-file case selected 100 variables evenly across the
+India file's 5,972-column schema. Its requested union also included 100 absent
+sentinel names. Each method returned the same 724,115 x 100 result.
+
+| Case | Shape | DTA size | dtaparser `any_of` | dtaparser `all_of` | Stata load, inspect, keep | Stata direct projected `use` | Stata union-safe / dtaparser |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| India 2021 women | 724,115 x 5,972 | 5.196 GB | 301 ms | 301 ms | 552 ms | 482 ms | 1.83x |
+
+The India figures cover 11 measured warm-cache reads after one unmeasured
+warm-up. dtaparser was 45% faster than the union-safe Stata sequence and 38%
+faster than Stata's direct projection at the median.
+
+Allowing absent names did not impose a measurable penalty here. Across these
+trials, `any_of()` differed from `all_of()` by at most 1 ms at the median.
+
+The direct Stata projection is a useful lower bound but does not solve the same
+problem. It requires a varlist containing only names present in that file. Its
+mixed result is also a warning against treating file size alone as a prediction
+of projected read time. On the wide 230 MB fixture it nearly matched dtaparser;
+on the two taller fixtures it was slower than Stata's full-load sequence.
+
+## Interpretation
+
+The tested hypothesis holds for this matrix, the India file, and this machine. A pipeline can pass
+its cross-survey union directly to:
+
+```r
+dtaparser::read_dta(
+    path,
+    col_select = tidyselect::any_of(raw_variables_used_by_the_pipeline)
+)
+```
+
+Missing raw variables are omitted, present variables retain the union's order,
+and observation data for unselected columns are not decoded. This removes the
+need for a separate metadata read or survey-specific intersection before the
+main read.
+
+These numbers do not establish a universal advantage over Stata. The synthetic
+cases use fixed-width data, ten selected columns, and a 90% absent union. The
+India case adds one large real release-113 survey, 100 selected columns, and a
+50% absent union. All runs use a warm filesystem cache. Stata and R time only
+the read-to-in-memory-result operation; process startup and fixture generation
+are excluded. Other surveys, compressed source files, networked storage, or a
+different selected fraction may move the crossover. A corpus benchmark using
+the pipeline's real union is the next evidence worth collecting.
+
+## Environment and command
+
+- dtaparser 0.6.0 built from the working tree
+- Stata MP 18
+- R 4.6.1
+- macOS 26.5.2
+- Apple M4 Max, 16 cores, 128 GB memory
+
+```sh
+benchmarks/projection-introspection/benchmark.sh full 11
+benchmarks/projection-introspection/benchmark.sh india 11
+```
+
+The harness writes per-iteration timings, fixture sizes, and summaries below
+`target/projection-introspection/`. Generated DTA files and raw results are not
+committed.

--- a/benchmarks/projection-introspection/run.R
+++ b/benchmarks/projection-introspection/run.R
@@ -1,0 +1,155 @@
+args <- commandArgs(trailingOnly = TRUE)
+if (length(args) != 3L || !args[[1L]] %in% c("quick", "full", "india", "all")) {
+    stop("usage: run.R quick|full|india|all REPETITIONS OUTPUT_DIR")
+}
+profile <- args[[1L]]
+repetitions <- as.integer(args[[2L]])
+output_dir <- normalizePath(args[[3L]], winslash = "/", mustWork = FALSE)
+if (is.na(repetitions) || repetitions < 1L) stop("REPETITIONS must be positive")
+if (!requireNamespace("processx", quietly = TRUE)) stop("processx is required")
+
+script_argument <- grep("^--file=", commandArgs(trailingOnly = FALSE), value = TRUE)[[1L]]
+script_dir <- dirname(normalizePath(sub("^--file=", "", script_argument), winslash = "/"))
+sys.source(file.path(script_dir, "..", "benchmark-common.R"), envir = environment())
+benchmark_library <- benchmark_library_path()
+benchmark_activate_library("dtaparser", benchmark_library = benchmark_library)
+stata <- find_stata()
+rscript <- Sys.which("Rscript")
+
+synthetic_cases <- if (profile == "quick") {
+    data.frame(
+        case = c("tall", "wide"), rows = c(100000, 25000),
+        columns = c(100, 500), source = "synthetic"
+    )
+} else if (profile %in% c("full", "all")) {
+    data.frame(
+        case = c("tall", "wide", "tall-wide"),
+        rows = c(500000, 50000, 250000), columns = c(100, 1000, 500),
+        source = "synthetic"
+    )
+} else NULL
+real_cases <- if (profile %in% c("india", "all")) {
+    data.frame(
+        case = "india-2021-wm", rows = NA_real_, columns = NA_real_,
+        source = "india-2021-wm"
+    )
+} else NULL
+cases <- rbind(synthetic_cases, real_cases)
+dir.create(output_dir, recursive = TRUE, showWarnings = FALSE)
+
+raw_rows <- list()
+fixtures <- list()
+for (index in seq_len(nrow(cases))) {
+    item <- cases[index, ]
+    case_dir <- file.path(output_dir, item$case)
+    dir.create(case_dir, recursive = TRUE, showWarnings = FALSE)
+    input <- file.path(case_dir, "input.dta")
+    if (item$source == "synthetic") {
+        generation_result <- file.path(case_dir, "generation.tsv")
+        generated <- processx::run(
+            stata,
+            c("-q", "-b", "do", file.path(script_dir, "generate.do"), input,
+              as.character(item$rows), as.character(item$columns), generation_result),
+            wd = case_dir, error_on_status = FALSE, echo = FALSE
+        )
+        if (generated$status != 0L || !file.exists(generation_result) || !file.exists(input)) {
+            stop("fixture generation failed for ", item$case, ": ", generated$stderr)
+        }
+        generation <- scan(generation_result, what = character(), sep = "\t", quiet = TRUE)
+        if (length(generation) != 4L || generation[[1L]] != "ok") {
+            stop("invalid generation result for ", item$case)
+        }
+        item$bytes <- as.numeric(generation[[4L]])
+        present <- sprintf("v%05d", seq_len(10L))
+        union <- c(present, sprintf("absent%05d", seq_len(90L)))
+    } else {
+        private_input <- Sys.getenv(
+            "INDIA_2021_WM",
+            unset = "/opt/aww_cache/DHS/Original_Data/India 2021/wm.dta"
+        )
+        private_input <- normalizePath(private_input, winslash = "/", mustWork = TRUE)
+        if (!file.symlink(private_input, input)) {
+            stop("could not create a private India fixture alias")
+        }
+        metadata_names <- dtaparser:::.dta_metadata(input)
+        if (length(metadata_names) < 100L) stop("India fixture has fewer than 100 columns")
+        indices <- unique(as.integer(round(seq(1, length(metadata_names), length.out = 100L))))
+        if (length(indices) != 100L) stop("could not choose 100 distinct India columns")
+        present <- as.character(metadata_names[indices])
+        absent <- sprintf("_dtaparser_absent_%05d", seq_len(100L))
+        if (any(absent %in% metadata_names)) stop("absent-name sentinel exists in India fixture")
+        union <- c(present, absent)
+        item$columns <- length(metadata_names)
+        item$bytes <- as.numeric(file.info(private_input, extra_cols = FALSE)$size)
+    }
+    present_path <- file.path(case_dir, "present.txt")
+    union_path <- file.path(case_dir, "union.txt")
+    writeLines(paste(present, collapse = " "), present_path)
+    writeLines(paste(union, collapse = " "), union_path)
+
+    r_output <- file.path(case_dir, "r.tsv")
+    r_run <- processx::run(
+        rscript,
+        c("--vanilla", file.path(script_dir, "r-worker.R"), input,
+          present_path, union_path, as.character(repetitions), r_output),
+        env = c(
+            DTAPARSER_BENCH_LIB = benchmark_library,
+            R_ENVIRON_USER = "/dev/null", R_PROFILE_USER = "/dev/null"
+        ),
+        error_on_status = FALSE, echo = FALSE
+    )
+    if (r_run$status != 0L || !file.exists(r_output)) {
+        stop("R worker failed for ", item$case, ": ", r_run$stderr)
+    }
+    r_raw <- read.delim(
+        r_output, header = FALSE,
+        col.names = c("method", "iteration", "elapsed_seconds", "rows", "columns")
+    )
+
+    stata_output <- file.path(case_dir, "stata.tsv")
+    stata_run <- processx::run(
+        stata,
+        c("-q", "-b", "do", file.path(script_dir, "stata-worker.do"), input,
+          present_path, union_path, as.character(repetitions), stata_output),
+        wd = case_dir, error_on_status = FALSE, echo = FALSE
+    )
+    if (stata_run$status != 0L || !file.exists(stata_output)) {
+        stop("Stata worker failed for ", item$case, ": ", stata_run$stderr)
+    }
+    stata_raw <- read.delim(
+        stata_output, header = FALSE,
+        col.names = c("method", "iteration", "elapsed_seconds", "rows", "columns")
+    )
+    combined <- rbind(r_raw, stata_raw)
+    if (is.na(item$rows)) item$rows <- unique(combined$rows)
+    if (length(unique(combined$rows)) != 1L ||
+        any(combined$rows != item$rows) ||
+        any(combined$columns != length(present))) {
+        stop("worker result dimensions differ for ", item$case)
+    }
+    fixtures[[index]] <- data.frame(
+        case = item$case, source = item$source, rows = item$rows,
+        columns = item$columns, selected_columns = length(present),
+        union_columns = length(union), bytes = item$bytes,
+        stringsAsFactors = FALSE
+    )
+    combined$case <- item$case
+    raw_rows[[index]] <- combined[c("case", "method", "iteration", "elapsed_seconds", "rows", "columns")]
+    message(index, "/", nrow(cases), ": ", item$case)
+}
+
+raw <- do.call(rbind, raw_rows)
+fixture_table <- do.call(rbind, fixtures)
+write.table(raw, file.path(output_dir, "raw.tsv"), sep = "\t", quote = FALSE, row.names = FALSE)
+write.table(fixture_table, file.path(output_dir, "fixtures.tsv"), sep = "\t", quote = FALSE, row.names = FALSE)
+groups <- split(raw, interaction(raw$case, raw$method, drop = TRUE))
+summary <- do.call(rbind, lapply(groups, function(group) data.frame(
+    case = group$case[[1L]], method = group$method[[1L]],
+    median_seconds = median(group$elapsed_seconds),
+    min_seconds = min(group$elapsed_seconds),
+    max_seconds = max(group$elapsed_seconds), stringsAsFactors = FALSE
+)))
+summary <- summary[order(match(summary$case, cases$case), summary$median_seconds), ]
+rownames(summary) <- NULL
+write.table(summary, file.path(output_dir, "summary.tsv"), sep = "\t", quote = FALSE, row.names = FALSE)
+print(merge(summary, fixture_table, by = "case", sort = FALSE), row.names = FALSE)

--- a/benchmarks/projection-introspection/stata-worker.do
+++ b/benchmarks/projection-introspection/stata-worker.do
@@ -1,0 +1,53 @@
+version 18.0
+clear all
+set more off
+set maxvar 32767
+
+args input present_path union_path repetitions_arg output
+local repetitions = real("`repetitions_arg'")
+
+file open present_file using "`present_path'", read text
+file read present_file present
+file close present_file
+file open union_file using "`union_path'", read text
+file read union_file union
+file close union_file
+local expected : word count `present'
+
+quietly use `present' using "`input'", clear
+clear
+
+file open results using "`output'", write text replace
+forvalues iteration = 1/`repetitions' {
+    timer clear 1
+    timer on 1
+    quietly use "`input'", clear
+    local selected
+    foreach candidate of local union {
+        capture confirm variable `candidate'
+        if _rc == 0 local selected `selected' `candidate'
+    }
+    quietly keep `selected'
+    timer off 1
+    quietly timer list 1
+    local elapsed = r(t1)
+    if c(k) != `expected' {
+        file close results
+        error 9
+    }
+    file write results "stata-load-inspect-keep" _tab %9.0f (`iteration') _tab %21.9f (`elapsed') _tab %21.0f (_N) _tab %21.0f (c(k)) _n
+
+    timer clear 1
+    timer on 1
+    quietly use `present' using "`input'", clear
+    timer off 1
+    quietly timer list 1
+    local elapsed = r(t1)
+    if c(k) != `expected' {
+        file close results
+        error 9
+    }
+    file write results "stata-use-present" _tab %9.0f (`iteration') _tab %21.9f (`elapsed') _tab %21.0f (_N) _tab %21.0f (c(k)) _n
+}
+file close results
+exit, clear

--- a/r-package/dtaparser/README.md
+++ b/r-package/dtaparser/README.md
@@ -34,6 +34,39 @@ Across the full DHS, MICS, and NSFG comparison, `dtaparser` was faster on 1,803 
 
 These are warm-cache measurements from an Apple M4 Max, not performance guarantees. The multicore corpus refresh reused haven measurements made earlier on the same machine and files; the later India check likewise reran dtaparser only. See the [dated corpus report](https://github.com/jbearak/dta-parser/blob/main/benchmarks/r-corpus-performance/results-2026-08-24.md) for the full results and methodology.
 
+### Projected reads across surveys
+
+Pipelines that process many surveys can pass the union of every raw variable
+they use without first loading or special-casing each file:
+
+```r
+raw_variables <- c("caseid", "v005", "v012", "survey_specific_variable")
+data <- read_dta(
+  "survey.dta",
+  col_select = tidyselect::any_of(raw_variables)
+)
+```
+
+`any_of()` keeps requested variables that exist and silently omits those that
+do not. `read_dta()` resolves the selection from DTA metadata before reading
+observations, so it does not decode unselected columns.
+
+A warm-cache benchmark selected 100 variables spread across the 5.2 GB,
+5,972-column India 2021 DHS women's file. The `any_of()` union also contained
+100 absent names:
+
+| Method | Median read time |
+| --- | ---: |
+| `read_dta(any_of(union))` | 0.301 seconds |
+| Stata direct projected `use` with known-present names | 0.482 seconds |
+| Stata full `use`, inspect union, then `keep` | 0.552 seconds |
+
+All methods returned the same 724,115-row, 100-column result. These are medians
+from 11 runs on an Apple M4 Max. The direct Stata command is not union-safe;
+Stata errors if its varlist contains an absent name. See the
+[dated projection report](https://github.com/jbearak/dta-parser/blob/main/benchmarks/projection-introspection/results-2026-08-28.md)
+for the synthetic comparisons, per-method bounds, and limitations.
+
 ### Synthetic write benchmarks
 
 The primary synthetic benchmark gives dtaparser the exact output from Stata's


### PR DESCRIPTION
## Summary

- add a reproducible benchmark for union-safe projected DTA reads
- compare dtaparser any_of projections with Stata full-load and direct-projection workflows
- record synthetic and India 2021 DHS results and document the workflow

## Checks

- bash -n benchmarks/projection-introspection/benchmark.sh
- parsed both benchmark R scripts with Rscript
- git diff --check origin/main...HEAD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented union-safe projected reads across surveys using `any_of()`, including handling of unavailable variables without decoding unselected columns.
  * Added guidance, limitations, comparisons, and examples for projected reads.
  * Added comprehensive documentation for the projection-introspection benchmark suite and its supported profiles.

* **Benchmarks**
  * Added reproducible R and Stata benchmarks covering synthetic datasets and the India 2021 DHS women’s file.
  * Added benchmark reporting for performance, matching results, absent-column handling, and execution details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->