### PR TITLE
Optimize native-backed DTA writes

### DIFF
--- a/benchmarks/large-scale/README.md
+++ b/benchmarks/large-scale/README.md
@@ -44,10 +44,12 @@ in the primary matrix, independently of the rotating secondary order. Raw
 primary rows retain the exact shared input SHA-256 in addition to elapsed time,
 peak RSS, and output size. After all timing completes, an untimed fresh-process
 write validates each R writer at both scales before publication. dtatools must
-preserve the semantic DTA model, including storage types. Haven must preserve
-the values and metadata in its own read model, and its expected widening of all
-numeric storage to `double` is recorded separately. Those rows are retained in
-`write-validation.tsv`. The default is seven iterations per writer and size.
+preserve its read model and each declared numeric storage type. Haven must
+preserve the values and metadata in its own read model, and its expected
+widening of all numeric storage to `double` is recorded separately. Exact
+fixed-string widths are not exposed by either read model and are not part of
+this validation. Those rows are retained in `write-validation.tsv`. The default
+is seven iterations per writer and size.
 
 The [2026-08-28 write report](results-2026-08-28.md) records the latest complete
 seven-iteration comparison. The [2026-08-27 report](results-2026-08-27.md) is

--- a/benchmarks/large-scale/README.md
+++ b/benchmarks/large-scale/README.md
@@ -43,9 +43,11 @@ write workload. Stata necessarily precedes both R writers; their order rotates
 in the primary matrix, independently of the rotating secondary order. Raw
 primary rows retain the exact shared input SHA-256 in addition to elapsed time,
 peak RSS, and output size. After all timing completes, an untimed fresh-process
-write and semantic reread validate each R writer at both scales before
-publication. Those rows are retained in `write-validation.tsv`. The default is
-seven iterations per writer and size.
+write validates each R writer at both scales before publication. dtatools must
+preserve the semantic DTA model, including storage types. Haven must preserve
+the values and metadata in its own read model, and its expected widening of all
+numeric storage to `double` is recorded separately. Those rows are retained in
+`write-validation.tsv`. The default is seven iterations per writer and size.
 
 The [2026-08-28 write report](results-2026-08-28.md) records the latest complete
 seven-iteration comparison. The [2026-08-27 report](results-2026-08-27.md) is

--- a/benchmarks/large-scale/README.md
+++ b/benchmarks/large-scale/README.md
@@ -15,15 +15,16 @@ outside timed regions. There are no timing assertions or CI gates.
 
 The same run has two synthetic write benchmarks. In every primary iteration, a
 fresh Stata process generates the data in memory and times its first `save`.
-dtatools then loads and saves that exact Stata output. This rules out timing an
-unchanged-file save after `use`. The 40 columns cover every numeric Stata
-storage type: 4 `byte`, 4 `int`,
-9 `long`, 4 `float`, and 9 `double` columns, plus 10 fixed-width strings. Four
+Each fresh R writer process then loads that exact output with dtatools before
+either dtatools or Haven saves the resulting Stata-class object. This rules out
+timing an unchanged-file save after `use`. The 40 columns cover every numeric
+Stata storage type: 4 `byte`, 4 `int`, 9 `long`, 4 `float`, and 9 `double`
+columns, plus 10 fixed-width strings. Four
 of the longs have value labels; two doubles are Stata dates and two are Stata
-datetimes. the dtatools package's reader retains those storage declarations, while Stata
-creates them directly with storage-qualified `generate` commands. The canonical
-100 MB and 1 GB inputs used by the read benchmarks come from the same Stata
-generator.
+datetimes. The dtatools reader retains those storage declarations, while Stata
+creates them directly with storage-qualified `generate` commands. The
+canonical 100 MB and 1 GB inputs used by the read benchmarks come from the
+same Stata generator.
 
 The secondary benchmark compares dtatools with Haven on the exact same
 freshly constructed ordinary R data frame. Its 40 columns are 11 doubles, 11
@@ -31,18 +32,20 @@ integers, 4 logicals, 2 `Date` columns, 2 UTC `POSIXct` columns, and 10 characte
 columns. They have no Stata storage, format, label, or value-label attributes.
 Its checked-in row counts are independent of the primary DTA fixture, so a
 change to the primary storage mix cannot silently change the secondary workload.
-Stata is excluded because it cannot receive an in-memory R data frame, and
-Haven is excluded from the primary matrix because its reader widens Stata
-numeric storage into ordinary R vectors.
+Stata is excluded because it cannot receive an in-memory R data frame. The
+primary R writer order rotates after Stata's first save.
 
 Every writer runs in a fresh process. Stata's primary operation timer covers
-only its first `save`; the dtatools package's starts after it reads Stata's output. The
-secondary timer starts after the R input has been constructed. Peak RSS
-covers the whole fresh process because the in-memory input is part of the write
-workload. Stata necessarily precedes dtatools in each primary pair; writer order
-rotates in the independent secondary matrix. Raw primary rows retain the exact
-paired input SHA-256 in addition to elapsed time, peak RSS, and output size. The
-default is seven iterations per writer and size.
+only its first `save`; each R writer's timer starts after dtatools reads Stata's
+output. The secondary timer starts after the R input has been constructed. Peak
+RSS covers the whole fresh process because the in-memory input is part of the
+write workload. Stata necessarily precedes both R writers; their order rotates
+in the primary matrix, independently of the rotating secondary order. Raw
+primary rows retain the exact shared input SHA-256 in addition to elapsed time,
+peak RSS, and output size. After all timing completes, an untimed fresh-process
+write and semantic reread validate each R writer at both scales before
+publication. Those rows are retained in `write-validation.tsv`. The default is
+seven iterations per writer and size.
 
 The [2026-08-28 write report](results-2026-08-28.md) records the latest complete
 seven-iteration comparison. The [2026-08-27 report](results-2026-08-27.md) is
@@ -114,9 +117,9 @@ benchmarks/large-scale/dtatools-write-only.sh 7
 
 The dtatools-only runner rebuilds the current package, verifies the primary
 synthetic hashes against the fixed reference rows, and publishes both its raw
-measurements and a combined dtatools/Stata comparison beneath
+measurements and a combined Stata/dtatools/Haven comparison beneath
 `target/large-scale/dtatools-write-runs/`. Pass a complete run directory as
-the second argument to override `target/large-scale/CURRENT`.
+the second argument to override `target/large-scale/PRIMARY_WRITE_CURRENT`.
 
 Run only the complete paired primary matrix with:
 

--- a/benchmarks/large-scale/README.md
+++ b/benchmarks/large-scale/README.md
@@ -106,7 +106,7 @@ benchmarks/large-scale/benchmark.sh 1 1
 ```
 
 After a complete comparison, rerun only the primary dtatools writes while
-retaining the selected run's Stata measurements:
+retaining the selected run's Haven and Stata measurements:
 
 ```sh
 benchmarks/large-scale/dtatools-write-only.sh 7
@@ -125,10 +125,9 @@ benchmarks/large-scale/primary-write-only.sh 7
 ```
 
 This runner rebuilds dtatools, asks Stata to publish a complete immutable
-synthetic-input generation, and
-publishes the paired Stata/dtatools results under
-`target/large-scale/primary-write-runs/`. It runs neither the read benchmark nor
-the large corpus suite.
+synthetic-input generation, and publishes the dtatools, Haven, and Stata results
+under `target/large-scale/primary-write-runs/`. It runs neither the read
+benchmark nor the large corpus suite.
 
 Run only the secondary ordinary-R matrix with:
 
@@ -155,10 +154,10 @@ The default raw report has 1,212 rows:
 2 sizes × 2 workloads × 3 implementations × 101 iterations
 ```
 
-The primary `write-raw.tsv` has 28 rows by default:
+The primary `write-raw.tsv` has 42 rows by default:
 
 ```text
-2 sizes × 2 writers × 7 iterations
+2 sizes × 3 writers × 7 iterations
 ```
 
 The secondary `r-write-raw.tsv` also has 28 rows:

--- a/benchmarks/large-scale/combine-write-summary.R
+++ b/benchmarks/large-scale/combine-write-summary.R
@@ -34,7 +34,8 @@ output <- normalizePath(args[[7L]], winslash = "/", mustWork = FALSE)
 
 contract_fields <- c(
     "workload", "fixture_storage_schema", "fixture_creator",
-    "fixture_generator_sha256", "stata_save_state", "r_writer_input"
+    "fixture_generator_sha256", "stata_save_state", "r_writer_input",
+    "full_scale_validation"
 )
 if (nrow(current_provenance) != 1L || nrow(reference_provenance) != 1L ||
     !all(contract_fields %in% names(current_provenance)) ||

--- a/benchmarks/large-scale/combine-write-summary.R
+++ b/benchmarks/large-scale/combine-write-summary.R
@@ -1,8 +1,9 @@
 args <- commandArgs(trailingOnly = TRUE)
-if (length(args) != 7L) {
+if (length(args) != 9L) {
     stop(paste(
-        "usage: combine-write-summary.R CURRENT_RAW CURRENT_SUMMARY CURRENT_PROVENANCE",
-        "REFERENCE_RAW REFERENCE_SUMMARY REFERENCE_PROVENANCE OUTPUT"
+        "usage: combine-write-summary.R CURRENT_RAW CURRENT_SUMMARY",
+        "CURRENT_PROVENANCE CURRENT_VALIDATION REFERENCE_RAW",
+        "REFERENCE_SUMMARY REFERENCE_PROVENANCE REFERENCE_VALIDATION OUTPUT"
     ))
 }
 
@@ -17,6 +18,7 @@ sys.source(
     file.path(script_dir, "..", "benchmark-common.R"),
     envir = environment()
 )
+sys.source(file.path(script_dir, "write-run-common.R"), envir = environment())
 
 read_table <- function(path) {
     read.delim(
@@ -27,10 +29,12 @@ read_table <- function(path) {
 current_raw <- read_table(args[[1L]])
 current_summary <- read_table(args[[2L]])
 current_provenance <- read_table(args[[3L]])
-reference_raw <- read_table(args[[4L]])
-reference_summary <- read_table(args[[5L]])
-reference_provenance <- read_table(args[[6L]])
-output <- normalizePath(args[[7L]], winslash = "/", mustWork = FALSE)
+current_validation <- read_table(args[[4L]])
+reference_raw <- read_table(args[[5L]])
+reference_summary <- read_table(args[[6L]])
+reference_provenance <- read_table(args[[7L]])
+reference_validation <- read_table(args[[8L]])
+output <- normalizePath(args[[9L]], winslash = "/", mustWork = FALSE)
 
 contract_fields <- c(
     "workload", "fixture_storage_schema", "fixture_creator",
@@ -45,10 +49,125 @@ if (nrow(current_provenance) != 1L || nrow(reference_provenance) != 1L ||
     stop("current and reference writes do not share the primary workload contract")
 }
 
-if (!identical(unique(current_raw$writer), "dtatools") ||
-    !identical(unique(current_summary$writer), "dtatools")) {
-    stop("current write results must contain only dtatools")
+datasets <- c("100mb", "1gb")
+parse_iterations <- function(provenance, description) {
+    text <- as.character(provenance$iterations)
+    value <- suppressWarnings(as.integer(text))
+    if (length(text) != 1L || is.na(value) || value < 1L ||
+        !identical(as.character(value), text)) {
+        stop(description, " provenance has invalid iterations")
+    }
+    value
 }
+summary_key <- function(data) paste(data$dataset, data$writer, sep = "\r")
+validate_summary_matrix <- function(data, writers, iterations, description) {
+    required <- c(
+        "dataset", "writer", "iterations", "input_bytes",
+        "median_seconds", "p05_seconds", "p95_seconds",
+        "median_peak_rss_bytes", "median_output_bytes",
+        "provenance_id", "build_provenance_id"
+    )
+    expected <- expand.grid(
+        dataset = datasets, writer = writers, stringsAsFactors = FALSE
+    )
+    if (!all(required %in% names(data)) || anyDuplicated(summary_key(data)) ||
+        !setequal(summary_key(data), summary_key(expected)) ||
+        any(data$iterations != iterations)) {
+        stop(description, " summary is not the exact expected matrix")
+    }
+}
+validate_binding <- function(data, provenance, description) {
+    required <- c("provenance_id", "build_provenance_id")
+    if (!all(required %in% names(data)) ||
+        !identical(unique(data$provenance_id), provenance$provenance_id) ||
+        !identical(
+            unique(data$build_provenance_id),
+            provenance$build_provenance_id
+        )) {
+        stop(description, " is not bound to its provenance")
+    }
+}
+validate_validation_matrix <- function(
+    data, raw, writers, provenance, description
+) {
+    required <- c(
+        "dataset", "dataset_sha256", "writer", "rows", "columns",
+        "output_bytes", "parity_status", "storage_status",
+        "input_storage_schema", "output_storage_schema",
+        "provenance_id", "build_provenance_id"
+    )
+    expected <- expand.grid(
+        dataset = datasets, writer = writers, stringsAsFactors = FALSE
+    )
+    if (!all(required %in% names(data)) ||
+        anyDuplicated(summary_key(data)) ||
+        !setequal(summary_key(data), summary_key(expected))) {
+        stop(description, " validation is not the exact expected matrix")
+    }
+    validate_binding(data, provenance, paste(description, "validation"))
+    fixture_schema <- provenance$fixture_storage_schema[[1L]]
+    widened_schema <- "byte=0,int=0,long=0,float=0,double=30,string=10"
+    for (index in seq_len(nrow(data))) {
+        row <- data[index, , drop = FALSE]
+        matching <- raw[
+            raw$dataset == row$dataset & raw$writer == row$writer,
+            , drop = FALSE
+        ]
+        if (!nrow(matching) ||
+            !identical(unique(matching$dataset_sha256), row$dataset_sha256) ||
+            !identical(unique(matching$rows), row$rows) ||
+            !identical(unique(matching$columns), row$columns) ||
+            !identical(unique(matching$output_bytes), row$output_bytes) ||
+            row$input_storage_schema != fixture_schema) {
+            stop(description, " validation does not match its timed rows")
+        }
+        if (row$writer == "dtatools") {
+            valid <- row$parity_status == "semantic-dta-identical" &&
+                row$storage_status == "preserved" &&
+                row$output_storage_schema == fixture_schema
+        } else {
+            valid <- row$parity_status == "haven-model-identical" &&
+                row$storage_status == "numeric-storage-widened-to-double" &&
+                row$output_storage_schema == widened_schema
+        }
+        if (!valid) stop(description, " validation status is invalid")
+    }
+}
+validate_bundle <- function(
+    raw, summary, validation, provenance, writers, validation_writers,
+    description
+) {
+    iterations <- parse_iterations(provenance, description)
+    if (!identical(provenance$writers, paste(writers, collapse = ","))) {
+        stop(description, " provenance has unexpected writers")
+    }
+    validate_write_result_matrix(raw, datasets, writers, iterations, description)
+    validate_summary_matrix(summary, writers, iterations, description)
+    expected_summary <- summarize_write_results(
+        raw, datasets, writers, "input_bytes"
+    )
+    rownames(summary) <- NULL
+    rownames(expected_summary) <- NULL
+    if (!identical(summary, expected_summary)) {
+        stop(description, " summary does not match its raw results")
+    }
+    validate_binding(raw, provenance, paste(description, "raw results"))
+    validate_binding(summary, provenance, paste(description, "summary"))
+    validate_validation_matrix(
+        validation, raw, validation_writers, provenance, description
+    )
+}
+validate_bundle(
+    current_raw, current_summary, current_validation, current_provenance,
+    "dtatools", "dtatools", "current write"
+)
+reference_writers <- c("dtatools", "haven", "stata")
+validate_bundle(
+    reference_raw, reference_summary, reference_validation,
+    reference_provenance, reference_writers, c("dtatools", "haven"),
+    "reference write"
+)
+
 fixed_writers <- c("haven", "stata")
 fixed_raw <- reference_raw[reference_raw$writer %in% fixed_writers, , drop = FALSE]
 fixed_summary <- reference_summary[

--- a/benchmarks/large-scale/combine-write-summary.R
+++ b/benchmarks/large-scale/combine-write-summary.R
@@ -18,6 +18,7 @@ sys.source(
     file.path(script_dir, "..", "benchmark-common.R"),
     envir = environment()
 )
+sys.source(file.path(script_dir, "provenance.R"), envir = environment())
 sys.source(file.path(script_dir, "write-run-common.R"), envir = environment())
 
 read_table <- function(path) {
@@ -26,15 +27,45 @@ read_table <- function(path) {
         check.names = FALSE, stringsAsFactors = FALSE
     )
 }
+read_provenance <- function(path) {
+    read.delim(
+        normalizePath(path, winslash = "/", mustWork = TRUE),
+        check.names = FALSE, stringsAsFactors = FALSE,
+        colClasses = "character", na.strings = character()
+    )
+}
 current_raw <- read_table(args[[1L]])
 current_summary <- read_table(args[[2L]])
-current_provenance <- read_table(args[[3L]])
+current_provenance <- read_provenance(args[[3L]])
 current_validation <- read_table(args[[4L]])
 reference_raw <- read_table(args[[5L]])
 reference_summary <- read_table(args[[6L]])
-reference_provenance <- read_table(args[[7L]])
+reference_provenance <- read_provenance(args[[7L]])
 reference_validation <- read_table(args[[8L]])
 output <- normalizePath(args[[9L]], winslash = "/", mustWork = FALSE)
+
+validate_provenance <- function(provenance, description) {
+    required <- c("provenance_id", "created_at_utc", "build_provenance_id")
+    if (nrow(provenance) != 1L || anyDuplicated(names(provenance)) ||
+        !all(required %in% names(provenance))) {
+        stop(description, " provenance is not a single complete record")
+    }
+    benchmark_assert_provenance_fields(provenance)
+    stable_fields <- setdiff(
+        names(provenance), c("provenance_id", "created_at_utc")
+    )
+    expected_id <- benchmark_provenance_id(provenance[stable_fields])
+    if (!identical(as.character(provenance$provenance_id[[1L]]), expected_id)) {
+        stop(description, " provenance ID does not match its stable fields")
+    }
+    if (!grepl(
+        "^[0-9a-f]{64}$", as.character(provenance$build_provenance_id[[1L]])
+    )) {
+        stop(description, " build provenance ID is invalid")
+    }
+}
+validate_provenance(current_provenance, "current write")
+validate_provenance(reference_provenance, "reference write")
 
 contract_fields <- c(
     "workload", "fixture_storage_schema", "fixture_creator",

--- a/benchmarks/large-scale/combine-write-summary.R
+++ b/benchmarks/large-scale/combine-write-summary.R
@@ -173,6 +173,9 @@ validate_bundle <- function(
         stop(description, " provenance has unexpected writers")
     }
     validate_write_result_matrix(raw, datasets, writers, iterations, description)
+    validate_primary_write_inputs(
+        raw, datasets, writers, provenance, description
+    )
     validate_summary_matrix(summary, writers, iterations, description)
     expected_summary <- summarize_write_results(
         raw, datasets, writers, "input_bytes"

--- a/benchmarks/large-scale/combine-write-summary.R
+++ b/benchmarks/large-scale/combine-write-summary.R
@@ -93,7 +93,7 @@ validate_validation_matrix <- function(
     required <- c(
         "dataset", "dataset_sha256", "writer", "rows", "columns",
         "output_bytes", "parity_status", "storage_status",
-        "input_storage_schema", "output_storage_schema",
+        "input_storage_class_counts", "output_storage_class_counts",
         "provenance_id", "build_provenance_id"
     )
     expected <- expand.grid(
@@ -118,17 +118,17 @@ validate_validation_matrix <- function(
             !identical(unique(matching$rows), row$rows) ||
             !identical(unique(matching$columns), row$columns) ||
             !identical(unique(matching$output_bytes), row$output_bytes) ||
-            row$input_storage_schema != fixture_schema) {
+            row$input_storage_class_counts != fixture_schema) {
             stop(description, " validation does not match its timed rows")
         }
         if (row$writer == "dtatools") {
-            valid <- row$parity_status == "semantic-dta-identical" &&
-                row$storage_status == "preserved" &&
-                row$output_storage_schema == fixture_schema
+            valid <- row$parity_status == "dtatools-model-identical" &&
+                row$storage_status == "declared-numeric-storage-preserved" &&
+                row$output_storage_class_counts == fixture_schema
         } else {
             valid <- row$parity_status == "haven-model-identical" &&
                 row$storage_status == "numeric-storage-widened-to-double" &&
-                row$output_storage_schema == widened_schema
+                row$output_storage_class_counts == widened_schema
         }
         if (!valid) stop(description, " validation status is invalid")
     }
@@ -148,7 +148,13 @@ validate_bundle <- function(
     )
     rownames(summary) <- NULL
     rownames(expected_summary) <- NULL
-    if (!identical(summary, expected_summary)) {
+    time_fields <- c("median_seconds", "p05_seconds", "p95_seconds")
+    exact_fields <- setdiff(names(expected_summary), time_fields)
+    times_match <- all(vapply(time_fields, function(field) {
+        all(abs(summary[[field]] - expected_summary[[field]]) <= 1e-12)
+    }, logical(1L)))
+    if (!identical(summary[exact_fields], expected_summary[exact_fields]) ||
+        !times_match) {
         stop(description, " summary does not match its raw results")
     }
     validate_binding(raw, provenance, paste(description, "raw results"))

--- a/benchmarks/large-scale/combine-write-summary.R
+++ b/benchmarks/large-scale/combine-write-summary.R
@@ -34,7 +34,7 @@ output <- normalizePath(args[[7L]], winslash = "/", mustWork = FALSE)
 
 contract_fields <- c(
     "workload", "fixture_storage_schema", "fixture_creator",
-    "fixture_generator_sha256", "stata_save_state", "dtatools_input"
+    "fixture_generator_sha256", "stata_save_state", "r_writer_input"
 )
 if (nrow(current_provenance) != 1L || nrow(reference_provenance) != 1L ||
     !all(contract_fields %in% names(current_provenance)) ||
@@ -48,14 +48,14 @@ if (!identical(unique(current_raw$writer), "dtatools") ||
     !identical(unique(current_summary$writer), "dtatools")) {
     stop("current write results must contain only dtatools")
 }
-fixed_writers <- "stata"
+fixed_writers <- c("haven", "stata")
 fixed_raw <- reference_raw[reference_raw$writer %in% fixed_writers, , drop = FALSE]
 fixed_summary <- reference_summary[
     reference_summary$writer %in% fixed_writers, , drop = FALSE
 ]
 if (!setequal(unique(fixed_raw$writer), fixed_writers) ||
     !setequal(unique(fixed_summary$writer), fixed_writers)) {
-    stop("reference write results must contain Stata")
+    stop("reference write results must contain Haven and Stata")
 }
 
 dataset_key <- function(data) paste(data$dataset, data$dataset_sha256, sep = "\r")
@@ -74,7 +74,7 @@ if (!identical(current_shape, reference_shape)) {
 current_summary$measurement <- "current-dtatools"
 fixed_summary$measurement <- "fixed-reference"
 combined <- rbind(current_summary, fixed_summary)
-writer_order <- c("dtatools", "stata")
+writer_order <- c("dtatools", "haven", "stata")
 dataset_order <- c("100mb", "1gb")
 combined <- combined[
     order(match(combined$dataset, dataset_order),

--- a/benchmarks/large-scale/dtatools-write-only.sh
+++ b/benchmarks/large-scale/dtatools-write-only.sh
@@ -18,7 +18,8 @@ if [ -z "$reference_run" ]; then
     reference_run="$target_dir/$reference_relative"
 fi
 reference_run=$(CDPATH= cd -- "$reference_run" && pwd)
-for file in write-raw.tsv write-summary.tsv write-provenance.tsv; do
+for file in write-raw.tsv write-summary.tsv write-provenance.tsv \
+    write-validation.tsv; do
     if [ ! -f "$reference_run/$file" ]; then
         printf 'reference run is missing %s\n' "$file" >&2
         exit 2
@@ -53,11 +54,15 @@ Rscript --vanilla "$script_dir/write-run.R" \
     "$iterations"
 cp "$reference_run/write-provenance.tsv" \
     "$run_stage/reference-write-provenance.tsv"
+cp "$reference_run/write-validation.tsv" \
+    "$run_stage/reference-write-validation.tsv"
 Rscript --vanilla "$script_dir/combine-write-summary.R" \
     "$run_stage/write-raw.tsv" "$run_stage/write-summary.tsv" \
-    "$run_stage/write-provenance.tsv" "$reference_run/write-raw.tsv" \
+    "$run_stage/write-provenance.tsv" "$run_stage/write-validation.tsv" \
+    "$reference_run/write-raw.tsv" \
     "$reference_run/write-summary.tsv" \
     "$reference_run/write-provenance.tsv" \
+    "$reference_run/write-validation.tsv" \
     "$run_stage/comparison-summary.tsv"
 
 publish_benchmark_run \

--- a/benchmarks/large-scale/dtatools-write-only.sh
+++ b/benchmarks/large-scale/dtatools-write-only.sh
@@ -10,11 +10,11 @@ reference_run=${2:-}
 
 require_positive_integer "$iterations" "iterations"
 if [ -z "$reference_run" ]; then
-    if [ ! -f "$target_dir/CURRENT" ]; then
+    if [ ! -f "$target_dir/PRIMARY_WRITE_CURRENT" ]; then
         printf '%s\n' "pass the prior complete run directory" >&2
         exit 2
     fi
-    IFS= read -r reference_relative < "$target_dir/CURRENT"
+    IFS= read -r reference_relative < "$target_dir/PRIMARY_WRITE_CURRENT"
     reference_run="$target_dir/$reference_relative"
 fi
 reference_run=$(CDPATH= cd -- "$reference_run" && pwd)

--- a/benchmarks/large-scale/results-2026-08-28.md
+++ b/benchmarks/large-scale/results-2026-08-28.md
@@ -5,7 +5,7 @@ Run date: 2026-08-28.
 Environment: Apple M4 Max, 128 GB RAM, macOS 26.5.2, R 4.6.1,
 dtatools 0.6.0, Haven 2.5.5, and Stata/MP 18. The primary matrix built and
 installed the package into a fresh private benchmark library from clean commit
-`17673a250db26d2a354675fa0f5f8b611eef53b9` (`git_dirty = FALSE`). The
+`29749d1a60736a7213221d16f7f363df8cf00258` (`git_dirty = FALSE`). The
 secondary matrix is retained from clean commit
 `db89c7e537a2d71de80262bc2fd46917fa5f9f44`; it does not exercise the optimized
 native-backed path. The corpus qualification remains from clean commit
@@ -27,29 +27,32 @@ first `save`. Four longs are value-labelled; two doubles are dates and two are
 datetimes. Each fresh R process then reads that exact Stata output with
 dtatools before timing either dtatools or Haven. The R writer order rotates.
 Raw rows retain the shared input SHA-256 to enforce input identity.
+After timing, one fresh output from each R writer at each scale was reread and
+required to be semantically identical to its input. The four successful checks
+are retained in `write-validation.tsv` in the private bundle.
 
 | Scale | Writer | Median time | 5th--95th percentile | Median peak RSS | Median output |
 | --- | --- | ---: | ---: | ---: | ---: |
 | 100 MB | Stata | 0.013 s | 0.0130--0.0140 s | 211.943 MB | 100.000 MB |
-| 100 MB | dtatools | 0.023 s | 0.0230--0.0240 s | 380.092 MB | 93.969 MB |
-| 100 MB | Haven | 1.226 s | 1.2213--1.2396 s | 471.613 MB | 118.093 MB |
-| 1 GB | Stata | 0.130 s | 0.1283--0.1320 s | 1.307 GB | 1.000 GB |
-| 1 GB | dtatools | 0.151 s | 0.1496--0.1779 s | 0.840 GB | 0.940 GB |
-| 1 GB | Haven | 9.059 s | 8.9931--9.0724 s | 1.285 GB | 1.181 GB |
+| 100 MB | dtatools | 0.023 s | 0.0230--0.0237 s | 382.517 MB | 93.969 MB |
+| 100 MB | Haven | 1.232 s | 1.2255--1.2388 s | 471.663 MB | 118.093 MB |
+| 1 GB | Stata | 0.131 s | 0.1286--0.1324 s | 1.307 GB | 1.000 GB |
+| 1 GB | dtatools | 0.150 s | 0.1486--0.1643 s | 0.839 GB | 0.940 GB |
+| 1 GB | Haven | 9.052 s | 9.0159--9.1530 s | 1.283 GB | 1.181 GB |
 
-On these inputs, Haven took 53.3 times dtatools' median at 100 MB and 60.0 times
-at 1 GB. dtatools took 1.77 times Stata's median at 100 MB and 1.16 times at
-1 GB. Compared with Haven, dtatools used 19.4% less peak RSS at 100 MB and
-34.6% less at 1 GB. Its output was approximately 20.4% smaller than Haven's and
-6.0% smaller than Stata's after inferring narrower storage. dtatools used 79.3%
-more peak RSS than Stata at 100 MB but 35.7% less at 1 GB.
+On these inputs, Haven took 53.6 times dtatools' median at 100 MB and 60.3 times
+at 1 GB. dtatools took 1.77 times Stata's median at 100 MB and 1.15 times at
+1 GB. Compared with Haven, dtatools used 18.9% less peak RSS at 100 MB and
+34.7% less at 1 GB. Its output was approximately 20.4% smaller than Haven's and
+6.0% smaller than Stata's after inferring narrower storage. dtatools used 80.5%
+more peak RSS than Stata at 100 MB but 35.8% less at 1 GB.
 
 The primary run provenance ID is
-`dfd2e2342797c090e3bfccc651269c0151dde9d97f5ca93381502207b2eb1c77`;
+`9a7e4508119f8144450818a8560c2a841f3def27f4403f686c1e8e29311d92f3`;
 its build provenance ID is
-`eed19ad2e59d3335e14ca2c2b609f23edd568e4df381253131b5c2ba8accfe34`.
+`bbf81f583615c0f5a8dceeb980faf4acf484b317ad07bf5ac3839b3789300da9`.
 The content-bound private bundle is retained at
-`target/large-scale/primary-write-runs/20260829T101836Z-dfd2e2342797c090-66335`.
+`target/large-scale/primary-write-runs/20260829T103547Z-9a7e4508119f8144-73068`.
 
 ## Secondary ordinary-R matrix
 
@@ -81,7 +84,7 @@ The content-bound private bundle is retained at
 
 Against clean commit `db89c7e537a2d71de80262bc2fd46917fa5f9f44`, the
 dtatools primary median fell from 0.119 s to 0.023 s at 100 MB (80.7%) and
-from 1.225 s to 0.151 s at 1 GB (87.7%). The ordinary-R matrix was not rerun
+from 1.225 s to 0.150 s at 1 GB (87.8%). The ordinary-R matrix was not rerun
 because it does not use native-backed imported columns. These cross-run
 comparisons are useful directional checks, not timing assertions or
 cross-machine performance guarantees.

--- a/benchmarks/large-scale/results-2026-08-28.md
+++ b/benchmarks/large-scale/results-2026-08-28.md
@@ -28,10 +28,12 @@ datetimes. Each fresh R process then reads that exact Stata output with
 dtatools before timing either dtatools or Haven. The R writer order rotates.
 Raw rows retain the shared input SHA-256 to enforce input identity.
 After timing, one fresh output from each R writer at each scale was reread and
-validated. dtatools preserved the full semantic DTA model. Haven preserved
-values and the metadata represented by its read model, while widening all 30
-numeric columns to `double`. The four parity and storage-schema checks are
-retained in `write-validation.tsv` in the private bundle.
+validated. dtatools preserved its read model and each declared numeric storage
+type. Haven preserved values and the metadata represented by its read model,
+while widening all 30 numeric columns to `double`. Exact fixed-string widths
+are not exposed by either read model and were not compared. The four parity and
+storage-class checks are retained in `write-validation.tsv` in the private
+bundle.
 
 | Scale | Writer | Median time | 5th--95th percentile | Median peak RSS | Median output |
 | --- | --- | ---: | ---: | ---: | ---: |

--- a/benchmarks/large-scale/results-2026-08-28.md
+++ b/benchmarks/large-scale/results-2026-08-28.md
@@ -5,7 +5,7 @@ Primary refresh date: 2026-08-29. Retained secondary matrix date: 2026-08-28.
 Environment: Apple M4 Max, 128 GB RAM, macOS 26.5.2, R 4.6.1,
 dtatools 0.6.0, Haven 2.5.5, and Stata/MP 18. The primary matrix built and
 installed the package into a fresh private benchmark library from clean commit
-`29749d1a60736a7213221d16f7f363df8cf00258` (`git_dirty = FALSE`). The
+`7fe0a675e5cde4a3e3e28d2f75d0d94845df7ad4` (`git_dirty = FALSE`). The
 secondary matrix is retained from clean commit
 `db89c7e537a2d71de80262bc2fd46917fa5f9f44`; it does not exercise the optimized
 native-backed path. The corpus qualification remains from clean commit
@@ -35,27 +35,27 @@ retained in `write-validation.tsv` in the private bundle.
 
 | Scale | Writer | Median time | 5th--95th percentile | Median peak RSS | Median output |
 | --- | --- | ---: | ---: | ---: | ---: |
-| 100 MB | Stata | 0.013 s | 0.0130--0.0140 s | 211.943 MB | 100.000 MB |
-| 100 MB | dtatools | 0.023 s | 0.0230--0.0237 s | 382.517 MB | 93.969 MB |
-| 100 MB | Haven | 1.232 s | 1.2255--1.2388 s | 471.663 MB | 118.093 MB |
-| 1 GB | Stata | 0.131 s | 0.1286--0.1324 s | 1.307 GB | 1.000 GB |
-| 1 GB | dtatools | 0.150 s | 0.1486--0.1643 s | 0.839 GB | 0.940 GB |
-| 1 GB | Haven | 9.052 s | 9.0159--9.1530 s | 1.283 GB | 1.181 GB |
+| 100 MB | Stata | 0.013 s | 0.0130--0.0147 s | 211.993 MB | 100.000 MB |
+| 100 MB | dtatools | 0.023 s | 0.0230--0.0240 s | 378.913 MB | 93.969 MB |
+| 100 MB | Haven | 1.224 s | 1.2102--1.2404 s | 470.532 MB | 118.093 MB |
+| 1 GB | Stata | 0.131 s | 0.1293--0.1327 s | 1.307 GB | 1.000 GB |
+| 1 GB | dtatools | 0.150 s | 0.1480--0.1726 s | 0.839 GB | 0.940 GB |
+| 1 GB | Haven | 9.047 s | 8.9818--9.2264 s | 1.284 GB | 1.181 GB |
 
-On these inputs, Haven took 53.6 times dtatools' median at 100 MB and 60.3 times
+On these inputs, Haven took 53.2 times dtatools' median at 100 MB and 60.3 times
 at 1 GB. dtatools took 1.77 times Stata's median at 100 MB and 1.15 times at
-1 GB. Compared with Haven, dtatools used 18.9% less peak RSS at 100 MB and
-34.7% less at 1 GB. Its output was approximately 20.4% smaller than Haven's and
+1 GB. Compared with Haven, dtatools used 19.5% less peak RSS at 100 MB and
+34.6% less at 1 GB. Its output was approximately 20.4% smaller than Haven's and
 6.0% smaller than Stata's. dtatools preserved declared numeric storage and
 wrote narrower fixed strings; Haven widened all numeric columns to `double`.
-dtatools used 80.5% more peak RSS than Stata at 100 MB but 35.8% less at 1 GB.
+dtatools used 78.7% more peak RSS than Stata at 100 MB but 35.8% less at 1 GB.
 
 The primary run provenance ID is
-`9a7e4508119f8144450818a8560c2a841f3def27f4403f686c1e8e29311d92f3`;
+`8c14442582aa15ca04205f6cdd4644a6dbcbcd0da147faf994697f2a0718c8ab`;
 its build provenance ID is
-`bbf81f583615c0f5a8dceeb980faf4acf484b317ad07bf5ac3839b3789300da9`.
+`804e32d96406c0b9abfeb78489950edde75d656e6dc3b23e75268e6e889058f8`.
 The content-bound private bundle is retained at
-`target/large-scale/primary-write-runs/20260829T103547Z-9a7e4508119f8144-73068`.
+`target/large-scale/primary-write-runs/20260829T105330Z-8c14442582aa15ca-81110`.
 
 ## Secondary ordinary-R matrix
 

--- a/benchmarks/large-scale/results-2026-08-28.md
+++ b/benchmarks/large-scale/results-2026-08-28.md
@@ -5,7 +5,7 @@ Run date: 2026-08-28.
 Environment: Apple M4 Max, 128 GB RAM, macOS 26.5.2, R 4.6.1,
 dtatools 0.6.0, Haven 2.5.5, and Stata/MP 18. The primary matrix built and
 installed the package into a fresh private benchmark library from clean commit
-`63cf659661b0035f9cebe925ec00240d5cc8cc98` (`git_dirty = FALSE`). The
+`87cf2f4724edeae7ce5d5c98a0c73bbdfc72a6e6` (`git_dirty = FALSE`). The
 secondary matrix is retained from clean commit
 `db89c7e537a2d71de80262bc2fd46917fa5f9f44`; it does not exercise the optimized
 native-backed path. The corpus qualification was rerun separately with the
@@ -27,22 +27,22 @@ paired input SHA-256 to enforce input identity.
 
 | Scale | Writer | Median time | 5th--95th percentile | Median peak RSS | Median output |
 | --- | --- | ---: | ---: | ---: | ---: |
-| 100 MB | dtatools | 0.023 s | 0.0220--0.0240 s | 382.124 MB | 93.969 MB |
-| 100 MB | Stata | 0.013 s | 0.0130--0.0140 s | 211.960 MB | 100.000 MB |
-| 1 GB | dtatools | 0.150 s | 0.1480--0.1779 s | 839.008 MB | 939.677 MB |
-| 1 GB | Stata | 0.128 s | 0.1273--0.1300 s | 1.307 GB | 1.000 GB |
+| 100 MB | dtatools | 0.023 s | 0.0230--0.0237 s | 380.125 MB | 93.969 MB |
+| 100 MB | Stata | 0.013 s | 0.0130--0.0140 s | 211.993 MB | 100.000 MB |
+| 1 GB | dtatools | 0.150 s | 0.1493--0.1520 s | 840.810 MB | 939.677 MB |
+| 1 GB | Stata | 0.130 s | 0.1283--0.1314 s | 1.307 GB | 1.000 GB |
 
-On these inputs, dtatools took 1.77 times Stata's median at 100 MB and 1.17
+On these inputs, dtatools took 1.77 times Stata's median at 100 MB and 1.15
 times at 1 GB. Its output was approximately 6.0% smaller after inferring
-narrower storage. dtatools used 80.3% more peak RSS at 100 MB but 35.8% less
+narrower storage. dtatools used 79.3% more peak RSS at 100 MB but 35.7% less
 at 1 GB.
 
 The primary run provenance ID is
-`d7d144483f1c8b42dcb4b3fd0d6a35150353565a6d2c7a8cdc6aa93f41a77eb5`;
+`111a5b36025115fee183be0b21fd791001888ea0ce151ffd1fc918c2324d71de`;
 its build provenance ID is
-`df7402d309a3ef13c92cb6ca827e6b3bbaae7ee0597613c59c2ff4feff09bb20`.
+`c608870fcb7ef0d062aaff552b16b85588502b4d7a9871d0ef4767b64e9f6d69`.
 The content-bound private bundle is retained at
-`target/large-scale/primary-write-runs/20260829T000707Z-d7d144483f1c8b42-14262`.
+`target/large-scale/primary-write-runs/20260829T020331Z-111a5b36025115fe-76245`.
 
 ## Secondary ordinary-R matrix
 

--- a/benchmarks/large-scale/results-2026-08-28.md
+++ b/benchmarks/large-scale/results-2026-08-28.md
@@ -3,10 +3,13 @@
 Run date: 2026-08-28.
 
 Environment: Apple M4 Max, 128 GB RAM, macOS 26.5.2, R 4.6.1,
-dtatools 0.6.0, Haven 2.5.5, and Stata/MP 18. Both matrices built and
+dtatools 0.6.0, Haven 2.5.5, and Stata/MP 18. The primary matrix built and
 installed the package into a fresh private benchmark library from clean commit
-`db89c7e537a2d71de80262bc2fd46917fa5f9f44` (`git_dirty = FALSE`). The read
-benchmark and corpus round-trip suite were not rerun.
+`63cf659661b0035f9cebe925ec00240d5cc8cc98` (`git_dirty = FALSE`). The
+secondary matrix is retained from clean commit
+`db89c7e537a2d71de80262bc2fd46917fa5f9f44`; it does not exercise the optimized
+native-backed path. The corpus qualification was rerun separately with the
+same primary package source.
 
 Every writer ran seven times in a fresh process. Peak RSS covers the whole
 process, including the in-memory input, so it is a workflow memory measurement
@@ -24,22 +27,22 @@ paired input SHA-256 to enforce input identity.
 
 | Scale | Writer | Median time | 5th--95th percentile | Median peak RSS | Median output |
 | --- | --- | ---: | ---: | ---: | ---: |
-| 100 MB | dtatools | 0.119 s | 0.1183--0.1240 s | 314.687 MB | 93.969 MB |
-| 100 MB | Stata | 0.014 s | 0.0133--0.0154 s | 211.943 MB | 100.000 MB |
-| 1 GB | dtatools | 1.225 s | 1.2146--1.2298 s | 771.457 MB | 939.677 MB |
-| 1 GB | Stata | 0.131 s | 0.1293--0.1429 s | 1.307 GB | 1.000 GB |
+| 100 MB | dtatools | 0.023 s | 0.0220--0.0240 s | 382.124 MB | 93.969 MB |
+| 100 MB | Stata | 0.013 s | 0.0130--0.0140 s | 211.960 MB | 100.000 MB |
+| 1 GB | dtatools | 0.150 s | 0.1480--0.1779 s | 839.008 MB | 939.677 MB |
+| 1 GB | Stata | 0.128 s | 0.1273--0.1300 s | 1.307 GB | 1.000 GB |
 
-On these inputs, dtatools took 8.50 times Stata's median at 100 MB and 9.35
+On these inputs, dtatools took 1.77 times Stata's median at 100 MB and 1.17
 times at 1 GB. Its output was approximately 6.0% smaller after inferring
-narrower storage. dtatools used 48.5% more peak RSS at 100 MB but 41.0% less
+narrower storage. dtatools used 80.3% more peak RSS at 100 MB but 35.8% less
 at 1 GB.
 
 The primary run provenance ID is
-`61666a0d4faed8c48dbe255156957db1adfb50b30a691f92b7c4111c28a7709e`;
+`d7d144483f1c8b42dcb4b3fd0d6a35150353565a6d2c7a8cdc6aa93f41a77eb5`;
 its build provenance ID is
-`80a4402116f3474d02e3eede5daf8e4088dfba64eae64b8639ed996046fbd966`.
+`df7402d309a3ef13c92cb6ca827e6b3bbaae7ee0597613c59c2ff4feff09bb20`.
 The content-bound private bundle is retained at
-`target/large-scale/primary-write-runs/20260828T093919Z-61666a0d4faed8c4-62107`.
+`target/large-scale/primary-write-runs/20260829T000707Z-d7d144483f1c8b42-14262`.
 
 ## Secondary ordinary-R matrix
 
@@ -67,12 +70,11 @@ its build provenance ID is
 The content-bound private bundle is retained at
 `target/large-scale/standard-r-write-runs/20260828T094150Z-258d65732d583389-65209`.
 
-## Change from the August 27 run
+## Change from the previous clean build
 
-Against the redesigned matrices in the
-[August 27 report](results-2026-08-27.md), the dtatools package's primary median fell from
-0.430 s to 0.119 s at 100 MB (72.3%) and from 4.104 s to 1.225 s at 1 GB
-(70.2%). Its ordinary-R median fell from 0.276 s to 0.183 s at 100 MB (33.7%)
-and from 2.567 s to 1.797 s at 1 GB (30.0%). These cross-run comparisons are
-useful directional checks on the changed code, not timing assertions or
+Against clean commit `db89c7e537a2d71de80262bc2fd46917fa5f9f44`, the
+dtatools primary median fell from 0.119 s to 0.023 s at 100 MB (80.7%) and
+from 1.225 s to 0.150 s at 1 GB (87.8%). The ordinary-R matrix was not rerun
+because it does not use native-backed imported columns. These cross-run
+comparisons are useful directional checks, not timing assertions or
 cross-machine performance guarantees.

--- a/benchmarks/large-scale/results-2026-08-28.md
+++ b/benchmarks/large-scale/results-2026-08-28.md
@@ -5,7 +5,7 @@ Primary refresh date: 2026-08-29. Retained secondary matrix date: 2026-08-28.
 Environment: Apple M4 Max, 128 GB RAM, macOS 26.5.2, R 4.6.1,
 dtatools 0.6.0, Haven 2.5.5, and Stata/MP 18. The primary matrix built and
 installed the package into a fresh private benchmark library from clean commit
-`7fe0a675e5cde4a3e3e28d2f75d0d94845df7ad4` (`git_dirty = FALSE`). The
+`00d6b495aee090fd9ba76da2a9904816512ae065` (`git_dirty = FALSE`). The
 secondary matrix is retained from clean commit
 `db89c7e537a2d71de80262bc2fd46917fa5f9f44`; it does not exercise the optimized
 native-backed path. The corpus qualification remains from clean commit
@@ -37,27 +37,27 @@ bundle.
 
 | Scale | Writer | Median time | 5th--95th percentile | Median peak RSS | Median output |
 | --- | --- | ---: | ---: | ---: | ---: |
-| 100 MB | Stata | 0.013 s | 0.0130--0.0147 s | 211.993 MB | 100.000 MB |
-| 100 MB | dtatools | 0.023 s | 0.0230--0.0240 s | 378.913 MB | 93.969 MB |
-| 100 MB | Haven | 1.224 s | 1.2102--1.2404 s | 470.532 MB | 118.093 MB |
-| 1 GB | Stata | 0.131 s | 0.1293--0.1327 s | 1.307 GB | 1.000 GB |
-| 1 GB | dtatools | 0.150 s | 0.1480--0.1726 s | 0.839 GB | 0.940 GB |
-| 1 GB | Haven | 9.047 s | 8.9818--9.2264 s | 1.284 GB | 1.181 GB |
+| 100 MB | Stata | 0.013 s | 0.0130--0.0161 s | 211.911 MB | 100.000 MB |
+| 100 MB | dtatools | 0.023 s | 0.0223--0.0240 s | 380.010 MB | 93.969 MB |
+| 100 MB | Haven | 1.235 s | 1.2272--1.2416 s | 472.121 MB | 118.093 MB |
+| 1 GB | Stata | 0.130 s | 0.1290--0.1317 s | 1.307 GB | 1.000 GB |
+| 1 GB | dtatools | 0.150 s | 0.1490--0.1814 s | 0.839 GB | 0.940 GB |
+| 1 GB | Haven | 9.045 s | 9.0032--9.0859 s | 1.285 GB | 1.181 GB |
 
-On these inputs, Haven took 53.2 times dtatools' median at 100 MB and 60.3 times
+On these inputs, Haven took 53.7 times dtatools' median at 100 MB and 60.3 times
 at 1 GB. dtatools took 1.77 times Stata's median at 100 MB and 1.15 times at
 1 GB. Compared with Haven, dtatools used 19.5% less peak RSS at 100 MB and
-34.6% less at 1 GB. Its output was approximately 20.4% smaller than Haven's and
+34.7% less at 1 GB. Its output was 20.4% smaller than Haven's and
 6.0% smaller than Stata's. dtatools preserved declared numeric storage and
 wrote narrower fixed strings; Haven widened all numeric columns to `double`.
-dtatools used 78.7% more peak RSS than Stata at 100 MB but 35.8% less at 1 GB.
+dtatools used 79.3% more peak RSS than Stata at 100 MB but 35.8% less at 1 GB.
 
 The primary run provenance ID is
-`8c14442582aa15ca04205f6cdd4644a6dbcbcd0da147faf994697f2a0718c8ab`;
+`4d8364bcd6a665c44b64cb585010b2434d69ea75e3bbc83122c6ab43b3fd19bc`;
 its build provenance ID is
-`804e32d96406c0b9abfeb78489950edde75d656e6dc3b23e75268e6e889058f8`.
+`4dcb7e75047a698dd30e6331190cb4515372d5dbc9b2f78635546f31046061a4`.
 The content-bound private bundle is retained at
-`target/large-scale/primary-write-runs/20260829T105330Z-8c14442582aa15ca-81110`.
+`target/large-scale/primary-write-runs/20260829T110428Z-4d8364bcd6a665c4-87680`.
 
 ## Secondary ordinary-R matrix
 

--- a/benchmarks/large-scale/results-2026-08-28.md
+++ b/benchmarks/large-scale/results-2026-08-28.md
@@ -1,6 +1,6 @@
 # Synthetic DTA writer results
 
-Run date: 2026-08-28.
+Primary refresh date: 2026-08-29. Retained secondary matrix date: 2026-08-28.
 
 Environment: Apple M4 Max, 128 GB RAM, macOS 26.5.2, R 4.6.1,
 dtatools 0.6.0, Haven 2.5.5, and Stata/MP 18. The primary matrix built and
@@ -28,8 +28,10 @@ datetimes. Each fresh R process then reads that exact Stata output with
 dtatools before timing either dtatools or Haven. The R writer order rotates.
 Raw rows retain the shared input SHA-256 to enforce input identity.
 After timing, one fresh output from each R writer at each scale was reread and
-required to be semantically identical to its input. The four successful checks
-are retained in `write-validation.tsv` in the private bundle.
+validated. dtatools preserved the full semantic DTA model. Haven preserved
+values and the metadata represented by its read model, while widening all 30
+numeric columns to `double`. The four parity and storage-schema checks are
+retained in `write-validation.tsv` in the private bundle.
 
 | Scale | Writer | Median time | 5th--95th percentile | Median peak RSS | Median output |
 | --- | --- | ---: | ---: | ---: | ---: |
@@ -44,8 +46,9 @@ On these inputs, Haven took 53.6 times dtatools' median at 100 MB and 60.3 times
 at 1 GB. dtatools took 1.77 times Stata's median at 100 MB and 1.15 times at
 1 GB. Compared with Haven, dtatools used 18.9% less peak RSS at 100 MB and
 34.7% less at 1 GB. Its output was approximately 20.4% smaller than Haven's and
-6.0% smaller than Stata's after inferring narrower storage. dtatools used 80.5%
-more peak RSS than Stata at 100 MB but 35.8% less at 1 GB.
+6.0% smaller than Stata's. dtatools preserved declared numeric storage and
+wrote narrower fixed strings; Haven widened all numeric columns to `double`.
+dtatools used 80.5% more peak RSS than Stata at 100 MB but 35.8% less at 1 GB.
 
 The primary run provenance ID is
 `9a7e4508119f8144450818a8560c2a841f3def27f4403f686c1e8e29311d92f3`;

--- a/benchmarks/large-scale/results-2026-08-28.md
+++ b/benchmarks/large-scale/results-2026-08-28.md
@@ -5,11 +5,13 @@ Run date: 2026-08-28.
 Environment: Apple M4 Max, 128 GB RAM, macOS 26.5.2, R 4.6.1,
 dtatools 0.6.0, Haven 2.5.5, and Stata/MP 18. The primary matrix built and
 installed the package into a fresh private benchmark library from clean commit
-`87cf2f4724edeae7ce5d5c98a0c73bbdfc72a6e6` (`git_dirty = FALSE`). The
+`17673a250db26d2a354675fa0f5f8b611eef53b9` (`git_dirty = FALSE`). The
 secondary matrix is retained from clean commit
 `db89c7e537a2d71de80262bc2fd46917fa5f9f44`; it does not exercise the optimized
-native-backed path. The corpus qualification was rerun separately with the
-same primary package source.
+native-backed path. The corpus qualification remains from clean commit
+`87cf2f4724edeae7ce5d5c98a0c73bbdfc72a6e6`; the later package-source change
+delegates the direct encoder's width calculation to the existing shared method
+without changing its values.
 
 Every writer ran seven times in a fresh process. Peak RSS covers the whole
 process, including the in-memory input, so it is a workflow memory measurement
@@ -18,31 +20,36 @@ decimal MB and GB.
 
 ## Primary Stata-first-save matrix
 
-The primary matrix compares dtatools and Stata on the exact same generated DTA
-input. In every iteration, Stata creates 4 `byte`, 4 `int`, 9 `long`, 4 `float`,
-9 `double`, and 10 string columns in memory and times its first `save`. Four
-longs are value-labelled; two doubles are dates and two are datetimes.
-dtatools then reads and writes that exact Stata output. Raw rows retain the
-paired input SHA-256 to enforce input identity.
+The primary matrix compares Stata, dtatools, and Haven on the same generated
+Stata-class fixture. In every iteration, Stata creates 4 `byte`, 4 `int`, 9
+`long`, 4 `float`, 9 `double`, and 10 string columns in memory and times its
+first `save`. Four longs are value-labelled; two doubles are dates and two are
+datetimes. Each fresh R process then reads that exact Stata output with
+dtatools before timing either dtatools or Haven. The R writer order rotates.
+Raw rows retain the shared input SHA-256 to enforce input identity.
 
 | Scale | Writer | Median time | 5th--95th percentile | Median peak RSS | Median output |
 | --- | --- | ---: | ---: | ---: | ---: |
-| 100 MB | dtatools | 0.023 s | 0.0230--0.0237 s | 380.125 MB | 93.969 MB |
-| 100 MB | Stata | 0.013 s | 0.0130--0.0140 s | 211.993 MB | 100.000 MB |
-| 1 GB | dtatools | 0.150 s | 0.1493--0.1520 s | 840.810 MB | 939.677 MB |
-| 1 GB | Stata | 0.130 s | 0.1283--0.1314 s | 1.307 GB | 1.000 GB |
+| 100 MB | Stata | 0.013 s | 0.0130--0.0140 s | 211.943 MB | 100.000 MB |
+| 100 MB | dtatools | 0.023 s | 0.0230--0.0240 s | 380.092 MB | 93.969 MB |
+| 100 MB | Haven | 1.226 s | 1.2213--1.2396 s | 471.613 MB | 118.093 MB |
+| 1 GB | Stata | 0.130 s | 0.1283--0.1320 s | 1.307 GB | 1.000 GB |
+| 1 GB | dtatools | 0.151 s | 0.1496--0.1779 s | 0.840 GB | 0.940 GB |
+| 1 GB | Haven | 9.059 s | 8.9931--9.0724 s | 1.285 GB | 1.181 GB |
 
-On these inputs, dtatools took 1.77 times Stata's median at 100 MB and 1.15
-times at 1 GB. Its output was approximately 6.0% smaller after inferring
-narrower storage. dtatools used 79.3% more peak RSS at 100 MB but 35.7% less
-at 1 GB.
+On these inputs, Haven took 53.3 times dtatools' median at 100 MB and 60.0 times
+at 1 GB. dtatools took 1.77 times Stata's median at 100 MB and 1.16 times at
+1 GB. Compared with Haven, dtatools used 19.4% less peak RSS at 100 MB and
+34.6% less at 1 GB. Its output was approximately 20.4% smaller than Haven's and
+6.0% smaller than Stata's after inferring narrower storage. dtatools used 79.3%
+more peak RSS than Stata at 100 MB but 35.7% less at 1 GB.
 
 The primary run provenance ID is
-`111a5b36025115fee183be0b21fd791001888ea0ce151ffd1fc918c2324d71de`;
+`dfd2e2342797c090e3bfccc651269c0151dde9d97f5ca93381502207b2eb1c77`;
 its build provenance ID is
-`c608870fcb7ef0d062aaff552b16b85588502b4d7a9871d0ef4767b64e9f6d69`.
+`eed19ad2e59d3335e14ca2c2b609f23edd568e4df381253131b5c2ba8accfe34`.
 The content-bound private bundle is retained at
-`target/large-scale/primary-write-runs/20260829T020331Z-111a5b36025115fe-76245`.
+`target/large-scale/primary-write-runs/20260829T101836Z-dfd2e2342797c090-66335`.
 
 ## Secondary ordinary-R matrix
 
@@ -74,7 +81,7 @@ The content-bound private bundle is retained at
 
 Against clean commit `db89c7e537a2d71de80262bc2fd46917fa5f9f44`, the
 dtatools primary median fell from 0.119 s to 0.023 s at 100 MB (80.7%) and
-from 1.225 s to 0.150 s at 1 GB (87.8%). The ordinary-R matrix was not rerun
+from 1.225 s to 0.151 s at 1 GB (87.7%). The ordinary-R matrix was not rerun
 because it does not use native-backed imported columns. These cross-run
 comparisons are useful directional checks, not timing assertions or
 cross-machine performance guarantees.

--- a/benchmarks/large-scale/test-stata-primary.sh
+++ b/benchmarks/large-scale/test-stata-primary.sh
@@ -59,19 +59,11 @@ if ! grep -Eq '^SYNTHETIC_WRITE[[:space:]]+haven[[:space:]]+ok' \
     exit 1
 fi
 
-DTATOOLS_BENCH_LIB="$benchmark_library" R_ENVIRON_USER=/dev/null \
-R_PROFILE_USER=/dev/null Rscript --vanilla -e '
-    arguments <- commandArgs(TRUE)
-    sys.source(arguments[[4L]], envir = environment())
-    benchmark_activate_library(c("dtatools", "haven"))
-    before <- dtatools::read_dta(arguments[[1L]], use_numeric_altrep = FALSE)
-    after <- dtatools::read_dta(arguments[[2L]], use_numeric_altrep = FALSE)
-    stopifnot(identical(before, after))
-    haven_before <- haven::read_dta(arguments[[1L]])
-    haven_after <- haven::read_dta(arguments[[3L]])
-    stopifnot(identical(haven_before, haven_after))
-' "$work_dir/input.dta" "$work_dir/dtatools-output.dta" \
-    "$work_dir/haven-output.dta" \
-    "$script_dir/../benchmark-common.R"
+for writer in dtatools haven; do
+    DTATOOLS_BENCH_LIB="$benchmark_library" R_ENVIRON_USER=/dev/null \
+    R_PROFILE_USER=/dev/null Rscript --vanilla \
+        "$script_dir/validate-write-output.R" "$writer" \
+        "$work_dir/input.dta" "$work_dir/${writer}-output.dta"
+done
 
 printf '%s\n' "Stata-first primary write workflow: PASS"

--- a/benchmarks/large-scale/test-stata-primary.sh
+++ b/benchmarks/large-scale/test-stata-primary.sh
@@ -40,22 +40,38 @@ fi
 DTATOOLS_BENCH_LIB="$benchmark_library" R_ENVIRON_USER=/dev/null \
 R_PROFILE_USER=/dev/null Rscript --vanilla \
     "$script_dir/write-worker.R" dtatools stata-storage \
-    "$work_dir/input.dta" "$work_dir/output.dta" > "$work_dir/worker.tsv"
+    "$work_dir/input.dta" "$work_dir/dtatools-output.dta" \
+    > "$work_dir/dtatools-worker.tsv"
 if ! grep -Eq '^SYNTHETIC_WRITE[[:space:]]+dtatools[[:space:]]+ok' \
-    "$work_dir/worker.tsv"; then
+    "$work_dir/dtatools-worker.tsv"; then
     printf '%s\n' "dtatools did not load and save the Stata-generated file" >&2
+    exit 1
+fi
+
+DTATOOLS_BENCH_LIB="$benchmark_library" R_ENVIRON_USER=/dev/null \
+R_PROFILE_USER=/dev/null Rscript --vanilla \
+    "$script_dir/write-worker.R" haven stata-storage \
+    "$work_dir/input.dta" "$work_dir/haven-output.dta" \
+    > "$work_dir/haven-worker.tsv"
+if ! grep -Eq '^SYNTHETIC_WRITE[[:space:]]+haven[[:space:]]+ok' \
+    "$work_dir/haven-worker.tsv"; then
+    printf '%s\n' "Haven did not load and save the Stata-generated file" >&2
     exit 1
 fi
 
 DTATOOLS_BENCH_LIB="$benchmark_library" R_ENVIRON_USER=/dev/null \
 R_PROFILE_USER=/dev/null Rscript --vanilla -e '
     arguments <- commandArgs(TRUE)
-    sys.source(arguments[[3L]], envir = environment())
-    benchmark_activate_library("dtatools")
+    sys.source(arguments[[4L]], envir = environment())
+    benchmark_activate_library(c("dtatools", "haven"))
     before <- dtatools::read_dta(arguments[[1L]], use_numeric_altrep = FALSE)
     after <- dtatools::read_dta(arguments[[2L]], use_numeric_altrep = FALSE)
     stopifnot(identical(before, after))
-' "$work_dir/input.dta" "$work_dir/output.dta" \
+    haven_before <- haven::read_dta(arguments[[1L]])
+    haven_after <- haven::read_dta(arguments[[3L]])
+    stopifnot(identical(haven_before, haven_after))
+' "$work_dir/input.dta" "$work_dir/dtatools-output.dta" \
+    "$work_dir/haven-output.dta" \
     "$script_dir/../benchmark-common.R"
 
 printf '%s\n' "Stata-first primary write workflow: PASS"

--- a/benchmarks/large-scale/validate-write-output.R
+++ b/benchmarks/large-scale/validate-write-output.R
@@ -17,17 +17,44 @@ sys.source(
 )
 benchmark_activate_library(c("dtatools", if (writer == "haven") "haven"))
 
+storage_schema <- function(path) {
+    data <- dtatools::read_dta(path, n_max = 0)
+    levels <- c("byte", "int", "long", "float", "double", "string")
+    storage <- vapply(data, function(column) {
+        value <- attr(column, "stata.storage", exact = TRUE)
+        if (is.null(value)) "string" else value
+    }, character(1L))
+    counts <- as.integer(table(factor(storage, levels = levels)))
+    names(counts) <- levels
+    list(
+        counts = counts,
+        text = paste(paste(levels, counts, sep = "="), collapse = ",")
+    )
+}
+
+input_storage <- storage_schema(input)
+output_storage <- storage_schema(output)
 if (writer == "dtatools") {
     before <- dtatools::read_dta(input, use_numeric_altrep = FALSE)
     after <- dtatools::read_dta(output, use_numeric_altrep = FALSE)
+    parity_status <- "semantic-dta-identical"
+    storage_status <- "preserved"
+    storage_valid <- identical(input_storage$counts, output_storage$counts)
 } else {
     before <- haven::read_dta(input)
     after <- haven::read_dta(output)
+    parity_status <- "haven-model-identical"
+    storage_status <- "numeric-storage-widened-to-double"
+    expected_storage <- input_storage$counts
+    expected_storage[["double"]] <- sum(expected_storage[1:5])
+    expected_storage[1:4] <- 0L
+    storage_valid <- identical(expected_storage, output_storage$counts)
 }
-if (!identical(before, after)) {
-    stop(writer, " full-scale semantic round-trip mismatch")
+if (!identical(before, after) || !storage_valid) {
+    stop(writer, " full-scale parity or storage validation failed")
 }
 cat(sprintf(
-    "WRITE_VALIDATION\t%s\tok\t%s\t%s\n",
-    writer, nrow(after), ncol(after)
+    "WRITE_VALIDATION\t%s\tok\t%s\t%s\t%s\t%s\t%s\t%s\n",
+    writer, nrow(after), ncol(after), parity_status, storage_status,
+    input_storage$text, output_storage$text
 ))

--- a/benchmarks/large-scale/validate-write-output.R
+++ b/benchmarks/large-scale/validate-write-output.R
@@ -1,0 +1,33 @@
+args <- commandArgs(trailingOnly = TRUE)
+if (length(args) != 3L || !args[[1L]] %in% c("dtatools", "haven")) {
+    stop("usage: validate-write-output.R dtatools|haven INPUT_DTA OUTPUT_DTA")
+}
+
+writer <- args[[1L]]
+input <- normalizePath(args[[2L]], winslash = "/", mustWork = TRUE)
+output <- normalizePath(args[[3L]], winslash = "/", mustWork = TRUE)
+script_argument <- grep(
+    "^--file=", commandArgs(trailingOnly = FALSE), value = TRUE
+)[[1L]]
+script_path <- normalizePath(sub("^--file=", "", script_argument), winslash = "/")
+script_dir <- dirname(script_path)
+sys.source(
+    file.path(script_dir, "..", "benchmark-common.R"),
+    envir = environment()
+)
+benchmark_activate_library(c("dtatools", if (writer == "haven") "haven"))
+
+if (writer == "dtatools") {
+    before <- dtatools::read_dta(input, use_numeric_altrep = FALSE)
+    after <- dtatools::read_dta(output, use_numeric_altrep = FALSE)
+} else {
+    before <- haven::read_dta(input)
+    after <- haven::read_dta(output)
+}
+if (!identical(before, after)) {
+    stop(writer, " full-scale semantic round-trip mismatch")
+}
+cat(sprintf(
+    "WRITE_VALIDATION\t%s\tok\t%s\t%s\n",
+    writer, nrow(after), ncol(after)
+))

--- a/benchmarks/large-scale/validate-write-output.R
+++ b/benchmarks/large-scale/validate-write-output.R
@@ -37,8 +37,8 @@ output_storage <- storage_schema(output)
 if (writer == "dtatools") {
     before <- dtatools::read_dta(input, use_numeric_altrep = FALSE)
     after <- dtatools::read_dta(output, use_numeric_altrep = FALSE)
-    parity_status <- "semantic-dta-identical"
-    storage_status <- "preserved"
+    parity_status <- "dtatools-model-identical"
+    storage_status <- "declared-numeric-storage-preserved"
     storage_valid <- identical(input_storage$counts, output_storage$counts)
 } else {
     before <- haven::read_dta(input)

--- a/benchmarks/large-scale/write-run-common.R
+++ b/benchmarks/large-scale/write-run-common.R
@@ -115,6 +115,13 @@ write_result_tuple <- function(data) {
 
 validate_write_result_matrix <- function(raw, datasets, writers, iterations,
                                          description) {
+    required <- c(
+        "dataset", "writer", "iteration", "writer_order", "rows", "columns",
+        "elapsed_seconds", "peak_rss_bytes", "output_bytes"
+    )
+    if (!all(required %in% names(raw))) {
+        stop(description, " results are missing required measurement fields")
+    }
     expected <- expand.grid(
         dataset = datasets, writer = writers,
         iteration = seq_len(iterations), stringsAsFactors = FALSE
@@ -122,6 +129,48 @@ validate_write_result_matrix <- function(raw, datasets, writers, iterations,
     if (anyDuplicated(write_result_tuple(raw)) ||
         !setequal(write_result_tuple(raw), write_result_tuple(expected))) {
         stop(description, " results are not the exact expected matrix")
+    }
+
+    positive_number <- function(field, whole = FALSE) {
+        value <- suppressWarnings(as.numeric(raw[[field]]))
+        invalid <- !is.finite(value) | value <= 0
+        if (whole) invalid <- invalid | value != floor(value)
+        if (any(invalid)) {
+            stop(description, " results have invalid ", field)
+        }
+    }
+    positive_number("iteration", whole = TRUE)
+    positive_number("writer_order", whole = TRUE)
+    positive_number("rows", whole = TRUE)
+    positive_number("columns", whole = TRUE)
+    positive_number("elapsed_seconds")
+    byte_fields <- grep("_bytes$", names(raw), value = TRUE)
+    for (field in byte_fields) positive_number(field, whole = TRUE)
+
+    groups <- split(raw, interaction(raw$dataset, raw$iteration, drop = TRUE))
+    valid_order <- vapply(groups, function(group) {
+        identical(
+            sort(as.integer(group$writer_order)),
+            seq_along(writers)
+        )
+    }, logical(1L))
+    if (!all(valid_order)) {
+        stop(description, " results have invalid writer order metadata")
+    }
+    shapes <- split(raw, raw$dataset)
+    valid_shape <- vapply(shapes, function(group) {
+        length(unique(group$rows)) == 1L &&
+            length(unique(group$columns)) == 1L
+    }, logical(1L))
+    if (!all(valid_shape)) {
+        stop(description, " results have inconsistent row or column metadata")
+    }
+    hash_fields <- grep("_sha256$", names(raw), value = TRUE)
+    for (field in hash_fields) {
+        value <- as.character(raw[[field]])
+        if (anyNA(value) || any(!grepl("^[0-9a-f]{64}$", value))) {
+            stop(description, " results have invalid ", field)
+        }
     }
     invisible(NULL)
 }

--- a/benchmarks/large-scale/write-run-common.R
+++ b/benchmarks/large-scale/write-run-common.R
@@ -199,7 +199,19 @@ validate_primary_write_inputs <- function(
     }
 
     r_writers <- setdiff(writers, "stata")
-    if (!"stata" %in% writers || !length(r_writers)) return(invisible(NULL))
+    if (!"stata" %in% writers) {
+        valid_inputs <- vapply(datasets, function(dataset) {
+            observed <- unique(as.character(
+                raw$input_sha256[raw$dataset == dataset]
+            ))
+            identical(observed, expected_hashes[[dataset]])
+        }, logical(1L))
+        if (!all(valid_inputs)) {
+            stop(description, " inputs do not match their canonical datasets")
+        }
+        return(invisible(NULL))
+    }
+    if (!length(r_writers)) return(invisible(NULL))
     groups <- split(raw, interaction(raw$dataset, raw$iteration, drop = TRUE))
     exact_pair <- vapply(groups, function(group) {
         ordered_writers <- group$writer[order(group$writer_order)]

--- a/benchmarks/large-scale/write-run-common.R
+++ b/benchmarks/large-scale/write-run-common.R
@@ -175,6 +175,45 @@ validate_write_result_matrix <- function(raw, datasets, writers, iterations,
     invisible(NULL)
 }
 
+validate_primary_write_inputs <- function(
+    raw, datasets, writers, provenance, description
+) {
+    required <- c("dataset_sha256", "input_sha256")
+    provenance_fields <- paste0("dataset_", datasets, "_sha256")
+    if (!all(required %in% names(raw)) ||
+        !all(provenance_fields %in% names(provenance))) {
+        stop(description, " is missing primary input identity fields")
+    }
+    expected_hashes <- as.character(
+        unlist(provenance[1L, provenance_fields], use.names = FALSE)
+    )
+    names(expected_hashes) <- datasets
+    valid_dataset_hashes <- vapply(datasets, function(dataset) {
+        observed <- unique(as.character(
+            raw$dataset_sha256[raw$dataset == dataset]
+        ))
+        identical(observed, expected_hashes[[dataset]])
+    }, logical(1L))
+    if (!all(valid_dataset_hashes)) {
+        stop(description, " dataset hashes do not match provenance")
+    }
+
+    r_writers <- setdiff(writers, "stata")
+    if (!"stata" %in% writers || !length(r_writers)) return(invisible(NULL))
+    groups <- split(raw, interaction(raw$dataset, raw$iteration, drop = TRUE))
+    exact_pair <- vapply(groups, function(group) {
+        ordered_writers <- group$writer[order(group$writer_order)]
+        nrow(group) == length(writers) &&
+            length(unique(group$input_sha256)) == 1L &&
+            identical(ordered_writers[[1L]], "stata") &&
+            setequal(ordered_writers[-1L], r_writers)
+    }, logical(1L))
+    if (!all(exact_pair)) {
+        stop(description, " R writers did not consume each exact timed Stata output")
+    }
+    invisible(NULL)
+}
+
 summarize_write_results <- function(raw, datasets, writers, fields) {
     groups <- split(raw, interaction(raw$dataset, raw$writer, drop = TRUE))
     summary <- do.call(rbind, lapply(groups, function(group) {

--- a/benchmarks/large-scale/write-run.R
+++ b/benchmarks/large-scale/write-run.R
@@ -194,13 +194,15 @@ validate_full_scale_output <- function(dataset, writer) {
         error_on_status = FALSE, echo = FALSE
     )
     validation_fields <- parse_fields(validation$stdout, "WRITE_VALIDATION")
-    expected <- c(
+    expected_prefix <- c(
         writer, "ok", as.character(dataset$rows),
         as.character(stata_fixture_columns)
     )
-    if (!identical(validation_fields, expected) || validation$status != 0L) {
+    if (length(validation_fields) != 8L ||
+        !identical(validation_fields[1:4], expected_prefix) ||
+        validation$status != 0L) {
         stop(
-            writer, " full-scale semantic validation failed: ",
+            writer, " full-scale output validation failed: ",
             validation$stderr
         )
     }
@@ -209,7 +211,11 @@ validate_full_scale_output <- function(dataset, writer) {
         dataset = dataset$dataset, dataset_sha256 = dataset$sha256,
         writer = writer, rows = measurement$rows,
         columns = measurement$columns, output_bytes = measurement$bytes,
-        semantic_status = "identical", stringsAsFactors = FALSE
+        parity_status = validation_fields[[5L]],
+        storage_status = validation_fields[[6L]],
+        input_storage_schema = validation_fields[[7L]],
+        output_storage_schema = validation_fields[[8L]],
+        stringsAsFactors = FALSE
     )
 }
 
@@ -266,7 +272,10 @@ stable_provenance <- cbind(data.frame(
     fixture_generator_sha256 = stata_generator_sha256,
     stata_save_state = "first-save-after-generate",
     r_writer_input = "exact-stata-first-save-output-read-by-dtatools",
-    full_scale_validation = "untimed-semantic-roundtrip-each-r-writer-and-size",
+    full_scale_validation = paste(
+        "untimed-dtatools-semantic-and-haven-model-parity",
+        "with-storage-schema-each-size"
+    ),
     execution_order = if ("stata" %in% writers && length(r_writers)) {
         "stata-then-rotating-r-writers"
     } else if (length(r_writers) > 1L) {

--- a/benchmarks/large-scale/write-run.R
+++ b/benchmarks/large-scale/write-run.R
@@ -213,8 +213,8 @@ validate_full_scale_output <- function(dataset, writer) {
         columns = measurement$columns, output_bytes = measurement$bytes,
         parity_status = validation_fields[[5L]],
         storage_status = validation_fields[[6L]],
-        input_storage_schema = validation_fields[[7L]],
-        output_storage_schema = validation_fields[[8L]],
+        input_storage_class_counts = validation_fields[[7L]],
+        output_storage_class_counts = validation_fields[[8L]],
         stringsAsFactors = FALSE
     )
 }
@@ -273,8 +273,8 @@ stable_provenance <- cbind(data.frame(
     stata_save_state = "first-save-after-generate",
     r_writer_input = "exact-stata-first-save-output-read-by-dtatools",
     full_scale_validation = paste(
-        "untimed-dtatools-semantic-and-haven-model-parity",
-        "with-storage-schema-each-size"
+        "untimed-read-model-parity-and-numeric-storage-class-checks",
+        "each-size"
     ),
     execution_order = if ("stata" %in% writers && length(r_writers)) {
         "stata-then-rotating-r-writers"

--- a/benchmarks/large-scale/write-run.R
+++ b/benchmarks/large-scale/write-run.R
@@ -22,7 +22,7 @@ context <- initialize_write_runner(
     input_scope = "target",
     input_name = "datasets.tsv",
     artifact_description = "synthetic write",
-    required_packages = c("dtatools", "processx")
+    required_packages = c("dtatools", "haven", "processx")
 )
 manifest_path <- context$input_path
 outputs <- context$outputs
@@ -40,12 +40,13 @@ stata_generator_sha256 <- benchmark_file_sha256(stata_generator)
 writer_selection <- Sys.getenv("DTATOOLS_WRITE_WRITERS")
 writers <- if (nzchar(writer_selection)) {
     strsplit(writer_selection, ",", fixed = TRUE)[[1L]]
-} else c("dtatools", "stata")
-allowed_writers <- c("dtatools", "stata")
+} else c("dtatools", "haven", "stata")
+allowed_writers <- c("dtatools", "haven", "stata")
 if (!length(writers) || any(!writers %in% allowed_writers) ||
     anyDuplicated(writers)) {
     stop("DTATOOLS_WRITE_WRITERS must select unique supported writers")
 }
+r_writers <- writers[writers != "stata"]
 
 datasets <- read_stata_fixture_manifest(
     manifest_path, stata_generator_sha256
@@ -58,7 +59,7 @@ if ("stata" %in% writers) {
     stata <- find_stata()
 }
 runtime_binding <- write_runtime_binding(
-    rscript, packages = "processx", stata = stata
+    rscript, packages = c("haven", "processx"), stata = stata
 )
 benchmark_environment <- c(
     DTATOOLS_BENCH_LIB = benchmark_library,
@@ -128,21 +129,32 @@ measure_iteration <- function(dataset, iteration) {
         if (!file.symlink(dataset$path, input)) stop("could not create input alias")
         input_sha256 <- dataset$sha256
     }
-    if ("dtatools" %in% writers) {
-        process <- run_timed_process(
-            rscript,
-            c("--vanilla", file.path(script_dir, "write-worker.R"),
-              "dtatools", "stata-storage", input,
-              file.path(work_dir, "output.dta")),
-            work_dir, benchmark_environment
-        )
-        fields <- parse_fields(process$stdout, "SYNTHETIC_WRITE")
-        results[[length(results) + 1L]] <- measurement_row(
-            dataset, input_sha256, "dtatools", iteration,
-            if ("stata" %in% writers) 2L else 1L,
-            fields, process$stderr
-        )
-        message(dataset$dataset, " dtatools ", iteration, "/", iterations)
+    if (length(r_writers)) {
+        shift <- (match(dataset$dataset, datasets$dataset) + iteration - 2L) %%
+            length(r_writers)
+        order <- r_writers[c(
+            seq.int(shift + 1L, length(r_writers)),
+            if (shift) seq_len(shift) else integer()
+        )]
+        for (index in seq_along(order)) {
+            writer <- order[[index]]
+            process <- run_timed_process(
+                rscript,
+                c("--vanilla", file.path(script_dir, "write-worker.R"),
+                  writer, "stata-storage", input,
+                  file.path(work_dir, paste0(writer, "-output.dta"))),
+                work_dir, benchmark_environment
+            )
+            fields <- parse_fields(process$stdout, "SYNTHETIC_WRITE")
+            results[[length(results) + 1L]] <- measurement_row(
+                dataset, input_sha256, writer, iteration,
+                index + as.integer("stata" %in% writers),
+                fields, process$stderr
+            )
+            message(
+                dataset$dataset, " ", writer, " ", iteration, "/", iterations
+            )
+        }
     }
     results
 }
@@ -185,20 +197,23 @@ stable_provenance <- cbind(data.frame(
     dataset_100mb_sha256 = datasets$sha256[[1L]],
     dataset_1gb_sha256 = datasets$sha256[[2L]],
     iterations = iterations,
-    workload = "stata-first-save-to-dtatools-roundtrip",
+    workload = "stata-first-save-to-r-writers",
     fixture_storage_schema = stata_fixture_schema,
     fixture_creator = "stata-first-save",
     fixture_generator_sha256 = stata_generator_sha256,
     stata_save_state = "first-save-after-generate",
-    dtatools_input = "exact-stata-first-save-output",
-    execution_order = if (setequal(writers, c("dtatools", "stata"))) {
-        "stata-before-dtatools"
+    r_writer_input = "exact-stata-first-save-output-read-by-dtatools",
+    execution_order = if ("stata" %in% writers && length(r_writers)) {
+        "stata-then-rotating-r-writers"
+    } else if (length(r_writers) > 1L) {
+        "rotating-r-writers"
     } else paste0(writers, "-only"),
     writers = paste(writers, collapse = ","),
     r_version = R.version.string,
     r_platform = R.version$platform,
     dtatools_version = as.character(utils::packageVersion("dtatools")),
     dtatools_path = normalizePath(find.package("dtatools"), winslash = "/"),
+    haven_version = as.character(utils::packageVersion("haven")),
     os_version = unname(Sys.info()[["version"]]),
     machine = unname(Sys.info()[["machine"]]),
     stringsAsFactors = FALSE, check.names = FALSE
@@ -206,23 +221,25 @@ stable_provenance <- cbind(data.frame(
 validate_write_result_matrix(
     raw, datasets$dataset, writers, iterations, "synthetic write"
 )
-if (setequal(writers, c("dtatools", "stata"))) {
+if ("stata" %in% writers && length(r_writers)) {
     pairs <- split(raw, interaction(
         raw$dataset, raw$iteration, drop = TRUE
     ))
     exact_pair <- vapply(pairs, function(pair) {
-        nrow(pair) == 2L && length(unique(pair$input_sha256)) == 1L &&
-            identical(
-                pair$writer[order(pair$writer_order)],
-                c("stata", "dtatools")
-            )
+        ordered_writers <- pair$writer[order(pair$writer_order)]
+        nrow(pair) == length(writers) &&
+            length(unique(pair$input_sha256)) == 1L &&
+            identical(ordered_writers[[1L]], "stata") &&
+            setequal(ordered_writers[-1L], r_writers)
     }, logical(1L))
     if (!all(exact_pair)) {
-        stop("dtatools did not consume each exact timed Stata output")
+        stop("R writers did not consume each exact timed Stata output")
     }
 }
 if (!identical(
-    write_runtime_binding(rscript, packages = "processx", stata = stata),
+    write_runtime_binding(
+        rscript, packages = c("haven", "processx"), stata = stata
+    ),
     runtime_binding
 )) {
     stop("benchmark runtime changed during synthetic writes")

--- a/benchmarks/large-scale/write-run.R
+++ b/benchmarks/large-scale/write-run.R
@@ -159,6 +159,60 @@ measure_iteration <- function(dataset, iteration) {
     results
 }
 
+validate_full_scale_output <- function(dataset, writer) {
+    work_dir <- tempfile(
+        pattern = paste0("synthetic-write-validation-", dataset$dataset, "-"),
+        tmpdir = output_parent
+    )
+    dir.create(work_dir)
+    on.exit(unlink(work_dir, recursive = TRUE, force = TRUE), add = TRUE)
+    output <- file.path(work_dir, paste0(writer, "-output.dta"))
+    process <- processx::run(
+        rscript,
+        c("--vanilla", file.path(script_dir, "write-worker.R"),
+          writer, "stata-storage", dataset$path, output),
+        wd = work_dir, env = benchmark_environment,
+        error_on_status = FALSE, echo = FALSE
+    )
+    fields <- parse_fields(process$stdout, "SYNTHETIC_WRITE")
+    measurement <- tryCatch(
+        parse_fixture_write_result(fields, writer),
+        error = function(condition) {
+            stop(conditionMessage(condition), ": ", process$stderr)
+        }
+    )
+    if (measurement$rows != dataset$rows ||
+        measurement$columns != stata_fixture_columns ||
+        measurement$bytes <= 0 || !file.exists(output)) {
+        stop(writer, " full-scale validation write returned invalid output")
+    }
+    validation <- processx::run(
+        rscript,
+        c("--vanilla", file.path(script_dir, "validate-write-output.R"),
+          writer, dataset$path, output),
+        wd = work_dir, env = benchmark_environment,
+        error_on_status = FALSE, echo = FALSE
+    )
+    validation_fields <- parse_fields(validation$stdout, "WRITE_VALIDATION")
+    expected <- c(
+        writer, "ok", as.character(dataset$rows),
+        as.character(stata_fixture_columns)
+    )
+    if (!identical(validation_fields, expected) || validation$status != 0L) {
+        stop(
+            writer, " full-scale semantic validation failed: ",
+            validation$stderr
+        )
+    }
+    message(dataset$dataset, " ", writer, " full-scale validation")
+    data.frame(
+        dataset = dataset$dataset, dataset_sha256 = dataset$sha256,
+        writer = writer, rows = measurement$rows,
+        columns = measurement$columns, output_bytes = measurement$bytes,
+        semantic_status = "identical", stringsAsFactors = FALSE
+    )
+}
+
 rows <- vector("list", nrow(datasets) * iterations * length(writers))
 row_index <- 0L
 for (dataset_index in seq_len(nrow(datasets))) {
@@ -172,6 +226,15 @@ for (dataset_index in seq_len(nrow(datasets))) {
     }
 }
 raw <- do.call(rbind, rows)
+
+validation <- if (length(r_writers)) {
+    do.call(rbind, lapply(seq_len(nrow(datasets)), function(dataset_index) {
+        dataset <- datasets[dataset_index, , drop = FALSE]
+        do.call(rbind, lapply(r_writers, function(writer) {
+            validate_full_scale_output(dataset, writer)
+        }))
+    }))
+} else data.frame()
 
 final_build <- verify_benchmark_provenance(
     checkout_root, benchmark_library, build_provenance_path
@@ -203,6 +266,7 @@ stable_provenance <- cbind(data.frame(
     fixture_generator_sha256 = stata_generator_sha256,
     stata_save_state = "first-save-after-generate",
     r_writer_input = "exact-stata-first-save-output-read-by-dtatools",
+    full_scale_validation = "untimed-semantic-roundtrip-each-r-writer-and-size",
     execution_order = if ("stata" %in% writers && length(r_writers)) {
         "stata-then-rotating-r-writers"
     } else if (length(r_writers) > 1L) {
@@ -243,6 +307,14 @@ if (!identical(
     runtime_binding
 )) {
     stop("benchmark runtime changed during synthetic writes")
+}
+
+if (nrow(validation)) {
+    validation$provenance_id <- benchmark_provenance_id(stable_provenance)
+    validation$build_provenance_id <- stable_provenance$build_provenance_id
+    atomic_tsv(
+        validation, file.path(output_parent, "write-validation.tsv")
+    )
 }
 
 finalize_write_results(

--- a/benchmarks/large-scale/write-run.R
+++ b/benchmarks/large-scale/write-run.R
@@ -294,21 +294,9 @@ stable_provenance <- cbind(data.frame(
 validate_write_result_matrix(
     raw, datasets$dataset, writers, iterations, "synthetic write"
 )
-if ("stata" %in% writers && length(r_writers)) {
-    pairs <- split(raw, interaction(
-        raw$dataset, raw$iteration, drop = TRUE
-    ))
-    exact_pair <- vapply(pairs, function(pair) {
-        ordered_writers <- pair$writer[order(pair$writer_order)]
-        nrow(pair) == length(writers) &&
-            length(unique(pair$input_sha256)) == 1L &&
-            identical(ordered_writers[[1L]], "stata") &&
-            setequal(ordered_writers[-1L], r_writers)
-    }, logical(1L))
-    if (!all(exact_pair)) {
-        stop("R writers did not consume each exact timed Stata output")
-    }
-}
+validate_primary_write_inputs(
+    raw, datasets$dataset, writers, stable_provenance, "synthetic write"
+)
 if (!identical(
     write_runtime_binding(
         rscript, packages = c("haven", "processx"), stata = stata

--- a/benchmarks/large-scale/write-worker.R
+++ b/benchmarks/large-scale/write-worker.R
@@ -1,12 +1,13 @@
 args <- commandArgs(trailingOnly = TRUE)
 valid_mode <- length(args) == 4L && (
-    identical(args[1:2], c("dtatools", "stata-storage")) ||
+    (args[[1L]] %in% c("dtatools", "haven") &&
+     identical(args[[2L]], "stata-storage")) ||
     (args[[1L]] %in% c("dtatools", "haven") &&
      identical(args[[2L]], "standard-r"))
 )
 if (!valid_mode) {
     stop(paste(
-        "usage: write-worker.R dtatools stata-storage INPUT_DTA OUTPUT_DTA;",
+        "usage: write-worker.R dtatools|haven stata-storage INPUT_DTA OUTPUT_DTA;",
         "or write-worker.R dtatools|haven standard-r ROWS OUTPUT_DTA"
     ))
 }

--- a/benchmarks/r-corpus-roundtrip/results-2026-08-28.md
+++ b/benchmarks/r-corpus-roundtrip/results-2026-08-28.md
@@ -16,14 +16,14 @@ filenames, stable per-file identifiers, labels, values, or raw rows.
 ## Qualification source
 
 The package source was frozen at clean commit
-`63cf659661b0035f9cebe925ec00240d5cc8cc98`. The qualification is bound to
+`87cf2f4724edeae7ce5d5c98a0c73bbdfc72a6e6`. The qualification is bound to
 these content hashes:
 
 - Inventory SHA-256: `077b9c7474a3af2ce5f7b488a81a49952e022af032315080f27e50cad9dc6c49`
-- Source tarball SHA-256: `c12e7dd404e0c1daa4fc0949f9624a917bcee21d9b0c1b681a6f47f8275b5d00`
-- Installed package SHA-256: `9b435aa64aba3f3205c65fe56217a2af34902b884c773f1bdf3754f0d938f52c`
+- Source tarball SHA-256: `85139f621495c78c3948725e92695e98dc56cc45684ec4d74f834ecabdd02fe2`
+- Installed package SHA-256: `db4516b0c891f217b91ad1c31d8f362089464b5319124906c2a035adc29e9839`
 - Raw qualification SHA-256: `ffde54e2877c99f04842012662926488f0d338544e3b39ab502f733c62673677`
-- Raw benchmark SHA-256: `bb49b5121d256e54a37d4fadd5812203f74d91f9d66eeb4c2cdf20c7e40316ce`
+- Raw benchmark SHA-256: `2d336365b3dc556f69b6df547141b393772e154f87917182260d80a13de15c1e`
 - Harness SHA-256: `efd2d75d79c646db91dff12ad910e51d257973c8a0474f32fe5845bded28dee4`
 - R executable SHA-256: `e22f791c1b2c9b87fafb1813a585a56221505e35d6d12221b09b5f49a00b0f40`
 - Rscript executable SHA-256: `6bd8b8412ef511087496292e1ec58ecc25a22e998e6bad88a6f16fa7f06b402f`
@@ -77,57 +77,57 @@ Times are sums; peak RSS is the largest fresh-process value in the group.
 
 | Corpus | Writer | Files | Total write time | Peak RSS | Output |
 | --- | --- | ---: | ---: | ---: | ---: |
-| DHS | dtatools | 643 | 127.049 s | 5.308 GB | 47.740 GB |
+| DHS | dtatools | 643 | 127.351 s | 5.309 GB | 47.740 GB |
 | DHS | Stata | 643 | 10.413 s | 5.268 GB | 47.827 GB |
-| MICS | dtatools | 949 | 16.814 s | 0.310 GB | 3.764 GB |
-| MICS | Stata | 949 | 0.940 s | 0.112 GB | 3.731 GB |
-| NSFG | dtatools | 229 | 26.884 s | 0.769 GB | 5.929 GB |
-| NSFG | Stata | 229 | 1.651 s | 0.451 GB | 5.912 GB |
-| Total | dtatools | 1,821 | 170.747 s | 5.308 GB | 57.433 GB |
-| Total | Stata | 1,821 | 13.004 s | 5.268 GB | 57.470 GB |
+| MICS | dtatools | 949 | 16.837 s | 0.310 GB | 3.764 GB |
+| MICS | Stata | 949 | 1.000 s | 0.112 GB | 3.731 GB |
+| NSFG | dtatools | 229 | 26.878 s | 0.771 GB | 5.929 GB |
+| NSFG | Stata | 229 | 1.630 s | 0.452 GB | 5.912 GB |
+| Total | dtatools | 1,821 | 171.066 s | 5.309 GB | 57.433 GB |
+| Total | Stata | 1,821 | 13.043 s | 5.267 GB | 57.470 GB |
 
 ### Source-release breakdown
 
 | Corpus | Source release | Writer | Files | Total write time | Peak RSS | Output |
 | --- | ---: | --- | ---: | ---: | ---: | ---: |
-| DHS | 111 | dtatools | 130 | 28.282 s | 0.878 GB | 8.545 GB |
-| DHS | 111 | Stata | 130 | 1.815 s | 0.740 GB | 8.521 GB |
-| DHS | 113 | dtatools | 485 | 94.039 s | 5.308 GB | 37.923 GB |
-| DHS | 113 | Stata | 485 | 8.263 s | 5.268 GB | 38.035 GB |
-| DHS | 114 | dtatools | 24 | 4.287 s | 0.348 GB | 1.192 GB |
+| DHS | 111 | dtatools | 130 | 28.435 s | 0.878 GB | 8.545 GB |
+| DHS | 111 | Stata | 130 | 1.872 s | 0.740 GB | 8.521 GB |
+| DHS | 113 | dtatools | 485 | 94.166 s | 5.309 GB | 37.923 GB |
+| DHS | 113 | Stata | 485 | 8.208 s | 5.267 GB | 38.035 GB |
+| DHS | 114 | dtatools | 24 | 4.311 s | 0.348 GB | 1.192 GB |
 | DHS | 114 | Stata | 24 | 0.314 s | 0.165 GB | 1.192 GB |
 | DHS | 117 | dtatools | 1 | 0.211 s | 0.218 GB | 0.030 GB |
-| DHS | 117 | Stata | 1 | 0.009 s | 0.073 GB | 0.029 GB |
-| DHS | 118 | dtatools | 3 | 0.230 s | 0.242 GB | 0.051 GB |
-| DHS | 118 | Stata | 3 | 0.012 s | 0.093 GB | 0.050 GB |
-| MICS | 117 | dtatools | 494 | 7.407 s | 0.238 GB | 1.706 GB |
-| MICS | 117 | Stata | 494 | 0.439 s | 0.089 GB | 1.675 GB |
-| MICS | 118 | dtatools | 455 | 9.407 s | 0.310 GB | 2.058 GB |
-| MICS | 118 | Stata | 455 | 0.501 s | 0.112 GB | 2.056 GB |
-| NSFG | 105 | dtatools | 10 | 0.084 s | 0.129 GB | 0.009 GB |
-| NSFG | 105 | Stata | 10 | 0.003 s | 0.070 GB | 0.009 GB |
-| NSFG | 108 | dtatools | 5 | 0.028 s | 0.106 GB | 0.003 GB |
-| NSFG | 108 | Stata | 5 | 0.001 s | 0.046 GB | 0.003 GB |
+| DHS | 117 | Stata | 1 | 0.005 s | 0.073 GB | 0.029 GB |
+| DHS | 118 | dtatools | 3 | 0.228 s | 0.241 GB | 0.051 GB |
+| DHS | 118 | Stata | 3 | 0.014 s | 0.093 GB | 0.050 GB |
+| MICS | 117 | dtatools | 494 | 7.420 s | 0.238 GB | 1.706 GB |
+| MICS | 117 | Stata | 494 | 0.449 s | 0.089 GB | 1.675 GB |
+| MICS | 118 | dtatools | 455 | 9.417 s | 0.310 GB | 2.058 GB |
+| MICS | 118 | Stata | 455 | 0.551 s | 0.112 GB | 2.056 GB |
+| NSFG | 105 | dtatools | 10 | 0.090 s | 0.129 GB | 0.009 GB |
+| NSFG | 105 | Stata | 10 | 0.006 s | 0.069 GB | 0.009 GB |
+| NSFG | 108 | dtatools | 5 | 0.027 s | 0.106 GB | 0.003 GB |
+| NSFG | 108 | Stata | 5 | 0.002 s | 0.046 GB | 0.003 GB |
 | NSFG | 110 | dtatools | 7 | 0.059 s | 0.114 GB | 0.015 GB |
-| NSFG | 110 | Stata | 7 | 0.006 s | 0.057 GB | 0.015 GB |
-| NSFG | 113 | dtatools | 28 | 1.094 s | 0.769 GB | 0.680 GB |
-| NSFG | 113 | Stata | 28 | 0.127 s | 0.451 GB | 0.680 GB |
-| NSFG | 114 | dtatools | 44 | 6.174 s | 0.392 GB | 1.226 GB |
-| NSFG | 114 | Stata | 44 | 0.340 s | 0.224 GB | 1.213 GB |
-| NSFG | 115 | dtatools | 9 | 0.448 s | 0.243 GB | 0.111 GB |
+| NSFG | 110 | Stata | 7 | 0.004 s | 0.057 GB | 0.015 GB |
+| NSFG | 113 | dtatools | 28 | 1.079 s | 0.771 GB | 0.680 GB |
+| NSFG | 113 | Stata | 28 | 0.119 s | 0.452 GB | 0.680 GB |
+| NSFG | 114 | dtatools | 44 | 6.203 s | 0.392 GB | 1.226 GB |
+| NSFG | 114 | Stata | 44 | 0.344 s | 0.224 GB | 1.213 GB |
+| NSFG | 115 | dtatools | 9 | 0.450 s | 0.243 GB | 0.111 GB |
 | NSFG | 115 | Stata | 9 | 0.026 s | 0.084 GB | 0.103 GB |
-| NSFG | 117 | dtatools | 69 | 11.523 s | 0.420 GB | 2.259 GB |
-| NSFG | 117 | Stata | 69 | 0.709 s | 0.212 GB | 2.261 GB |
-| NSFG | 118 | dtatools | 57 | 7.474 s | 0.619 GB | 1.627 GB |
-| NSFG | 118 | Stata | 57 | 0.439 s | 0.387 GB | 1.626 GB |
+| NSFG | 117 | dtatools | 69 | 11.481 s | 0.422 GB | 2.259 GB |
+| NSFG | 117 | Stata | 69 | 0.688 s | 0.212 GB | 2.261 GB |
+| NSFG | 118 | dtatools | 57 | 7.489 s | 0.621 GB | 1.627 GB |
+| NSFG | 118 | Stata | 57 | 0.441 s | 0.387 GB | 1.626 GB |
 
 The generated wide case produced a 21.169 MB release-119 file with both
-writers. Its measured write time and peak process RSS were 1.680 seconds and
+writers. Its measured write time and peak process RSS were 1.682 seconds and
 0.195 GB for dtatools, and 0.003 seconds and 0.322 GB for Stata.
 
 These are warm-cache, machine- and corpus-specific measurements, not
 performance guarantees. The content-bound private bundle is retained at
-`target/r-corpus-roundtrip/20260829T000721Z-15943.pkTaEh`; its raw tables and
+`target/r-corpus-roundtrip/20260829T020342Z-77936.nAhYxo`; its raw tables and
 worker outputs remain ignored and unpublished. Haven was deliberately omitted
 from the corpus writes because a third complete pass would not strengthen the
 qualification gate. It remains part of the repeated synthetic comparison in

--- a/benchmarks/r-corpus-roundtrip/results-2026-08-28.md
+++ b/benchmarks/r-corpus-roundtrip/results-2026-08-28.md
@@ -15,15 +15,16 @@ filenames, stable per-file identifiers, labels, values, or raw rows.
 
 ## Qualification source
 
-The package source was frozen at clean merged commit
-`6d465ffc734a013a65b67aec61fa7275e6788e33`. The qualification is bound to
+The package source was frozen at clean commit
+`63cf659661b0035f9cebe925ec00240d5cc8cc98`. The qualification is bound to
 these content hashes:
 
 - Inventory SHA-256: `077b9c7474a3af2ce5f7b488a81a49952e022af032315080f27e50cad9dc6c49`
-- Source tarball SHA-256: `58891bf951028c77274a2ce8c4018e296330147e02b2841651d5ee10863b2a2e`
-- Installed package SHA-256: `02f3b32be0e00a06bfc39285db5d3c4d5684b254e858e0c72358c2f851834f01`
+- Source tarball SHA-256: `c12e7dd404e0c1daa4fc0949f9624a917bcee21d9b0c1b681a6f47f8275b5d00`
+- Installed package SHA-256: `9b435aa64aba3f3205c65fe56217a2af34902b884c773f1bdf3754f0d938f52c`
 - Raw qualification SHA-256: `ffde54e2877c99f04842012662926488f0d338544e3b39ab502f733c62673677`
-- Harness SHA-256: `6e39299a5f7b894a3c59fceb154a7ba4139364d30ea87b6f0a912b7e6953db5a`
+- Raw benchmark SHA-256: `bb49b5121d256e54a37d4fadd5812203f74d91f9d66eeb4c2cdf20c7e40316ce`
+- Harness SHA-256: `efd2d75d79c646db91dff12ad910e51d257973c8a0474f32fe5845bded28dee4`
 - R executable SHA-256: `e22f791c1b2c9b87fafb1813a585a56221505e35d6d12221b09b5f49a00b0f40`
 - Rscript executable SHA-256: `6bd8b8412ef511087496292e1ec58ecc25a22e998e6bad88a6f16fa7f06b402f`
 - `/usr/bin/time` executable SHA-256: `d2210b72e8c978748a0f0ac7d0819dda4dd411bb7a2e9730476038b0d695e7a2`
@@ -76,57 +77,57 @@ Times are sums; peak RSS is the largest fresh-process value in the group.
 
 | Corpus | Writer | Files | Total write time | Peak RSS | Output |
 | --- | --- | ---: | ---: | ---: | ---: |
-| DHS | dtatools | 643 | 681.926 s | 5.240 GB | 47.740 GB |
-| DHS | Stata | 643 | 9.776 s | 5.268 GB | 47.827 GB |
-| MICS | dtatools | 949 | 44.415 s | 0.248 GB | 3.764 GB |
-| MICS | Stata | 949 | 0.896 s | 0.112 GB | 3.731 GB |
-| NSFG | dtatools | 229 | 73.899 s | 0.702 GB | 5.929 GB |
-| NSFG | Stata | 229 | 1.585 s | 0.452 GB | 5.912 GB |
-| Total | dtatools | 1,821 | 800.240 s | 5.240 GB | 57.433 GB |
-| Total | Stata | 1,821 | 12.257 s | 5.268 GB | 57.470 GB |
+| DHS | dtatools | 643 | 127.049 s | 5.308 GB | 47.740 GB |
+| DHS | Stata | 643 | 10.413 s | 5.268 GB | 47.827 GB |
+| MICS | dtatools | 949 | 16.814 s | 0.310 GB | 3.764 GB |
+| MICS | Stata | 949 | 0.940 s | 0.112 GB | 3.731 GB |
+| NSFG | dtatools | 229 | 26.884 s | 0.769 GB | 5.929 GB |
+| NSFG | Stata | 229 | 1.651 s | 0.451 GB | 5.912 GB |
+| Total | dtatools | 1,821 | 170.747 s | 5.308 GB | 57.433 GB |
+| Total | Stata | 1,821 | 13.004 s | 5.268 GB | 57.470 GB |
 
 ### Source-release breakdown
 
 | Corpus | Source release | Writer | Files | Total write time | Peak RSS | Output |
 | --- | ---: | --- | ---: | ---: | ---: | ---: |
-| DHS | 111 | dtatools | 130 | 154.854 s | 0.812 GB | 8.545 GB |
-| DHS | 111 | Stata | 130 | 1.676 s | 0.740 GB | 8.521 GB |
-| DHS | 113 | dtatools | 485 | 510.341 s | 5.240 GB | 37.923 GB |
-| DHS | 113 | Stata | 485 | 7.792 s | 5.268 GB | 38.035 GB |
-| DHS | 114 | dtatools | 24 | 15.650 s | 0.281 GB | 1.192 GB |
-| DHS | 114 | Stata | 24 | 0.293 s | 0.165 GB | 1.192 GB |
-| DHS | 117 | dtatools | 1 | 0.472 s | 0.191 GB | 0.030 GB |
-| DHS | 117 | Stata | 1 | 0.005 s | 0.073 GB | 0.029 GB |
-| DHS | 118 | dtatools | 3 | 0.609 s | 0.202 GB | 0.051 GB |
-| DHS | 118 | Stata | 3 | 0.010 s | 0.093 GB | 0.050 GB |
-| MICS | 117 | dtatools | 494 | 19.832 s | 0.202 GB | 1.706 GB |
-| MICS | 117 | Stata | 494 | 0.392 s | 0.089 GB | 1.675 GB |
-| MICS | 118 | dtatools | 455 | 24.583 s | 0.248 GB | 2.058 GB |
-| MICS | 118 | Stata | 455 | 0.504 s | 0.112 GB | 2.056 GB |
-| NSFG | 105 | dtatools | 10 | 0.206 s | 0.129 GB | 0.009 GB |
-| NSFG | 105 | Stata | 10 | 0.005 s | 0.069 GB | 0.009 GB |
-| NSFG | 108 | dtatools | 5 | 0.078 s | 0.106 GB | 0.003 GB |
+| DHS | 111 | dtatools | 130 | 28.282 s | 0.878 GB | 8.545 GB |
+| DHS | 111 | Stata | 130 | 1.815 s | 0.740 GB | 8.521 GB |
+| DHS | 113 | dtatools | 485 | 94.039 s | 5.308 GB | 37.923 GB |
+| DHS | 113 | Stata | 485 | 8.263 s | 5.268 GB | 38.035 GB |
+| DHS | 114 | dtatools | 24 | 4.287 s | 0.348 GB | 1.192 GB |
+| DHS | 114 | Stata | 24 | 0.314 s | 0.165 GB | 1.192 GB |
+| DHS | 117 | dtatools | 1 | 0.211 s | 0.218 GB | 0.030 GB |
+| DHS | 117 | Stata | 1 | 0.009 s | 0.073 GB | 0.029 GB |
+| DHS | 118 | dtatools | 3 | 0.230 s | 0.242 GB | 0.051 GB |
+| DHS | 118 | Stata | 3 | 0.012 s | 0.093 GB | 0.050 GB |
+| MICS | 117 | dtatools | 494 | 7.407 s | 0.238 GB | 1.706 GB |
+| MICS | 117 | Stata | 494 | 0.439 s | 0.089 GB | 1.675 GB |
+| MICS | 118 | dtatools | 455 | 9.407 s | 0.310 GB | 2.058 GB |
+| MICS | 118 | Stata | 455 | 0.501 s | 0.112 GB | 2.056 GB |
+| NSFG | 105 | dtatools | 10 | 0.084 s | 0.129 GB | 0.009 GB |
+| NSFG | 105 | Stata | 10 | 0.003 s | 0.070 GB | 0.009 GB |
+| NSFG | 108 | dtatools | 5 | 0.028 s | 0.106 GB | 0.003 GB |
 | NSFG | 108 | Stata | 5 | 0.001 s | 0.046 GB | 0.003 GB |
-| NSFG | 110 | dtatools | 7 | 0.211 s | 0.115 GB | 0.015 GB |
-| NSFG | 110 | Stata | 7 | 0.004 s | 0.057 GB | 0.015 GB |
-| NSFG | 113 | dtatools | 28 | 3.256 s | 0.702 GB | 0.680 GB |
-| NSFG | 113 | Stata | 28 | 0.124 s | 0.452 GB | 0.680 GB |
-| NSFG | 114 | dtatools | 44 | 15.414 s | 0.325 GB | 1.226 GB |
-| NSFG | 114 | Stata | 44 | 0.341 s | 0.223 GB | 1.213 GB |
-| NSFG | 115 | dtatools | 9 | 1.052 s | 0.208 GB | 0.111 GB |
-| NSFG | 115 | Stata | 9 | 0.022 s | 0.084 GB | 0.103 GB |
-| NSFG | 117 | dtatools | 69 | 32.340 s | 0.354 GB | 2.259 GB |
-| NSFG | 117 | Stata | 69 | 0.672 s | 0.212 GB | 2.261 GB |
-| NSFG | 118 | dtatools | 57 | 21.342 s | 0.551 GB | 1.627 GB |
-| NSFG | 118 | Stata | 57 | 0.416 s | 0.387 GB | 1.626 GB |
+| NSFG | 110 | dtatools | 7 | 0.059 s | 0.114 GB | 0.015 GB |
+| NSFG | 110 | Stata | 7 | 0.006 s | 0.057 GB | 0.015 GB |
+| NSFG | 113 | dtatools | 28 | 1.094 s | 0.769 GB | 0.680 GB |
+| NSFG | 113 | Stata | 28 | 0.127 s | 0.451 GB | 0.680 GB |
+| NSFG | 114 | dtatools | 44 | 6.174 s | 0.392 GB | 1.226 GB |
+| NSFG | 114 | Stata | 44 | 0.340 s | 0.224 GB | 1.213 GB |
+| NSFG | 115 | dtatools | 9 | 0.448 s | 0.243 GB | 0.111 GB |
+| NSFG | 115 | Stata | 9 | 0.026 s | 0.084 GB | 0.103 GB |
+| NSFG | 117 | dtatools | 69 | 11.523 s | 0.420 GB | 2.259 GB |
+| NSFG | 117 | Stata | 69 | 0.709 s | 0.212 GB | 2.261 GB |
+| NSFG | 118 | dtatools | 57 | 7.474 s | 0.619 GB | 1.627 GB |
+| NSFG | 118 | Stata | 57 | 0.439 s | 0.387 GB | 1.626 GB |
 
 The generated wide case produced a 21.169 MB release-119 file with both
-writers. Its measured write time and peak process RSS were 1.666 seconds and
+writers. Its measured write time and peak process RSS were 1.680 seconds and
 0.195 GB for dtatools, and 0.003 seconds and 0.322 GB for Stata.
 
 These are warm-cache, machine- and corpus-specific measurements, not
 performance guarantees. The content-bound private bundle is retained at
-`target/r-corpus-roundtrip/20260828T140833Z-5388.8DVhTM`; its raw tables and
+`target/r-corpus-roundtrip/20260829T000721Z-15943.pkTaEh`; its raw tables and
 worker outputs remain ignored and unpublished. Haven was deliberately omitted
 from the corpus writes because a third complete pass would not strengthen the
 qualification gate. It remains part of the repeated synthetic comparison in

--- a/benchmarks/r-corpus-roundtrip/results-2026-08-28.md
+++ b/benchmarks/r-corpus-roundtrip/results-2026-08-28.md
@@ -121,9 +121,9 @@ Times are sums; peak RSS is the largest fresh-process value in the group.
 | NSFG | 118 | dtatools | 57 | 7.489 s | 0.621 GB | 1.627 GB |
 | NSFG | 118 | Stata | 57 | 0.441 s | 0.387 GB | 1.626 GB |
 
-The generated wide case produced a 21.169 MB release-119 file with both
-writers. Its measured write time and peak process RSS were 1.682 seconds and
-0.195 GB for dtatools, and 0.003 seconds and 0.322 GB for Stata.
+The generated wide case used a release-119 input and produced 21.169 MB outputs
+with both writers. Its measured write time and peak process RSS were 1.682
+seconds and 0.195 GB for dtatools, and 0.003 seconds and 0.322 GB for Stata.
 
 These are warm-cache, machine- and corpus-specific measurements, not
 performance guarantees. The content-bound private bundle is retained at

--- a/benchmarks/r-corpus-roundtrip/results-2026-08-28.md
+++ b/benchmarks/r-corpus-roundtrip/results-2026-08-28.md
@@ -78,7 +78,7 @@ Times are sums; peak RSS is the largest fresh-process value in the group.
 | Corpus | Writer | Files | Total write time | Peak RSS | Output |
 | --- | --- | ---: | ---: | ---: | ---: |
 | DHS | dtatools | 643 | 127.351 s | 5.309 GB | 47.740 GB |
-| DHS | Stata | 643 | 10.413 s | 5.268 GB | 47.827 GB |
+| DHS | Stata | 643 | 10.413 s | 5.267 GB | 47.827 GB |
 | MICS | dtatools | 949 | 16.837 s | 0.310 GB | 3.764 GB |
 | MICS | Stata | 949 | 1.000 s | 0.112 GB | 3.731 GB |
 | NSFG | dtatools | 229 | 26.878 s | 0.771 GB | 5.929 GB |

--- a/docs/adr/0007-stream-writes-through-sibling-files.md
+++ b/docs/adr/0007-stream-writes-through-sibling-files.md
@@ -1,9 +1,9 @@
 ---
-status: accepted
+status: superseded by ADR-0011
 ---
 
 # Stream writes through sibling files
 
 `write_dta()` validates and plans the complete input, emits aggregated conversion warnings, and then streams row-major DTA data through a seekable sibling temporary file. The Rust writer retains schema metadata and `strL` deduplication indexes rather than buffering the complete output. It runs serially and polls for R interruption during validation and writing.
 
-The seekable file lets the writer backpatch the DTA section map after recording actual offsets. Closing and atomically renaming a sibling temporary file keeps an existing destination intact after validation, serialization, I/O, or interruption failures. The R interface replaces regular files, preserves existing permissions where supported, and rejects directories, symbolic links, and other non-regular filesystem entries.
+The seekable file lets the writer backpatch the DTA section map after recording actual offsets. Closing and atomically renaming a sibling temporary file keeps an existing destination intact after validation, serialization, interruption, or I/O failures reported before replacement. The contract excludes delayed close or writeback failures and crash durability. The R interface replaces regular files, preserves existing permissions where supported, and rejects directories, symbolic links, and other non-regular filesystem entries.

--- a/docs/adr/0011-parallelize-native-backed-dta-observations.md
+++ b/docs/adr/0011-parallelize-native-backed-dta-observations.md
@@ -1,0 +1,9 @@
+---
+status: accepted
+---
+
+# Parallelize native-backed DTA observations
+
+`write_dta()` bulk-encodes fixed-width observations when every column exposes immutable native storage and parallelizes sufficiently large multi-column blocks. The common writer retains row ordering and checks each completed block, while inputs that require an R callback or `strL` planning use the scalar serial path. This supersedes ADR-0007's serial-writer decision because per-cell dispatch made otherwise direct writes roughly nine times slower than Stata.
+
+The writer uses a bounded 64 MiB observation block and assigns disjoint columns and output byte ranges to each worker. It flushes and closes the sibling file before atomic replacement but does not force it to durable storage; the public contract does not promise crash durability, and Stata's timed `save` has no equivalent durability barrier.

--- a/r-package/dtatools/R/write-dta.R
+++ b/r-package/dtatools/R/write-dta.R
@@ -28,10 +28,10 @@
 #' Only local, uncompressed files are supported. The complete input is validated
 #' before native serialization starts. Output streams to a sibling temporary
 #' file and atomically replaces the destination only after the file is closed;
-#' an existing destination therefore survives validation, I/O, and interruption
-#' failures. Symbolic-link, directory, and other non-regular destinations are
-#' rejected. Output is
-#' always little-endian.
+#' an existing destination therefore survives validation, interruption, and I/O
+#' failures reported before replacement. Delayed close or writeback failures and
+#' crash durability are not covered. Symbolic-link, directory, and other
+#' non-regular destinations are rejected. Output is always little-endian.
 #'
 #' @param data A data frame or tibble.
 #' @param path Local output path. If the final filename has no extension,

--- a/r-package/dtatools/README.md
+++ b/r-package/dtatools/README.md
@@ -74,7 +74,7 @@ first save of an in-memory fixture covering every numeric Stata storage type:
 
 | Scale | dtatools | Stata | Comparison |
 | --- | ---: | ---: | ---: |
-| 100 MB | about 0.02 seconds | about 0.01 seconds | about 1.6 times Stata |
+| 100 MB | about 0.02 seconds | about 0.01 seconds | under 2 times Stata |
 | 1 GB | about 0.15 seconds | about 0.13 seconds | about 1.2 times Stata |
 
 The secondary benchmark gives dtatools and haven the same ordinary R data

--- a/r-package/dtatools/README.md
+++ b/r-package/dtatools/README.md
@@ -69,13 +69,18 @@ for the synthetic comparisons, per-method bounds, and limitations.
 
 ### Synthetic write benchmarks
 
-The primary synthetic benchmark gives dtatools the exact output from Stata's
-first save of an in-memory fixture covering every numeric Stata storage type:
+The primary synthetic benchmark gives dtatools and haven the exact output from
+Stata's first save of an in-memory fixture covering every numeric Stata storage
+type:
 
-| Scale | dtatools | Stata | Comparison |
+| Scale | Stata | dtatools | haven |
 | --- | ---: | ---: | ---: |
-| 100 MB | about 0.02 seconds | about 0.01 seconds | under 2 times Stata |
-| 1 GB | about 0.15 seconds | about 0.13 seconds | about 1.2 times Stata |
+| 100 MB | 0.013 seconds | 0.023 seconds | 1.226 seconds |
+| 1 GB | 0.129 seconds | 0.153 seconds | 9.011 seconds |
+
+Haven took 53.3 times as long as dtatools at 100 MB and 58.9 times as long at
+1 GB on these Stata-class inputs. dtatools took 1.77 times Stata's median at
+100 MB and 1.19 times at 1 GB.
 
 The secondary benchmark gives dtatools and haven the same ordinary R data
 frame, without Stata storage or labelling metadata:

--- a/r-package/dtatools/README.md
+++ b/r-package/dtatools/README.md
@@ -75,10 +75,10 @@ type:
 
 | Scale | Stata | dtatools | haven |
 | --- | ---: | ---: | ---: |
-| 100 MB | 0.013 seconds | 0.023 seconds | 1.224 seconds |
-| 1 GB | 0.131 seconds | 0.150 seconds | 9.047 seconds |
+| 100 MB | 0.013 seconds | 0.023 seconds | 1.235 seconds |
+| 1 GB | 0.130 seconds | 0.150 seconds | 9.045 seconds |
 
-Haven took 53.2 times as long as dtatools at 100 MB and 60.3 times as long at
+Haven took 53.7 times as long as dtatools at 100 MB and 60.3 times as long at
 1 GB on these Stata-class inputs. dtatools took 1.77 times Stata's median at
 100 MB and 1.15 times at 1 GB.
 dtatools preserved the declared numeric storage types. Haven preserved values

--- a/r-package/dtatools/README.md
+++ b/r-package/dtatools/README.md
@@ -76,11 +76,11 @@ type:
 | Scale | Stata | dtatools | haven |
 | --- | ---: | ---: | ---: |
 | 100 MB | 0.013 seconds | 0.023 seconds | 1.226 seconds |
-| 1 GB | 0.129 seconds | 0.153 seconds | 9.011 seconds |
+| 1 GB | 0.130 seconds | 0.151 seconds | 9.059 seconds |
 
-Haven took 53.3 times as long as dtatools at 100 MB and 58.9 times as long at
+Haven took 53.3 times as long as dtatools at 100 MB and 60.0 times as long at
 1 GB on these Stata-class inputs. dtatools took 1.77 times Stata's median at
-100 MB and 1.19 times at 1 GB.
+100 MB and 1.16 times at 1 GB.
 
 The secondary benchmark gives dtatools and haven the same ordinary R data
 frame, without Stata storage or labelling metadata:

--- a/r-package/dtatools/README.md
+++ b/r-package/dtatools/README.md
@@ -74,8 +74,8 @@ first save of an in-memory fixture covering every numeric Stata storage type:
 
 | Scale | dtatools | Stata | Comparison |
 | --- | ---: | ---: | ---: |
-| 100 MB | 0.023 seconds | 0.013 seconds | 1.77 times Stata |
-| 1 GB | 0.151 seconds | 0.129 seconds | 1.17 times Stata |
+| 100 MB | about 0.02 seconds | about 0.01 seconds | about 1.6 times Stata |
+| 1 GB | about 0.15 seconds | about 0.13 seconds | about 1.2 times Stata |
 
 The secondary benchmark gives dtatools and haven the same ordinary R data
 frame, without Stata storage or labelling metadata:

--- a/r-package/dtatools/README.md
+++ b/r-package/dtatools/README.md
@@ -75,10 +75,10 @@ type:
 
 | Scale | Stata | dtatools | haven |
 | --- | ---: | ---: | ---: |
-| 100 MB | 0.013 seconds | 0.023 seconds | 1.232 seconds |
-| 1 GB | 0.131 seconds | 0.150 seconds | 9.052 seconds |
+| 100 MB | 0.013 seconds | 0.023 seconds | 1.224 seconds |
+| 1 GB | 0.131 seconds | 0.150 seconds | 9.047 seconds |
 
-Haven took 53.6 times as long as dtatools at 100 MB and 60.3 times as long at
+Haven took 53.2 times as long as dtatools at 100 MB and 60.3 times as long at
 1 GB on these Stata-class inputs. dtatools took 1.77 times Stata's median at
 100 MB and 1.15 times at 1 GB.
 dtatools preserved the declared numeric storage types. Haven preserved values

--- a/r-package/dtatools/README.md
+++ b/r-package/dtatools/README.md
@@ -81,6 +81,9 @@ type:
 Haven took 53.6 times as long as dtatools at 100 MB and 60.3 times as long at
 1 GB on these Stata-class inputs. dtatools took 1.77 times Stata's median at
 100 MB and 1.15 times at 1 GB.
+dtatools preserved the declared numeric storage types. Haven preserved values
+and the metadata represented by its read model but widened all 30 numeric
+columns to `double`.
 
 The secondary benchmark gives dtatools and haven the same ordinary R data
 frame, without Stata storage or labelling metadata:

--- a/r-package/dtatools/README.md
+++ b/r-package/dtatools/README.md
@@ -75,12 +75,12 @@ type:
 
 | Scale | Stata | dtatools | haven |
 | --- | ---: | ---: | ---: |
-| 100 MB | 0.013 seconds | 0.023 seconds | 1.226 seconds |
-| 1 GB | 0.130 seconds | 0.151 seconds | 9.059 seconds |
+| 100 MB | 0.013 seconds | 0.023 seconds | 1.232 seconds |
+| 1 GB | 0.131 seconds | 0.150 seconds | 9.052 seconds |
 
-Haven took 53.3 times as long as dtatools at 100 MB and 60.0 times as long at
+Haven took 53.6 times as long as dtatools at 100 MB and 60.3 times as long at
 1 GB on these Stata-class inputs. dtatools took 1.77 times Stata's median at
-100 MB and 1.16 times at 1 GB.
+100 MB and 1.15 times at 1 GB.
 
 The secondary benchmark gives dtatools and haven the same ordinary R data
 frame, without Stata storage or labelling metadata:

--- a/r-package/dtatools/README.md
+++ b/r-package/dtatools/README.md
@@ -74,8 +74,8 @@ first save of an in-memory fixture covering every numeric Stata storage type:
 
 | Scale | dtatools | Stata | Comparison |
 | --- | ---: | ---: | ---: |
-| 100 MB | 0.119 seconds | 0.014 seconds | 8.50 times Stata |
-| 1 GB | 1.225 seconds | 0.131 seconds | 9.35 times Stata |
+| 100 MB | 0.023 seconds | 0.014 seconds | 1.64 times Stata |
+| 1 GB | 0.151 seconds | 0.129 seconds | 1.17 times Stata |
 
 The secondary benchmark gives dtatools and haven the same ordinary R data
 frame, without Stata storage or labelling metadata:

--- a/r-package/dtatools/README.md
+++ b/r-package/dtatools/README.md
@@ -74,7 +74,7 @@ first save of an in-memory fixture covering every numeric Stata storage type:
 
 | Scale | dtatools | Stata | Comparison |
 | --- | ---: | ---: | ---: |
-| 100 MB | 0.023 seconds | 0.014 seconds | 1.64 times Stata |
+| 100 MB | 0.023 seconds | 0.013 seconds | 1.77 times Stata |
 | 1 GB | 0.151 seconds | 0.129 seconds | 1.17 times Stata |
 
 The secondary benchmark gives dtatools and haven the same ordinary R data

--- a/r-package/dtatools/man/write_dta.Rd
+++ b/r-package/dtatools/man/write_dta.Rd
@@ -64,10 +64,10 @@ newly authored tables.
 Only local, uncompressed files are supported. The complete input is validated
 before native serialization starts. Output streams to a sibling temporary
 file and atomically replaces the destination only after the file is closed;
-an existing destination therefore survives validation, I/O, and interruption
-failures. Symbolic-link, directory, and other non-regular destinations are
-rejected. Output is
-always little-endian.
+an existing destination therefore survives validation, interruption, and I/O
+failures reported before replacement. Delayed close or writeback failures and
+crash durability are not covered. Symbolic-link, directory, and other
+non-regular destinations are rejected. Output is always little-endian.
 }
 
 \examples{

--- a/r-package/dtatools/src/dta-tools/src/lib.rs
+++ b/r-package/dtatools/src/dta-tools/src/lib.rs
@@ -80,7 +80,7 @@ pub use types::{
 };
 pub use value_labels::{parse_value_labels, parse_value_labels_with_encoding};
 pub use write::{
-    dta_write_numeric_value_is_representable, write_dta_to,
+    dta_write_numeric_value_is_representable, encode_numeric, write_dta_to,
     write_prevalidated_dta_with_observation_source_to, DtaWriteColumn, DtaWriteColumnSource,
     DtaWriteColumnValues, DtaWriteData, DtaWriteError, DtaWriteLabelValue, DtaWriteNumericValue,
     DtaWriteObservationSource, DtaWriteOptions, DtaWriteRawNumericValue, DtaWriteSummary,

--- a/r-package/dtatools/src/dta-tools/src/types.rs
+++ b/r-package/dtatools/src/dta-tools/src/types.rs
@@ -112,7 +112,8 @@ impl DtaType {
         }
     }
 
-    pub(crate) const fn storage_width(&self) -> u32 {
+    /// Return this type's width in an observation row.
+    pub const fn storage_width(&self) -> u32 {
         match self {
             Self::Byte => 1,
             Self::Int => 2,

--- a/r-package/dtatools/src/dta-tools/src/write.rs
+++ b/r-package/dtatools/src/dta-tools/src/write.rs
@@ -21,7 +21,7 @@ const MAX_NOTES: usize = 9_999;
 const MAX_NOTE_BYTES: usize = 67_784;
 const MAX_STRL_BYTES: usize = 2_000_000_000;
 const WRITE_INTERRUPT_BYTES: usize = 8 * 1024 * 1024;
-const OBSERVATION_BUFFER_BYTES: usize = WRITE_INTERRUPT_BYTES;
+const OBSERVATION_BUFFER_BYTES: usize = 64 * 1024 * 1024;
 const ZERO_BLOCK: [u8; 8 * 1024] = [0; 8 * 1024];
 
 /// A numeric value supplied to the DTA writer.
@@ -78,8 +78,9 @@ pub trait DtaWriteColumnSource {
 
 /// Dataset-wide observation access for adapters with optimized native storage.
 ///
-/// The common writer retains row ordering, buffering, storage encoding, and
-/// error handling while adapters vary only how they retrieve each value.
+/// The common writer retains row ordering, bounded buffering, and error
+/// handling. The hidden bulk seam is reserved for trusted in-tree adapters
+/// that already own the final DTA storage encoding.
 pub trait DtaWriteObservationSource {
     fn begin_row(&self, _row: u64) -> Result<(), DtaWriteError> {
         Ok(())
@@ -87,6 +88,24 @@ pub trait DtaWriteObservationSource {
 
     fn check_interrupt(&self) -> Result<(), DtaWriteError> {
         Ok(())
+    }
+
+    /// Append a contiguous range of complete, row-major observations encoded
+    /// as final DTA bytes, including little-endian numerics and zero-padded
+    /// fixed strings.
+    ///
+    /// The implementation must append exactly `(end - start) * row_width`
+    /// bytes. The common writer checks that byte count but cannot validate the
+    /// encoded cells. Returning `false` leaves `buffer` unchanged and asks the
+    /// common writer to use the scalar methods below.
+    #[doc(hidden)]
+    fn append_observation_rows(
+        &self,
+        _buffer: &mut Vec<u8>,
+        _start: u64,
+        _end: u64,
+    ) -> Result<bool, DtaWriteError> {
+        Ok(false)
     }
 
     fn raw_numeric_value(
@@ -984,8 +1003,13 @@ fn append_raw_numeric(buffer: &mut Vec<u8>, value: DtaWriteRawNumericValue) {
     }
 }
 
-fn append_numeric(buffer: &mut Vec<u8>, dta_type: &DtaType, value: DtaWriteNumericValue) {
-    let value = match (dta_type, value) {
+#[doc(hidden)]
+/// Encode one validated numeric value in the requested numeric DTA storage.
+///
+/// `dta_type` must be `Byte`, `Int`, `Long`, `Float`, or `Double`. Validation
+/// must already have established that nonmissing values fit that storage.
+pub fn encode_numeric(dta_type: &DtaType, value: DtaWriteNumericValue) -> DtaWriteRawNumericValue {
+    match (dta_type, value) {
         (DtaType::Byte, DtaWriteNumericValue::Value(value)) => {
             DtaWriteRawNumericValue::Byte(value as i8)
         }
@@ -1017,8 +1041,11 @@ fn append_numeric(buffer: &mut Vec<u8>, dta_type: &DtaType, value: DtaWriteNumer
             DtaWriteRawNumericValue::Double(f64::from_bits(tag.double_bits()))
         }
         _ => unreachable!("validated numeric storage type"),
-    };
-    append_raw_numeric(buffer, value);
+    }
+}
+
+fn append_numeric(buffer: &mut Vec<u8>, dta_type: &DtaType, value: DtaWriteNumericValue) {
+    append_raw_numeric(buffer, encode_numeric(dta_type, value));
 }
 
 #[derive(Debug)]
@@ -1472,19 +1499,40 @@ fn write_observations<W: Write, S: DtaWriteObservationSource + ?Sized>(
         .checked_mul(buffered_rows)
         .ok_or(DtaWriteError::Overflow("observation buffer"))?;
     let mut buffer = Vec::with_capacity(buffer_capacity);
-    for row in 0..row_count {
-        source.begin_row(row)?;
-        for column_index in 0..data.columns.len() {
-            append_observation_value(&mut buffer, data, source, version, strls, column_index, row)?;
+    let mut start = 0_u64;
+    while start < row_count {
+        let end = row_count.min(start + rows_per_buffer as u64);
+        if !source.append_observation_rows(&mut buffer, start, end)? {
+            for row in start..end {
+                source.begin_row(row)?;
+                for column_index in 0..data.columns.len() {
+                    append_observation_value(
+                        &mut buffer,
+                        data,
+                        source,
+                        version,
+                        strls,
+                        column_index,
+                        row,
+                    )?;
+                }
+            }
         }
-        if (row + 1) % rows_per_buffer as u64 == 0 {
-            writer.write_all(&buffer)?;
-            buffer.clear();
-            source.check_interrupt()?;
+        let expected = usize::try_from(end - start)
+            .ok()
+            .and_then(|rows| rows.checked_mul(row_width))
+            .ok_or(DtaWriteError::Overflow("observation buffer"))?;
+        if buffer.len() != expected {
+            return Err(DtaWriteError::Source {
+                column: "<dataset>".into(),
+                row: start,
+                message: "bulk observation source returned the wrong byte count".into(),
+            });
         }
-    }
-    if !buffer.is_empty() {
         writer.write_all(&buffer)?;
+        buffer.clear();
+        source.check_interrupt()?;
+        start = end;
     }
     Ok(())
 }

--- a/r-package/dtatools/src/dta-tools/tests/write.rs
+++ b/r-package/dtatools/src/dta-tools/tests/write.rs
@@ -73,6 +73,68 @@ impl DtaWriteObservationSource for AdaptedObservationSource {
     }
 }
 
+struct BulkObservationSource {
+    calls: Cell<usize>,
+}
+
+impl DtaWriteObservationSource for BulkObservationSource {
+    fn append_observation_rows(
+        &self,
+        buffer: &mut Vec<u8>,
+        start: u64,
+        end: u64,
+    ) -> Result<bool, DtaWriteError> {
+        self.calls.set(self.calls.get() + 1);
+        for value in &ADAPTED_NUMERIC_VALUES[start as usize..end as usize] {
+            let raw = match value {
+                DtaWriteNumericValue::Value(value) => *value as i32,
+                DtaWriteNumericValue::Missing(MissingTag::System) => 2_147_483_621,
+                DtaWriteNumericValue::Missing(_) => unreachable!("test data has system missing"),
+            };
+            buffer.extend_from_slice(&raw.to_le_bytes());
+        }
+        Ok(true)
+    }
+
+    fn numeric_value(
+        &self,
+        _column: usize,
+        _row: u64,
+    ) -> Result<DtaWriteNumericValue, DtaWriteError> {
+        unreachable!("the bulk test source must bypass scalar values")
+    }
+
+    fn string_value(&self, _column: usize, _row: u64) -> Result<Cow<'_, str>, DtaWriteError> {
+        unreachable!("the bulk test source is numeric")
+    }
+}
+
+struct WrongLengthBulkObservationSource;
+
+impl DtaWriteObservationSource for WrongLengthBulkObservationSource {
+    fn append_observation_rows(
+        &self,
+        buffer: &mut Vec<u8>,
+        _start: u64,
+        _end: u64,
+    ) -> Result<bool, DtaWriteError> {
+        buffer.push(0);
+        Ok(true)
+    }
+
+    fn numeric_value(
+        &self,
+        _column: usize,
+        _row: u64,
+    ) -> Result<DtaWriteNumericValue, DtaWriteError> {
+        unreachable!("the malformed bulk source reports that it handled the rows")
+    }
+
+    fn string_value(&self, _column: usize, _row: u64) -> Result<Cow<'_, str>, DtaWriteError> {
+        unreachable!("the malformed bulk source is numeric")
+    }
+}
+
 struct InterruptingStrlSource {
     value: String,
     interrupt_at: usize,
@@ -283,6 +345,21 @@ fn prevalidated_adapter_avoids_a_redundant_value_pass() {
     assert_eq!(source.calls.get(), 0);
     assert_eq!(adapted.into_inner(), checked);
 
+    let bulk_source = BulkObservationSource {
+        calls: Cell::new(0),
+    };
+    let mut bulk = Cursor::new(Vec::new());
+    write_prevalidated_dta_with_observation_source_to(
+        &mut bulk,
+        &data,
+        &DtaWriteOptions::default(),
+        &bulk_source,
+        3,
+    )
+    .unwrap();
+    assert_eq!(bulk_source.calls.get(), 1);
+    assert_eq!(bulk.into_inner(), checked);
+
     let row_count_error = write_prevalidated_dta_with_observation_source_to(
         &mut Cursor::new(Vec::new()),
         &data,
@@ -311,6 +388,33 @@ fn prevalidated_adapter_avoids_a_redundant_value_pass() {
         DtaWriteError::InvalidVariable { .. }
     ));
     assert_eq!(source.calls.get(), 0);
+}
+
+#[test]
+fn prevalidated_bulk_sources_must_return_complete_rows() {
+    let values = [DtaWriteNumericValue::Value(0.0)];
+    let data = DtaWriteData {
+        dataset_label: String::new().into(),
+        notes: Vec::new(),
+        columns: vec![DtaWriteColumn {
+            name: "value".into(),
+            dta_type: DtaType::Long,
+            format: "%12.0g".into(),
+            label: String::new().into(),
+            has_value_labels: false,
+            value_labels: Vec::new(),
+            values: DtaWriteColumnValues::Numeric(&values),
+        }],
+    };
+    let error = write_prevalidated_dta_with_observation_source_to(
+        &mut Cursor::new(Vec::new()),
+        &data,
+        &DtaWriteOptions::default(),
+        &WrongLengthBulkObservationSource,
+        1,
+    )
+    .unwrap_err();
+    assert!(matches!(error, DtaWriteError::Source { .. }));
 }
 
 #[test]

--- a/r-package/dtatools/src/rust/src/lib.rs
+++ b/r-package/dtatools/src/rust/src/lib.rs
@@ -14,12 +14,13 @@ use ahash::AHashMap;
 use dta_tools::{
     classify_byte_missing_for_version, classify_float_missing_bits_for_version,
     classify_int_missing_for_version, classify_long_missing_for_version,
-    dta_write_numeric_value_is_representable, write_prevalidated_dta_with_observation_source_to,
-    ColumnValues, DtaColumnSink, DtaData, DtaError, DtaFile, DtaMetadata, DtaSink, DtaType,
-    DtaWriteColumn, DtaWriteColumnSource, DtaWriteColumnValues, DtaWriteData, DtaWriteError,
-    DtaWriteLabelValue, DtaWriteNumericValue, DtaWriteObservationSource, DtaWriteOptions,
-    DtaWriteRawNumericValue, DtaWriteValueLabel, FormatVersion, MissingTag, ParallelDtaSink,
-    ReadOptions, TextEncoding, ValueLabelTable, VariableInfo,
+    dta_write_numeric_value_is_representable, encode_numeric,
+    write_prevalidated_dta_with_observation_source_to, ColumnValues, DtaColumnSink, DtaData,
+    DtaError, DtaFile, DtaMetadata, DtaSink, DtaType, DtaWriteColumn, DtaWriteColumnSource,
+    DtaWriteColumnValues, DtaWriteData, DtaWriteError, DtaWriteLabelValue, DtaWriteNumericValue,
+    DtaWriteObservationSource, DtaWriteOptions, DtaWriteRawNumericValue, DtaWriteValueLabel,
+    FormatVersion, MissingTag, ParallelDtaSink, ReadOptions, TextEncoding, ValueLabelTable,
+    VariableInfo,
 };
 
 type Sexp = *mut c_void;
@@ -33,6 +34,7 @@ const RAWSXP: c_int = 24;
 const CE_UTF8: c_int = 1;
 const INTERRUPT_STRIDE: usize = 16_384;
 const WRITE_CALLBACK_REGION_BYTES: usize = 8 * 1024 * 1024;
+const DIRECT_OBSERVATION_BYTES_PER_WORKER: usize = 512 * 1024;
 const R_DATA_FRAME_MAX_ROWS: u64 = c_int::MAX as u64;
 const SECONDS_1960_TO_1970: f64 = 315_619_200.0;
 const DAYS_1960_TO_1970: f64 = 3_653.0;
@@ -2268,6 +2270,38 @@ impl DirectCompactValue {
     }
 }
 
+unsafe fn write_raw_numeric_to_ptr(output: *mut u8, value: DtaWriteRawNumericValue) {
+    match value {
+        DtaWriteRawNumericValue::Byte(value) => ptr::write(output, value as u8),
+        DtaWriteRawNumericValue::Int(value) => {
+            ptr::copy_nonoverlapping(value.to_le_bytes().as_ptr(), output, size_of::<i16>())
+        }
+        DtaWriteRawNumericValue::Long(value) => {
+            ptr::copy_nonoverlapping(value.to_le_bytes().as_ptr(), output, size_of::<i32>())
+        }
+        DtaWriteRawNumericValue::Float(value) => ptr::copy_nonoverlapping(
+            value.to_bits().to_le_bytes().as_ptr(),
+            output,
+            size_of::<f32>(),
+        ),
+        DtaWriteRawNumericValue::Double(value) => ptr::copy_nonoverlapping(
+            value.to_bits().to_le_bytes().as_ptr(),
+            output,
+            size_of::<f64>(),
+        ),
+    }
+}
+
+fn write_type_width(dta_type: &DtaType) -> usize {
+    match dta_type {
+        DtaType::Byte => 1,
+        DtaType::Int => 2,
+        DtaType::Long | DtaType::Float => 4,
+        DtaType::Double | DtaType::StrL => 8,
+        DtaType::FixedString(width) => usize::from(*width),
+    }
+}
+
 unsafe fn direct_compact_at(
     source: &RWriteSource<'_>,
     index: usize,
@@ -2635,6 +2669,129 @@ struct RWriteObservationSource<'data, 'source> {
     sources: &'data [RWriteSource<'source>],
 }
 
+fn r_write_source_result<T>(
+    column: &DtaWriteColumn<'_>,
+    row: u64,
+    result: Result<T, RWriteError>,
+) -> Result<T, DtaWriteError> {
+    result.map_err(|error| match error {
+        RWriteError::Interrupted => DtaWriteError::Interrupted,
+        RWriteError::Message(message) => DtaWriteError::Source {
+            column: column.name.to_string(),
+            row,
+            message,
+        },
+    })
+}
+
+#[derive(Clone, Copy)]
+struct DirectObservationRegion {
+    output: usize,
+    start: u64,
+    start_index: usize,
+    rows: usize,
+    row_width: usize,
+}
+
+unsafe fn encode_direct_observation_column(
+    column: &DtaWriteColumn<'_>,
+    source: &RWriteSource<'_>,
+    region: DirectObservationRegion,
+    column_offset: usize,
+) -> Result<(), DtaWriteError> {
+    let DirectObservationRegion {
+        output,
+        start,
+        start_index,
+        rows,
+        row_width,
+    } = region;
+    let output = output as *mut u8;
+    match column.dta_type {
+        DtaType::Byte | DtaType::Int | DtaType::Long | DtaType::Float | DtaType::Double => {
+            if source.raw_numeric {
+                let mut replacements = 0_u64;
+                for offset in 0..rows {
+                    let row_index = start_index + offset;
+                    let destination = output.add(offset * row_width + column_offset);
+                    let (value, missing) = direct_compact_at(source, row_index)
+                        .expect("raw numeric source is compact");
+                    let valid = missing.is_some() || (!value.is_nan() && value.is_representable());
+                    if valid {
+                        write_raw_numeric_to_ptr(destination, value.raw());
+                    } else {
+                        replacements += 1;
+                        write_raw_numeric_to_ptr(
+                            destination,
+                            encode_numeric(
+                                &column.dta_type,
+                                DtaWriteNumericValue::Missing(MissingTag::System),
+                            ),
+                        );
+                    }
+                }
+                source
+                    .numeric_replacements
+                    .set(source.numeric_replacements.get() + replacements);
+                return Ok(());
+            }
+            for offset in 0..rows {
+                let row = start + offset as u64;
+                let value = r_write_source_result(
+                    column,
+                    row,
+                    source.numeric_value_at(row, &column.dta_type),
+                )?;
+                write_raw_numeric_to_ptr(
+                    output.add(offset * row_width + column_offset),
+                    encode_numeric(&column.dta_type, value),
+                );
+            }
+        }
+        DtaType::FixedString(width) => {
+            let data = &*source
+                .descriptor
+                .direct_string_data
+                .cast::<DictStringData>();
+            for offset in 0..rows {
+                let row_index = start_index + offset;
+                if row_index >= data.length {
+                    return Err(DtaWriteError::Source {
+                        column: column.name.to_string(),
+                        row: start + offset as u64,
+                        message: "R row index is outside the string dictionary".into(),
+                    });
+                }
+                let id = ptr::read(data.value_ids.add(row_index));
+                let &(value, length) =
+                    data.value_views
+                        .get(id as usize)
+                        .ok_or_else(|| DtaWriteError::Source {
+                            column: column.name.to_string(),
+                            row: start + offset as u64,
+                            message: "R string dictionary contains an invalid value ID".into(),
+                        })?;
+                if length > usize::from(width) {
+                    return Err(DtaWriteError::InvalidValue {
+                        column: column.name.to_string(),
+                        row: start + offset as u64,
+                        message: format!(
+                            "string must contain at most {width} UTF-8 bytes and no NUL"
+                        ),
+                    });
+                }
+                ptr::copy_nonoverlapping(
+                    value,
+                    output.add(offset * row_width + column_offset),
+                    length,
+                );
+            }
+        }
+        DtaType::StrL => unreachable!("strL disables the direct observation path"),
+    }
+    Ok(())
+}
+
 impl RWriteObservationSource<'_, '_> {
     fn source_result<T>(
         &self,
@@ -2642,14 +2799,143 @@ impl RWriteObservationSource<'_, '_> {
         row: u64,
         result: Result<T, RWriteError>,
     ) -> Result<T, DtaWriteError> {
-        result.map_err(|error| match error {
-            RWriteError::Interrupted => DtaWriteError::Interrupted,
-            RWriteError::Message(message) => DtaWriteError::Source {
-                column: self.data.columns[column_index].name.to_string(),
-                row,
-                message,
-            },
-        })
+        r_write_source_result(&self.data.columns[column_index], row, result)
+    }
+
+    fn has_direct_observations(&self) -> bool {
+        self.data
+            .columns
+            .iter()
+            .zip(self.sources)
+            .all(|(column, source)| match column.dta_type {
+                DtaType::Byte
+                | DtaType::Int
+                | DtaType::Long
+                | DtaType::Float
+                | DtaType::Double => !source.descriptor.direct_numeric_values.is_null(),
+                DtaType::FixedString(_) => !source.descriptor.direct_string_data.is_null(),
+                DtaType::StrL => false,
+            })
+    }
+
+    fn append_direct_observation_rows(
+        &self,
+        buffer: &mut Vec<u8>,
+        start: u64,
+        end: u64,
+        available_parallelism: usize,
+    ) -> Result<usize, DtaWriteError> {
+        let start_index =
+            usize::try_from(start).map_err(|_| DtaWriteError::Overflow("row index"))?;
+        let rows = usize::try_from(end - start)
+            .map_err(|_| DtaWriteError::Overflow("observation row count"))?;
+        let row_width = self
+            .data
+            .columns
+            .iter()
+            .try_fold(0_usize, |width, column| {
+                width
+                    .checked_add(write_type_width(&column.dta_type))
+                    .ok_or(DtaWriteError::Overflow("observation width"))
+            })?;
+        let region_bytes = rows
+            .checked_mul(row_width)
+            .ok_or(DtaWriteError::Overflow("observation buffer"))?;
+        let buffer_start = buffer.len();
+        buffer.resize(
+            buffer_start
+                .checked_add(region_bytes)
+                .ok_or(DtaWriteError::Overflow("observation buffer"))?,
+            0,
+        );
+        let output = unsafe { buffer.as_mut_ptr().add(buffer_start) };
+        let mut offsets = Vec::with_capacity(self.data.columns.len());
+        let mut offset = 0_usize;
+        for column in &self.data.columns {
+            offsets.push(offset);
+            offset += write_type_width(&column.dta_type);
+        }
+
+        let useful_for_size = region_bytes
+            .div_ceil(DIRECT_OBSERVATION_BYTES_PER_WORKER)
+            .max(1);
+        let workers = available_parallelism
+            .max(1)
+            .min(self.data.columns.len())
+            .min(useful_for_size);
+        if workers <= 1 {
+            let region = DirectObservationRegion {
+                output: output as usize,
+                start,
+                start_index,
+                rows,
+                row_width,
+            };
+            for (index, (column, source)) in self.data.columns.iter().zip(self.sources).enumerate()
+            {
+                unsafe {
+                    encode_direct_observation_column(column, source, region, offsets[index])
+                }?;
+            }
+            return Ok(workers);
+        }
+
+        let mut ordered = (0..self.data.columns.len()).collect::<Vec<_>>();
+        ordered.sort_unstable_by_key(|&index| {
+            std::cmp::Reverse(write_type_width(&self.data.columns[index].dta_type))
+        });
+        let mut assignments = vec![Vec::<usize>::new(); workers];
+        let mut assigned_widths = vec![0_usize; workers];
+        for index in ordered {
+            let worker = assigned_widths
+                .iter()
+                .enumerate()
+                .min_by_key(|&(_, width)| width)
+                .map(|(index, _)| index)
+                .expect("there is at least one direct observation worker");
+            assignments[worker].push(index);
+            assigned_widths[worker] += write_type_width(&self.data.columns[index].dta_type);
+        }
+
+        let columns_address = self.data.columns.as_ptr() as usize;
+        let sources_address = self.sources.as_ptr() as usize;
+        let region = DirectObservationRegion {
+            output: output as usize,
+            start,
+            start_index,
+            rows,
+            row_width,
+        };
+        std::thread::scope(|scope| -> Result<(), DtaWriteError> {
+            let mut handles = Vec::with_capacity(workers);
+            for assignment in assignments {
+                let offsets = &offsets;
+                handles.push(scope.spawn(move || -> Result<(), DtaWriteError> {
+                    // Every worker owns distinct columns and therefore distinct
+                    // source Cells and output byte ranges. Direct sources expose
+                    // immutable Rust-owned storage, so no worker calls the R API.
+                    for index in assignment {
+                        let column =
+                            unsafe { &*(columns_address as *const DtaWriteColumn<'_>).add(index) };
+                        let source =
+                            unsafe { &*(sources_address as *const RWriteSource<'_>).add(index) };
+                        unsafe {
+                            encode_direct_observation_column(column, source, region, offsets[index])
+                        }?;
+                    }
+                    Ok(())
+                }));
+            }
+            for handle in handles {
+                handle.join().map_err(|_| DtaWriteError::Source {
+                    column: "<dataset>".into(),
+                    row: start,
+                    message: "direct observation worker panicked".into(),
+                })??;
+            }
+            Ok(())
+        })?;
+        Ok(workers)
     }
 }
 
@@ -2668,6 +2954,20 @@ impl DtaWriteObservationSource for RWriteObservationSource<'_, '_> {
         } else {
             Ok(())
         }
+    }
+
+    fn append_observation_rows(
+        &self,
+        buffer: &mut Vec<u8>,
+        start: u64,
+        end: u64,
+    ) -> Result<bool, DtaWriteError> {
+        if !self.has_direct_observations() {
+            return Ok(false);
+        }
+        let available = std::thread::available_parallelism().map_or(1, usize::from);
+        self.append_direct_observation_rows(buffer, start, end, available)?;
+        Ok(true)
     }
 
     fn raw_numeric_value(
@@ -2919,8 +3219,7 @@ unsafe fn write_impl(request: RWriteRequest) -> Result<(), RWriteError> {
     let file = writer
         .into_inner()
         .map_err(|error| format!("could not flush DTA output: {}", error.error()))?;
-    file.sync_all()
-        .map_err(|error| format!("could not synchronize DTA output: {error}"))?;
+    drop(file);
     for (index, source) in sources.iter().enumerate() {
         ptr::write(
             numeric_replacements.add(index),
@@ -3020,11 +3319,121 @@ pub unsafe extern "C" fn dtatools_free_error(error: *mut c_char) {
 
 #[cfg(test)]
 mod tests {
-    use super::{
-        direct_r_missing_code, observed_value, selected_row_count, temporal_kind,
-        validate_r_row_count, write_callback_status, write_numeric_value, RWriteError,
-        TemporalKind, WriteCallbackErrorBuffer, R_DATA_FRAME_MAX_ROWS,
+    use std::borrow::Cow;
+    use std::ffi::{c_char, c_int, c_void};
+    use std::ptr;
+
+    use ahash::AHashMap;
+    use dta_tools::{
+        DtaType, DtaWriteColumn, DtaWriteColumnValues, DtaWriteData,
     };
+
+    use super::{
+        direct_r_missing_code, dtatools_dictstring_free, observed_value, selected_row_count,
+        temporal_kind, validate_r_row_count, write_callback_status, write_numeric_value,
+        DictStringData, RWriteColumnDescriptor, RWriteObservationSource, RWriteSource,
+        RWriteError, TemporalKind, WriteCallbackErrorBuffer, R_DATA_FRAME_MAX_ROWS,
+    };
+
+    #[no_mangle]
+    unsafe extern "C" fn dtatools_write_numeric_region(
+        _reader: *const c_void,
+        _start: usize,
+        _length: usize,
+        _values: *mut f64,
+        _missing_codes: *mut c_int,
+        _error_message: *mut c_char,
+        _error_capacity: usize,
+    ) -> c_int {
+        0
+    }
+
+    fn direct_numeric_descriptor(
+        dta_type: c_int,
+        values: *const c_void,
+        kind: c_int,
+        shift: f64,
+        scale: f64,
+    ) -> RWriteColumnDescriptor {
+        RWriteColumnDescriptor {
+            name: ptr::null(),
+            dta_type,
+            format: ptr::null(),
+            label: ptr::null(),
+            numeric_values: ptr::null(),
+            string_values: ptr::null_mut(),
+            label_values: ptr::null(),
+            label_texts: ptr::null_mut(),
+            label_count: 0,
+            has_value_labels: 0,
+            numeric_shift: shift,
+            numeric_scale: scale,
+            direct_numeric_values: values,
+            direct_numeric_kind: kind,
+            direct_numeric_format_version: 118,
+            direct_numeric_temporal: 0,
+            direct_numeric_no_na: 0,
+            direct_string_data: ptr::null_mut(),
+        }
+    }
+
+    fn direct_string_descriptor(
+        width: c_int,
+        data: *mut c_void,
+    ) -> RWriteColumnDescriptor {
+        let mut descriptor =
+            direct_numeric_descriptor(width + 4, ptr::null(), 0, 0.0, 1.0);
+        descriptor.direct_string_data = data;
+        descriptor
+    }
+
+    fn encode_direct_test_rows(
+        descriptors: &[RWriteColumnDescriptor],
+        dta_types: &[DtaType],
+        row_count: usize,
+        available_parallelism: usize,
+    ) -> (Vec<u8>, Vec<u64>, usize) {
+        let sources = descriptors
+            .iter()
+            .map(|descriptor| RWriteSource::new(descriptor, row_count as u64, 1, 1).unwrap())
+            .collect::<Vec<_>>();
+        let columns = dta_types
+            .iter()
+            .enumerate()
+            .map(|(index, dta_type)| DtaWriteColumn {
+                name: Cow::Owned(format!("x{index}")),
+                dta_type: dta_type.clone(),
+                format: Cow::Borrowed(""),
+                label: Cow::Borrowed(""),
+                has_value_labels: false,
+                value_labels: Vec::new(),
+                values: DtaWriteColumnValues::Source(&sources[index]),
+            })
+            .collect();
+        let data = DtaWriteData {
+            dataset_label: Cow::Borrowed(""),
+            notes: Vec::new(),
+            columns,
+        };
+        let observation_source = RWriteObservationSource {
+            data: &data,
+            sources: &sources,
+        };
+        let mut output = Vec::new();
+        let workers = observation_source
+            .append_direct_observation_rows(
+                &mut output,
+                0,
+                row_count as u64,
+                available_parallelism,
+            )
+            .unwrap();
+        let replacements = sources
+            .iter()
+            .map(|source| source.numeric_replacements.get())
+            .collect();
+        (output, replacements, workers)
+    }
 
     #[test]
     fn temporal_formats_match_haven_prefix_rules() {
@@ -3101,5 +3510,107 @@ mod tests {
             validate_r_row_count(R_DATA_FRAME_MAX_ROWS + 1, 1, None).unwrap(),
             R_DATA_FRAME_MAX_ROWS
         );
+    }
+
+    #[test]
+    fn threaded_direct_observation_encoding_matches_the_serial_path() {
+        const ROWS: usize = 48_000;
+
+        let ordinary_integers = (0..ROWS)
+            .map(|index| {
+                if index.is_multiple_of(17) {
+                    c_int::MIN
+                } else {
+                    index as c_int - 24_000
+                }
+            })
+            .collect::<Vec<_>>();
+        let ordinary_doubles = (0..ROWS)
+            .map(|index| {
+                if index.is_multiple_of(19) {
+                    f64::NAN
+                } else {
+                    index as f64 / 10.0
+                }
+            })
+            .collect::<Vec<_>>();
+        let compact_bytes = (0..ROWS)
+            .map(|index| [-5_i8, 100, -128, 101][index % 4])
+            .collect::<Vec<_>>();
+        let compact_ints = (0..ROWS)
+            .map(|index| [-30_000_i16, 30_000, i16::MIN, 32_741][index % 4])
+            .collect::<Vec<_>>();
+        let compact_longs = (0..ROWS)
+            .map(|index| [-1_000_000_i32, 1_000_000, i32::MIN, 2_147_483_621][index % 4])
+            .collect::<Vec<_>>();
+        let compact_floats = (0..ROWS)
+            .map(|index| {
+                [
+                    1.5_f32,
+                    -2.25,
+                    f32::from_bits(0x7fc0_0001),
+                    f32::from_bits(0x7f00_0000),
+                ][index % 4]
+            })
+            .collect::<Vec<_>>();
+
+        let mut dictionary = AHashMap::new();
+        dictionary.insert("alpha".to_owned(), 0_u32);
+        dictionary.insert("beta".to_owned(), 1_u32);
+        let mut views = vec![(ptr::null(), 0); dictionary.len()];
+        for (value, &id) in &dictionary {
+            views[id as usize] = (value.as_ptr(), value.len());
+        }
+        let ids = (0..ROWS).map(|index| (index % 2) as u32).collect();
+        let dictionary_data = Box::into_raw(Box::new(DictStringData::new(
+            ids,
+            dictionary,
+            views,
+        )));
+
+        let descriptors = vec![
+            direct_numeric_descriptor(
+                2,
+                ordinary_integers.as_ptr().cast(),
+                1,
+                0.0,
+                1.0,
+            ),
+            direct_numeric_descriptor(
+                4,
+                ordinary_doubles.as_ptr().cast(),
+                2,
+                5.0,
+                10.0,
+            ),
+            direct_numeric_descriptor(0, compact_bytes.as_ptr().cast(), 3, 0.0, 1.0),
+            direct_numeric_descriptor(1, compact_ints.as_ptr().cast(), 4, 0.0, 1.0),
+            direct_numeric_descriptor(2, compact_longs.as_ptr().cast(), 5, 0.0, 1.0),
+            direct_numeric_descriptor(3, compact_floats.as_ptr().cast(), 6, 0.0, 1.0),
+            direct_string_descriptor(8, dictionary_data.cast()),
+        ];
+        let dta_types = vec![
+            DtaType::Long,
+            DtaType::Double,
+            DtaType::Byte,
+            DtaType::Int,
+            DtaType::Long,
+            DtaType::Float,
+            DtaType::FixedString(8),
+        ];
+
+        let (serial, serial_replacements, serial_workers) =
+            encode_direct_test_rows(&descriptors, &dta_types, ROWS, 1);
+        let (threaded, threaded_replacements, threaded_workers) =
+            encode_direct_test_rows(&descriptors, &dta_types, ROWS, 2);
+
+        assert!(serial.len() > 512 * 1024);
+        assert_eq!(serial_workers, 1);
+        assert_eq!(threaded_workers, 2);
+        assert_eq!(threaded, serial);
+        assert_eq!(threaded_replacements, serial_replacements);
+        assert!(threaded_replacements.iter().any(|&count| count > 0));
+
+        unsafe { dtatools_dictstring_free(dictionary_data.cast()) };
     }
 }

--- a/r-package/dtatools/src/rust/src/lib.rs
+++ b/r-package/dtatools/src/rust/src/lib.rs
@@ -2293,13 +2293,7 @@ unsafe fn write_raw_numeric_to_ptr(output: *mut u8, value: DtaWriteRawNumericVal
 }
 
 fn write_type_width(dta_type: &DtaType) -> usize {
-    match dta_type {
-        DtaType::Byte => 1,
-        DtaType::Int => 2,
-        DtaType::Long | DtaType::Float => 4,
-        DtaType::Double | DtaType::StrL => 8,
-        DtaType::FixedString(width) => usize::from(*width),
-    }
+    dta_type.storage_width() as usize
 }
 
 unsafe fn direct_compact_at(

--- a/r-package/dtatools/src/rust/src/lib.rs
+++ b/r-package/dtatools/src/rust/src/lib.rs
@@ -2808,11 +2808,9 @@ impl RWriteObservationSource<'_, '_> {
             .iter()
             .zip(self.sources)
             .all(|(column, source)| match column.dta_type {
-                DtaType::Byte
-                | DtaType::Int
-                | DtaType::Long
-                | DtaType::Float
-                | DtaType::Double => !source.descriptor.direct_numeric_values.is_null(),
+                DtaType::Byte | DtaType::Int | DtaType::Long | DtaType::Float | DtaType::Double => {
+                    !source.descriptor.direct_numeric_values.is_null()
+                }
                 DtaType::FixedString(_) => !source.descriptor.direct_string_data.is_null(),
                 DtaType::StrL => false,
             })
@@ -2911,9 +2909,10 @@ impl RWriteObservationSource<'_, '_> {
             for assignment in assignments {
                 let offsets = &offsets;
                 handles.push(scope.spawn(move || -> Result<(), DtaWriteError> {
-                    // Every worker owns distinct columns and therefore distinct
-                    // source Cells and output byte ranges. Direct sources expose
-                    // immutable Rust-owned storage, so no worker calls the R API.
+                    // The main R thread exposed the source buffers before spawning
+                    // and keeps their protected owners live. Workers only read
+                    // those buffers; each column's source state and output byte
+                    // ranges belong to one worker, and no worker calls the R API.
                     for index in assignment {
                         let column =
                             unsafe { &*(columns_address as *const DtaWriteColumn<'_>).add(index) };
@@ -3324,15 +3323,13 @@ mod tests {
     use std::ptr;
 
     use ahash::AHashMap;
-    use dta_tools::{
-        DtaType, DtaWriteColumn, DtaWriteColumnValues, DtaWriteData,
-    };
+    use dta_tools::{DtaType, DtaWriteColumn, DtaWriteColumnValues, DtaWriteData};
 
     use super::{
         direct_r_missing_code, dtatools_dictstring_free, observed_value, selected_row_count,
         temporal_kind, validate_r_row_count, write_callback_status, write_numeric_value,
-        DictStringData, RWriteColumnDescriptor, RWriteObservationSource, RWriteSource,
-        RWriteError, TemporalKind, WriteCallbackErrorBuffer, R_DATA_FRAME_MAX_ROWS,
+        DictStringData, RWriteColumnDescriptor, RWriteError, RWriteObservationSource, RWriteSource,
+        TemporalKind, WriteCallbackErrorBuffer, R_DATA_FRAME_MAX_ROWS,
     };
 
     #[no_mangle]
@@ -3377,12 +3374,8 @@ mod tests {
         }
     }
 
-    fn direct_string_descriptor(
-        width: c_int,
-        data: *mut c_void,
-    ) -> RWriteColumnDescriptor {
-        let mut descriptor =
-            direct_numeric_descriptor(width + 4, ptr::null(), 0, 0.0, 1.0);
+    fn direct_string_descriptor(width: c_int, data: *mut c_void) -> RWriteColumnDescriptor {
+        let mut descriptor = direct_numeric_descriptor(width + 4, ptr::null(), 0, 0.0, 1.0);
         descriptor.direct_string_data = data;
         descriptor
     }
@@ -3421,12 +3414,7 @@ mod tests {
         };
         let mut output = Vec::new();
         let workers = observation_source
-            .append_direct_observation_rows(
-                &mut output,
-                0,
-                row_count as u64,
-                available_parallelism,
-            )
+            .append_direct_observation_rows(&mut output, 0, row_count as u64, available_parallelism)
             .unwrap();
         let replacements = sources
             .iter()
@@ -3562,27 +3550,11 @@ mod tests {
             views[id as usize] = (value.as_ptr(), value.len());
         }
         let ids = (0..ROWS).map(|index| (index % 2) as u32).collect();
-        let dictionary_data = Box::into_raw(Box::new(DictStringData::new(
-            ids,
-            dictionary,
-            views,
-        )));
+        let dictionary_data = Box::into_raw(Box::new(DictStringData::new(ids, dictionary, views)));
 
         let descriptors = vec![
-            direct_numeric_descriptor(
-                2,
-                ordinary_integers.as_ptr().cast(),
-                1,
-                0.0,
-                1.0,
-            ),
-            direct_numeric_descriptor(
-                4,
-                ordinary_doubles.as_ptr().cast(),
-                2,
-                5.0,
-                10.0,
-            ),
+            direct_numeric_descriptor(2, ordinary_integers.as_ptr().cast(), 1, 0.0, 1.0),
+            direct_numeric_descriptor(4, ordinary_doubles.as_ptr().cast(), 2, 5.0, 10.0),
             direct_numeric_descriptor(0, compact_bytes.as_ptr().cast(), 3, 0.0, 1.0),
             direct_numeric_descriptor(1, compact_ints.as_ptr().cast(), 4, 0.0, 1.0),
             direct_numeric_descriptor(2, compact_longs.as_ptr().cast(), 5, 0.0, 1.0),


### PR DESCRIPTION
## Summary

- replace the native-backed row-by-row per-cell writer path with bounded bulk observation blocks
- encode independent direct columns in scoped worker threads while keeping callback, ALTREP, and strL cases on the scalar fallback
- preserve conversion, missing-value, replacement-count, and atomic sibling-file behavior
- document the bulk-source contract, thread-safety invariant, and durability boundary
- add byte-for-byte scalar versus forced two-worker coverage and publish provenance-bound benchmark evidence

## Performance

On the seven-run paired Stata-first-save benchmark:

- 100 MB: dtatools 0.023 s versus Stata 0.013 s, or 1.77x
- 1 GB: dtatools 0.150 s versus Stata 0.130 s, or 1.15x

The original path was roughly 9x Stata on both scales. Profiling traced most of that gap to one generic trait call and result path per cell, not R callbacks or filesystem flush time.

## Validation

- cargo test --workspace --locked
- root and R bridge clippy with warnings denied
- root and R bridge formatting checks
- rustdoc with warnings denied
- 260 installed-package writer assertions
- exact 1,823-file corpus qualification: 1,821 passes, two hash-bound expected exclusions, zero failures
- generated 32,768-column release-119 qualification passes
- 1,822 paired dtatools and Stata corpus writes complete
- R CMD check --no-manual --as-cran: all tests pass; two known warnings and one note remain for unpublished renamed-repository URLs, unavailable checkbashisms, and the pre-existing linked Rust abort symbol
- benchmark, portability, and safety reviewers clean after four review passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added faster parallel writing for compatible numeric and fixed-string data.
  - Added efficient bulk processing for observation batches.
  - Invalid or unrepresentable numeric values are safely replaced with system-missing values.

- **Bug Fixes**
  - Improved validation and error reporting for incomplete or malformed output data.
  - Preserved existing destination files during validation, interruption, and pre-replacement I/O failures.

- **Documentation**
  - Clarified little-endian output and limitations around delayed write failures and crash durability.
  - Updated benchmark comparisons, validation guidance, and architectural documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->