### PR TITLE
Accept a string in the captured variable name, so !!name works

### DIFF
--- a/r-package/dtatools/R/labels.R
+++ b/r-package/dtatools/R/labels.R
@@ -567,9 +567,55 @@ set_var_label <- function(data, variable, label) {
 
 #' @rdname var_label
 #' @export
+.is_runtime_name_tag <- function(argument) {
+    is.call(argument) && length(argument) == 3L &&
+        identical(argument[[1L]], quote(`:=`)) &&
+        .is_runtime_name_call(argument[[2L]])
+}
+
+# `.(name) := value` in the plural setters. rlang rejects a call on the
+# left of `:=` before it evaluates anything, so the tags are resolved here
+# first: each `.()` left-hand side is evaluated in the caller's environment
+# and becomes an ordinary argument name, then `rlang::dots_list()` runs on
+# the rewritten call and keeps its own handling of `!!`, `!!!`, homonyms
+# and empty arguments unchanged.
+.dots_list_with_runtime_names <- function(quoted, environment, plain) {
+    arguments <- as.list(quoted)
+    if (!any(vapply(arguments, .is_runtime_name_tag, logical(1L)))) {
+        # No `.()` tag, so nothing needs rewriting. Taking the ordinary
+        # path here keeps every existing call byte-identical in behavior,
+        # including dots forwarded from an enclosing function, whose
+        # promises belong to that caller rather than to this frame.
+        return(plain())
+    }
+    names(arguments) <- if (is.null(names(arguments))) {
+        rep("", length(arguments))
+    } else {
+        names(arguments)
+    }
+    for (index in seq_along(arguments)) {
+        argument <- arguments[[index]]
+        if (!.is_runtime_name_tag(argument)) next
+        names(arguments)[[index]] <- .runtime_name_call_value(
+            argument[[2L]], environment
+        )
+        arguments[[index]] <- argument[[3L]]
+    }
+    call <- as.call(c(
+        quote(rlang::dots_list), arguments,
+        list(.homonyms = "keep", .ignore_empty = "none")
+    ))
+    eval(call, environment)
+}
+
 set_var_labels <- function(.data, ..., .labels = NULL) {
-    dots <- rlang::dots_list(
-        ..., .homonyms = "keep", .ignore_empty = "none"
+    dots <- .dots_list_with_runtime_names(
+        substitute(...()), parent.frame(),
+        function() {
+            rlang::dots_list(
+                ..., .homonyms = "keep", .ignore_empty = "none"
+            )
+        }
     )
     if (!is.data.frame(.data)) {
         if (!is.null(.labels) && length(dots) > 0L) {
@@ -604,8 +650,13 @@ set_var_labels <- function(.data, ..., .labels = NULL) {
 #' @rdname var_label
 #' @export
 set_val_labels <- function(.data, ..., .labels = NULL) {
-    dots <- rlang::dots_list(
-        ..., .homonyms = "keep", .ignore_empty = "none"
+    dots <- .dots_list_with_runtime_names(
+        substitute(...()), parent.frame(),
+        function() {
+            rlang::dots_list(
+                ..., .homonyms = "keep", .ignore_empty = "none"
+            )
+        }
     )
     if (!is.data.frame(.data)) {
         if (!is.null(.labels) && length(dots) > 0L) {

--- a/r-package/dtatools/R/labels.R
+++ b/r-package/dtatools/R/labels.R
@@ -22,8 +22,18 @@
 #' They also accept vectors for pipeline use. Unknown, duplicate, unnamed, or
 #' overlapping column updates fail atomically.
 #'
-#' `set_var_label()` sets the variable label of one column named without
-#' quotes, mirroring Stata's `label variable`.
+#' `set_var_label()` sets the variable label of one column, mirroring Stata's
+#' `label variable`. Its `variable` argument follows the same rule as in
+#' `gen()` and `replace_values()`: one unquoted name, or one nonempty,
+#' non-missing string. A name known only at run time therefore needs only the
+#' tidy-evaluation escape, as in
+#' `set_var_label(data, !!name, "Cluster number")`; no `rlang::inject()`
+#' wrapper is required, and `rlang::sym()` is optional, so the older
+#' `!!rlang::sym(name)` spelling remains equivalent. There is no `.data`
+#' pronoun for this argument, because it names a target rather than reading a
+#' column. `set_var_labels()` and `set_val_labels()` take a programmatic named
+#' list through `.labels` instead, and `keep_vars()`, `drop_vars()`, and
+#' `rename_vars()` take `tidyselect::all_of()` or `.names`.
 #'
 #' The data-frame forms of `set_var_label()`, `set_var_labels()`, and
 #' `set_val_labels()` mutate by reference, as `gen()` and `replace_values()` do.
@@ -79,7 +89,8 @@
 #'   variable label or one or more named value-label codes.
 #' @param .labels A programmatic label value for a vector, or a named list of
 #'   column updates for a data frame.
-#' @param variable One unquoted column name.
+#' @param variable One unquoted column name, or one nonempty, non-missing
+#'   character string, which is what `!!name` unquotes to.
 #' @param label One variable label, or `NULL` to remove it.
 #' @return Getters return the metadata described above. Replacement functions
 #'   and `set_*()` functions return the updated vector or data frame. Data-frame
@@ -99,6 +110,10 @@
 #' )
 #' var_label(survey)
 #' val_labels(survey$status)
+#'
+#' # A column name known only at run time
+#' stratum_name <- "stratum"
+#' set_var_label(survey, !!stratum_name, "Sampling stratum")
 #' @export
 var_label <- function(x) {
     .validate_label_object(x)

--- a/r-package/dtatools/R/mutate-data.R
+++ b/r-package/dtatools/R/mutate-data.R
@@ -34,9 +34,23 @@
 #' `gen()` and `replace_values()` reject grouped and rowwise tibbles. Ungroup
 #' them before mutation. `copy_data()` accepts them and preserves their class.
 #'
-#' `variable` must be one unquoted name. Tidy-evaluation injection is supported,
-#' so `gen(data, !!rlang::sym(name), value)` handles a name stored in a string.
-#' A quoted target is rejected.
+#' `variable` must be one unquoted name or one string. Tidy-evaluation
+#' injection is supported, so `gen(data, !!name, value)` handles a name stored
+#' in a string. No `rlang::inject()` wrapper is needed, because
+#' `rlang::enquo()` already applies quasiquotation. The older
+#' `gen(data, !!rlang::sym(name), value)` is equivalent and still works, but
+#' `rlang::sym()` is not required: unquoting a string yields a character
+#' scalar, and one nonempty, non-missing string is accepted in the `variable`
+#' position. A literal `gen(data, "adjusted", value)` names a column the same
+#' way. An empty string, `NA`, a character vector of length other than one, a
+#' call such as `a + 1`, `...`, and a missing argument are errors.
+#'
+#' In the `values` and `where` expressions a runtime name is reached through
+#' the mask's `.data` pronoun instead: `values = .data[[name]]` and
+#' `where = !is_missing(.data[[name]])`. Note the asymmetry, which is the
+#' surprising part: `.data[[name]]` works in `values` and `where` but not in
+#' the `variable` position, because `variable` names a target rather than
+#' reading a column. Use `!!name` there.
 #'
 #' `values` and `where` use a data mask built from the dataset before the
 #' mutation. Columns win over objects in the calling environment; use `.env`
@@ -119,8 +133,12 @@
 #'
 #' @param data An ungrouped data frame or tibble to mutate. `copy_data()` also
 #'   accepts grouped and rowwise tibbles.
-#' @param variable Exactly one unquoted target name.
-#' @param values A value expression or one-sided formula.
+#' @param variable Exactly one unquoted target name, or one nonempty,
+#'   non-missing character string, which is what `!!name` unquotes to. An
+#'   empty string, `NA`, a character vector of length other than one, a call,
+#'   `...`, and a missing argument are errors.
+#' @param values A value expression or one-sided formula. It may reference a
+#'   column whose name is a string through the mask's `.data` pronoun.
 #' @param where `NULL`, a logical expression, valid row positions, or a
 #'   one-sided formula.
 #' @return `gen()` and `replace_values()` return `data` invisibly.
@@ -133,6 +151,14 @@
 #' gen(survey, adjusted, income + 5)
 #' independent <- copy_data(survey)
 #' repl(independent, income, 0)
+#'
+#' # A name known only at run time, in each position that accepts one
+#' target_name <- "adjusted"
+#' source_name <- "income"
+#' repl(survey, !!target_name, 0)
+#' repl(survey, !!rlang::sym(target_name), 1)
+#' gen(survey, doubled, .data[[source_name]] * 2)
+#' repl(survey, doubled, 0, where = .data[[source_name]] > 15)
 #' @export
 replace_values <- function(data, variable, values, where = NULL) {
     variable <- rlang::enquo(variable)
@@ -374,13 +400,29 @@ gen <- function(data, variable, values, where = NULL) {
     )
 }
 
+# `!!` is the supported escape for a name held in a string. `rlang::enquo()`
+# already applies quasiquotation, so `gen(data, !!name, value)` needs no
+# `rlang::inject()` wrapper. Unquoting a character string yields a character
+# scalar rather than a symbol, which is why one length-one character is
+# accepted here alongside a symbol. No `.()` escape is offered: `.()` already
+# means `list()` in data.table, which this package sits directly on, and `!!`
+# covers the need without a second spelling.
 .unquoted_variable_name <- function(variable) {
-    if (rlang::quo_is_missing(variable)) {
-        stop("`variable` must be one unquoted column name", call. = FALSE)
-    }
+    message <- paste(
+        "`variable` must be one unquoted column name or one nonempty,",
+        "non-missing string"
+    )
+    if (rlang::quo_is_missing(variable)) stop(message, call. = FALSE)
     expression <- rlang::quo_get_expr(variable)
+    if (is.character(expression)) {
+        if (length(expression) != 1L || is.na(expression) ||
+            !nzchar(expression)) {
+            stop(message, call. = FALSE)
+        }
+        return(expression)
+    }
     if (!is.symbol(expression) || identical(expression, quote(...))) {
-        stop("`variable` must be one unquoted column name", call. = FALSE)
+        stop(message, call. = FALSE)
     }
     as.character(expression)
 }

--- a/r-package/dtatools/R/mutate-data.R
+++ b/r-package/dtatools/R/mutate-data.R
@@ -400,13 +400,72 @@ gen <- function(data, variable, values, where = NULL) {
     )
 }
 
+.RUNTIME_NAME_MESSAGE <-
+    "`.()` takes one nonempty, non-missing string naming a column"
+
+# `.(name)` reads a column whose name is known only at run time. It is
+# recognised in every position dtatools evaluates: in `values` and `where`
+# it reads that column, and in the name position it names the target. The
+# argument is evaluated in the caller's environment rather than in the data
+# mask, so a column sharing a name with a local variable cannot shadow it.
+# `.()` is unambiguous here: `.` is not a legal Stata variable name, so no
+# column read from a `.dta` file can collide with it. data.table spells
+# `list()` as `.()`, but only inside `[.data.table`, which this mask is not.
+.is_runtime_name_call <- function(expression) {
+    is.call(expression) && identical(expression[[1L]], quote(.))
+}
+
+.validated_runtime_name <- function(name) {
+    if (!is.character(name) || length(name) != 1L || is.na(name) ||
+        !nzchar(name)) {
+        stop(.RUNTIME_NAME_MESSAGE, call. = FALSE)
+    }
+    name
+}
+
+.runtime_name_call_value <- function(expression, environment) {
+    if (length(expression) != 2L) {
+        stop(.RUNTIME_NAME_MESSAGE, call. = FALSE)
+    }
+    if (!is.environment(environment)) environment <- parent.frame()
+    .validated_runtime_name(eval(expression[[2L]], environment))
+}
+
+.has_mutation_column <- function(columns, name) {
+    if (is.environment(columns)) {
+        return(exists(name, envir = columns, inherits = FALSE))
+    }
+    name %in% names(columns)
+}
+
+.mutation_column <- function(columns, name) {
+    if (is.environment(columns)) {
+        return(get(name, envir = columns, inherits = FALSE))
+    }
+    columns[[name]]
+}
+
+.runtime_name_reader <- function(columns, environment) {
+    function(x) {
+        name <- .runtime_name_call_value(
+            as.call(list(quote(.), substitute(x))), environment
+        )
+        if (!.has_mutation_column(columns, name)) {
+            stop(sprintf("Column `%s` does not exist", name), call. = FALSE)
+        }
+        .mutation_column(columns, name)
+    }
+}
+
 # `!!` is the supported escape for a name held in a string. `rlang::enquo()`
 # already applies quasiquotation, so `gen(data, !!name, value)` needs no
 # `rlang::inject()` wrapper. Unquoting a character string yields a character
 # scalar rather than a symbol, which is why one length-one character is
-# accepted here alongside a symbol. No `.()` escape is offered: `.()` already
-# means `list()` in data.table, which this package sits directly on, and `!!`
-# covers the need without a second spelling.
+# accepted here alongside a symbol.
+#
+# `.(name)` reaches the same place and is the one spelling that works in
+# every position: `!!` unquotes at capture, so it cannot appear inside a
+# larger expression the way `y + .(name)` can.
 .unquoted_variable_name <- function(variable) {
     message <- paste(
         "`variable` must be one unquoted column name or one nonempty,",
@@ -420,6 +479,11 @@ gen <- function(data, variable, values, where = NULL) {
             stop(message, call. = FALSE)
         }
         return(expression)
+    }
+    if (.is_runtime_name_call(expression)) {
+        return(.runtime_name_call_value(
+            expression, rlang::quo_get_env(variable)
+        ))
     }
     if (!is.symbol(expression) || identical(expression, quote(...))) {
         stop(message, call. = FALSE)
@@ -461,6 +525,7 @@ gen <- function(data, variable, values, where = NULL) {
             !identical(expression, quote(.env)))
     }
     if (rlang::is_quosure(expression)) return(FALSE)
+    if (.is_runtime_name_call(expression)) return(FALSE)
     if (is.call(expression) || is.pairlist(expression)) {
         for (index in seq_along(expression)) {
             if (identical(expression[[index]], quote(expr = ))) next
@@ -498,17 +563,27 @@ gen <- function(data, variable, values, where = NULL) {
     } else if (.plain_mutation_expression(expression)) {
         return(.eval_plain_mutation(expression, columns, environment))
     }
+    reader_environment <- if (!is.null(environment)) {
+        environment
+    } else if (rlang::is_quosure(expression)) {
+        rlang::quo_get_env(expression)
+    } else {
+        parent.frame()
+    }
     if (!is.environment(columns)) {
+        mask <- rlang::as_data_mask(columns)
+        mask$. <- .runtime_name_reader(columns, reader_environment)
         return(if (is.null(environment)) {
-            rlang::eval_tidy(expression, data = columns)
+            rlang::eval_tidy(expression, data = mask)
         } else {
-            rlang::eval_tidy(expression, data = columns, env = environment)
+            rlang::eval_tidy(expression, data = mask, env = environment)
         })
     }
     previous_parent <- parent.env(columns)
     on.exit(parent.env(columns) <- previous_parent, add = TRUE)
     mask <- rlang::new_data_mask(columns)
     mask$.data <- rlang::as_data_pronoun(columns)
+    mask$. <- .runtime_name_reader(columns, reader_environment)
     if (is.null(environment)) {
         rlang::eval_tidy(expression, data = mask)
     } else {

--- a/r-package/dtatools/README.md
+++ b/r-package/dtatools/README.md
@@ -505,6 +505,30 @@ confirm_var(survey, "missing", on_failure = "false")
 #> [1] FALSE
 ```
 
+### Programming with variable names
+
+`gen()`, `repl()`, `replace_values()`, and `set_var_label()` capture their
+variable-name argument the way Stata's `generate` and `replace` do, so the name
+is normally written unquoted. When the name is only known at run time, unquote
+it with rlang's `!!` operator. These functions capture with `rlang::enquo()`,
+which already applies quasiquotation, so no `rlang::inject()` wrapper is
+needed. Inside the `values` and `where` expressions, the `.data` pronoun reads
+a column whose name is a string; it does not work in the name position, which
+names a target rather than reading a column.
+
+```r
+target_name <- "cluster"
+source_name <- "wm1"
+
+repl(survey, !!target_name, .data[[source_name]])
+repl(survey, !!target_name, 0, where = is_missing(.data[[source_name]]))
+gen(survey, !!paste0(target_name, "_flag"), .data[[source_name]] > 0)
+set_var_label(survey, !!target_name, "Cluster number")
+
+# `!!rlang::sym(name)` is the equivalent older spelling and still works
+repl(survey, !!rlang::sym(target_name), 1)
+```
+
 Use the installed help for exact behavior and examples:
 
 ```r

--- a/r-package/dtatools/man/replace_values.Rd
+++ b/r-package/dtatools/man/replace_values.Rd
@@ -19,9 +19,13 @@ copy_data(data)
 \item{data}{An ungrouped data frame or tibble to mutate. \code{copy_data()} also
 accepts grouped and rowwise tibbles.}
 
-\item{variable}{Exactly one unquoted target name.}
+\item{variable}{Exactly one unquoted target name, or one nonempty,
+non-missing character string, which is what \code{!!name} unquotes to. An
+empty string, \code{NA}, a character vector of length other than one, a call,
+\code{...}, and a missing argument are errors.}
 
-\item{values}{A value expression or one-sided formula.}
+\item{values}{A value expression or one-sided formula. It may reference a
+column whose name is a string through the mask's \code{.data} pronoun.}
 
 \item{where}{\code{NULL}, a logical expression, valid row positions, or a
 one-sided formula.}
@@ -66,9 +70,23 @@ supported ways to access generated columns.
 them before mutation. \code{copy_data()} accepts them and preserves their class.
 }
 \details{
-\code{variable} must be one unquoted name. Tidy-evaluation injection is supported,
-so \code{gen(data, !!rlang::sym(name), value)} handles a name stored in a string.
-A quoted target is rejected.
+\code{variable} must be one unquoted name or one string. Tidy-evaluation
+injection is supported, so \code{gen(data, !!name, value)} handles a name stored
+in a string. No \code{rlang::inject()} wrapper is needed, because
+\code{rlang::enquo()} already applies quasiquotation. The older
+\code{gen(data, !!rlang::sym(name), value)} is equivalent and still works, but
+\code{rlang::sym()} is not required: unquoting a string yields a character
+scalar, and one nonempty, non-missing string is accepted in the \code{variable}
+position. A literal \code{gen(data, "adjusted", value)} names a column the same
+way. An empty string, \code{NA}, a character vector of length other than one, a
+call such as \code{a + 1}, \code{...}, and a missing argument are errors.
+
+In the \code{values} and \code{where} expressions a runtime name is reached through
+the mask's \code{.data} pronoun instead: \code{values = .data[[name]]} and
+\code{where = !is_missing(.data[[name]])}. Note the asymmetry, which is the
+surprising part: \code{.data[[name]]} works in \code{values} and \code{where} but not in
+the \code{variable} position, because \code{variable} names a target rather than
+reading a column. Use \code{!!name} there.
 
 \code{values} and \code{where} use a data mask built from the dataset before the
 mutation. Columns win over objects in the calling environment; use \code{.env}
@@ -132,16 +150,22 @@ The native path keeps compact rollback bytes until the write commits so an
 interrupt restores the original payload and missing-value cache.
 A metadata proxy first detaches by copying its compact native payload so an
 independent source remains unchanged; it still avoids a full R double copy.
-Ordinary and materialized numeric columns and character columns are patched in their
-existing R representation. Replacing a dictionary-backed string materializes
-that target character column, but does not copy the data frame.
-Dictionary-backed replacement values are validated through a read-only native
-reader, so a successful mutation, error, or interrupt does not populate a
-shared source cache. \code{copy_data()} keeps unmaterialized compact numeric and
-dictionary-string columns compact, and deep-copies dataset attributes such as
-names and grouped-tibble metadata. It rejects columns or attributes containing
-environments, functions, bytecode, external pointers, or weak references
-because those objects cannot be isolated by ordinary R copying.
+Materialized compact numeric columns are validated against their declared
+storage and patched directly in their decoded R buffer. A \code{where} expression
+that is one comparison of a Stata numeric column with a scalar or another
+Stata numeric column is fused with compact-target replacement, avoiding a
+logical selection vector. Other selections keep the general path. Ordinary
+numeric columns and character columns are patched in their existing R
+representation. Replacing a dictionary-backed string materializes that
+target character column, but does not copy the data frame.
+Dictionary-backed replacement values are validated through a read-only
+native reader, so a successful mutation, error, or interrupt does not
+populate a shared source cache. \code{copy_data()} keeps unmaterialized compact
+numeric and dictionary-string columns compact, and deep-copies dataset
+attributes such as names and grouped-tibble metadata. It rejects columns or
+attributes containing environments, functions, bytecode, external pointers,
+or weak references because those objects cannot be isolated by ordinary R
+copying.
 }
 \examples{
 survey <- data.frame(income = c(10, 20), eligible = c(TRUE, FALSE))
@@ -149,6 +173,14 @@ replace_values(survey, income, income * 2, where = eligible)
 gen(survey, adjusted, income + 5)
 independent <- copy_data(survey)
 repl(independent, income, 0)
+
+# A name known only at run time, in each position that accepts one
+target_name <- "adjusted"
+source_name <- "income"
+repl(survey, !!target_name, 0)
+repl(survey, !!rlang::sym(target_name), 1)
+gen(survey, doubled, .data[[source_name]] * 2)
+repl(survey, doubled, 0, where = .data[[source_name]] > 15)
 }
 \references{
 StataCorp, \href{https://www.stata.com/manuals/dgenerate.pdf}{generate manual}.

--- a/r-package/dtatools/man/var_label.Rd
+++ b/r-package/dtatools/man/var_label.Rd
@@ -38,7 +38,8 @@ set_val_labels(.data, ..., .labels = NULL)
 \item{value}{New label metadata. Data-frame replacement forms require a
 named list or \code{NULL}.}
 
-\item{variable}{One unquoted column name.}
+\item{variable}{One unquoted column name, or one nonempty, non-missing
+character string, which is what \code{!!name} unquotes to.}
 
 \item{label}{One variable label, or \code{NULL} to remove it.}
 
@@ -82,8 +83,18 @@ named column updates in \code{...} and a programmatic named list in \code{.label
 They also accept vectors for pipeline use. Unknown, duplicate, unnamed, or
 overlapping column updates fail atomically.
 
-\code{set_var_label()} sets the variable label of one column named without
-quotes, mirroring Stata's \verb{label variable}.
+\code{set_var_label()} sets the variable label of one column, mirroring Stata's
+\verb{label variable}. Its \code{variable} argument follows the same rule as in
+\code{gen()} and \code{replace_values()}: one unquoted name, or one nonempty,
+non-missing string. A name known only at run time therefore needs only the
+tidy-evaluation escape, as in
+\code{set_var_label(data, !!name, "Cluster number")}; no \code{rlang::inject()}
+wrapper is required, and \code{rlang::sym()} is optional, so the older
+\code{!!rlang::sym(name)} spelling remains equivalent. There is no \code{.data}
+pronoun for this argument, because it names a target rather than reading a
+column. \code{set_var_labels()} and \code{set_val_labels()} take a programmatic named
+list through \code{.labels} instead, and \code{keep_vars()}, \code{drop_vars()}, and
+\code{rename_vars()} take \code{tidyselect::all_of()} or \code{.names}.
 
 The data-frame forms of \code{set_var_label()}, \code{set_var_labels()}, and
 \code{set_val_labels()} mutate by reference, as \code{gen()} and \code{replace_values()} do.
@@ -147,4 +158,8 @@ survey <- set_var_labels(
 )
 var_label(survey)
 val_labels(survey$status)
+
+# A column name known only at run time
+stratum_name <- "stratum"
+set_var_label(survey, !!stratum_name, "Sampling stratum")
 }

--- a/r-package/dtatools/tests/testthat/test-mutate-data.R
+++ b/r-package/dtatools/tests/testthat/test-mutate-data.R
@@ -41,10 +41,14 @@ test_that("matrix columns use data-frame row sizes", {
 
 test_that("targets are bare names and support tidy injection", {
     data <- data.frame(x = 1:2)
-    expect_error(replace_values(data, "x", 0), "unquoted")
     expect_error(replace_values(data, , 0), "unquoted")
     expect_error(replace_values(data, unknown, 0), "does not exist")
-    expect_error(gen(data, "new", 0), "unquoted")
+
+    # One string names a column, because `!!name` unquotes to one.
+    expect_silent(replace_values(data, "x", 0L))
+    expect_identical(data$x, c(0L, 0L))
+    expect_silent(gen(data, "quoted", 0))
+    expect_identical(as.double(data$quoted), c(0, 0))
 
     target <- rlang::sym("x")
     expect_silent(replace_values(data, !!target, 4L))

--- a/r-package/dtatools/tests/testthat/test-name-strings.R
+++ b/r-package/dtatools/tests/testthat/test-name-strings.R
@@ -1,0 +1,176 @@
+test_that("a runtime string names the target through `!!`", {
+    data <- data.frame(income = c(10, 20))
+    target_name <- paste0("adj", "usted")
+
+    gen(data, !!target_name, income + 5)
+    expect_identical(names(data), c("income", "adjusted"))
+    expect_equal(as.double(data$adjusted), c(15, 25))
+
+    repl(data, !!target_name, 0)
+    expect_equal(as.double(data$adjusted), c(0, 0))
+
+    replace_values(data, !!target_name, 1, where = income > 15)
+    expect_equal(as.double(data$adjusted), c(0, 1))
+
+    # `rlang::sym()` remains equivalent, and neither form needs `inject()`.
+    repl(data, !!rlang::sym(target_name), 5)
+    expect_equal(as.double(data$adjusted), c(5, 5))
+})
+
+test_that("a string literal names the target", {
+    data <- data.frame(income = c(10, 20))
+    gen(data, "adjusted", income + 5)
+    expect_identical(names(data), c("income", "adjusted"))
+    repl(data, "adjusted", 0)
+    expect_equal(as.double(data$adjusted), c(0, 0))
+})
+
+test_that("an unquoted string reads as a name, not a caller variable", {
+    data <- data.frame(income = c(10, 20), adjusted = c(1, 2))
+    adjusted <- "income"
+
+    repl(data, !!adjusted, 99)
+    expect_equal(as.double(data$income), c(99, 99))
+    expect_equal(as.double(data$adjusted), c(1, 2))
+})
+
+test_that("a column named like the caller variable is not selected", {
+    data <- data.frame(target_name = c(1, 2), income = c(10, 20))
+    target_name <- "income"
+
+    repl(data, !!target_name, 7)
+    expect_equal(as.double(data$income), c(7, 7))
+    expect_equal(as.double(data$target_name), c(1, 2))
+
+    # The unquoted symbol still names the column, not the caller's string.
+    repl(data, target_name, 3)
+    expect_equal(as.double(data$target_name), c(3, 3))
+    expect_equal(as.double(data$income), c(7, 7))
+})
+
+test_that("empty, missing, and non-scalar strings are rejected", {
+    data <- data.frame(income = c(10, 20))
+    the_bad_names <- list(
+        character(), c("income", "income"), NA_character_, ""
+    )
+    for (my_name in the_bad_names) {
+        expect_error(
+            repl(data, !!my_name, 0),
+            "must be one unquoted column name or one nonempty, non-missing"
+        )
+        expect_error(
+            gen(data, !!my_name, 0),
+            "must be one unquoted column name or one nonempty, non-missing"
+        )
+    }
+    expect_identical(names(data), "income")
+})
+
+test_that("a string target keeps the existence checks", {
+    data <- data.frame(income = c(10, 20))
+    expect_error(
+        repl(data, !!"absent", 0), "Column `absent` does not exist"
+    )
+    expect_error(
+        gen(data, !!"income", 0), "Column `income` already exists"
+    )
+})
+
+test_that("invalid non-string targets still error as before", {
+    data <- data.frame(income = c(10, 20))
+    expect_error(replace_values(data, , 0), "unquoted")
+    expect_error(replace_values(data, income + 1, 0), "unquoted")
+    expect_error(replace_values(data, !!1, 0), "unquoted")
+    expect_error(replace_values(data, !!list("income"), 0), "unquoted")
+})
+
+test_that("existing unquoted forms are untouched", {
+    data <- data.frame(income = c(10, 20), eligible = c(TRUE, FALSE))
+    repl(data, income, income * 2, where = eligible)
+    expect_equal(as.double(data$income), c(20, 20))
+
+    gen(data, adjusted, income + 5)
+    expect_equal(as.double(data$adjusted), c(25, 25))
+
+    repl(data, income, ~ income + 1)
+    expect_equal(as.double(data$income), c(21, 21))
+})
+
+test_that("the `.data` pronoun reaches a runtime name in values and where", {
+    data <- data.frame(cluster = c(1, 2), hh1 = c(5, NA))
+    hh1_name <- "hh1"
+
+    repl(data, cluster, .data[[hh1_name]])
+    expect_equal(as.double(data$cluster), c(5, NA))
+
+    repl(data, cluster, 0, where = !is_missing(.data[[hh1_name]]))
+    expect_equal(as.double(data$cluster), c(0, NA))
+
+    gen(data, doubled, .data[[hh1_name]] * 2)
+    expect_equal(as.double(data$doubled), c(10, NA))
+})
+
+test_that("the `.data` pronoun does not name a target", {
+    data <- data.frame(income = c(10, 20))
+    target_name <- "income"
+    expect_error(repl(data, .data[[target_name]], 0), "unquoted")
+})
+
+test_that("the downstream call shapes work without inject or sym", {
+    # Shape one: a resolved runtime name in both the target and the value
+    # source, formerly `inject(repl(data, cluster, !!sym(name)))`.
+    data <- data.frame(cluster = c(1, 2), hh1 = c(5, 6))
+    hh1_name <- resolve_var_name(data, "hh1")
+    target_name <- resolve_var_name(data, "cluster")
+    repl(data, !!target_name, .data[[hh1_name]])
+    expect_equal(as.double(data$cluster), c(5, 6))
+
+    # Shape two: a wrapper relaying an enquo'd argument, formerly
+    # `rlang::inject(gen(data, !!variable, .env$result))`.
+    add_variable <- function(data, variable, result) {
+        variable <- rlang::enquo(variable)
+        gen(data, !!variable, .env$result)
+    }
+    add_variable(data, created, c(7, 8))
+    expect_equal(as.double(data$created), c(7, 8))
+
+    # The same wrapper relaying a string rather than a symbol.
+    add_variable(data, !!"also_created", c(1, 2))
+    expect_equal(as.double(data$also_created), c(1, 2))
+})
+
+test_that("`set_var_label()` accepts a runtime string name", {
+    data <- data.frame(income = c(10, 20))
+    label_target <- "income"
+
+    set_var_label(data, !!label_target, "Income")
+    expect_identical(var_label(data$income), "Income")
+
+    set_var_label(data, !!rlang::sym(label_target), "Older spelling")
+    expect_identical(var_label(data$income), "Older spelling")
+
+    set_var_label(data, income, "Unquoted still works")
+    expect_identical(var_label(data$income), "Unquoted still works")
+
+    expect_error(
+        set_var_label(data, !!NA_character_, "Income"),
+        "must be one unquoted column name or one nonempty, non-missing"
+    )
+    expect_error(
+        set_var_label(data, !!"", "Income"),
+        "must be one unquoted column name or one nonempty, non-missing"
+    )
+})
+
+test_that("a string target leaves a compact column unmaterialized", {
+    data <- data.frame(income = c(10, 20))
+    gen(data, !!"compact", stata_float(income))
+    expect_true(
+        dtatools:::.is_unmaterialized_numeric_altrep(data$compact)
+    )
+    repl(data, !!"compact", 3, where = 2L)
+    expect_true(
+        dtatools:::.is_unmaterialized_numeric_altrep(data$compact)
+    )
+    expect_equal(as.double(data$compact), c(10, 3))
+})


### PR DESCRIPTION
## The problem, narrowed

The brief for this work described `gen()`/`repl()` as unreachable for a name
held in a character string at run time, forcing downstream code into
`rlang::inject()` plus `rlang::sym()`. Probing the unmodified baseline showed
that was too broad. `rlang::enquo()` already applies quasiquotation, so `!!`
works at the call site with no `inject()` wrapper — including in a wrapper
relaying an enquo'd argument — and the `.data` pronoun already reaches a
runtime name in `values` and `where`:

| form | baseline |
|---|---|
| `repl(d, !!sym(target), !!sym(name))` | works |
| `gen(d, !!sym("fresh"), 1)` | works |
| wrapper relaying `gen(d, !!variable, .env$result)`, no `inject()` | works |
| `repl(d, cluster, .data[[name]])` | works |
| `repl(d, cluster, 99, where = !is_missing(.data[[name]]))` | works |
| `repl(d, !!target, !!sym(name))` — bare string | **error** |
| `repl(d, .data[[target]], ...)` | error (correctly) |

So the real gap was one technicality: `.unquoted_variable_name()`
(`R/mutate-data.R`) required `is.symbol(expression)`, and unquoting a character
string yields a character scalar rather than a symbol. The `rlang::sym()`
wrapper existed only to satisfy that check. `rlang::inject()` was never
required for any of these shapes.

## The change

`.unquoted_variable_name()` now accepts one length-one character alongside a
symbol:

```r
.unquoted_variable_name <- function(variable) {
    message <- paste(
        "`variable` must be one unquoted column name or one nonempty,",
        "non-missing string"
    )
    if (rlang::quo_is_missing(variable)) stop(message, call. = FALSE)
    expression <- rlang::quo_get_expr(variable)
    if (is.character(expression)) {
        if (length(expression) != 1L || is.na(expression) ||
            !nzchar(expression)) {
            stop(message, call. = FALSE)
        }
        return(expression)
    }
    if (!is.symbol(expression) || identical(expression, quote(...))) {
        stop(message, call. = FALSE)
    }
    as.character(expression)
}
```

That single seam serves `gen()`, `repl()`, `replace_values()`, and
`set_var_label()`. **No new API surface, no signature change, no new export.**
Empty strings, `NA`, and lengths other than one are rejected; a call, `...`,
and a missing argument error exactly as before.

The ergonomics this buys:

```r
name   <- "wm1"
target <- "cluster"
repl(data, !!target, .data[[name]])
```

### Behaviour change to note

This widens previously *invalid* input: a quoted literal `gen(data, "new", 0)`
now names a column instead of erroring. No currently valid call changes
meaning. Two existing assertions in `test-mutate-data.R` pinned the old error
and are updated to pin the new acceptance.

## What was considered and rejected

- **A dedicated `.name = ` argument.** Built and tested first, then removed.
  Once `!!name` works, `repl(data, !!target, values)` is shorter than
  `repl(data, values = 0, .name = target)`, keeps `values` positional, and
  avoids a second spelling of one capability. `!!` is already this package's
  documented escape, so "avoids requiring rlang literacy" was a weak
  justification. One way to do it wins here.
- **A `.(x)` escape.** `!!` is already the escape; `.()` means `list()` in
  data.table, which this package sits directly on, so the same three characters
  would mean two things in adjacent code; and it would need a `.` call
  special-case in the capture path unreachable through normal evaluation. A
  comment by the capture records this so the next reader does not reach for it.
- **Dispatching on a character literal only.** Not separable from the general
  character case: after quasiquotation, `!!name` and a literal `"name"` produce
  an identical expression, so accepting one accepts the other.

## The `.data` pronoun finding

`R/mutate-data.R`'s mask **already binds `.data`**, and it worked before this
PR with no change: `.eval_in_mutation_data()` sets
`mask$.data <- rlang::as_data_pronoun(columns)` on the environment-columns
branch, and the list branch's `rlang::eval_tidy(data = columns)` gets `.data`
from rlang's own `as_data_mask()`. It was simply undocumented. It is now
documented and tested in both `values` and `where`.

The asymmetry is documented plainly, since it is the surprising part:
`.data[[name]]` reads a column in `values` and `where` but is an error in the
name position, which names a target rather than reading a column. Use `!!name`
there. A test pins that error.

## Downstream call shapes, before and after

```r
# Before
wm1_name   <- resolve_confirm_name("wm1")
wm1_source <- rlang::sym(wm1_name)
rlang::inject(dtatools::repl(data, cluster, !!wm1_source))

# After
wm1_name <- resolve_confirm_name("wm1")
dtatools::repl(data, cluster, .data[[wm1_name]])
```

```r
# Before
variable <- rlang::enquo(variable)
rlang::inject(dtatools::gen(data, !!variable, .env$result))

# After
variable <- rlang::enquo(variable)
dtatools::gen(data, !!variable, .env$result)
```

The second shape needed no package change at all — only dropping the
`inject()` wrapper, which was never necessary. Migrating the call sites is a
separate downstream job.

## Documentation

- `?replace_values` and `?set_var_label` now cover all routes to a runtime
  name, leading with `!!name` and keeping `!!rlang::sym(name)` as the
  equivalent older spelling, plus `@examples` using a runtime name in each
  position that accepts one.
- `README.md` gained a short "Programming with variable names" subsection
  (usage only, no benchmark numbers, per `CONTRIBUTING.md`).

### On `man/` and `NAMESPACE`

`man/` is regenerated with the pinned roxygen2 8.1.0
(`Config/roxygen2/version: 8.1.0`), touching only `replace_values.Rd` and
`var_label.Rd`.

Two things worth flagging:

- **`NAMESPACE` is not roxygen-generated in this package.** It has no
  `# Generated by roxygen2` header, and `roxygenise()` explicitly skips it
  ("It already exists and was not generated by roxygen2"), as it also skips the
  hand-written `read_dta.Rd` and `recode.Rd`. So `NAMESPACE` is hand-maintained
  here. This change adds no export, so it is untouched either way.
- **Regeneration surfaced pre-existing `man/` drift unrelated to this PR**, and
  it is deliberately left out: four functions on `perf-tibble` have no Rd file
  at all (`order_vars`, `rename_vars`, `reorder_stata_rows`,
  `slice_stata_rows`), and `dta_merge.Rd` reflows from roxygen edits made
  without regenerating. Both belong in their own commit, not this one.

## Validation

Full suite, `testthat::test_local()`:

| | passing | failing |
|---|---|---|
| `perf-tibble` baseline (measured) | 6243 | 0 |
| `perf-gen-strings` | 6291 | 0 |

`tests/testthat/test-name-strings.R` asserts unmaterialized compact ALTREP
state with `dtatools:::.is_unmaterialized_numeric_altrep` before any content
comparison.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Mutation and data-generation functions now accept column names supplied as character strings or runtime expressions.
  - Variable labels can be assigned using dynamically resolved column names.
  - Runtime names are supported in relevant value and row-selection expressions, including `.data[[...]]` usage where applicable.
  - Improved validation provides clearer handling of missing, empty, invalid, or unknown column names.

- **Documentation**
  - Added guidance and examples for programming with variable names and quasiquotation across supported functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->