### PR TITLE
Fix generated compact numeric missing initialization

### DIFF
--- a/r-package/dtatools/src/init.c
+++ b/r-package/dtatools/src/init.c
@@ -5913,8 +5913,7 @@ SEXP C_dtatools_generate_numeric(
     }
 
     numeric_data plan = {
-        NULL, row_count, kind, temporal, 119,
-        rows == R_NilValue ? 0 : row_count
+        NULL, row_count, kind, temporal, 119, row_count
     };
     compact_replacement_plan replacement_plan =
         compact_replacement_plan_create(
@@ -5930,11 +5929,9 @@ SEXP C_dtatools_generate_numeric(
         RAWSXP, (R_xlen_t) (row_count * width)
     ));
     plan.values = RAW(backing);
-    if (rows != R_NilValue) {
-        for (size_t index = 0; index < row_count; index++) {
-            if ((index & 16383) == 0) R_CheckUserInterrupt();
-            write_numeric_missing(plan.values, (R_xlen_t) index, kind, 0);
-        }
+    for (size_t index = 0; index < row_count; index++) {
+        if ((index & 16383) == 0) R_CheckUserInterrupt();
+        write_numeric_missing(plan.values, (R_xlen_t) index, kind, 0);
     }
     apply_compact_replacement(&plan, &row_plan, &replacement_plan);
 


### PR DESCRIPTION
## Summary

- initialize every generated compact numeric row as Stata system missing
- begin missing-count bookkeeping at the generated row count
- let subsequent replacements update the count in step with the backing bytes

## Verification

- direct compact numeric generation regression: passed for partially assigned rows and full-vector missing values
- `testthat::test_local("r-package/dtatools", filter = "mutate-data")`: reached the mutation cases, then the interrupt test subprocess loaded an older installed `dtatools` that predates the private `.inject_reference_write_interrupt` test hook

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compact numeric generation by consistently initializing output rows as missing values.
  * Corrected missing-value tracking so replacements are applied accurately across all generation modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->