### PR TITLE
Add Stata-verified DTA and Arrow corpus round trips

### DIFF
--- a/benchmarks/r-corpus-roundtrip/README.md
+++ b/benchmarks/r-corpus-roundtrip/README.md
@@ -90,6 +90,17 @@ size. This leaves headroom on a 128 GiB host and narrows concurrency for the
 largest inputs. Override the limits with `DTATOOLS_VERIFY_JOBS` and
 `DTATOOLS_VERIFY_MEMORY_GIB`. Each Stata comparison uses one processor.
 
+After every wave, the runner atomically writes `verification.partial.tsv` so
+an interrupted run has a durable ordered checkpoint. To investigate the
+unverified tail after an interruption, restart at its one-based ordered corpus
+position:
+
+```sh
+benchmarks/r-corpus-roundtrip/verify.sh from 1617
+```
+
+This recovery mode does not replace the final uninterrupted full-run gate.
+
 Passing work directories are deleted. Every failure is retained beneath
 `target/r-corpus-roundtrip-verification/`, and the ordered `verification.tsv`
 contains only corpus IDs and compact comparison locations, never source paths,

--- a/benchmarks/r-corpus-roundtrip/README.md
+++ b/benchmarks/r-corpus-roundtrip/README.md
@@ -52,3 +52,47 @@ The aggregate-only [2026-08-28 report](results-2026-08-28.md) records the
 latest complete qualification against dtatools 0.6.0 under the documented
 Stata/MP 18 executable scope. The [2026-08-27 report](results-2026-08-27.md)
 remains the historical first complete qualification and write comparison.
+
+## Exact Stata verification
+
+`verify.sh` runs the stricter correctness loop. For each source it
+writes a direct DTA copy, an Arrow copy, and a DTA copy read back from Arrow.
+Stata compares the original with both DTA outputs. The comparison covers
+dimensions, variable order and names, storage types, display formats, dataset
+and variable labels, value-label assignments and definitions, notes, and every
+stored value. Notes means the dataset notes represented by the package; Stata
+variable notes are arbitrary variable characteristics and are outside the
+package's documented read model.
+
+Start with the smallest files:
+
+```sh
+benchmarks/r-corpus-roundtrip/verify.sh smallest 10
+```
+
+Run one previously failing file until it passes completely:
+
+```sh
+benchmarks/r-corpus-roundtrip/verify.sh id DHS-0123456789abcdef01234567
+```
+
+Only then restart the full size-ordered loop:
+
+```sh
+benchmarks/r-corpus-roundtrip/verify.sh full
+```
+
+Full verification uses up to 16 independent dataset processes and completes
+every selected dataset before reporting failures. Work is admitted in
+smallest-first, size-aware waves: the default estimated-memory ceiling is 96
+GiB, and each dataset reserves the larger of 512 MiB or 16 times its source
+size. This leaves headroom on a 128 GiB host and narrows concurrency for the
+largest inputs. Override the limits with `DTATOOLS_VERIFY_JOBS` and
+`DTATOOLS_VERIFY_MEMORY_GIB`. Each Stata comparison uses one processor.
+
+Passing work directories are deleted. Every failure is retained beneath
+`target/r-corpus-roundtrip-verification/`, and the ordered `verification.tsv`
+contains only corpus IDs and compact comparison locations, never source paths,
+labels, or values. Single-ID and smallest-file runs remain serial. Each
+invocation builds and installs the current checkout afresh, so a single-ID
+recheck cannot accidentally use the package that produced the prior failure.

--- a/benchmarks/r-corpus-roundtrip/common.R
+++ b/benchmarks/r-corpus-roundtrip/common.R
@@ -2,6 +2,74 @@ source(file.path(script_dir, "..", "benchmark-common.R"), local = TRUE)
 
 roundtrip_corpora <- c("DHS", "MICS", "NSFG")
 
+roundtrip_order_smallest <- function(inventory) {
+    inventory[
+        order(inventory$bytes, inventory$relative_path, method = "radix"),
+        ,
+        drop = FALSE
+    ]
+}
+
+roundtrip_verification_limits <- function(
+    jobs = Sys.getenv("DTATOOLS_VERIFY_JOBS", "16"),
+    memory_gib = Sys.getenv("DTATOOLS_VERIFY_MEMORY_GIB", "96")
+) {
+    jobs <- suppressWarnings(as.integer(jobs))
+    memory_gib <- suppressWarnings(as.numeric(memory_gib))
+    if (length(jobs) != 1L || is.na(jobs) || jobs < 1L) {
+        stop("DTATOOLS_VERIFY_JOBS must be a positive integer")
+    }
+    if (length(memory_gib) != 1L || is.na(memory_gib) ||
+        !is.finite(memory_gib) || memory_gib <= 0) {
+        stop("DTATOOLS_VERIFY_MEMORY_GIB must be a positive number")
+    }
+    list(jobs = jobs, memory_bytes = memory_gib * 1024^3)
+}
+
+roundtrip_verification_waves <- function(
+    bytes, jobs, memory_bytes,
+    expansion = 16, minimum_bytes = 512 * 1024^2
+) {
+    if (!length(bytes)) return(list())
+    estimates <- pmax(minimum_bytes, expansion * as.double(bytes))
+    waves <- list()
+    current <- integer()
+    current_memory <- 0
+    for (index in seq_along(estimates)) {
+        estimate <- estimates[[index]]
+        exceeds <- length(current) >= jobs ||
+            (length(current) > 0L && current_memory + estimate > memory_bytes)
+        if (exceeds) {
+            waves[[length(waves) + 1L]] <- current
+            current <- integer()
+            current_memory <- 0
+        }
+        current <- c(current, index)
+        current_memory <- current_memory + estimate
+    }
+    if (length(current)) waves[[length(waves) + 1L]] <- current
+    waves
+}
+
+roundtrip_select_verification <- function(inventory, selection, argument = "") {
+    ordered <- roundtrip_order_smallest(inventory)
+    if (identical(selection, "full")) return(ordered)
+    if (identical(selection, "smallest")) {
+        count <- suppressWarnings(as.integer(argument))
+        if (length(count) != 1L || is.na(count) || count < 1L ||
+            !identical(as.character(count), argument)) {
+            stop("smallest count must be a positive integer")
+        }
+        return(utils::head(ordered, count))
+    }
+    if (identical(selection, "id")) {
+        selected <- inventory[inventory$id == argument, , drop = FALSE]
+        if (nrow(selected) != 1L) stop("stable corpus ID was not found")
+        return(selected)
+    }
+    stop("verification selection must be full, smallest, or id")
+}
+
 roundtrip_stable_id <- function(corpus, relative_path, sha256) {
     digest <- tools::sha256sum(bytes = charToRaw(paste(
         corpus, relative_path, sha256, sep = "\037"

--- a/benchmarks/r-corpus-roundtrip/common.R
+++ b/benchmarks/r-corpus-roundtrip/common.R
@@ -54,6 +54,15 @@ roundtrip_verification_waves <- function(
 roundtrip_select_verification <- function(inventory, selection, argument = "") {
     ordered <- roundtrip_order_smallest(inventory)
     if (identical(selection, "full")) return(ordered)
+    if (identical(selection, "from")) {
+        position <- suppressWarnings(as.integer(argument))
+        if (length(position) != 1L || is.na(position) || position < 1L ||
+            position > nrow(ordered) ||
+            !identical(as.character(position), argument)) {
+            stop("from position must identify an ordered corpus row")
+        }
+        return(ordered[seq.int(position, nrow(ordered)), , drop = FALSE])
+    }
     if (identical(selection, "smallest")) {
         count <- suppressWarnings(as.integer(argument))
         if (length(count) != 1L || is.na(count) || count < 1L ||
@@ -67,7 +76,7 @@ roundtrip_select_verification <- function(inventory, selection, argument = "") {
         if (nrow(selected) != 1L) stop("stable corpus ID was not found")
         return(selected)
     }
-    stop("verification selection must be full, smallest, or id")
+    stop("verification selection must be full, from, smallest, or id")
 }
 
 roundtrip_stable_id <- function(corpus, relative_path, sha256) {

--- a/benchmarks/r-corpus-roundtrip/stata-compare.do
+++ b/benchmarks/r-corpus-roundtrip/stata-compare.do
@@ -1,0 +1,206 @@
+version 18
+set more off
+set maxvar 120000
+set processors 1
+
+args source candidate output_kind source_release
+global DTATOOLS_OUTPUT_KIND "`output_kind'"
+
+capture program drop fail
+program define fail
+    args category variable observation
+    if "`variable'" == "" local variable "."
+    if "`observation'" == "" local observation "."
+    file open result using "stata-compare-result.tsv", write text replace
+    file write result "mismatch" _tab "$DTATOOLS_OUTPUT_KIND" _tab ///
+        "`category'" _tab "`variable'" _tab "`observation'" _n
+    file close result
+    exit 9
+end
+
+capture noisily use "`source'", clear
+if _rc fail "source-open" "" ""
+local source_n = _N
+local source_k = c(k)
+unab source_names : _all
+local source_dlabel : data label
+if `source_release' < 118 {
+    local source_dlabel = ustrfrom(`"`source_dlabel'"', "windows-1252", 1)
+}
+else local source_dlabel = ustrfix(`"`source_dlabel'"')
+
+capture noisily describe using "`candidate'"
+if _rc fail "candidate-open" "" ""
+if r(N) != `source_n' fail "dimensions" "" ""
+if r(k) != `source_k' fail "dimensions" "" ""
+
+preserve
+quietly use "`candidate'", clear
+unab candidate_names : _all
+local candidate_dlabel : data label
+restore
+if `"`source_names'"' != `"`candidate_names'"' fail "variable-names" "" ""
+if `"`source_dlabel'"' != `"`candidate_dlabel'"' fail "dataset-label" "" ""
+
+local normalized_source "normalized-source-`output_kind'.dta"
+capture erase "`normalized_source'"
+clear
+quietly copy "`source'" "`normalized_source'", replace
+if `source_release' < 118 quietly unicode encoding set windows-1252
+else quietly unicode encoding set utf-8
+quietly unicode analyze "`normalized_source'", redo
+quietly unicode translate "`normalized_source'", invalid(mark) transutf8
+quietly unicode erasebackups, badidea
+quietly use "`normalized_source'", clear
+mata: __dtatools_source_vlabels = J(1, st_nvar(), "")
+mata: for (__dtatools_i = 1; __dtatools_i <= st_nvar(); __dtatools_i++) __dtatools_source_vlabels[__dtatools_i] = st_varlabel(__dtatools_i)
+mata: __dtatools_source_values = J(0, 1, .)
+mata: __dtatools_source_labels = J(0, 1, "")
+mata: __dtatools_candidate_values = J(0, 1, .)
+mata: __dtatools_candidate_labels = J(0, 1, "")
+mata:
+real scalar __dtatools_value_labels_equal(
+    real colvector source_values,
+    string colvector source_labels,
+    real colvector candidate_values,
+    string colvector candidate_labels
+) {
+    real colvector used
+    real scalar source_index, candidate_index, matched
+    if (rows(source_values) != rows(candidate_values)) return(0)
+    used = J(rows(candidate_values), 1, 0)
+    for (source_index = 1; source_index <= rows(source_values); source_index++) {
+        matched = 0
+        for (candidate_index = 1; candidate_index <= rows(candidate_values); candidate_index++) {
+            if (!used[candidate_index] &
+                source_values[source_index] == candidate_values[candidate_index] &
+                source_labels[source_index] == candidate_labels[candidate_index]) {
+                used[candidate_index] = 1
+                matched = 1
+                break
+            }
+        }
+        if (!matched) return(0)
+    }
+    return(1)
+}
+end
+quietly use "`source'", clear
+
+local source_index 0
+foreach variable of local source_names {
+    local ++source_index
+    local original_source_type : type `variable'
+    preserve
+    quietly use "`normalized_source'", clear
+    local source_type : type `variable'
+    if substr("`original_source_type'", 1, 3) == "str" & ///
+        "`original_source_type'" != "strL" {
+        tempvar normalized_length
+        quietly generate long `normalized_length' = strlen(`variable')
+        quietly summarize `normalized_length', meanonly
+        local source_width = max(real(substr("`original_source_type'", 4, .)), r(max))
+        if `source_width' > 2045 local source_type "strL"
+        else local source_type "str`source_width'"
+    }
+    restore
+    local source_format : format `variable'
+    local source_vallab : value label `variable'
+    preserve
+    quietly use "`candidate'", clear
+    local candidate_type : type `variable'
+    local candidate_format : format `variable'
+    local candidate_vallab : value label `variable'
+    mata: st_numscalar("__dtatools_vlabel_equal", st_varlabel(st_varindex("`variable'")) == __dtatools_source_vlabels[`source_index'])
+    restore
+
+    if "`source_type'" != "`candidate_type'" fail "storage-type" "`variable'" ""
+    if "`source_format'" != "`candidate_format'" fail "display-format" "`variable'" ""
+    if scalar(__dtatools_vlabel_equal) == 0 fail "variable-label" "`variable'" ""
+    if "`source_vallab'" != "" & "`candidate_vallab'" == "" {
+        tempfile assigned_label_probe
+        capture quietly label save `source_vallab' using ///
+            "`assigned_label_probe'", replace
+        if _rc local source_vallab ""
+        else fail "value-label-assignment" "`variable'" ""
+    }
+    if "`source_vallab'" == "" & "`candidate_vallab'" != "" {
+        fail "value-label-assignment" "`variable'" ""
+    }
+    if "`source_vallab'" != "" {
+        preserve
+        quietly use "`normalized_source'", clear
+        mata: st_vlload("`source_vallab'", __dtatools_source_values, __dtatools_source_labels)
+        restore
+        preserve
+        quietly use "`candidate'", clear
+        mata: st_vlload("`candidate_vallab'", __dtatools_candidate_values, __dtatools_candidate_labels)
+        restore
+        mata: st_numscalar("__dt_vldef_eq", __dtatools_value_labels_equal(__dtatools_source_values, __dtatools_source_labels, __dtatools_candidate_values, __dtatools_candidate_labels))
+        if scalar(__dt_vldef_eq) == 0 {
+            fail "value-label-definitions" "`variable'" ""
+        }
+    }
+}
+
+local source_note_count : char _dta[note0]
+if "`source_note_count'" == "" local source_note_count 0
+preserve
+quietly use "`candidate'", clear
+local candidate_note_count : char _dta[note0]
+if "`candidate_note_count'" == "" local candidate_note_count 0
+restore
+if `source_note_count' != `candidate_note_count' fail "dataset-notes" "" ""
+if `source_note_count' > 0 {
+    forvalues note = 1/`source_note_count' {
+        local source_note : char _dta[note`note']
+        if `source_release' < 118 {
+            local source_note = ustrfrom(`"`source_note'"', "windows-1252", 1)
+        }
+        else local source_note = ustrfix(`"`source_note'"')
+        preserve
+        quietly use "`candidate'", clear
+        local candidate_note : char _dta[note`note']
+        restore
+        if `"`source_note'"' != `"`candidate_note'"' fail "dataset-notes" "" ""
+    }
+}
+
+quietly use "`normalized_source'", clear
+local cf_count 0
+local cf_guard_index 0
+foreach variable of local source_names {
+    if regexm("`variable'", "^__[0-9]+$") {
+        local ++cf_count
+        local ++cf_guard_index
+        local cf_guard "__dtcf`cf_guard_index'"
+        capture confirm new variable `cf_guard'
+        while _rc {
+            local ++cf_guard_index
+            local cf_guard "__dtcf`cf_guard_index'"
+            capture confirm new variable `cf_guard'
+        }
+        local cf_old`cf_count' "`variable'"
+        local cf_new`cf_count' "`cf_guard'"
+        rename `variable' `cf_guard'
+    }
+}
+if `cf_count' > 0 {
+    tempfile cf_source cf_candidate
+    quietly save "`cf_source'"
+    quietly use "`candidate'", clear
+    forvalues cf_index = 1/`cf_count' {
+        rename `cf_old`cf_index'' `cf_new`cf_index''
+    }
+    quietly save "`cf_candidate'"
+    quietly use "`cf_source'", clear
+    capture noisily cf _all using "`cf_candidate'"
+}
+else capture noisily cf _all using "`candidate'"
+if _rc fail "stored-values" "" ""
+capture erase "`normalized_source'"
+
+file open result using "stata-compare-result.tsv", write text replace
+file write result "pass" _tab "`output_kind'" _tab "." _tab "." _tab "." _n
+file close result
+exit 0

--- a/benchmarks/r-corpus-roundtrip/test-framework.R
+++ b/benchmarks/r-corpus-roundtrip/test-framework.R
@@ -51,6 +51,10 @@ stopifnot(
         roundtrip_select_verification(ordered_fixture, "id", "tie")$id,
         "tie"
     ),
+    identical(
+        roundtrip_select_verification(ordered_fixture, "from", "2")$relative_path,
+        c("b.dta", "z.dta")
+    ),
     nrow(roundtrip_select_verification(ordered_fixture, "full")) == 3L
 )
 limits <- roundtrip_verification_limits("16", "96")
@@ -79,7 +83,11 @@ invalid_selection <- tryCatch(
     roundtrip_select_verification(ordered_fixture, "smallest", "0"),
     error = identity
 )
-stopifnot(inherits(invalid_selection, "error"))
+invalid_from <- tryCatch(
+    roundtrip_select_verification(ordered_fixture, "from", "4"),
+    error = identity
+)
+stopifnot(inherits(invalid_selection, "error"), inherits(invalid_from, "error"))
 invalid_hash <- tryCatch(
     benchmark_validate_sha256("not-a-hash", 1L, "test file"),
     error = identity

--- a/benchmarks/r-corpus-roundtrip/test-framework.R
+++ b/benchmarks/r-corpus-roundtrip/test-framework.R
@@ -28,6 +28,58 @@ stopifnot(
     any(inventory$sha256 == benchmark_file_sha256(fixture)),
     !anyDuplicated(inventory$id)
 )
+ordered_fixture <- inventory
+ordered_fixture$bytes <- c(20, 10)
+ordered_fixture$relative_path <- c("z.dta", "a.dta")
+ordered_fixture <- rbind(
+    ordered_fixture,
+    transform(ordered_fixture[1L, ], id = "tie", bytes = 10,
+              relative_path = "b.dta")
+)
+stopifnot(
+    identical(
+        roundtrip_order_smallest(ordered_fixture)$relative_path,
+        c("a.dta", "b.dta", "z.dta")
+    ),
+    identical(
+        roundtrip_select_verification(
+            ordered_fixture, "smallest", "2"
+        )$relative_path,
+        c("a.dta", "b.dta")
+    ),
+    identical(
+        roundtrip_select_verification(ordered_fixture, "id", "tie")$id,
+        "tie"
+    ),
+    nrow(roundtrip_select_verification(ordered_fixture, "full")) == 3L
+)
+limits <- roundtrip_verification_limits("16", "96")
+stopifnot(
+    identical(limits$jobs, 16L),
+    identical(limits$memory_bytes, 96 * 1024^3),
+    identical(
+        roundtrip_verification_waves(
+            c(1, 1, 40), jobs = 2L, memory_bytes = 100,
+            expansion = 2, minimum_bytes = 1
+        ),
+        list(c(1L, 2L), 3L)
+    ),
+    identical(
+        roundtrip_verification_waves(
+            c(30, 30, 30), jobs = 16L, memory_bytes = 100,
+            expansion = 2, minimum_bytes = 1
+        ),
+        list(1L, 2L, 3L)
+    )
+)
+invalid_jobs <- tryCatch(roundtrip_verification_limits("0", "96"), error = identity)
+invalid_memory <- tryCatch(roundtrip_verification_limits("16", "nope"), error = identity)
+stopifnot(inherits(invalid_jobs, "error"), inherits(invalid_memory, "error"))
+invalid_selection <- tryCatch(
+    roundtrip_select_verification(ordered_fixture, "smallest", "0"),
+    error = identity
+)
+stopifnot(inherits(invalid_selection, "error"))
 invalid_hash <- tryCatch(
     benchmark_validate_sha256("not-a-hash", 1L, "test file"),
     error = identity

--- a/benchmarks/r-corpus-roundtrip/verify-worker.R
+++ b/benchmarks/r-corpus-roundtrip/verify-worker.R
@@ -1,0 +1,67 @@
+args <- commandArgs(trailingOnly = TRUE)
+if (length(args) != 4L) {
+    stop("usage: verify-worker.R INPUT DIRECT_DTA ARROW VIA_ARROW_DTA")
+}
+
+script_argument <- grep(
+    "^--file=", commandArgs(trailingOnly = FALSE), value = TRUE
+)[[1L]]
+script_dir <- dirname(normalizePath(
+    sub("^--file=", "", script_argument), winslash = "/"
+))
+source(file.path(script_dir, "common.R"), local = TRUE)
+benchmark_activate_library("dtatools")
+
+input <- normalizePath(args[[1L]], winslash = "/", mustWork = TRUE)
+direct <- args[[2L]]
+arrow <- args[[3L]]
+via_arrow <- args[[4L]]
+stage <- "source-read"
+rows <- columns <- NA_integer_
+
+unexpected_warning <- function(condition) {
+    stop(
+        sprintf("%s warning: %s", stage, conditionMessage(condition)),
+        call. = FALSE
+    )
+}
+
+result <- tryCatch({
+    data <- dtatools::read_dta(input)
+    rows <- nrow(data)
+    columns <- ncol(data)
+
+    stage <- "direct-dta-write"
+    withCallingHandlers(
+        dtatools::save_dta(data, direct, version = 19L),
+        warning = unexpected_warning
+    )
+
+    stage <- "arrow-write"
+    withCallingHandlers(
+        dtatools::save_arrow(data, arrow),
+        warning = unexpected_warning
+    )
+
+    stage <- "arrow-read"
+    arrow_data <- withCallingHandlers(
+        dtatools::read_arrow(arrow),
+        warning = unexpected_warning
+    )
+
+    stage <- "arrow-dta-write"
+    withCallingHandlers(
+        dtatools::save_dta(arrow_data, via_arrow, version = 19L),
+        warning = unexpected_warning
+    )
+    stage <- "r-pass"
+    TRUE
+}, error = function(condition) {
+    message("verification worker: ", conditionMessage(condition))
+    FALSE
+})
+
+cat(sprintf(
+    "DTATOOLS_VERIFY\t%s\t%s\t%s\n", stage, rows, columns
+))
+if (!result) quit(status = 1L)

--- a/benchmarks/r-corpus-roundtrip/verify.R
+++ b/benchmarks/r-corpus-roundtrip/verify.R
@@ -1,6 +1,6 @@
 args <- commandArgs(trailingOnly = TRUE)
 if (length(args) < 3L || length(args) > 4L) {
-    stop("usage: verify.R CACHE_ROOT OUTPUT_DIR full|smallest|id [ARGUMENT]")
+    stop("usage: verify.R CACHE_ROOT OUTPUT_DIR full|from|smallest|id [ARGUMENT]")
 }
 if (!requireNamespace("processx", quietly = TRUE)) stop("processx is required")
 
@@ -63,7 +63,9 @@ parse_stata <- function(path, kind) {
 work_root <- file.path(output_dir, "work")
 dir.create(work_root, recursive = TRUE, showWarnings = FALSE)
 results_path <- file.path(output_dir, "verification.tsv")
+partial_results_path <- file.path(output_dir, "verification.partial.tsv")
 if (file.exists(results_path)) unlink(results_path)
+if (file.exists(partial_results_path)) unlink(partial_results_path)
 
 result_row <- function(item, status, stage, output = "", category = "",
                        variable = "", observation = "") {
@@ -144,7 +146,7 @@ verify_one <- function(index) {
 }
 
 limits <- roundtrip_verification_limits()
-if (selection != "full") limits$jobs <- 1L
+if (!selection %in% c("full", "from")) limits$jobs <- 1L
 waves <- roundtrip_verification_waves(
     selected$bytes, limits$jobs, limits$memory_bytes
 )
@@ -179,6 +181,9 @@ for (wave_number in seq_along(waves)) {
         row
     }, wave_rows, indices)
     rows[indices] <- wave_rows
+    checkpoint <- do.call(rbind, rows[seq_len(max(indices))])
+    rownames(checkpoint) <- NULL
+    atomic_tsv(checkpoint, partial_results_path)
     completed <- completed + length(indices)
     failures <- sum(vapply(wave_rows, function(row) {
         !identical(row$status[[1L]], "pass") &&
@@ -192,6 +197,7 @@ for (wave_number in seq_along(waves)) {
 results <- do.call(rbind, rows)
 rownames(results) <- NULL
 atomic_tsv(results, results_path)
+unlink(partial_results_path)
 failure_count <- sum(results$status == "failure")
 if (failure_count > 0L) {
     stop(

--- a/benchmarks/r-corpus-roundtrip/verify.R
+++ b/benchmarks/r-corpus-roundtrip/verify.R
@@ -1,0 +1,208 @@
+args <- commandArgs(trailingOnly = TRUE)
+if (length(args) < 3L || length(args) > 4L) {
+    stop("usage: verify.R CACHE_ROOT OUTPUT_DIR full|smallest|id [ARGUMENT]")
+}
+if (!requireNamespace("processx", quietly = TRUE)) stop("processx is required")
+
+cache_root <- normalizePath(args[[1L]], winslash = "/", mustWork = TRUE)
+output_dir <- normalizePath(args[[2L]], winslash = "/", mustWork = FALSE)
+selection <- args[[3L]]
+argument <- if (length(args) == 4L) args[[4L]] else ""
+script_argument <- grep("^--file=", commandArgs(trailingOnly = FALSE), value = TRUE)[[1L]]
+script_dir <- dirname(normalizePath(sub("^--file=", "", script_argument), winslash = "/"))
+source(file.path(script_dir, "common.R"), local = TRUE)
+
+library <- benchmark_library_path()
+rscript <- normalizePath(Sys.which("Rscript"), winslash = "/", mustWork = TRUE)
+stata <- find_stata()
+dir.create(output_dir, recursive = TRUE, showWarnings = FALSE)
+
+inventory <- roundtrip_inventory(cache_root)
+selected <- roundtrip_select_verification(inventory, selection, argument)
+inventory_hash <- benchmark_file_sha256({
+    path <- file.path(output_dir, "inventory.tsv")
+    atomic_tsv(inventory[c("corpus", "id", "relative_path", "release", "bytes", "sha256")], path, quote = TRUE)
+    path
+})
+binding <- cbind(
+    data.frame(
+        schema_version = 1L,
+        inventory_sha256 = inventory_hash,
+        package_sha256 = benchmark_directory_sha256(
+            benchmark_installed_package_path(library)
+        ),
+        comparator_sha256 = benchmark_file_sha256(
+            file.path(script_dir, "stata-compare.do")
+        ),
+        stringsAsFactors = FALSE
+    ),
+    benchmark_runtime_binding(stata, rscript_executable = rscript)
+)
+atomic_tsv(binding, file.path(output_dir, "verification-binding.tsv"))
+
+run <- function(command, arguments, wd = NULL) {
+    processx::run(
+        command, arguments, wd = wd,
+        env = c(
+            DTATOOLS_BENCH_LIB = library,
+            R_ENVIRON_USER = "/dev/null", R_PROFILE_USER = "/dev/null"
+        ),
+        error_on_status = FALSE, echo = FALSE
+    )
+}
+
+parse_stata <- function(path, kind) {
+    if (!file.exists(path)) return(c("stata-worker-error", kind, "protocol", "", ""))
+    fields <- strsplit(readLines(path, n = 1L, warn = FALSE), "\t", fixed = TRUE)[[1L]]
+    if (length(fields) != 5L || fields[[2L]] != kind) {
+        return(c("stata-worker-error", kind, "protocol", "", ""))
+    }
+    fields
+}
+
+work_root <- file.path(output_dir, "work")
+dir.create(work_root, recursive = TRUE, showWarnings = FALSE)
+results_path <- file.path(output_dir, "verification.tsv")
+if (file.exists(results_path)) unlink(results_path)
+
+result_row <- function(item, status, stage, output = "", category = "",
+                       variable = "", observation = "") {
+    data.frame(
+        corpus = item$corpus, id = item$id, bytes = item$bytes,
+        status = status, stage = stage, output = output,
+        category = category, variable = variable, observation = observation,
+        stringsAsFactors = FALSE
+    )
+}
+
+verify_one <- function(index) {
+    item <- selected[index, , drop = FALSE]
+    exclusion <- roundtrip_exclusion_reason(item)
+    if (!is.na(exclusion)) {
+        return(result_row(item, "expected-exclusion", exclusion))
+    }
+
+    work_dir <- file.path(work_root, item$id)
+    tryCatch({
+        unlink(work_dir, recursive = TRUE, force = TRUE)
+        dir.create(work_dir, recursive = TRUE)
+        input <- benchmark_snapshot_file(
+            item$path, file.path(work_dir, "input.dta"), item$bytes, item$sha256
+        )
+        direct <- file.path(work_dir, "direct.dta")
+        arrow <- file.path(work_dir, "copy.arrow")
+        via_arrow <- file.path(work_dir, "via-arrow.dta")
+        worker <- run(
+            rscript,
+            c("--vanilla", file.path(script_dir, "verify-worker.R"),
+              input, direct, arrow, via_arrow)
+        )
+        marker <- parse_fields(worker$stdout, "DTATOOLS_VERIFY")
+        if (worker$status != 0L || length(marker) != 3L ||
+            marker[[1L]] != "r-pass") {
+            stage <- if (length(marker)) marker[[1L]] else "r-worker-error"
+            writeLines(worker$stdout, file.path(work_dir, "r-worker.stdout"), useBytes = TRUE)
+            writeLines(worker$stderr, file.path(work_dir, "r-worker.stderr"), useBytes = TRUE)
+            return(result_row(item, "failure", stage))
+        }
+
+        for (kind in c("direct", "via-arrow")) {
+            candidate <- if (kind == "direct") direct else via_arrow
+            result_path <- file.path(work_dir, "stata-compare-result.tsv")
+            unlink(result_path)
+            comparison <- run(
+                stata,
+                c("-q", "-b", "do", file.path(script_dir, "stata-compare.do"),
+                  input, candidate, kind, as.character(item$release)),
+                work_dir
+            )
+            fields <- parse_stata(result_path, kind)
+            if (fields[[1L]] != "pass" || comparison$status != 0L) {
+                writeLines(comparison$stdout, file.path(
+                    work_dir, paste0("stata-", kind, ".stdout")
+                ), useBytes = TRUE)
+                writeLines(comparison$stderr, file.path(
+                    work_dir, paste0("stata-", kind, ".stderr")
+                ), useBytes = TRUE)
+                return(result_row(
+                    item, "failure", "stata-compare", fields[[2L]],
+                    fields[[3L]], fields[[4L]], fields[[5L]]
+                ))
+            }
+        }
+
+        row <- result_row(item, "pass", "complete", "both")
+        unlink(work_dir, recursive = TRUE, force = TRUE)
+        row
+    }, error = function(condition) {
+        dir.create(work_dir, recursive = TRUE, showWarnings = FALSE)
+        writeLines(conditionMessage(condition), file.path(
+            work_dir, "orchestrator.stderr"
+        ), useBytes = TRUE)
+        result_row(item, "failure", "orchestrator-error")
+    })
+}
+
+limits <- roundtrip_verification_limits()
+if (selection != "full") limits$jobs <- 1L
+waves <- roundtrip_verification_waves(
+    selected$bytes, limits$jobs, limits$memory_bytes
+)
+message(
+    "verification schedule: ", length(waves), " size-aware waves, up to ",
+    limits$jobs, " processes and ",
+    format(limits$memory_bytes / 1024^3, trim = TRUE), " GiB estimated memory"
+)
+rows <- vector("list", nrow(selected))
+completed <- 0L
+for (wave_number in seq_along(waves)) {
+    indices <- waves[[wave_number]]
+    wave_rows <- if (length(indices) == 1L) {
+        list(verify_one(indices[[1L]]))
+    } else {
+        parallel::mclapply(
+            indices, verify_one, mc.cores = length(indices),
+            mc.preschedule = FALSE, mc.set.seed = FALSE
+        )
+    }
+    wave_rows <- Map(function(row, index) {
+        if (inherits(row, "try-error") || !is.data.frame(row) ||
+            nrow(row) != 1L) {
+            item <- selected[index, , drop = FALSE]
+            work_dir <- file.path(work_root, item$id)
+            dir.create(work_dir, recursive = TRUE, showWarnings = FALSE)
+            writeLines(as.character(row), file.path(
+                work_dir, "orchestrator.stderr"
+            ), useBytes = TRUE)
+            return(result_row(item, "failure", "dataset-process-error"))
+        }
+        row
+    }, wave_rows, indices)
+    rows[indices] <- wave_rows
+    completed <- completed + length(indices)
+    failures <- sum(vapply(wave_rows, function(row) {
+        !identical(row$status[[1L]], "pass") &&
+            !identical(row$status[[1L]], "expected-exclusion")
+    }, logical(1L)))
+    message(
+        completed, "/", nrow(selected), ": wave ", wave_number, "/",
+        length(waves), " complete; ", failures, " failures"
+    )
+}
+results <- do.call(rbind, rows)
+rownames(results) <- NULL
+atomic_tsv(results, results_path)
+failure_count <- sum(results$status == "failure")
+if (failure_count > 0L) {
+    stop(
+        "verification completed all selected datasets with ", failure_count,
+        " failures; see verification.tsv and retained work directories"
+    )
+}
+if (selection == "full" &&
+    !(nrow(results) == 1823L && sum(results$status == "pass") == 1821L &&
+      sum(results$status == "expected-exclusion") == 2L)) {
+    stop("full verification did not achieve 1,821 passes and two bound exclusions")
+}
+message("verification complete: ", sum(results$status == "pass"), " passes, ",
+        sum(results$status == "expected-exclusion"), " exclusions")

--- a/benchmarks/r-corpus-roundtrip/verify.sh
+++ b/benchmarks/r-corpus-roundtrip/verify.sh
@@ -14,9 +14,10 @@ if test -n "${CI:-}${GITHUB_ACTIONS:-}${GITHUB_RUN_ID:-}${GITHUB_WORKFLOW:-}"; t
 fi
 case "$selection" in
     full) test -z "$argument" || { echo "full takes no argument" >&2; exit 2; } ;;
+    from) test -n "$argument" || { echo "from requires an ordered position" >&2; exit 2; } ;;
     smallest) test -n "$argument" || { echo "smallest requires a count" >&2; exit 2; } ;;
     id) test -n "$argument" || { echo "id requires a stable corpus ID" >&2; exit 2; } ;;
-    *) echo "usage: verify.sh [full | smallest COUNT | id STABLE_ID]" >&2; exit 2 ;;
+    *) echo "usage: verify.sh [full | from POSITION | smallest COUNT | id STABLE_ID]" >&2; exit 2 ;;
 esac
 
 run_root="$checkout/target/r-corpus-roundtrip-verification"

--- a/benchmarks/r-corpus-roundtrip/verify.sh
+++ b/benchmarks/r-corpus-roundtrip/verify.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+set -eu
+umask 077
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd -P)
+checkout=$(CDPATH= cd -- "$script_dir/../.." && pwd -P)
+cache_root=${AWW_CACHE_ROOT:-/opt/aww_cache}
+selection=${1:-full}
+argument=${2:-}
+
+if test -n "${CI:-}${GITHUB_ACTIONS:-}${GITHUB_RUN_ID:-}${GITHUB_WORKFLOW:-}"; then
+    echo "the private corpus verification is manual and refuses CI" >&2
+    exit 2
+fi
+case "$selection" in
+    full) test -z "$argument" || { echo "full takes no argument" >&2; exit 2; } ;;
+    smallest) test -n "$argument" || { echo "smallest requires a count" >&2; exit 2; } ;;
+    id) test -n "$argument" || { echo "id requires a stable corpus ID" >&2; exit 2; } ;;
+    *) echo "usage: verify.sh [full | smallest COUNT | id STABLE_ID]" >&2; exit 2 ;;
+esac
+
+run_root="$checkout/target/r-corpus-roundtrip-verification"
+mkdir -p "$run_root"
+stamp=$(date -u '+%Y%m%dT%H%M%SZ')
+run_dir=$(mktemp -d "$run_root/$stamp-$$.XXXXXX")
+build_dir="$run_dir/build"
+library="$run_dir/library"
+mkdir -p "$build_dir" "$library"
+
+(cd "$build_dir" && R CMD build "$checkout/r-package/dtatools")
+set -- "$build_dir"/dtatools_*.tar.gz
+if test "$#" -ne 1 || ! test -f "$1"; then
+    echo "expected exactly one dtatools source package" >&2
+    exit 1
+fi
+R CMD INSTALL --library="$library" "$1"
+export DTATOOLS_BENCH_LIB="$library"
+export R_ENVIRON_USER=/dev/null
+export R_PROFILE_USER=/dev/null
+
+if test -n "$argument"; then
+    Rscript --vanilla "$script_dir/verify.R" "$cache_root" "$run_dir" "$selection" "$argument"
+else
+    Rscript --vanilla "$script_dir/verify.R" "$cache_root" "$run_dir" "$selection"
+fi
+printf 'published %s\n' "$run_dir"

--- a/r-package/dtatools/R/save-arrow.R
+++ b/r-package/dtatools/R/save-arrow.R
@@ -284,6 +284,7 @@ save_arrow <- function(data, path,
     tz <- NULL
     units <- ""
     storage_code <- -1L
+    string_storage <- -1L
     values <- column
 
     value_labels <- list(double(), character(), FALSE)
@@ -317,6 +318,19 @@ save_arrow <- function(data, path,
             )
             ordered <- is.ordered(column)
         } else if (identical(kind, "character")) {
+            declared <- attr(column, "stata.string.storage", exact = TRUE)
+            if (!is.null(declared)) {
+                if (!is.character(declared) || length(declared) != 1L ||
+                    is.na(declared) ||
+                    !grepl("^(strL|str([1-9]|[1-9][0-9]{1,2}|1[0-9]{3}|20[0-3][0-9]|204[0-5]))$", declared)) {
+                    .dta_write_abort(sprintf(
+                        "Column `%s` has an invalid `stata.string.storage` declaration",
+                        name
+                    ))
+                }
+                string_storage <- if (declared == "strL") 0L else
+                    as.integer(sub("^str", "", declared))
+            }
             # Unmaterialized dictionary-string columns are already UTF-8 and
             # export natively; enc2utf8() would materialize every CHARSXP.
             if (!.is_unmaterialized_dictstring(column)) {
@@ -346,12 +360,12 @@ save_arrow <- function(data, path,
         values, levels, ordered,
         variable_label, format, storage_code, tz, units,
         value_labels[[1L]], value_labels[[2L]], value_labels[[3L]],
-        inherits(column, "haven_labelled")
+        inherits(column, "haven_labelled"), string_storage
     )
 }
 
 .arrow_known_column_attributes <- function(kind) {
-    common <- c("label", "format.stata")
+    common <- c("label", "format.stata", "stata.string.storage")
     switch(kind,
         factor = c(common, "levels", "class"),
         date = c(common, "labels", "class"),

--- a/r-package/dtatools/R/save-dta.R
+++ b/r-package/dtatools/R/save-dta.R
@@ -640,7 +640,21 @@ save_dta <- function(data, path, version = 19L,
         plan <- .Call(C_dtatools_write_string_plan, column)
         maximum <- plan[[1L]]
         values <- plan[[3L]]
-        fixed <- maximum <= strl_threshold && maximum <= 2045L
+        declared <- attr(column, "stata.string.storage", exact = TRUE)
+        if (!is.null(declared) && (!is.character(declared) ||
+            length(declared) != 1L || is.na(declared) ||
+            !grepl("^(strL|str([1-9]|[1-9][0-9]{1,2}|1[0-9]{3}|20[0-3][0-9]|204[0-5]))$", declared))) {
+            .dta_write_abort(sprintf(
+                "Column `%s` has an invalid `stata.string.storage` declaration",
+                name
+            ))
+        }
+        declared_width <- if (!is.null(declared) && declared != "strL") {
+            as.integer(sub("^str", "", declared))
+        } else NULL
+        if (!is.null(declared_width)) maximum <- max(maximum, declared_width)
+        fixed <- !identical(declared, "strL") &&
+            maximum <= strl_threshold && maximum <= 2045L
         width <- max(1L, maximum)
         type_code <- if (fixed) width + 4L else 2050L
         storage <- if (fixed) "fixed" else "strL"

--- a/r-package/dtatools/src/dta-tools/src/arrow/profile.rs
+++ b/r-package/dtatools/src/dta-tools/src/arrow/profile.rs
@@ -156,6 +156,9 @@ pub struct ArrowFieldDocument {
     pub format: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub storage: Option<StataStorage>,
+    /// Declared DTA string storage: `str1` through `str2045`, or `strL`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub string_storage: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub value_labels: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/r-package/dtatools/src/dta-tools/src/write.rs
+++ b/r-package/dtatools/src/dta-tools/src/write.rs
@@ -1544,19 +1544,28 @@ fn write_strls<W: Write, S: DtaWriteObservationSource + ?Sized>(
     plans: &[Option<Box<StrlColumnPlan>>],
 ) -> Result<(), DtaWriteError> {
     write_tag(writer, b"<strls>")?;
-    for (column_index, plan) in plans.iter().enumerate() {
-        let Some(plan) = plan else {
-            continue;
-        };
-        let column_name = &data.columns[column_index].name;
-        for (word_index, &canonical_word) in plan.canonical.iter().enumerate() {
-            let mut remaining = canonical_word;
-            while remaining != 0 {
-                let bit = remaining.trailing_zeros() as usize;
-                let row_index = word_index
-                    .checked_mul(64)
-                    .and_then(|value| value.checked_add(bit))
-                    .ok_or(DtaWriteError::Overflow("GSO observation"))?;
+    let word_count = plans
+        .iter()
+        .filter_map(|plan| plan.as_ref().map(|plan| plan.canonical.len()))
+        .max()
+        .unwrap_or(0);
+    for word_index in 0..word_count {
+        let mut rows = plans.iter().filter_map(|plan| {
+            plan.as_ref()
+                .and_then(|plan| plan.canonical.get(word_index).copied())
+        }).fold(0, |left, right| left | right);
+        while rows != 0 {
+            let bit = rows.trailing_zeros() as usize;
+            let row_index = word_index
+                .checked_mul(64)
+                .and_then(|value| value.checked_add(bit))
+                .ok_or(DtaWriteError::Overflow("GSO observation"))?;
+            for (column_index, plan) in plans.iter().enumerate() {
+                let Some(plan) = plan else { continue };
+                if plan.canonical[word_index] & (1_u64 << bit) == 0 {
+                    continue;
+                }
+                let column_name = &data.columns[column_index].name;
                 let row = u64::try_from(row_index)
                     .map_err(|_| DtaWriteError::Overflow("GSO observation"))?;
                 source.begin_row(row)?;
@@ -1595,8 +1604,8 @@ fn write_strls<W: Write, S: DtaWriteObservationSource + ?Sized>(
                     source.check_interrupt()?;
                 }
                 writer.write_all(&[0])?;
-                remaining &= remaining - 1;
             }
+            rows &= rows - 1;
         }
     }
     write_tag(writer, b"</strls>")?;

--- a/r-package/dtatools/src/dta-tools/src/write.rs
+++ b/r-package/dtatools/src/dta-tools/src/write.rs
@@ -1550,10 +1550,13 @@ fn write_strls<W: Write, S: DtaWriteObservationSource + ?Sized>(
         .max()
         .unwrap_or(0);
     for word_index in 0..word_count {
-        let mut rows = plans.iter().filter_map(|plan| {
-            plan.as_ref()
-                .and_then(|plan| plan.canonical.get(word_index).copied())
-        }).fold(0, |left, right| left | right);
+        let mut rows = plans
+            .iter()
+            .filter_map(|plan| {
+                plan.as_ref()
+                    .and_then(|plan| plan.canonical.get(word_index).copied())
+            })
+            .fold(0, |left, right| left | right);
         while rows != 0 {
             let bit = rows.trailing_zeros() as usize;
             let row_index = word_index

--- a/r-package/dtatools/src/dta-tools/tests/arrow.rs
+++ b/r-package/dtatools/src/dta-tools/tests/arrow.rs
@@ -99,6 +99,7 @@ fn field_document(
         label: format!("label for a {class} column"),
         format: String::new(),
         storage,
+        string_storage: None,
         value_labels: None,
         missing,
         missing_release: None,

--- a/r-package/dtatools/src/init.c
+++ b/r-package/dtatools/src/init.c
@@ -42,6 +42,7 @@ typedef struct {
     const char *label;
     const char *format;
     int storage;
+    int string_storage;
     int ordered;
     const char *tz;
     const char *units;
@@ -2823,17 +2824,17 @@ SEXP C_dtatools_write(SEXP specification, SEXP path) {
     return numeric_replacements;
 }
 
-/* One Arrow write column: a fourteen-element list built by
+/* One Arrow write column: a fifteen-element list built by
  * .prepare_arrow_write(): name, kind, values, levels, ordered, label, format,
  * storage, tz, units, label_values, label_texts, has_value_labels,
- * haven_labelled. Character data must already be UTF-8; the R layer normalizes
+ * haven_labelled, string_storage. Character data must already be UTF-8; the R layer normalizes
  * with enc2utf8(). */
 static void arrow_write_column_descriptor(
     SEXP column, size_t index, size_t row_count, SEXP string_roots,
     R_xlen_t *root_index, dtatools_arrow_column *descriptor
 ) {
-    if (TYPEOF(column) != VECSXP || XLENGTH(column) != 14) {
-        Rf_error("internal Arrow column must be a fourteen-element list");
+    if (TYPEOF(column) != VECSXP || XLENGTH(column) != 15) {
+        Rf_error("internal Arrow column must be a fifteen-element list");
     }
     SEXP kind_value = VECTOR_ELT(column, 1);
     SEXP values = VECTOR_ELT(column, 2);
@@ -2844,6 +2845,7 @@ static void arrow_write_column_descriptor(
     SEXP label_texts = VECTOR_ELT(column, 11);
     SEXP has_value_labels = VECTOR_ELT(column, 12);
     SEXP haven_labelled = VECTOR_ELT(column, 13);
+    SEXP string_storage = VECTOR_ELT(column, 14);
     if (TYPEOF(kind_value) != INTSXP || XLENGTH(kind_value) != 1 ||
         TYPEOF(ordered) != LGLSXP || XLENGTH(ordered) != 1 ||
         TYPEOF(storage) != INTSXP || XLENGTH(storage) != 1 ||
@@ -2853,7 +2855,8 @@ static void arrow_write_column_descriptor(
         XLENGTH(has_value_labels) != 1 ||
         LOGICAL(has_value_labels)[0] == NA_LOGICAL ||
         TYPEOF(haven_labelled) != LGLSXP || XLENGTH(haven_labelled) != 1 ||
-        LOGICAL(haven_labelled)[0] == NA_LOGICAL) {
+        LOGICAL(haven_labelled)[0] == NA_LOGICAL ||
+        TYPEOF(string_storage) != INTSXP || XLENGTH(string_storage) != 1) {
         Rf_error("invalid internal Arrow column metadata");
     }
     if ((size_t) XLENGTH(values) != row_count) {
@@ -2863,6 +2866,7 @@ static void arrow_write_column_descriptor(
     memset(descriptor, 0, sizeof(*descriptor));
     descriptor->kind = INTEGER(kind_value)[0];
     descriptor->storage = INTEGER(storage)[0];
+    descriptor->string_storage = INTEGER(string_storage)[0];
     descriptor->ordered = LOGICAL(ordered)[0] == 1;
     descriptor->strings = R_NilValue;
     descriptor->name = write_rooted_scalar_string(
@@ -3006,8 +3010,8 @@ SEXP C_dtatools_save_arrow(
     size_t row_count = 0;
     if (column_count > 0) {
         SEXP first = VECTOR_ELT(columns, 0);
-        if (TYPEOF(first) != VECSXP || XLENGTH(first) != 14) {
-            Rf_error("internal Arrow column must be a fourteen-element list");
+        if (TYPEOF(first) != VECSXP || XLENGTH(first) != 15) {
+            Rf_error("internal Arrow column must be a fifteen-element list");
         }
         row_count = (size_t) XLENGTH(VECTOR_ELT(first, 2));
     }
@@ -3075,8 +3079,8 @@ SEXP C_dtatools_datasig(SEXP specification, SEXP threads) {
     size_t row_count = 0;
     if (column_count > 0) {
         SEXP first = VECTOR_ELT(columns, 0);
-        if (TYPEOF(first) != VECSXP || XLENGTH(first) != 14) {
-            Rf_error("internal Arrow column must be a fourteen-element list");
+        if (TYPEOF(first) != VECSXP || XLENGTH(first) != 15) {
+            Rf_error("internal Arrow column must be a fifteen-element list");
         }
         row_count = (size_t) XLENGTH(VECTOR_ELT(first, 2));
     }

--- a/r-package/dtatools/src/rust/src/arrow_ffi.rs
+++ b/r-package/dtatools/src/rust/src/arrow_ffi.rs
@@ -59,6 +59,8 @@ pub struct RArrowColumnDescriptor {
     format: *const c_char,
     /// -1 none; 0 byte, 1 int, 2 long, 3 float, 4 double (kind 9 only).
     storage: c_int,
+    /// -1 none; 0 strL; 1..=2045 fixed-string byte width.
+    string_storage: c_int,
     ordered: c_int,
     tz: *const c_char,
     units: *const c_char,
@@ -834,6 +836,7 @@ struct ExtractedColumn {
     ordered: bool,
     haven_labelled: bool,
     value_labels: Option<ValueLabelTable>,
+    string_storage: Option<String>,
     input: ColumnInput,
     row_count: usize,
 }
@@ -869,6 +872,12 @@ unsafe fn extract_column(
             None
         };
     let value_labels = value_label_table(descriptor, &name)?;
+    let string_storage = match descriptor.string_storage {
+        -1 => None,
+        0 => Some("strL".to_owned()),
+        1..=2045 => Some(format!("str{}", descriptor.string_storage)),
+        _ => return Err(format!("column `{name}` has invalid string storage")),
+    };
 
     let input = match kind {
         RArrowKind::Logical => ColumnInput::Logical {
@@ -934,6 +943,7 @@ unsafe fn extract_column(
         ordered: descriptor.ordered != 0,
         haven_labelled: descriptor.haven_labelled != 0,
         value_labels,
+        string_storage,
         input,
         row_count,
     })
@@ -1045,7 +1055,8 @@ unsafe fn encode_column(
             }
         }
         ColumnInput::CharacterEager { values } => {
-            let document = with_labels(base_document);
+            let mut document = with_labels(base_document);
+            document.string_storage.clone_from(&column.string_storage);
             (
                 needs_document(&document).then_some(document),
                 string_array(values, name)?,
@@ -1055,7 +1066,8 @@ unsafe fn encode_column(
         ColumnInput::CharacterDict { data } => {
             let data = &*data.cast::<crate::DictStringData>();
             let array = dictstring_array(data, row_count, name)?;
-            let document = with_labels(base_document);
+            let mut document = with_labels(base_document);
+            document.string_storage.clone_from(&column.string_storage);
             (needs_document(&document).then_some(document), array, 0)
         }
         ColumnInput::Raw { values } => {
@@ -1679,6 +1691,13 @@ unsafe fn attach_simple_attributes(
     if !attributes.format().is_empty() {
         let format = scalar_string(attributes.format(), guard)?;
         set_attr(vector, "format.stata", format)?;
+    }
+    if let Some(storage) = attributes
+        .document
+        .and_then(|document| document.string_storage.as_deref())
+    {
+        let storage = scalar_string(storage, guard)?;
+        set_attr(vector, "stata.string.storage", storage)?;
     }
     Ok(())
 }

--- a/r-package/dtatools/src/rust/src/lib.rs
+++ b/r-package/dtatools/src/rust/src/lib.rs
@@ -657,6 +657,15 @@ unsafe fn attach_variable_attributes(
         let format = scalar_string(&variable.format, guard)?;
         set_attr(vector, "format.stata", format)?;
     }
+    let string_storage = match variable.dta_type {
+        DtaType::FixedString(width) => Some(format!("str{width}")),
+        DtaType::StrL => Some("strL".to_owned()),
+        _ => None,
+    };
+    if let Some(string_storage) = string_storage {
+        let value = scalar_string(&string_storage, guard)?;
+        set_attr(vector, "stata.string.storage", value)?;
+    }
     if let Some(table) = table {
         let labels = label_attribute(table, guard)?;
         set_attr(vector, "labels", labels)?;
@@ -2164,6 +2173,56 @@ fn save_dta_type(code: c_int) -> Result<DtaType, String> {
     }
 }
 
+fn wider_numeric_type(dta_type: &DtaType) -> Option<DtaType> {
+    match dta_type {
+        DtaType::Byte => Some(DtaType::Int),
+        DtaType::Int => Some(DtaType::Long),
+        DtaType::Long | DtaType::Float => Some(DtaType::Double),
+        DtaType::Double | DtaType::FixedString(_) | DtaType::StrL => None,
+    }
+}
+
+fn legacy_source_output_type(
+    source: &RWriteSource<'_>,
+    mut dta_type: DtaType,
+) -> Result<DtaType, String> {
+    if !source.direct_numeric_kind.is_compact()
+        || source.direct_numeric_version.is_none_or(|version| {
+            !matches!(
+                version,
+                FormatVersion::V105
+                    | FormatVersion::V108
+                    | FormatVersion::V110
+                    | FormatVersion::V111
+            )
+        })
+    {
+        return Ok(dta_type);
+    }
+
+    for index in 0..source.row_count {
+        let index = usize::try_from(index).map_err(|_| "R row index is too large".to_owned())?;
+        let Some((value, missing_code)) = (unsafe { direct_numeric_at(source, index) })? else {
+            return Ok(dta_type);
+        };
+        if missing_code != -1 {
+            continue;
+        }
+        let value = write_numeric_value(
+            value,
+            source.descriptor.numeric_shift,
+            source.descriptor.numeric_scale,
+        );
+        while !dta_write_numeric_value_is_representable(&dta_type, value) {
+            let Some(wider) = wider_numeric_type(&dta_type) else {
+                break;
+            };
+            dta_type = wider;
+        }
+    }
+    Ok(dta_type)
+}
+
 fn direct_numeric_is_output_encoded(
     descriptor: &RWriteColumnDescriptor,
     kind: DirectNumericKind,
@@ -3226,7 +3285,7 @@ unsafe fn write_impl(request: RWriteRequest) -> Result<(), RWriteError> {
         if !descriptor.numeric_shift.is_finite() || !descriptor.numeric_scale.is_finite() {
             return Err("numeric write transform must be finite".into());
         }
-        let dta_type = save_dta_type(descriptor.dta_type)?;
+        let dta_type = legacy_source_output_type(source, save_dta_type(descriptor.dta_type)?)?;
         let value_labels = r_value_labels(descriptor)?;
         columns.push(DtaWriteColumn {
             name: Cow::Borrowed(required_c_str(descriptor.name, "variable name")?),

--- a/r-package/dtatools/tests/testthat/test-save-dta.R
+++ b/r-package/dtatools/tests/testthat/test-save-dta.R
@@ -265,20 +265,26 @@ test_that("malformed compact numerics follow materialized write semantics", {
     )
 })
 
-test_that("legacy compact numerics are revalidated for modern missing ranges", {
+test_that("legacy compact numerics widen around modern missing ranges", {
     legacy_path <- fixture("synthetic_v111.dta")
     legacy <- read_dta(legacy_path, col_select = "i")
     expect_true(dtatools:::.is_unmaterialized_numeric_altrep(legacy$i))
-    output <- tempfile(fileext = ".dta")
-    on.exit(unlink(output), add = TRUE)
-    expect_warning(
-        save_dta(legacy, output),
-        class = "dtatools_write_numeric_replacement_warning"
+    direct_output <- tempfile(fileext = ".dta")
+    arrow_output <- tempfile(fileext = ".arrow")
+    via_arrow_output <- tempfile(fileext = ".dta")
+    on.exit(unlink(c(direct_output, arrow_output, via_arrow_output)), add = TRUE)
+
+    expect_silent(save_dta(legacy, direct_output))
+    expect_silent(save_arrow(legacy, arrow_output))
+    expect_silent(
+        save_dta(read_arrow(arrow_output), via_arrow_output)
     )
-    expect_identical(
-        as.double(read_dta(output, use_numeric_altrep = FALSE)$i),
-        c(321, NA, NA, NA)
-    )
+    for (output in c(direct_output, via_arrow_output)) {
+        actual <- read_dta(output, use_numeric_altrep = FALSE)$i
+        expect_identical(stata_storage_type(actual), "long")
+        expect_identical(as.double(actual), as.double(legacy$i))
+        expect_identical(missing_tag(actual), missing_tag(legacy$i))
+    }
 })
 
 test_that("character missing values become empty strings and long values use strL", {
@@ -311,6 +317,66 @@ test_that("character missing values become empty strings and long values use str
         data, NULL, 4L, TRUE
     )
     expect_identical(specification[[3L]][[1L]][[7L]], data$short)
+})
+
+test_that("fixed strings retain declared storage through Arrow", {
+    data <- data.frame(caseid = "12345")
+    attr(data$caseid, "format.stata") <- "%12s"
+    attr(data$caseid, "stata.string.storage") <- "str12"
+    direct <- tempfile(fileext = ".dta")
+    arrow <- tempfile(fileext = ".arrow")
+    via_arrow <- tempfile(fileext = ".dta")
+    on.exit(unlink(c(direct, arrow, via_arrow)), add = TRUE)
+
+    expect_silent(save_dta(data, direct))
+    expect_silent(save_arrow(data, arrow))
+    expect_silent(save_dta(read_arrow(arrow), via_arrow))
+    for (path in c(direct, via_arrow)) {
+        bytes <- readBin(path, "raw", n = file.info(path)$size)
+        tag <- charToRaw("<variable_types>")
+        start <- grepRaw(tag, bytes, fixed = TRUE)[[1L]] + length(tag)
+        expect_identical(
+            readBin(bytes[start + 0:1], integer(), n = 1L, size = 2L,
+                    endian = "little"),
+            12L
+        )
+        actual <- read_dta(path)
+        expect_identical(as.character(actual$caseid), "12345")
+        expect_identical(
+            attr(actual$caseid, "stata.string.storage", exact = TRUE),
+            "str12"
+        )
+    }
+})
+
+test_that("multiple strL columns write interleaved observations", {
+    data <- data.frame(
+        first = c("", "first-two", "first-three"),
+        second = c("second-one", "", "second-three")
+    )
+    attr(data$first, "stata.string.storage") <- "strL"
+    attr(data$second, "stata.string.storage") <- "strL"
+    direct <- tempfile(fileext = ".dta")
+    arrow <- tempfile(fileext = ".arrow")
+    via_arrow <- tempfile(fileext = ".dta")
+    on.exit(unlink(c(direct, arrow, via_arrow)), add = TRUE)
+
+    expect_silent(save_dta(data, direct))
+    expect_silent(save_arrow(data, arrow))
+    expect_silent(save_dta(read_arrow(arrow), via_arrow))
+    for (path in c(direct, via_arrow)) {
+        actual <- read_dta(path)
+        expect_identical(
+            unname(lapply(actual, as.character)),
+            list(c("", "first-two", "first-three"),
+                 c("second-one", "", "second-three"))
+        )
+        expect_identical(
+            vapply(actual, attr, character(1), "stata.string.storage",
+                   exact = TRUE),
+            c(first = "strL", second = "strL")
+        )
+    }
 })
 
 test_that("ordered and unordered factors become labelled long integers", {
@@ -541,12 +607,18 @@ test_that("duplicate value-label keys from source metadata round-trip stably", {
         "stata_numeric", "stata_byte", "haven_labelled", "vctrs_vctr", "double"
     )
     path <- tempfile(fileext = ".dta")
-    on.exit(unlink(path), add = TRUE)
+    arrow <- tempfile(fileext = ".arrow")
+    via_arrow <- tempfile(fileext = ".dta")
+    on.exit(unlink(c(path, arrow, via_arrow)), add = TRUE)
 
     expect_silent(save_dta(data.frame(x = x), path))
-    actual <- attr(read_dta(path)$x, "labels", exact = TRUE)
-    expect_identical(names(actual), c("Refused", "Not ascertained", "Don't know"))
-    expect_identical(unname(missing_tag(actual)), c("a", "a", "b"))
+    expect_silent(save_arrow(data.frame(x = x), arrow))
+    expect_silent(save_dta(read_arrow(arrow), via_arrow))
+    for (output in c(path, via_arrow)) {
+        actual <- attr(read_dta(output)$x, "labels", exact = TRUE)
+        expect_identical(names(actual), c("Refused", "Not ascertained", "Don't know"))
+        expect_identical(unname(missing_tag(actual)), c("a", "a", "b"))
+    }
 })
 
 test_that("value-label text limits count UTF-8 bytes before touching the destination", {


### PR DESCRIPTION
## Summary

- add a reproducible Stata comparator for direct DTA and Arrow-derived DTA round trips
- add isolated, size-ordered corpus verification with stable IDs, hash-bound exclusions, retained failure artifacts, and compact private-safe results
- parallelize full and recovery runs across up to 16 dataset processes with a 96 GiB size-aware admission budget
- preserve explicit Stata string storage and repair multi-strL and duplicate value-label round trips found during corpus testing
- add per-wave checkpoints and ordered-position recovery for interrupted private runs

## Validation

- corpus-free round-trip framework: PASS
- test-save-dta.R: 287 expectations passed, 0 failures, 0 warnings, 0 skips
- interrupted initial corpus run: positions 1-1,616 passed with no failures before the process ended during wave 102
- recovery run for positions 1,617-1,823 is currently in progress with no failures reported so far

## Review status

This is a draft baseline for review while the private corpus recovery finishes. It does not yet claim the final uninterrupted gate of 1,821 passes plus two identity-bound exclusions. Private corpus files, paths, values, labels, logs, and run artifacts are not committed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for preserving declared Stata string storage types, including fixed-width strings and `strL`, across direct and Arrow-based writes.
  * Improved compatibility for legacy compact numeric data by widening types when necessary to preserve values.
  * Added comprehensive corpus round-trip verification with selectable datasets, parallel processing, checkpointing, failure reporting, and Stata comparisons.

* **Bug Fixes**
  * Preserved correct row ordering for multiple `strL` columns.
  * Improved retention of string metadata, value labels, missing values, and dataset attributes during round trips.

* **Tests**
  * Added coverage for string storage, numeric widening, metadata preservation, verification selection, scheduling, and validation errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->