### PR TITLE
Declare remaining dtatools NSE helpers

### DIFF
--- a/r-package/dtatools/inst/raven/nse.toml
+++ b/r-package/dtatools/inst/raven/nse.toml
@@ -27,6 +27,28 @@ name = "replace_values"
 formals = ["data", "variable", "values", "where"]
 captured = ["variable", "values", "where"]
 
+# keep_vars(survey, id, age) and drop_vars(survey, temporary): every argument
+# in `...` is quoted with rlang::enquos() and interpreted as a column
+# selection. `data` remains an ordinary argument.
+[[function]]
+name = "keep_vars"
+formals = ["data", "..."]
+captured = []
+captured_dots = true
+
+[[function]]
+name = "drop_vars"
+formals = ["data", "..."]
+captured = []
+captured_dots = true
+
+# set_var_label(survey, age, "Age"): `variable` is quoted and resolved as one
+# column name. `data` and `label` are evaluated normally.
+[[function]]
+name = "set_var_label"
+formals = ["data", "variable", "label"]
+captured = ["variable"]
+
 # tab(mtcars, cyl, gear): `x` and the dots are quoted column expressions. The
 # explicit `data` argument, and the literal controls after the dots, are not.
 [[function]]

--- a/r-package/dtatools/tests/testthat/test-raven-nse.R
+++ b/r-package/dtatools/tests/testthat/test-raven-nse.R
@@ -68,6 +68,9 @@ expected_policy <- list(
     gen = list(captured = c("variable", "values", "where"), captured_dots = FALSE),
     repl = list(captured = c("variable", "values", "where"), captured_dots = FALSE),
     replace_values = list(captured = c("variable", "values", "where"), captured_dots = FALSE),
+    keep_vars = list(captured = character(), captured_dots = TRUE),
+    drop_vars = list(captured = character(), captured_dots = TRUE),
+    set_var_label = list(captured = "variable", captured_dots = FALSE),
     tab = list(captured = "x", captured_dots = TRUE),
     read_dta = list(captured = "col_select", captured_dots = FALSE),
     read_arrow = list(captured = "col_select", captured_dots = FALSE)


### PR DESCRIPTION
## Summary

- declare `keep_vars()` and `drop_vars()` as capturing their dots in dtatools’ Raven NSE metadata
- declare `set_var_label()` as capturing its `variable` argument
- extend the policy drift test to cover all three helpers

## Verification

- installed the patched dtatools package into an isolated R library
- ran `test-raven-nse.R`: 47 assertions passed
- reproduced three `undefined-variable` diagnostics with the previous installed policy
- reran the same Raven fixture against the patched package: no diagnostics
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for improved handling of variable selections and labels in `keep_vars`, `drop_vars`, and `set_var_label`.
  * Variable arguments are now captured consistently, including flexible column selections.

* **Tests**
  * Added coverage to verify variable-selection and label-handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->