### PR TITLE
Declare dtatools' NSE contract for Raven

### DIFF
--- a/r-package/dtatools/inst/raven/nse.toml
+++ b/r-package/dtatools/inst/raven/nse.toml
@@ -1,0 +1,69 @@
+# NSE policies for dtatools' exported functions, read by Raven
+# (https://github.com/jbearak/raven) to avoid false `undefined-variable`
+# diagnostics on captured arguments.
+#
+# `R CMD INSTALL` copies this to <libpath>/dtatools/raven/nse.toml, where Raven
+# finds it alongside NAMESPACE. Keep it in step with the signatures in R/ --
+# `formals` must list the function's formal arguments in declaration order,
+# because Raven matches positional arguments against it.
+
+schema = 1
+
+# gen(survey, adjusted, income + 5): `variable`, `values`, and `where` are
+# quoted with rlang::enquo() and evaluated against the data mask, while `data`
+# is an ordinary argument that should still be checked.
+[[function]]
+name = "gen"
+formals = ["data", "variable", "values", "where"]
+captured = ["variable", "values", "where"]
+
+[[function]]
+name = "repl"
+formals = ["data", "variable", "values", "where"]
+captured = ["variable", "values", "where"]
+
+[[function]]
+name = "replace_values"
+formals = ["data", "variable", "values", "where"]
+captured = ["variable", "values", "where"]
+
+# tab(mtcars, cyl, gear): `x` and the dots are quoted column expressions. The
+# explicit `data` argument, and the literal controls after the dots, are not.
+[[function]]
+name = "tab"
+formals = ["x", "...", "data", "missing", "display"]
+captured = ["x"]
+captured_dots = true
+
+# read_dta(path, col_select = c(id, weight)): tidyselect over the file's
+# columns, matching Raven's built-in policy for haven's readers.
+[[function]]
+name = "read_dta"
+formals = [
+    "file",
+    "encoding",
+    "col_select",
+    "skip",
+    "n_max",
+    ".name_repair",
+    "threads",
+    "use_numeric_altrep",
+    "datasig",
+]
+captured = ["col_select"]
+
+[[function]]
+name = "read_arrow"
+formals = [
+    "file",
+    "col_select",
+    "skip",
+    "n_max",
+    "verify",
+    "profile",
+    ".name_repair",
+    "use_numeric_altrep",
+    "threads",
+    "datasig",
+]
+captured = ["col_select"]

--- a/r-package/dtatools/tests/testthat/test-raven-nse.R
+++ b/r-package/dtatools/tests/testthat/test-raven-nse.R
@@ -1,0 +1,96 @@
+# Guards `inst/raven/nse.toml` against drift. Raven matches positional
+# arguments against the declared `formals`, so a renamed or reordered argument
+# in R/ silently shifts which argument Raven suppresses. These tests fail
+# instead.
+
+# Minimal reader for the subset of TOML the declaration file uses: `[[function]]
+# table headers, `key = "string"`, `key = true/false`, and string arrays written
+# either on one line or across several. Comments and blank lines are dropped.
+# Deliberately not a general TOML parser -- it only has to read a file this
+# package writes.
+read_nse_declarations <- function(path) {
+    lines <- readLines(path, warn = FALSE)
+    lines <- sub("(^|\\s)#.*$", "", lines)
+    lines <- trimws(lines)
+    lines <- lines[nzchar(lines)]
+
+    # Join continuation lines so each array occupies one entry.
+    joined <- character(0)
+    buffer <- ""
+    for (line in lines) {
+        buffer <- if (nzchar(buffer)) paste(buffer, line) else line
+        if (lengths(regmatches(buffer, gregexpr("[", buffer, fixed = TRUE))) ==
+            lengths(regmatches(buffer, gregexpr("]", buffer, fixed = TRUE)))) {
+            joined <- c(joined, buffer)
+            buffer <- ""
+        }
+    }
+
+    declarations <- list()
+    current <- NULL
+    for (line in joined) {
+        if (identical(line, "[[function]]")) {
+            if (!is.null(current)) declarations[[length(declarations) + 1]] <- current
+            current <- list()
+            next
+        }
+        if (is.null(current)) next # pre-table keys such as `schema`
+        parts <- regmatches(line, regexpr("=", line), invert = TRUE)[[1]]
+        if (length(parts) != 2) next
+        key <- trimws(parts[[1]])
+        value <- trimws(parts[[2]])
+        current[[key]] <- if (startsWith(value, "[")) {
+            quoted <- unlist(regmatches(value, gregexpr('"[^"]*"', value)))
+            gsub('"', "", quoted, fixed = TRUE)
+        } else if (value %in% c("true", "false")) {
+            identical(value, "true")
+        } else {
+            gsub('"', "", value, fixed = TRUE)
+        }
+    }
+    if (!is.null(current)) declarations[[length(declarations) + 1]] <- current
+    declarations
+}
+
+declaration_path <- function() {
+    # `testthat::test_local()` runs against the source tree, an installed check
+    # against the installed package; try both.
+    installed <- system.file("raven", "nse.toml", package = "dtatools")
+    if (nzchar(installed)) return(installed)
+    testthat::test_path("..", "..", "inst", "raven", "nse.toml")
+}
+
+test_that("every declared function is exported by the package", {
+    declarations <- read_nse_declarations(declaration_path())
+    expect_gt(length(declarations), 0)
+    exported <- getNamespaceExports("dtatools")
+    for (declaration in declarations) {
+        expect_true(
+            declaration$name %in% exported,
+            info = paste(declaration$name, "is declared but not exported")
+        )
+    }
+})
+
+test_that("declared formals match the function signatures", {
+    for (declaration in read_nse_declarations(declaration_path())) {
+        actual <- names(formals(get(declaration$name, asNamespace("dtatools"))))
+        expect_identical(
+            declaration$formals,
+            actual,
+            info = paste(
+                "inst/raven/nse.toml declares", declaration$name,
+                "with formals that no longer match R/"
+            )
+        )
+    }
+})
+
+test_that("captured arguments name real formals", {
+    for (declaration in read_nse_declarations(declaration_path())) {
+        expect_true(
+            all(declaration$captured %in% declaration$formals),
+            info = paste(declaration$name, "captures a name that is not a formal")
+        )
+    }
+})

--- a/r-package/dtatools/tests/testthat/test-raven-nse.R
+++ b/r-package/dtatools/tests/testthat/test-raven-nse.R
@@ -60,6 +60,19 @@ declaration_path <- function() {
     testthat::test_path("..", "..", "inst", "raven", "nse.toml")
 }
 
+# The policy the package must keep declaring. Spelled out here so that deleting
+# a `[[function]]` table, or emptying its `captured` list, fails instead of
+# silently leaving Raven without the suppression -- the later tests only check
+# the tables that are still present.
+expected_policy <- list(
+    gen = list(captured = c("variable", "values", "where"), captured_dots = FALSE),
+    repl = list(captured = c("variable", "values", "where"), captured_dots = FALSE),
+    replace_values = list(captured = c("variable", "values", "where"), captured_dots = FALSE),
+    tab = list(captured = "x", captured_dots = TRUE),
+    read_dta = list(captured = "col_select", captured_dots = FALSE),
+    read_arrow = list(captured = "col_select", captured_dots = FALSE)
+)
+
 test_that("every declared function is exported by the package", {
     declarations <- read_nse_declarations(declaration_path())
     expect_gt(length(declarations), 0)
@@ -68,6 +81,26 @@ test_that("every declared function is exported by the package", {
         expect_true(
             declaration$name %in% exported,
             info = paste(declaration$name, "is declared but not exported")
+        )
+    }
+})
+
+test_that("the declaration file still carries the expected policy", {
+    declarations <- read_nse_declarations(declaration_path())
+    names(declarations) <- vapply(declarations, function(d) d$name, character(1))
+    expect_setequal(names(declarations), names(expected_policy))
+
+    for (name in names(expected_policy)) {
+        declaration <- declarations[[name]]
+        expect_identical(
+            declaration$captured,
+            expected_policy[[name]]$captured,
+            info = paste("inst/raven/nse.toml no longer captures the expected arguments of", name)
+        )
+        expect_identical(
+            isTRUE(declaration$captured_dots),
+            expected_policy[[name]]$captured_dots,
+            info = paste("inst/raven/nse.toml changed captured_dots for", name)
         )
     }
 })


### PR DESCRIPTION
## Why

Several dtatools exports capture their arguments with `rlang::enquo()`, so a static analyzer reading a call site sees bare column names where it expects variables:

```r
library(dtatools)
survey <- data.frame(income = c(10, 20))
gen(survey, adjusted, income + 5)
```

Raven 0.19.0 reports three undefined-variable warnings here. None is a bug.

## What

`inst/raven/nse.toml` states the contract once, next to the code it describes. `R CMD INSTALL` copies it to `<libpath>/dtatools/raven/nse.toml`, where Raven reads it alongside `NAMESPACE` — so every user of the package gets correct diagnostics without writing per-file `# raven: nse` directives.

Needs jbearak/raven#744, which adds the reading side. Until that ships, the file is inert — Raven ignores a directory it doesn't look in, so this is safe to merge first.

Six exports are covered:

| Function | Captured | Still checked |
| --- | --- | --- |
| `gen`, `repl`, `replace_values` | `variable`, `values`, `where` | `data` |
| `tab` | `x` and `...` | `data`, `missing`, `display` |
| `read_dta`, `read_arrow` | `col_select` (tidyselect) | everything else |

With it installed, the snippet above reports nothing, while `gen(typo_frame, adjusted, income + 5)` still reports `typo_frame`.

## Drift guard

Raven matches positional arguments against the declared `formals` list, so a renamed or reordered argument in `R/` would silently shift *which* argument gets suppressed. The failure mode is a hidden real bug rather than a visible false positive, which is exactly the kind that survives review.

`tests/testthat/test-raven-nse.R` compares every declared signature against `formals()` of the real function, checks each declared name is exported, and checks each `captured` name is a real formal. 19 assertions. Drift fails a test instead of quietly degrading diagnostics.

## One trade-off worth recording

`tab()`'s first formal `x` is `enquo`'d — it's a column expression when `data =` is supplied, and the data itself when piped (`mtcars |> tab(cyl, gear)`). Declaring it captured means `tab(typo_frame, cyl)` no longer flags `typo_frame`. That's correct for the signature as written, but it does give up a check.

## Verified

`R CMD INSTALL` places the file at `/opt/homebrew/lib/R/4.6/site-library/dtatools/raven/nse.toml`, `testthat::test_local(filter = "raven-nse")` passes 19/19, and a Raven build with the reading side turns 5 warnings into 1 on the example above.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added automated checks to verify that non-standard evaluation behavior remains aligned with exported function signatures.
  * Added validation for captured arguments and declaration completeness across data import, transformation, replacement, and table functions.

* **Chores**
  * Added configuration describing argument handling for exported data import, transformation, and table functions.
  * Improved consistency and reliability when using tidy-selection and dynamically captured arguments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->