### PR TITLE
Document resolved value-label mapping semantics

### DIFF
--- a/docs/adr/0016-own-resolved-value-label-mappings.md
+++ b/docs/adr/0016-own-resolved-value-label-mappings.md
@@ -1,0 +1,11 @@
+---
+status: accepted
+---
+
+# Own resolved value-label mappings
+
+`dtatools` treats the resolved code-to-text mapping on each variable as authoritative. Stata instead stores named value-label definitions at dataset scope and assigns variables to them. Imported table names can survive in R as serialization hints, but `dtatools` does not maintain a live shared registry whose name can override a variable's mapping.
+
+This intentionally changes one Stata merge edge case. When master and using define different mappings under the same table name, Stata retains the master's definition. A using-only variable can then display unrelated labels, which can silently misdirect a later label-based recode. `dta_merge()` keeps that variable's resolved using mapping. Writers may preserve an unambiguous imported name hint or synthesize independent definitions, but they never substitute one variable's mapping for another merely because the names match.
+
+Exact Stata ports should treat an unintended same-name, different-definition collision as a source-data bug and rename or reassign the Stata definition before merging. Public authoring APIs for a dataset-level registry are not needed to reproduce this accidental collision.

--- a/docs/r-label-metadata.md
+++ b/docs/r-label-metadata.md
@@ -61,34 +61,72 @@ Value-label codes are limited to values that Stata can use in a label definition
 
 System missing `.`, ordinary R `NA` and `NaN`, fractions, and infinities are rejected. Use `tagged_missing()`, `missing_tag()`, and `is_tagged_missing()` to create or inspect extended missing values without haven.
 
-### Value-label table names
+### Value labels and Stata table names
 
-Three pieces of Stata metadata have similar names but different jobs:
+Four pieces of metadata matter here:
 
-- `attr(column, "label")` is the human-readable variable label.
-- `attr(column, "labels")` maps numeric codes to displayed text.
-- `attr(column, "value.label.name")` identifies the Stata table that supplies that mapping.
+- A variable label is a human-readable description of the variable. R stores
+  it in `attr(column, "label")`.
+- A resolved value-label mapping assigns displayed text to the numeric codes of
+  one variable. R stores it in `attr(column, "labels")`.
+- A named Stata value-label definition is a dataset-level table containing one
+  such mapping.
+- A Stata assignment makes a variable refer to a named definition.
+
+`dtatools` treats the resolved mapping on each variable as authoritative. It
+does not maintain a live dataset-level registry in which several R columns
+share one definition. Editing one column's `labels` attribute therefore does
+not change any other column.
 
 `read_dta()` and `read_arrow()` attach `value.label.name` when an imported
 table name differs from the source variable name or when several source
 variables share the table. A projected read still checks all source variables,
-so it does not lose shared-table identity. The attribute is omitted for the
-ordinary one-variable case in which the table and variable have the same name.
+so it retains the table-name hint even if only one referring variable is
+selected. The attribute is omitted for the ordinary one-variable case in which
+the table and variable have the same name. `value.label.name` helps writers
+reconstruct source-format metadata, but it is not shared semantic state and it
+does not override the resolved `labels` mapping.
 
 `save_dta()` and `save_arrow()` preserve the imported name. Columns with the
 same name and the same mapping share one output table. Without the attribute,
-each writer uses the current variable name, as before. Comparison covers codes,
-extended missing tags, label text, duplicate imported entries, and source
-order. If columns claim one table name but carry different mappings, the writer
-emits one warning for the whole call and uses each affected variable name as a
-fallback. Other shared tables remain shared.
+each writer synthesizes a separate definition from the current variable name
+and resolved mapping. Comparison covers codes, extended missing tags, label
+text, duplicate imported entries, and source order. If columns claim one table
+name but carry different mappings, the writer emits one warning for the whole
+call and synthesizes independent variable-name definitions for the affected
+columns. It never chooses one mapping merely because two name hints match.
+Other unambiguous shared tables remain shared in the serialized file.
 
 The attribute is valid only with a usable `labels` mapping. An empty named
 mapping is usable and represents an empty Stata table; a table name without a
 mapping is a write error. Removing all value labels with a dtatools setter also
 removes `value.label.name`. Other metadata setters and supported reconstruction
-operations retain it. The attribute documents imported identity only. There is
-no public getter, setter, or registry editor for authoring shared tables.
+operations retain it. The attribute records an imported serialization detail
+only. There is no public getter, setter, or registry editor for authoring
+shared tables.
+
+### Compatibility with Stata merge
+
+Stata resolves value labels through its dataset-level namespace. During a
+merge, the master dataset's definition wins when the master and using datasets
+contain different mappings under the same table name. A using-only variable
+can then display the wrong text even though its values and labels were correct
+before the merge.
+
+For example, the Uzbekistan 2022 MICS birth-history data assign `bh4m` to a
+table named `labels4` containing month labels. The women's data assign `wm11`
+to a different `labels4` containing interview-privacy labels. With the women's
+data as master, Stata retains the privacy definition and applies it to the
+merged `bh4m`.
+
+`dta_merge()` does not reproduce that namespace collision. It carries the
+resolved month mapping with `bh4m` and the privacy mapping with `wm11`.
+This is the expected result from the variable-level mapping: `bh4m` remains a
+month variable after the merge. Stata's result can silently break a later
+recode that relies on displayed label text. Exact Stata ports can therefore
+differ when same-named definitions have different contents. Treat the Stata
+result as a source-data bug unless the shared namespace was intentional. Rename
+or reassign the definition in the Stata source before merging.
 
 ## Converting labels to factors
 

--- a/r-package/dtatools/R/dta-merge.R
+++ b/r-package/dtatools/R/dta-merge.R
@@ -35,6 +35,24 @@
 #' included), an additional warning names those variables, since the
 #' resolution keeps `x`'s side and Stata would say nothing.
 #'
+#' Value-label mappings belong to individual result variables. `dta_merge()`
+#' does not resolve them through Stata's dataset-level namespace of named
+#' definitions. This intentionally differs from Stata when `x` and `y` contain
+#' different definitions with the same name. Stata retains the definition from
+#' `x`, so a variable found only in `y` can display unrelated labels after the
+#' merge. `dta_merge()` retains that variable's resolved mapping from `y`.
+#'
+#' For example, suppose `x$wm11` uses a definition named `labels4` for
+#' interview-privacy codes, while `y$bh4m` uses its own `labels4` definition
+#' for month codes. Stata keeps the privacy definition and applies it to the
+#' merged `bh4m`. `dta_merge()` keeps the month mapping on `bh4m`. Correct an
+#' unintended collision in the Stata source before treating the two results as
+#' an exact compatibility comparison. A later writer may preserve an
+#' unambiguous imported name hint or synthesize separate definitions; it never
+#' substitutes one variable's mapping for another solely because names match.
+#' This is normally the expected result: Stata's collision can silently make a
+#' later label-based recode operate on unrelated text.
+#'
 #' Every merge generates a `_merge` variable, a `stata_byte` column using
 #' Stata's `_merge` codes with value labels `x only (1)`, `y only (2)`, and
 #' `matched (3)`. Merging errors if either input already has a `_merge`

--- a/r-package/dtatools/R/labels.R
+++ b/r-package/dtatools/R/labels.R
@@ -58,11 +58,12 @@
 #' Date and POSIXct classes, time zones, Stata formats, and unrelated attributes
 #' are preserved. Removing the table removes only compatibility classes added
 #' for the label table and retains unrelated classes.
-#' Imported nondefault or shared Stata table identity is carried separately in
-#' `attr(x, "value.label.name")`. Setters retain that package-owned attribute
-#' while value labels remain and remove it when all value labels are removed.
-#' This interface does not provide a public way to create or edit named shared
-#' tables.
+#' An imported nondefault or shared Stata table name may be carried separately
+#' in `attr(x, "value.label.name")`. The attribute is a serialization hint, not
+#' shared semantic state. Each vector's `labels` mapping is authoritative in R.
+#' Setters retain the hint while value labels remain and remove it when all
+#' value labels are removed. This interface does not provide a public way to
+#' create or edit named shared tables.
 #'
 #' See the
 #' \href{https://github.com/jbearak/dta-parser/blob/main/docs/r-label-metadata.md}{R label metadata guide}

--- a/r-package/dtatools/R/read-dta.R
+++ b/r-package/dtatools/R/read-dta.R
@@ -10,10 +10,15 @@
 #' characteristics, display formats, value labels, `strL` content, and Stata
 #' system/extended missing values are retained. Use [stata_notes()] and
 #' [stata_characteristics()] at dataset or variable scope.
-#' Imported value-label table identity is stored in `value.label.name` when the
-#' table name differs from the source variable name or the source table is
-#' shared. This differs from the variable label in `label` and the code-to-text
-#' mapping in `labels`. Projection checks sharing against all source variables.
+#' Stata stores named value-label definitions at dataset scope and assigns a
+#' definition to each labelled variable. `read_dta()` instead gives each
+#' variable its resolved code-to-text mapping in `labels`. An imported table
+#' name may also appear in `value.label.name` when it differs from the source
+#' variable name or the source table is shared. That attribute is a
+#' serialization hint, not a live shared table or a semantic namespace.
+#' Changing one variable's mapping does not change another variable that came
+#' from the same Stata definition. Projection checks all source variables when
+#' deciding whether to retain the name hint.
 #'
 #' @section Stata missing values:
 #' Stata system missing (`.`) is returned as `NA_real_`; in releases supporting

--- a/r-package/dtatools/R/save-arrow.R
+++ b/r-package/dtatools/R/save-arrow.R
@@ -29,10 +29,12 @@
 #' aggregated warning per conversion category. Attributes outside the profile's
 #' documented set are dropped with one warning naming each affected column and
 #' attribute.
-#' The recognized `value.label.name` attribute preserves an imported nondefault
-#' or shared Stata table name in the existing dataset registry and field
-#' reference. Columns that claim one name with different mappings produce one
-#' aggregated warning and fall back to separate variable-name tables.
+#' The recognized `value.label.name` attribute is a serialization hint for an
+#' imported nondefault or shared Stata table name in the existing dataset
+#' registry and field reference. It does not make the name part of a column's
+#' resolved value-label semantics. Columns that claim one name with different
+#' mappings produce one aggregated warning and fall back to independently
+#' synthesized variable-name tables.
 #'
 #' Unlike [save_dta()], factor class and orderedness, `POSIXct` timezones on
 #' ordinary R columns, and `difftime` units are preserved on read.

--- a/r-package/dtatools/R/save-dta.R
+++ b/r-package/dtatools/R/save-dta.R
@@ -24,10 +24,12 @@
 #' Duplicate value-label keys already present in imported source metadata are
 #' retained in stable order; the package's metadata setters remain stricter for
 #' newly authored tables.
-#' An imported `value.label.name` attribute preserves a nondefault or shared
-#' value-label table name. Columns that claim one name with different mappings
-#' produce one aggregated warning and fall back to separate variable-name
-#' tables. A table-name attribute without a usable `labels` mapping is invalid.
+#' An imported `value.label.name` attribute is a serialization hint for a
+#' nondefault or shared value-label table name. It does not make the name part
+#' of a column's resolved value-label semantics. Columns that claim one name
+#' with different mappings produce one aggregated warning and fall back to
+#' independently synthesized variable-name tables. A table-name attribute
+#' without a usable `labels` mapping is invalid.
 #'
 #' @section Output safety:
 #' Only local, uncompressed files are supported. The complete input is validated

--- a/r-package/dtatools/README.md
+++ b/r-package/dtatools/README.md
@@ -297,6 +297,19 @@ shows a from-file merge costs its read plus the merge itself. See
 [the joins note](../../docs/r-joins-with-stata-columns.md) for the evidence
 behind these differences.
 
+One Stata behavior is intentionally excluded. Stata stores named value-label
+definitions at dataset scope. If master and using contain different mappings
+with the same definition name, Stata keeps master's definition and can display
+the wrong labels on a using-only variable. `dta_merge()` keeps each variable's
+resolved mapping instead. For example, if master uses `labels4` for interview
+privacy and using assigns its own `labels4` month mapping to `bh4m`, Stata can
+show privacy labels for the merged `bh4m`; `dta_merge()` keeps the month labels.
+The latter is normally what the user intended. Stata's result can silently
+misdirect later recodes that use label text. Correct accidental name collisions
+in Stata source before comparing exact merge output. The
+[label metadata guide](../../docs/r-label-metadata.md#compatibility-with-stata-merge)
+explains the representation and writer behavior.
+
 ## Verify source data
 
 ```r
@@ -327,7 +340,7 @@ re-baselining until the profile freezes.
 ## Data returned to R
 
 Dataset and variable labels, numbered notes, arbitrary characteristics,
-display formats, and value-label tables are retained as attributes. Use
+display formats, and resolved value-label mappings are retained as attributes. Use
 `stata_notes()` and `stata_characteristics()` to inspect them, and pass a
 column name as `variable` for variable scope. Stata daily dates become `Date`;
 `%tc` and `%tC` values become UTC `POSIXct`.

--- a/r-package/dtatools/man/dta_merge.Rd
+++ b/r-package/dtatools/man/dta_merge.Rd
@@ -73,6 +73,24 @@ or characteristics (keys
 included), an additional warning names those variables, since the
 resolution keeps \code{x}'s side and Stata would say nothing.
 
+Value-label mappings belong to individual result variables. \code{dta_merge()}
+does not resolve them through Stata's dataset-level namespace of named
+definitions. This intentionally differs from Stata when \code{x} and \code{y} contain
+different definitions with the same name. Stata retains the definition from
+\code{x}, so a variable found only in \code{y} can display unrelated labels after the
+merge. \code{dta_merge()} retains that variable's resolved mapping from \code{y}.
+
+For example, suppose \code{x$wm11} uses a definition named \code{labels4} for
+interview-privacy codes, while \code{y$bh4m} uses its own \code{labels4} definition
+for month codes. Stata keeps the privacy definition and applies it to the
+merged \code{bh4m}. \code{dta_merge()} keeps the month mapping on \code{bh4m}. Correct an
+unintended collision in the Stata source before treating the two results as
+an exact compatibility comparison. A later writer may preserve an
+unambiguous imported name hint or synthesize separate definitions; it never
+substitutes one variable's mapping for another solely because names match.
+This is normally the expected result: Stata's collision can silently make a
+later label-based recode operate on unrelated text.
+
 Every merge generates a \verb{_merge} variable, a \code{stata_byte} column using
 Stata's \verb{_merge} codes with value labels \verb{x only (1)}, \verb{y only (2)}, and
 \code{matched (3)}. Merging errors if either input already has a \verb{_merge}

--- a/r-package/dtatools/man/read_dta.Rd
+++ b/r-package/dtatools/man/read_dta.Rd
@@ -63,11 +63,15 @@ supported vector operations.}
 Reads Stata releases 105, 108, 110--111, 113--115, and 117--119 through the native Rust parser,
 retaining dataset and variable labels, dataset notes, formats, value labels,
 long strings, temporal classes, and Stata tagged missing values.
-Imported value-label table identity is stored in \code{value.label.name} when
-the table name differs from the source variable name or the source table is
-shared. This differs from the variable label in \code{label} and the
-code-to-text mapping in \code{labels}. Projection checks sharing against all
-source variables.
+Stata stores named value-label definitions at dataset scope and assigns a
+definition to each labelled variable. \code{read_dta()} instead gives each
+variable its resolved code-to-text mapping in \code{labels}. An imported table
+name may also appear in \code{value.label.name} when it differs from the source
+variable name or the source table is shared. That attribute is a serialization
+hint, not a live shared table or a semantic namespace. Changing one variable's
+mapping does not change another variable that came from the same Stata
+definition. Projection checks all source variables when deciding whether to
+retain the name hint.
 }
 \section{Stata missing values}{
 Stata system missing (\code{.}) is returned as \code{NA_real_}; in releases

--- a/r-package/dtatools/man/save_arrow.Rd
+++ b/r-package/dtatools/man/save_arrow.Rd
@@ -77,10 +77,12 @@ Stata storage type cannot represent become Stata system missing with one
 aggregated warning per conversion category. Attributes outside the profile's
 documented set are dropped with one warning naming each affected column and
 attribute.
-The recognized \code{value.label.name} attribute preserves an imported nondefault
-or shared Stata table name in the existing dataset registry and field
-reference. Columns that claim one name with different mappings produce one
-aggregated warning and fall back to separate variable-name tables.
+The recognized \code{value.label.name} attribute is a serialization hint for an
+imported nondefault or shared Stata table name in the existing dataset
+registry and field reference. It does not make the name part of a column's
+resolved value-label semantics. Columns that claim one name with different
+mappings produce one aggregated warning and fall back to independently
+synthesized variable-name tables.
 
 Unlike \code{\link[=save_dta]{save_dta()}}, factor class and orderedness, \code{POSIXct} timezones on
 ordinary R columns, and \code{difftime} units are preserved on read.

--- a/r-package/dtatools/man/save_dta.Rd
+++ b/r-package/dtatools/man/save_dta.Rd
@@ -59,10 +59,12 @@ silently repaired or truncated.
 Duplicate value-label keys already present in imported source metadata are
 retained in stable order; the package's metadata setters remain stricter for
 newly authored tables.
-An imported \code{value.label.name} attribute preserves a nondefault or shared
-value-label table name. Columns that claim one name with different mappings
-produce one aggregated warning and fall back to separate variable-name
-tables. A table-name attribute without a usable \code{labels} mapping is invalid.
+An imported \code{value.label.name} attribute is a serialization hint for a
+nondefault or shared value-label table name. It does not make the name part
+of a column's resolved value-label semantics. Columns that claim one name
+with different mappings produce one aggregated warning and fall back to
+independently synthesized variable-name tables. A table-name attribute
+without a usable \code{labels} mapping is invalid.
 }
 
 \section{Output safety}{

--- a/r-package/dtatools/man/var_label.Rd
+++ b/r-package/dtatools/man/var_label.Rd
@@ -120,11 +120,12 @@ dependency-free classes \code{haven_labelled}, \code{vctrs_vctr}, and its storag
 Date and POSIXct classes, time zones, Stata formats, and unrelated attributes
 are preserved. Removing the table removes only compatibility classes added
 for the label table and retains unrelated classes.
-Imported nondefault or shared Stata table identity is carried separately in
-\code{attr(x, "value.label.name")}. Setters retain that package-owned attribute
-while value labels remain and remove it when all value labels are removed.
-This interface does not provide a public way to create or edit named shared
-tables.
+An imported nondefault or shared Stata table name may be carried separately
+in \code{attr(x, "value.label.name")}. The attribute is a serialization hint, not
+shared semantic state. Each vector's \code{labels} mapping is authoritative in R.
+Setters retain the hint while value labels remain and remove it when all
+value labels are removed. This interface does not provide a public way to
+create or edit named shared tables.
 
 See the
 \href{https://github.com/jbearak/dta-parser/blob/main/docs/r-label-metadata.md}{R label metadata guide}


### PR DESCRIPTION
## Summary

- define variable labels, resolved mappings, named Stata definitions, and assignments as separate concepts
- document resolved per-variable mappings as authoritative in `dtatools`, with imported table names treated as serialization hints
- explain the same-name/different-definition Stata merge collision and why `dta_merge()` intentionally preserves the expected variable mapping
- record the decision in ADR 0016 and clarify writer synthesis behavior

Closes #109

## Tests

- `git diff --check`
- focused `test-dta-merge.R`: pass
- focused `test-value-label-table-names.R`: pass
- full `devtools::test()`: all relevant tests pass; one unrelated existing interrupt-injection test errors because the callr subprocess cannot find `.inject_reference_write_interrupt` (`test-mutate-data.R:375`)
