### PR TITLE
Avoid repeated Stata corpus file loads

### DIFF
--- a/benchmarks/r-corpus-roundtrip/README.md
+++ b/benchmarks/r-corpus-roundtrip/README.md
@@ -29,6 +29,17 @@ Run the public, corpus-free harness test with:
 Rscript --vanilla benchmarks/r-corpus-roundtrip/test-framework.R
 ```
 
+After installing the checkout-local R package, run the public Stata comparator
+tests with:
+
+```sh
+Rscript --vanilla benchmarks/r-corpus-roundtrip/test-stata-comparator.R
+```
+
+This checks releases 115, 117, and 118, deliberate one-property mismatches,
+and a 20 MB, 1,000-variable performance fixture. The default performance limit
+is 2.5 seconds; `DTATOOLS_COMPARATOR_MAX_SECONDS` may set a host-specific limit.
+
 Run the complete qualification and benchmark from the checkout root:
 
 ```sh

--- a/benchmarks/r-corpus-roundtrip/stata-compare-mutate.do
+++ b/benchmarks/r-corpus-roundtrip/stata-compare-mutate.do
@@ -1,0 +1,22 @@
+version 18
+set more off
+
+args source candidate mutation
+quietly use "`source'", clear
+
+if "`mutation'" == "dimensions" quietly drop in 1
+else if "`mutation'" == "variable-names" rename price cost
+else if "`mutation'" == "storage-type" recast double price
+else if "`mutation'" == "display-format" format price %12.0g
+else if "`mutation'" == "dataset-label" label data "changed"
+else if "`mutation'" == "variable-label" label variable price "changed"
+else if "`mutation'" == "value-label-assignment" label values foreign .
+else if "`mutation'" == "value-label-definitions" {
+    label define origin 0 "changed", modify
+}
+else if "`mutation'" == "dataset-notes" notes: changed
+else if "`mutation'" == "stored-values" replace price = price + 1 in 1
+else exit 198
+
+quietly save "`candidate'", replace
+exit 0

--- a/benchmarks/r-corpus-roundtrip/stata-compare.do
+++ b/benchmarks/r-corpus-roundtrip/stata-compare.do
@@ -34,11 +34,11 @@ if _rc fail "candidate-open" "" ""
 if r(N) != `source_n' fail "dimensions" "" ""
 if r(k) != `source_k' fail "dimensions" "" ""
 
-preserve
-quietly use "`candidate'", clear
-unab candidate_names : _all
-local candidate_dlabel : data label
-restore
+capture frame drop __dtatools_candidate
+frame create __dtatools_candidate
+frame __dtatools_candidate: quietly use "`candidate'", clear
+frame __dtatools_candidate: unab candidate_names : _all
+frame __dtatools_candidate: local candidate_dlabel : data label
 if `"`source_names'"' != `"`candidate_names'"' fail "variable-names" "" ""
 if `"`source_dlabel'"' != `"`candidate_dlabel'"' fail "dataset-label" "" ""
 
@@ -51,9 +51,11 @@ else quietly unicode encoding set utf-8
 quietly unicode analyze "`normalized_source'", redo
 quietly unicode translate "`normalized_source'", invalid(mark) transutf8
 quietly unicode erasebackups, badidea
-quietly use "`normalized_source'", clear
-mata: __dtatools_source_vlabels = J(1, st_nvar(), "")
-mata: for (__dtatools_i = 1; __dtatools_i <= st_nvar(); __dtatools_i++) __dtatools_source_vlabels[__dtatools_i] = st_varlabel(__dtatools_i)
+capture frame drop __dtatools_normalized
+frame create __dtatools_normalized
+frame __dtatools_normalized: quietly use "`normalized_source'", clear
+frame __dtatools_normalized: mata: __dtatools_source_vlabels = J(1, st_nvar(), "")
+frame __dtatools_normalized: mata: for (__dtatools_i = 1; __dtatools_i <= st_nvar(); __dtatools_i++) __dtatools_source_vlabels[__dtatools_i] = st_varlabel(__dtatools_i)
 mata: __dtatools_source_values = J(0, 1, .)
 mata: __dtatools_source_labels = J(0, 1, "")
 mata: __dtatools_candidate_values = J(0, 1, .)
@@ -91,28 +93,23 @@ local source_index 0
 foreach variable of local source_names {
     local ++source_index
     local original_source_type : type `variable'
-    preserve
-    quietly use "`normalized_source'", clear
-    local source_type : type `variable'
+    frame __dtatools_normalized: local source_type : type `variable'
     if substr("`original_source_type'", 1, 3) == "str" & ///
         "`original_source_type'" != "strL" {
         tempvar normalized_length
-        quietly generate long `normalized_length' = strlen(`variable')
-        quietly summarize `normalized_length', meanonly
+        frame __dtatools_normalized: quietly generate long `normalized_length' = strlen(`variable')
+        frame __dtatools_normalized: quietly summarize `normalized_length', meanonly
         local source_width = max(real(substr("`original_source_type'", 4, .)), r(max))
         if `source_width' > 2045 local source_type "strL"
         else local source_type "str`source_width'"
+        frame __dtatools_normalized: drop `normalized_length'
     }
-    restore
     local source_format : format `variable'
     local source_vallab : value label `variable'
-    preserve
-    quietly use "`candidate'", clear
-    local candidate_type : type `variable'
-    local candidate_format : format `variable'
-    local candidate_vallab : value label `variable'
-    mata: st_numscalar("__dtatools_vlabel_equal", st_varlabel(st_varindex("`variable'")) == __dtatools_source_vlabels[`source_index'])
-    restore
+    frame __dtatools_candidate: local candidate_type : type `variable'
+    frame __dtatools_candidate: local candidate_format : format `variable'
+    frame __dtatools_candidate: local candidate_vallab : value label `variable'
+    frame __dtatools_candidate: mata: st_numscalar("__dtatools_vlabel_equal", st_varlabel(st_varindex("`variable'")) == __dtatools_source_vlabels[`source_index'])
 
     if "`source_type'" != "`candidate_type'" fail "storage-type" "`variable'" ""
     if "`source_format'" != "`candidate_format'" fail "display-format" "`variable'" ""
@@ -128,14 +125,8 @@ foreach variable of local source_names {
         fail "value-label-assignment" "`variable'" ""
     }
     if "`source_vallab'" != "" {
-        preserve
-        quietly use "`normalized_source'", clear
-        mata: st_vlload("`source_vallab'", __dtatools_source_values, __dtatools_source_labels)
-        restore
-        preserve
-        quietly use "`candidate'", clear
-        mata: st_vlload("`candidate_vallab'", __dtatools_candidate_values, __dtatools_candidate_labels)
-        restore
+        frame __dtatools_normalized: mata: st_vlload("`source_vallab'", __dtatools_source_values, __dtatools_source_labels)
+        frame __dtatools_candidate: mata: st_vlload("`candidate_vallab'", __dtatools_candidate_values, __dtatools_candidate_labels)
         mata: st_numscalar("__dt_vldef_eq", __dtatools_value_labels_equal(__dtatools_source_values, __dtatools_source_labels, __dtatools_candidate_values, __dtatools_candidate_labels))
         if scalar(__dt_vldef_eq) == 0 {
             fail "value-label-definitions" "`variable'" ""
@@ -145,11 +136,8 @@ foreach variable of local source_names {
 
 local source_note_count : char _dta[note0]
 if "`source_note_count'" == "" local source_note_count 0
-preserve
-quietly use "`candidate'", clear
-local candidate_note_count : char _dta[note0]
+frame __dtatools_candidate: local candidate_note_count : char _dta[note0]
 if "`candidate_note_count'" == "" local candidate_note_count 0
-restore
 if `source_note_count' != `candidate_note_count' fail "dataset-notes" "" ""
 if `source_note_count' > 0 {
     forvalues note = 1/`source_note_count' {
@@ -158,15 +146,12 @@ if `source_note_count' > 0 {
             local source_note = ustrfrom(`"`source_note'"', "windows-1252", 1)
         }
         else local source_note = ustrfix(`"`source_note'"')
-        preserve
-        quietly use "`candidate'", clear
-        local candidate_note : char _dta[note`note']
-        restore
+        frame __dtatools_candidate: local candidate_note : char _dta[note`note']
         if `"`source_note'"' != `"`candidate_note'"' fail "dataset-notes" "" ""
     }
 }
 
-quietly use "`normalized_source'", clear
+frame change __dtatools_normalized
 local cf_count 0
 local cf_guard_index 0
 foreach variable of local source_names {
@@ -188,11 +173,10 @@ foreach variable of local source_names {
 if `cf_count' > 0 {
     tempfile cf_source cf_candidate
     quietly save "`cf_source'"
-    quietly use "`candidate'", clear
     forvalues cf_index = 1/`cf_count' {
-        rename `cf_old`cf_index'' `cf_new`cf_index''
+        frame __dtatools_candidate: rename `cf_old`cf_index'' `cf_new`cf_index''
     }
-    quietly save "`cf_candidate'"
+    frame __dtatools_candidate: quietly save "`cf_candidate'"
     quietly use "`cf_source'", clear
     capture noisily cf _all using "`cf_candidate'"
 }

--- a/benchmarks/r-corpus-roundtrip/test-stata-comparator.R
+++ b/benchmarks/r-corpus-roundtrip/test-stata-comparator.R
@@ -1,0 +1,118 @@
+script_argument <- grep(
+    "^--file=", commandArgs(trailingOnly = FALSE), value = TRUE
+)[[1L]]
+script_dir <- dirname(normalizePath(
+    sub("^--file=", "", script_argument), winslash = "/"
+))
+source(file.path(script_dir, "common.R"), local = TRUE)
+
+if (!requireNamespace("processx", quietly = TRUE)) stop("processx is required")
+if (!requireNamespace("dtatools", quietly = TRUE)) stop("dtatools is required")
+
+stata <- find_stata()
+comparator <- Sys.getenv(
+    "DTATOOLS_STATA_COMPARATOR",
+    file.path(script_dir, "stata-compare.do")
+)
+fixture_root <- normalizePath(
+    file.path(script_dir, "..", "..", "tests", "fixtures", "dta"),
+    winslash = "/", mustWork = TRUE
+)
+root <- tempfile("stata-comparator-")
+dir.create(root)
+on.exit(unlink(root, recursive = TRUE, force = TRUE), add = TRUE)
+
+run_stata <- function(arguments, work_dir) {
+    processx::run(
+        stata, c("-q", "-b", "do", arguments), wd = work_dir,
+        error_on_status = FALSE, echo = FALSE
+    )
+}
+
+compare <- function(source, candidate, kind, release, work_dir) {
+    result_path <- file.path(work_dir, "stata-compare-result.tsv")
+    unlink(result_path)
+    run_stata(
+        c(comparator, source, candidate, kind, as.character(release)),
+        work_dir
+    )
+    if (!file.exists(result_path)) stop("Stata comparator wrote no result")
+    strsplit(
+        readLines(result_path, n = 1L, warn = FALSE), "\t", fixed = TRUE
+    )[[1L]]
+}
+
+for (release in c(115L, 117L, 118L)) {
+    work_dir <- file.path(root, paste0("release-", release))
+    dir.create(work_dir)
+    fixture <- file.path(fixture_root, paste0("all_types_v", release, ".dta"))
+    result <- compare(fixture, fixture, "direct", release, work_dir)
+    stopifnot(identical(result, c("pass", "direct", ".", ".", ".")))
+}
+for (release in c(115L, 118L)) {
+    work_dir <- file.path(root, paste0("empty-release-", release))
+    dir.create(work_dir)
+    fixture <- file.path(fixture_root, paste0("empty_v", release, ".dta"))
+    result <- compare(fixture, fixture, "direct", release, work_dir)
+    stopifnot(identical(result, c("pass", "direct", ".", ".", ".")))
+}
+
+guard_source <- file.path(root, "cf-guard-source.dta")
+guard_candidate <- file.path(root, "cf-guard-candidate.dta")
+dtatools::save_dta(
+    data.frame("__1" = 1:3, check.names = FALSE),
+    guard_source, version = 18L
+)
+stopifnot(file.copy(guard_source, guard_candidate))
+work_dir <- file.path(root, "cf-guard")
+dir.create(work_dir)
+result <- compare(guard_source, guard_candidate, "direct", 118L, work_dir)
+stopifnot(identical(result, c("pass", "direct", ".", ".", ".")))
+
+fixture <- file.path(fixture_root, "auto_v118.dta")
+mutations <- c(
+    "dimensions", "variable-names", "storage-type", "display-format",
+    "dataset-label", "variable-label", "value-label-assignment",
+    "value-label-definitions", "dataset-notes", "stored-values"
+)
+for (mutation in mutations) {
+    work_dir <- file.path(root, mutation)
+    dir.create(work_dir)
+    candidate <- file.path(work_dir, "candidate.dta")
+    run_stata(
+        c(file.path(script_dir, "stata-compare-mutate.do"), fixture,
+          candidate, mutation),
+        work_dir
+    )
+    result <- compare(fixture, candidate, "direct", 118L, work_dir)
+    stopifnot(
+        identical(result[[1L]], "mismatch"),
+        identical(result[[3L]], mutation)
+    )
+}
+
+value <- seq_len(10000L)
+wide <- as.data.frame(
+    setNames(rep(list(value), 1000L), sprintf("v%04d", seq_len(1000L))),
+    optional = TRUE
+)
+wide_source <- file.path(root, "wide-source.dta")
+wide_candidate <- file.path(root, "wide-candidate.dta")
+dtatools::save_dta(wide, wide_source, version = 18L)
+stopifnot(file.copy(wide_source, wide_candidate))
+work_dir <- file.path(root, "wide-comparison")
+dir.create(work_dir)
+elapsed <- system.time({
+    result <- compare(
+        wide_source, wide_candidate, "direct", 118L, work_dir
+    )
+})[["elapsed"]]
+limit <- suppressWarnings(as.double(Sys.getenv(
+    "DTATOOLS_COMPARATOR_MAX_SECONDS", "2.5"
+)))
+stopifnot(
+    identical(result, c("pass", "direct", ".", ".", ".")),
+    is.finite(limit), limit > 0, elapsed <= limit
+)
+message("Stata comparator tests passed in ", sprintf("%.2f", elapsed),
+        " seconds for the wide performance fixture")


### PR DESCRIPTION
## Summary

- load the source, normalized source, and candidate once in separate Stata frames
- compare variable metadata and notes from memory instead of reopening multi-gigabyte files for every variable
- retain Stata `cf` as the exact stored-value comparison
- add public Stata tests for releases 115, 117, and 118, zero-row files, special variable names, ten deliberate mismatch categories, and a wide performance fixture

## Performance

On the generated 20 MB, 1,000-variable fixture, the comparator fell from 5.05 seconds to 0.60 seconds in the direct benchmark. The committed complete Stata test finishes the comparison in about 0.9 seconds on this host.

The existing 3.9 GB corpus comparison is still running from its original worktree and was not interrupted or modified.

## Validation

- `Rscript --vanilla benchmarks/r-corpus-roundtrip/test-stata-comparator.R`
- `Rscript --vanilla benchmarks/r-corpus-roundtrip/test-framework.R`
- R syntax parsing
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Testing**
  - Added comprehensive round-trip validation across Stata releases 115, 117, and 118.
  - Added coverage for dataset metadata, labels, notes, formatting, storage types, dimensions, names, and stored values.
  - Added checks for empty datasets, invalid column names, and wide datasets with up to 1,000 variables.
  - Added configurable performance limits, with a 2.5-second default for the 20 MB fixture.

- **Documentation**
  - Added instructions for installing the local R package and running the Stata comparator test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->