### PR TITLE
Fix corpus recovery and string storage validation

### DIFF
--- a/benchmarks/r-corpus-roundtrip/README.md
+++ b/benchmarks/r-corpus-roundtrip/README.md
@@ -96,7 +96,8 @@ unverified tail after an interruption, restart at its one-based ordered corpus
 position:
 
 ```sh
-benchmarks/r-corpus-roundtrip/verify.sh from 1617
+benchmarks/r-corpus-roundtrip/verify.sh from \
+  target/r-corpus-roundtrip-verification/PREVIOUS_RUN 1617
 ```
 
 This recovery mode does not replace the final uninterrupted full-run gate.

--- a/benchmarks/r-corpus-roundtrip/common.R
+++ b/benchmarks/r-corpus-roundtrip/common.R
@@ -32,6 +32,12 @@ roundtrip_verification_waves <- function(
 ) {
     if (!length(bytes)) return(list())
     estimates <- pmax(minimum_bytes, expansion * as.double(bytes))
+    if (any(estimates > memory_bytes)) {
+        stop(paste0(
+            "a dataset's estimated working set exceeds the verification ",
+            "memory budget; increase DTATOOLS_VERIFY_MEMORY_GIB"
+        ))
+    }
     waves <- list()
     current <- integer()
     current_memory <- 0
@@ -49,6 +55,41 @@ roundtrip_verification_waves <- function(
     }
     if (length(current)) waves[[length(waves) + 1L]] <- current
     waves
+}
+
+roundtrip_recovery_inventory <- function(cache_root, previous_run) {
+    previous_run <- normalizePath(
+        previous_run, winslash = "/", mustWork = TRUE
+    )
+    inventory_path <- file.path(previous_run, "inventory.tsv")
+    if (!file.exists(inventory_path)) {
+        stop("the previous verification run has no inventory.tsv")
+    }
+    recorded <- read.delim(
+        inventory_path, check.names = FALSE, stringsAsFactors = FALSE,
+        colClasses = "character"
+    )
+    legacy_columns <- c(
+        "corpus", "id", "relative_path", "release", "bytes", "sha256"
+    )
+    if (!identical(names(recorded), legacy_columns)) {
+        return(roundtrip_cached_inventory(cache_root, inventory_path))
+    }
+    current <- roundtrip_inventory(cache_root, progress = FALSE)
+    expected <- data.frame(
+        corpus = current$corpus,
+        id = current$id,
+        relative_path = current$relative_path,
+        release = ifelse(is.na(current$release), NA_character_,
+                         as.character(current$release)),
+        bytes = sprintf("%.0f", current$bytes),
+        sha256 = current$sha256,
+        stringsAsFactors = FALSE
+    )
+    if (!identical(recorded, expected)) {
+        stop("corpus files changed since the recovery inventory was created")
+    }
+    current
 }
 
 roundtrip_select_verification <- function(inventory, selection, argument = "") {

--- a/benchmarks/r-corpus-roundtrip/test-framework.R
+++ b/benchmarks/r-corpus-roundtrip/test-framework.R
@@ -78,7 +78,20 @@ stopifnot(
 )
 invalid_jobs <- tryCatch(roundtrip_verification_limits("0", "96"), error = identity)
 invalid_memory <- tryCatch(roundtrip_verification_limits("16", "nope"), error = identity)
-stopifnot(inherits(invalid_jobs, "error"), inherits(invalid_memory, "error"))
+oversized_wave <- tryCatch(
+    roundtrip_verification_waves(
+        51, jobs = 16L, memory_bytes = 100,
+        expansion = 2, minimum_bytes = 1
+    ),
+    error = identity
+)
+stopifnot(
+    inherits(invalid_jobs, "error"),
+    inherits(invalid_memory, "error"),
+    inherits(oversized_wave, "error"),
+    grepl("DTATOOLS_VERIFY_MEMORY_GIB", conditionMessage(oversized_wave),
+          fixed = TRUE)
+)
 invalid_selection <- tryCatch(
     roundtrip_select_verification(ordered_fixture, "smallest", "0"),
     error = identity
@@ -254,6 +267,43 @@ write.table(
 )
 validated_cache <- roundtrip_cached_inventory(root, cached_inventory_path)
 stopifnot(identical(validated_cache$release, inventory$release))
+recovery_run <- file.path(root, "previous-run")
+dir.create(recovery_run)
+stopifnot(file.copy(
+    cached_inventory_path, file.path(recovery_run, "inventory.tsv")
+))
+validated_recovery <- roundtrip_recovery_inventory(root, recovery_run)
+stopifnot(identical(validated_recovery$id, inventory$id))
+legacy_recovery_run <- file.path(root, "legacy-previous-run")
+dir.create(legacy_recovery_run)
+write.table(
+    cached_inventory[c(
+        "corpus", "id", "relative_path", "release", "bytes", "sha256"
+    )],
+    file.path(legacy_recovery_run, "inventory.tsv"),
+    sep = "\t", row.names = FALSE, quote = TRUE
+)
+validated_legacy_recovery <- roundtrip_recovery_inventory(
+    root, legacy_recovery_run
+)
+stopifnot(identical(validated_legacy_recovery$id, inventory$id))
+wrong_legacy <- cached_inventory[c(
+    "corpus", "id", "relative_path", "release", "bytes", "sha256"
+)]
+wrong_legacy$sha256[[1L]] <- strrep("f", 64L)
+write.table(
+    wrong_legacy, file.path(legacy_recovery_run, "inventory.tsv"),
+    sep = "\t", row.names = FALSE, quote = TRUE
+)
+wrong_legacy_error <- tryCatch(
+    roundtrip_recovery_inventory(root, legacy_recovery_run),
+    error = identity
+)
+stopifnot(
+    inherits(wrong_legacy_error, "error"),
+    grepl("corpus files changed", conditionMessage(wrong_legacy_error),
+          fixed = TRUE)
+)
 stale_release <- cached_inventory
 stale_release$release[stale_release$corpus == "DHS"] <- 117L
 write.table(

--- a/benchmarks/r-corpus-roundtrip/verify.R
+++ b/benchmarks/r-corpus-roundtrip/verify.R
@@ -1,13 +1,20 @@
 args <- commandArgs(trailingOnly = TRUE)
-if (length(args) < 3L || length(args) > 4L) {
-    stop("usage: verify.R CACHE_ROOT OUTPUT_DIR full|from|smallest|id [ARGUMENT]")
+if (length(args) < 3L || length(args) > 5L) {
+    stop(paste0(
+        "usage: verify.R CACHE_ROOT OUTPUT_DIR full|smallest|id [ARGUMENT] ",
+        "or verify.R CACHE_ROOT OUTPUT_DIR from PREVIOUS_RUN POSITION"
+    ))
 }
 if (!requireNamespace("processx", quietly = TRUE)) stop("processx is required")
 
 cache_root <- normalizePath(args[[1L]], winslash = "/", mustWork = TRUE)
 output_dir <- normalizePath(args[[2L]], winslash = "/", mustWork = FALSE)
 selection <- args[[3L]]
-argument <- if (length(args) == 4L) args[[4L]] else ""
+argument <- if (selection == "from" && length(args) == 5L) {
+    args[[5L]]
+} else if (length(args) == 4L) {
+    args[[4L]]
+} else ""
 script_argument <- grep("^--file=", commandArgs(trailingOnly = FALSE), value = TRUE)[[1L]]
 script_dir <- dirname(normalizePath(sub("^--file=", "", script_argument), winslash = "/"))
 source(file.path(script_dir, "common.R"), local = TRUE)
@@ -17,16 +24,27 @@ rscript <- normalizePath(Sys.which("Rscript"), winslash = "/", mustWork = TRUE)
 stata <- find_stata()
 dir.create(output_dir, recursive = TRUE, showWarnings = FALSE)
 
-inventory <- roundtrip_inventory(cache_root)
+inventory <- if (selection == "from") {
+    if (length(args) != 5L) {
+        stop("from requires PREVIOUS_RUN and POSITION")
+    }
+    roundtrip_recovery_inventory(cache_root, args[[4L]])
+} else {
+    if (length(args) > 4L) stop("too many verification arguments")
+    roundtrip_inventory(cache_root)
+}
 selected <- roundtrip_select_verification(inventory, selection, argument)
 inventory_hash <- benchmark_file_sha256({
     path <- file.path(output_dir, "inventory.tsv")
-    atomic_tsv(inventory[c("corpus", "id", "relative_path", "release", "bytes", "sha256")], path, quote = TRUE)
+    atomic_tsv(inventory[c(
+        "corpus", "id", "relative_path", "release", "bytes", "modified",
+        "sha256"
+    )], path, quote = TRUE)
     path
 })
 binding <- cbind(
     data.frame(
-        schema_version = 1L,
+        schema_version = 2L,
         inventory_sha256 = inventory_hash,
         package_sha256 = benchmark_directory_sha256(
             benchmark_installed_package_path(library)

--- a/benchmarks/r-corpus-roundtrip/verify.sh
+++ b/benchmarks/r-corpus-roundtrip/verify.sh
@@ -7,17 +7,18 @@ checkout=$(CDPATH= cd -- "$script_dir/../.." && pwd -P)
 cache_root=${AWW_CACHE_ROOT:-/opt/aww_cache}
 selection=${1:-full}
 argument=${2:-}
+second_argument=${3:-}
 
 if test -n "${CI:-}${GITHUB_ACTIONS:-}${GITHUB_RUN_ID:-}${GITHUB_WORKFLOW:-}"; then
     echo "the private corpus verification is manual and refuses CI" >&2
     exit 2
 fi
 case "$selection" in
-    full) test -z "$argument" || { echo "full takes no argument" >&2; exit 2; } ;;
-    from) test -n "$argument" || { echo "from requires an ordered position" >&2; exit 2; } ;;
-    smallest) test -n "$argument" || { echo "smallest requires a count" >&2; exit 2; } ;;
-    id) test -n "$argument" || { echo "id requires a stable corpus ID" >&2; exit 2; } ;;
-    *) echo "usage: verify.sh [full | from POSITION | smallest COUNT | id STABLE_ID]" >&2; exit 2 ;;
+    full) test -z "$argument$second_argument" || { echo "full takes no argument" >&2; exit 2; } ;;
+    from) test -n "$argument" && test -n "$second_argument" || { echo "from requires PREVIOUS_RUN and POSITION" >&2; exit 2; } ;;
+    smallest) test -n "$argument" && test -z "$second_argument" || { echo "smallest requires one count" >&2; exit 2; } ;;
+    id) test -n "$argument" && test -z "$second_argument" || { echo "id requires one stable corpus ID" >&2; exit 2; } ;;
+    *) echo "usage: verify.sh [full | from PREVIOUS_RUN POSITION | smallest COUNT | id STABLE_ID]" >&2; exit 2 ;;
 esac
 
 run_root="$checkout/target/r-corpus-roundtrip-verification"
@@ -39,7 +40,9 @@ export DTATOOLS_BENCH_LIB="$library"
 export R_ENVIRON_USER=/dev/null
 export R_PROFILE_USER=/dev/null
 
-if test -n "$argument"; then
+if test -n "$second_argument"; then
+    Rscript --vanilla "$script_dir/verify.R" "$cache_root" "$run_dir" "$selection" "$argument" "$second_argument"
+elif test -n "$argument"; then
     Rscript --vanilla "$script_dir/verify.R" "$cache_root" "$run_dir" "$selection" "$argument"
 else
     Rscript --vanilla "$script_dir/verify.R" "$cache_root" "$run_dir" "$selection"

--- a/r-package/dtatools/R/save-dta.R
+++ b/r-package/dtatools/R/save-dta.R
@@ -39,7 +39,8 @@
 #' @param version Target Stata application version, either 18 or 19.
 #' @param label Dataset label. Defaults to the data frame's `label` attribute.
 #' @param strl_threshold Character columns whose maximum UTF-8 byte length is
-#'   greater than this value are stored as `strL`.
+#'   greater than this value are stored as `strL`. An explicit
+#'   `stata.string.storage` fixed-width declaration takes precedence.
 #' @param adjust_tz For `POSIXct` columns, whether to preserve displayed clock
 #'   time (`TRUE`) or the underlying UTC instant (`FALSE`).
 #' @return `data`, invisibly.
@@ -654,7 +655,8 @@ save_dta <- function(data, path, version = 19L,
         } else NULL
         if (!is.null(declared_width)) maximum <- max(maximum, declared_width)
         fixed <- !identical(declared, "strL") &&
-            maximum <= strl_threshold && maximum <= 2045L
+            maximum <= 2045L &&
+            (!is.null(declared_width) || maximum <= strl_threshold)
         width <- max(1L, maximum)
         type_code <- if (fixed) width + 4L else 2050L
         storage <- if (fixed) "fixed" else "strL"

--- a/r-package/dtatools/man/save_dta.Rd
+++ b/r-package/dtatools/man/save_dta.Rd
@@ -24,7 +24,8 @@ save_dta(
 \item{label}{Dataset label. Defaults to the data frame's \code{label} attribute.}
 
 \item{strl_threshold}{Character columns whose maximum UTF-8 byte length is
-greater than this value are stored as \code{strL}.}
+greater than this value are stored as \code{strL}. An explicit
+\code{stata.string.storage} fixed-width declaration takes precedence.}
 
 \item{adjust_tz}{For \code{POSIXct} columns, whether to preserve displayed clock
 time (\code{TRUE}) or the underlying UTC instant (\code{FALSE}).}

--- a/r-package/dtatools/src/dta-tools/src/arrow/profile.rs
+++ b/r-package/dtatools/src/dta-tools/src/arrow/profile.rs
@@ -414,6 +414,35 @@ pub(crate) fn validate_field_document(
             ),
         ));
     }
+    if let Some(string_storage) = document.string_storage.as_deref() {
+        let fixed_width = string_storage
+            .strip_prefix("str")
+            .and_then(|width| {
+                if width.starts_with('0') {
+                    None
+                } else {
+                    width.parse::<u16>().ok()
+                }
+            })
+            .is_some_and(|width| (1..=2045).contains(&width));
+        if string_storage != "strL" && !fixed_width {
+            return Err(field_malformed(
+                version,
+                field,
+                format!("declares invalid string storage `{string_storage}`"),
+            ));
+        }
+        if document.storage.is_some() || field.data_type() != &DataType::Utf8 {
+            return Err(field_malformed(
+                version,
+                field,
+                format!(
+                    "declares string storage incompatible with Arrow type {}",
+                    field.data_type()
+                ),
+            ));
+        }
+    }
     if let Some(storage) = document.storage {
         let expected_type = storage_type(storage);
         if field.data_type() != &expected_type {
@@ -614,6 +643,27 @@ mod tests {
                 .expect_err("unknown field-document keys are rejected");
             assert!(matches!(error, ArrowProfileError::MalformedProfile { .. }));
             assert!(error.to_string().contains("unknown field"));
+        }
+    }
+
+    #[test]
+    fn field_documents_reject_invalid_string_storage() {
+        let text = Field::new("text", DataType::Utf8, true);
+        for declaration in ["str0", "str01", "str2046", "STR12"] {
+            let json = format!(r#"{{"version":0,"string_storage":"{declaration}"}}"#);
+            let error = parse_field_document("0", &text, &json)
+                .expect_err("invalid string storage is rejected");
+            assert!(error.to_string().contains("string storage"));
+        }
+
+        for field in [
+            Field::new("number", DataType::Int32, true),
+            Field::new("large", DataType::LargeUtf8, true),
+        ] {
+            let error =
+                parse_field_document("0", &field, r#"{"version":0,"string_storage":"str12"}"#)
+                    .expect_err("string storage requires a UTF-8 field");
+            assert!(error.to_string().contains("string storage"));
         }
     }
 

--- a/r-package/dtatools/tests/testthat/helper-fixtures.R
+++ b/r-package/dtatools/tests/testthat/helper-fixtures.R
@@ -47,9 +47,17 @@ tagged_nan_for_test <- function(tag) {
 }
 
 without_stata_storage <- function(value) {
-    if (is.null(attr(value, "stata.storage", exact = TRUE))) return(value)
+    has_numeric_storage <- !is.null(attr(
+        value, "stata.storage", exact = TRUE
+    ))
+    has_string_storage <- !is.null(attr(
+        value, "stata.string.storage", exact = TRUE
+    ))
+    if (!has_numeric_storage && !has_string_storage) return(value)
 
     value <- dtatools:::.metadata_copy(value)
+    attr(value, "stata.string.storage") <- NULL
+    if (!has_numeric_storage) return(value)
     attr(value, "stata.storage") <- NULL
     classes <- attr(value, "class", exact = TRUE)
     if (!is.null(classes)) {

--- a/r-package/dtatools/tests/testthat/test-save-dta.R
+++ b/r-package/dtatools/tests/testthat/test-save-dta.R
@@ -328,9 +328,11 @@ test_that("fixed strings retain declared storage through Arrow", {
     via_arrow <- tempfile(fileext = ".dta")
     on.exit(unlink(c(direct, arrow, via_arrow)), add = TRUE)
 
-    expect_silent(save_dta(data, direct))
+    expect_silent(save_dta(data, direct, strl_threshold = 4L))
     expect_silent(save_arrow(data, arrow))
-    expect_silent(save_dta(read_arrow(arrow), via_arrow))
+    expect_silent(save_dta(
+        read_arrow(arrow), via_arrow, strl_threshold = 4L
+    ))
     for (path in c(direct, via_arrow)) {
         bytes <- readBin(path, "raw", n = file.info(path)$size)
         tag <- charToRaw("<variable_types>")

--- a/tests/r-haven/testthat/test-read-dta.R
+++ b/tests/r-haven/testthat/test-read-dta.R
@@ -475,7 +475,7 @@ test_that("projection, renaming, and row bounds match haven", {
     expect_identical(actual, rust_vectors)
     expect_identical(names(actual), c("origin", "make", "price"))
     expect_equal(without_stata_storage(actual$origin), expected$foreign)
-    expect_equal(actual$make, expected$make)
+    expect_equal(without_stata_storage(actual$make), expected$make)
     expect_equal(without_stata_storage(actual$price), expected$price)
     expect_identical(attr(actual, "label"), attr(expected, "label"))
     expect_identical(attr(actual, "notes"), attr(expected, "notes"))
@@ -723,7 +723,7 @@ test_that("explicit encodings match haven across ordinary textual surfaces", {
 
             expect_identical(actual, rust_vectors,
                              info = paste(info, "materialization"))
-            expect_identical(actual$make, expected$make,
+            expect_identical(without_stata_storage(actual$make), expected$make,
                              info = paste(info, "fixed string"))
             expect_identical(attr(actual, "label"), attr(expected, "label"),
                              info = paste(info, "dataset label"))
@@ -739,7 +739,9 @@ test_that("explicit encodings match haven across ordinary textual surfaces", {
     modern <- fixture("auto_v118.dta")
     expect_identical(read_dta(modern, encoding = "utf_8"),
                      read_dta(modern, encoding = "UTF8"))
-    expect_identical(read_dta(modern, encoding = "UTF-8")$make,
+    expect_identical(without_stata_storage(
+                         read_dta(modern, encoding = "UTF-8")$make
+                     ),
                      haven::read_dta(modern, encoding = "UTF-8")$make)
 
     note_bytes <- readBin(modern, "raw", file.info(modern)$size)


### PR DESCRIPTION
## Summary

- bind `from` recovery runs to the interrupted run immutable inventory, including compatibility validation for inventories created by #98
- reject verification waves whose single-dataset memory estimate exceeds the configured budget
- preserve explicit fixed-width Stata string storage when the automatic `strL` threshold is lower
- validate Arrow `string_storage` metadata and its Arrow type compatibility
- fix the R test normalization helper so CI compares the intended public semantics

All four CodeRabbit findings on #98 were valid; this PR contains the follow-up fixes after #98 was merged.

## Validation

- `Rscript --vanilla benchmarks/r-corpus-roundtrip/test-framework.R`
- focused installed-package tests for `test-input-sources.R`, `test-read-dta.R`, and `test-save-dta.R`
- `rustup run 1.98.0 cargo fmt --all --check`
- `rustup run 1.98.0 cargo test --workspace --all-targets --locked`
- R syntax parsing and shell syntax validation
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Recovery verification can resume from a previous run using its run directory and corpus position.
  - Verification now validates recovered inventories and prevents runs that exceed the configured memory budget.
  - Explicit fixed-width string storage declarations take precedence over automatic `strL` selection.
  - Field metadata supports validated `strL` and fixed-width `str1`–`str2045` declarations.

- **Bug Fixes**
  - Improved validation rejects invalid storage declarations and incompatible field types.

- **Documentation**
  - Updated verification usage and string-storage behavior documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->