### PR TITLE
Accept the (data, variable) shape in the label functions

### DIFF
--- a/r-package/dtatools/R/labels.R
+++ b/r-package/dtatools/R/labels.R
@@ -8,11 +8,19 @@
 #' and unrelated attributes.
 #'
 #' @section Getter results:
-#' For a vector, `var_label()` returns one character value or `NULL`, and
-#' `val_labels()` returns a named numeric vector or `NULL`. For a data frame,
-#' each returns a named list with one element per column, including `NULL`
-#' entries. `dataset_label()` accepts only a data frame or tibble and returns
-#' one character value or `NULL`.
+#' `var_label(data, variable)` returns one column's character label or
+#' `NULL`, and `val_labels(data, variable)` returns its named numeric
+#' vector or `NULL`. The `variable` argument follows the same rule as in
+#' `gen()` and `replace_values()`, so `var_label(data, hh1)`,
+#' `var_label(data, "hh1")`, `var_label(data, !!name)`, and
+#' `var_label(data, .(name))` are equivalent. Asking for a column that
+#' does not exist is an error.
+#'
+#' Without `variable`: for a vector, `var_label()` returns one character
+#' value or `NULL`, and `val_labels()` returns a named numeric vector or
+#' `NULL`. For a data frame, each returns a named list with one element
+#' per column, including `NULL` entries. `dataset_label()` accepts only a
+#' data frame or tibble and returns one character value or `NULL`.
 #'
 #' @section Setting labels:
 #' Replacement functions modify the supplied metadata. On a data frame,
@@ -31,9 +39,23 @@
 #' wrapper is required, and `rlang::sym()` is optional, so the older
 #' `!!rlang::sym(name)` spelling remains equivalent. There is no `.data`
 #' pronoun for this argument, because it names a target rather than reading a
-#' column. `set_var_labels()` and `set_val_labels()` take a programmatic named
+#' column. On a bare vector, `set_var_label(x, label)` sets the vector's
+#' label, as the non-data-frame branch of `set_var_labels()` does.
+#' `set_var_labels()` and `set_val_labels()` take a programmatic named
 #' list through `.labels` instead, and `keep_vars()`, `drop_vars()`, and
 #' `rename_vars()` take `tidyselect::all_of()` or `.names`.
+#'
+#' `set_var_labels(data, variable, label)` and
+#' `set_val_labels(data, variable, labels)` also accept the positional
+#' shape of `gen()` and `replace_values()`. It is recognized only when
+#' `.labels` is `NULL`, `.data` is a data frame, and `...` holds exactly
+#' two untagged arguments whose first is syntactically a name: a bare
+#' symbol, one string literal, `.(name)`, or `!!name`, which unquotes to
+#' a string literal at capture. The symbol is taken as the column name
+#' literally, never resolved against caller variables, and the second
+#' argument is evaluated in the caller's environment as that column's
+#' new metadata. A first argument that is any other expression, and
+#' every tagged call, keeps today's path and today's errors.
 #'
 #' The data-frame forms of `set_var_label()`, `set_var_labels()`, and
 #' `set_val_labels()` mutate by reference, as `gen()` and `replace_values()` do.
@@ -90,8 +112,11 @@
 #' @param .labels A programmatic label value for a vector, or a named list of
 #'   column updates for a data frame.
 #' @param variable One unquoted column name, or one nonempty, non-missing
-#'   character string, which is what `!!name` unquotes to.
-#' @param label One variable label, or `NULL` to remove it.
+#'   character string, which is what `!!name` unquotes to. Optional in
+#'   `var_label()` and `val_labels()`: when supplied, `x` must be a data
+#'   frame and only that column's metadata is returned.
+#' @param label One variable label, or `NULL` to remove it. In the vector
+#'   shape `set_var_label(x, label)` the label is the second argument.
 #' @return Getters return the metadata described above. Replacement functions
 #'   and `set_*()` functions return the updated vector or data frame. Data-frame
 #'   `set_*()` forms return it invisibly because they already mutated it by
@@ -108,15 +133,28 @@
 #'     status = "Interview status",
 #'     .labels = list(stratum = "Sampling stratum")
 #' )
+#' # One column at a time, in the (data, variable) shape of gen()
+#' var_label(survey, status)
+#' val_labels(survey, status)
+#' set_var_label(survey, status, "Interview status")
+#' set_val_labels(survey, status, c(Complete = 1, Refused = 2))
+#' set_var_labels(survey, stratum, "Sampling stratum")
+#'
 #' var_label(survey)
 #' val_labels(survey$status)
 #'
 #' # A column name known only at run time
 #' stratum_name <- "stratum"
 #' set_var_label(survey, !!stratum_name, "Sampling stratum")
+#' var_label(survey, !!stratum_name)
 #' @export
-var_label <- function(x) {
+var_label <- function(x, variable) {
     .validate_label_object(x)
+    variable <- rlang::enquo(variable)
+    if (!rlang::quo_is_missing(variable)) {
+        column <- .label_lookup_column(x, variable)
+        return(attr(column, "label", exact = TRUE))
+    }
     if (is.data.frame(x)) {
         return(stats::setNames(
             lapply(x, attr, which = "label", exact = TRUE),
@@ -129,8 +167,13 @@ var_label <- function(x) {
 
 #' @rdname var_label
 #' @export
-val_labels <- function(x) {
+val_labels <- function(x, variable) {
     .validate_label_object(x)
+    variable <- rlang::enquo(variable)
+    if (!rlang::quo_is_missing(variable)) {
+        column <- .label_lookup_column(x, variable)
+        return(attr(column, "labels", exact = TRUE))
+    }
     if (is.data.frame(x)) {
         return(stats::setNames(
             lapply(x, attr, which = "labels", exact = TRUE),
@@ -139,6 +182,23 @@ val_labels <- function(x) {
     }
 
     attr(x, "labels", exact = TRUE)
+}
+
+# `var_label(data, variable)` and `val_labels(data, variable)` read one
+# column's metadata. The name follows the same rule as in `gen()`: one
+# unquoted name, one string, `!!name`, or `.(name)`. A symbol is taken
+# as the column name literally, never resolved against caller variables.
+.label_lookup_column <- function(x, variable) {
+    if (!is.data.frame(x)) {
+        stop("`x` must be a data frame when `variable` is supplied",
+             call. = FALSE)
+    }
+    name <- .unquoted_variable_name(variable)
+    location <- match(name, names(x))
+    if (is.na(location)) {
+        stop(sprintf("Column `%s` does not exist", name), call. = FALSE)
+    }
+    x[[location]]
 }
 
 #' @rdname var_label
@@ -552,6 +612,12 @@ dataset_label <- function(data) {
 #' @export
 set_var_label <- function(data, variable, label) {
     if (!is.data.frame(data)) {
+        # `set_var_label(x, label)`: the vector shape, mirroring the
+        # non-data-frame branch of `set_var_labels()`. Any other
+        # non-data-frame call keeps its existing error.
+        if (!missing(variable) && missing(label)) {
+            return(`var_label<-`(data, variable))
+        }
         stop("`data` must be a data frame", call. = FALSE)
     }
     .reject_data_table_subclass(data)
@@ -565,8 +631,6 @@ set_var_label <- function(data, variable, label) {
     .apply_variable_label_updates(access, updates)
 }
 
-#' @rdname var_label
-#' @export
 .is_runtime_name_tag <- function(argument) {
     is.call(argument) && length(argument) == 3L &&
         identical(argument[[1L]], quote(`:=`)) &&
@@ -608,15 +672,64 @@ set_var_label <- function(data, variable, label) {
     eval(call, environment)
 }
 
+# `!!name` before rlang's quasiquotation runs: the parsed call
+# `!(!name)`. `rlang::enquos()` unquotes it to a string literal at
+# capture, which is why it counts as syntactically a name below.
+.is_double_bang_call <- function(expression) {
+    is.call(expression) && length(expression) == 2L &&
+        identical(expression[[1L]], quote(`!`)) &&
+        is.call(expression[[2L]]) && length(expression[[2L]]) == 2L &&
+        identical(expression[[2L]][[1L]], quote(`!`))
+}
+
+# `set_var_labels(data, variable, label)` and
+# `set_val_labels(data, variable, labels)`: the positional shape that
+# mirrors `gen(data, variable, ...)`. It is recognized on the defused
+# dots, before anything is evaluated, and only when `.labels` is NULL,
+# `.data` is a data frame, and `...` is exactly two untagged, nonempty
+# arguments whose first is syntactically a name: a bare symbol, one
+# string literal, `.(name)`, or `!!name`. Any other first argument
+# falls through to the existing path and its existing errors, and a
+# symbol is taken as the column name literally, never resolved against
+# caller variables. No call that succeeds today matches: two untagged
+# dots on a data frame have always been an error, because column
+# updates in `...` must be named.
+.is_positional_label_dots <- function(quoted) {
+    if (length(quoted) != 2L) return(FALSE)
+    tags <- names(quoted)
+    if (!is.null(tags) && any(nzchar(tags))) return(FALSE)
+    if (identical(quoted[[1L]], quote(expr = )) ||
+        identical(quoted[[2L]], quote(expr = ))) {
+        return(FALSE)
+    }
+    first <- quoted[[1L]]
+    is.symbol(first) ||
+        (is.character(first) && length(first) == 1L) ||
+        .is_runtime_name_call(first) ||
+        .is_double_bang_call(first)
+}
+
+#' @rdname var_label
+#' @export
 set_var_labels <- function(.data, ..., .labels = NULL) {
-    dots <- .dots_list_with_runtime_names(
-        substitute(...()), parent.frame(),
-        function() {
-            rlang::dots_list(
-                ..., .homonyms = "keep", .ignore_empty = "none"
-            )
-        }
-    )
+    quoted <- substitute(...())
+    dots <- if (is.data.frame(.data) && is.null(.labels) &&
+        .is_positional_label_dots(quoted)) {
+        pair <- rlang::enquos(...)
+        stats::setNames(
+            list(rlang::eval_tidy(pair[[2L]])),
+            .unquoted_variable_name(pair[[1L]])
+        )
+    } else {
+        .dots_list_with_runtime_names(
+            quoted, parent.frame(),
+            function() {
+                rlang::dots_list(
+                    ..., .homonyms = "keep", .ignore_empty = "none"
+                )
+            }
+        )
+    }
     if (!is.data.frame(.data)) {
         if (!is.null(.labels) && length(dots) > 0L) {
             stop("Supply a vector label in either `...` or `.labels`, not both",
@@ -650,14 +763,24 @@ set_var_labels <- function(.data, ..., .labels = NULL) {
 #' @rdname var_label
 #' @export
 set_val_labels <- function(.data, ..., .labels = NULL) {
-    dots <- .dots_list_with_runtime_names(
-        substitute(...()), parent.frame(),
-        function() {
-            rlang::dots_list(
-                ..., .homonyms = "keep", .ignore_empty = "none"
-            )
-        }
-    )
+    quoted <- substitute(...())
+    dots <- if (is.data.frame(.data) && is.null(.labels) &&
+        .is_positional_label_dots(quoted)) {
+        pair <- rlang::enquos(...)
+        stats::setNames(
+            list(rlang::eval_tidy(pair[[2L]])),
+            .unquoted_variable_name(pair[[1L]])
+        )
+    } else {
+        .dots_list_with_runtime_names(
+            quoted, parent.frame(),
+            function() {
+                rlang::dots_list(
+                    ..., .homonyms = "keep", .ignore_empty = "none"
+                )
+            }
+        )
+    }
     if (!is.data.frame(.data)) {
         if (!is.null(.labels) && length(dots) > 0L) {
             stop(

--- a/r-package/dtatools/man/var_label.Rd
+++ b/r-package/dtatools/man/var_label.Rd
@@ -12,9 +12,9 @@
 \alias{set_val_labels}
 \title{Get and set Stata label metadata}
 \usage{
-var_label(x)
+var_label(x, variable)
 
-val_labels(x)
+val_labels(x, variable)
 
 dataset_label(data)
 
@@ -33,15 +33,18 @@ set_val_labels(.data, ..., .labels = NULL)
 \arguments{
 \item{x}{A vector or data frame.}
 
+\item{variable}{One unquoted column name, or one nonempty, non-missing
+character string, which is what \code{!!name} unquotes to. Optional in
+\code{var_label()} and \code{val_labels()}: when supplied, \code{x} must be a data
+frame and only that column's metadata is returned.}
+
 \item{data}{A data frame or tibble.}
 
 \item{value}{New label metadata. Data-frame replacement forms require a
 named list or \code{NULL}.}
 
-\item{variable}{One unquoted column name, or one nonempty, non-missing
-character string, which is what \code{!!name} unquotes to.}
-
-\item{label}{One variable label, or \code{NULL} to remove it.}
+\item{label}{One variable label, or \code{NULL} to remove it. In the vector
+shape \code{set_var_label(x, label)} the label is the second argument.}
 
 \item{.data}{A vector or data frame to update.}
 
@@ -67,11 +70,19 @@ and unrelated attributes.
 }
 \section{Getter results}{
 
-For a vector, \code{var_label()} returns one character value or \code{NULL}, and
-\code{val_labels()} returns a named numeric vector or \code{NULL}. For a data frame,
-each returns a named list with one element per column, including \code{NULL}
-entries. \code{dataset_label()} accepts only a data frame or tibble and returns
-one character value or \code{NULL}.
+\code{var_label(data, variable)} returns one column's character label or
+\code{NULL}, and \code{val_labels(data, variable)} returns its named numeric
+vector or \code{NULL}. The \code{variable} argument follows the same rule as in
+\code{gen()} and \code{replace_values()}, so \code{var_label(data, hh1)},
+\code{var_label(data, "hh1")}, \code{var_label(data, !!name)}, and
+\code{var_label(data, .(name))} are equivalent. Asking for a column that
+does not exist is an error.
+
+Without \code{variable}: for a vector, \code{var_label()} returns one character
+value or \code{NULL}, and \code{val_labels()} returns a named numeric vector or
+\code{NULL}. For a data frame, each returns a named list with one element
+per column, including \code{NULL} entries. \code{dataset_label()} accepts only a
+data frame or tibble and returns one character value or \code{NULL}.
 }
 
 \section{Setting labels}{
@@ -92,9 +103,23 @@ tidy-evaluation escape, as in
 wrapper is required, and \code{rlang::sym()} is optional, so the older
 \code{!!rlang::sym(name)} spelling remains equivalent. There is no \code{.data}
 pronoun for this argument, because it names a target rather than reading a
-column. \code{set_var_labels()} and \code{set_val_labels()} take a programmatic named
+column. On a bare vector, \code{set_var_label(x, label)} sets the vector's
+label, as the non-data-frame branch of \code{set_var_labels()} does.
+\code{set_var_labels()} and \code{set_val_labels()} take a programmatic named
 list through \code{.labels} instead, and \code{keep_vars()}, \code{drop_vars()}, and
 \code{rename_vars()} take \code{tidyselect::all_of()} or \code{.names}.
+
+\code{set_var_labels(data, variable, label)} and
+\code{set_val_labels(data, variable, labels)} also accept the positional
+shape of \code{gen()} and \code{replace_values()}. It is recognized only when
+\code{.labels} is \code{NULL}, \code{.data} is a data frame, and \code{...} holds exactly
+two untagged arguments whose first is syntactically a name: a bare
+symbol, one string literal, \code{.(name)}, or \code{!!name}, which unquotes to
+a string literal at capture. The symbol is taken as the column name
+literally, never resolved against caller variables, and the second
+argument is evaluated in the caller's environment as that column's
+new metadata. A first argument that is any other expression, and
+every tagged call, keeps today's path and today's errors.
 
 The data-frame forms of \code{set_var_label()}, \code{set_var_labels()}, and
 \code{set_val_labels()} mutate by reference, as \code{gen()} and \code{replace_values()} do.
@@ -156,10 +181,18 @@ survey <- set_var_labels(
     status = "Interview status",
     .labels = list(stratum = "Sampling stratum")
 )
+# One column at a time, in the (data, variable) shape of gen()
+var_label(survey, status)
+val_labels(survey, status)
+set_var_label(survey, status, "Interview status")
+set_val_labels(survey, status, c(Complete = 1, Refused = 2))
+set_var_labels(survey, stratum, "Sampling stratum")
+
 var_label(survey)
 val_labels(survey$status)
 
 # A column name known only at run time
 stratum_name <- "stratum"
 set_var_label(survey, !!stratum_name, "Sampling stratum")
+var_label(survey, !!stratum_name)
 }

--- a/r-package/dtatools/tests/testthat/test-label-dual-shape.R
+++ b/r-package/dtatools/tests/testthat/test-label-dual-shape.R
@@ -1,0 +1,216 @@
+test_that("the accessors keep their vector and whole-data-frame shapes", {
+    status <- c(1, 2, 1)
+    var_label(status) <- "Interview status"
+    val_labels(status) <- c(Complete = 1, Refused = 2)
+
+    expect_identical(var_label(status), "Interview status")
+    expect_identical(val_labels(status), c(Complete = 1, Refused = 2))
+
+    survey <- data.frame(status = status, stratum = c(1, 1, 2))
+    expect_identical(
+        var_label(survey),
+        list(status = "Interview status", stratum = NULL)
+    )
+    expect_identical(
+        val_labels(survey),
+        list(status = c(Complete = 1, Refused = 2), stratum = NULL)
+    )
+})
+
+test_that("the accessors read one column in the (data, variable) shape", {
+    status <- c(1, 2, 1)
+    var_label(status) <- "Interview status"
+    val_labels(status) <- c(Complete = 1, Refused = 2)
+    survey <- data.frame(status = status, stratum = c(1, 1, 2))
+    status_name <- paste0("sta", "tus")
+
+    expect_identical(var_label(survey, status), "Interview status")
+    expect_identical(var_label(survey, "status"), "Interview status")
+    expect_identical(var_label(survey, !!status_name), "Interview status")
+    expect_identical(var_label(survey, .(status_name)), "Interview status")
+    expect_null(var_label(survey, stratum))
+
+    codes <- c(Complete = 1, Refused = 2)
+    expect_identical(val_labels(survey, status), codes)
+    expect_identical(val_labels(survey, "status"), codes)
+    expect_identical(val_labels(survey, !!status_name), codes)
+    expect_identical(val_labels(survey, .(status_name)), codes)
+    expect_null(val_labels(survey, stratum))
+})
+
+test_that("a symbol names the column literally, not a caller variable", {
+    survey <- data.frame(status = c(1, 2), stratum = c(1, 1))
+    var_label(survey) <- list(status = "Interview status")
+    status <- "stratum"
+
+    expect_identical(var_label(survey, status), "Interview status")
+    expect_null(var_label(survey, !!status))
+})
+
+test_that("asking for an absent column names it in the error", {
+    survey <- data.frame(status = c(1, 2))
+    expect_error(
+        var_label(survey, absent), "Column `absent` does not exist"
+    )
+    expect_error(
+        val_labels(survey, "absent"), "Column `absent` does not exist"
+    )
+})
+
+test_that("a variable argument requires a data frame", {
+    status <- c(1, 2, 1)
+    expect_error(
+        var_label(status, status),
+        "must be a data frame when `variable` is supplied"
+    )
+    expect_error(
+        val_labels(status, status),
+        "must be a data frame when `variable` is supplied"
+    )
+})
+
+test_that("set_var_label accepts a bare vector and a label", {
+    status <- c(1, 2, 1)
+    status <- set_var_label(status, "Interview status")
+    expect_identical(var_label(status), "Interview status")
+
+    status <- set_var_label(status, NULL)
+    expect_null(var_label(status))
+})
+
+test_that("set_var_label still rejects other non-data-frame calls", {
+    status <- c(1, 2, 1)
+    expect_error(set_var_label(status), "`data` must be a data frame")
+    expect_error(
+        set_var_label(status, status, "Interview status"),
+        "`data` must be a data frame"
+    )
+})
+
+test_that("set_var_labels accepts the positional (data, variable) shape", {
+    survey <- data.frame(status = c(1, 2), stratum = c(1, 1))
+    status_name <- paste0("sta", "tus")
+
+    set_var_labels(survey, status, "Interview status")
+    expect_identical(var_label(survey, status), "Interview status")
+    set_var_labels(survey, "status", "By string")
+    expect_identical(var_label(survey, status), "By string")
+    set_var_labels(survey, !!status_name, "By bang bang")
+    expect_identical(var_label(survey, status), "By bang bang")
+    set_var_labels(survey, .(status_name), "By dot call")
+    expect_identical(var_label(survey, status), "By dot call")
+
+    expect_null(var_label(survey, stratum))
+})
+
+test_that("set_val_labels accepts the positional (data, variable) shape", {
+    survey <- data.frame(status = c(1, 2), stratum = c(1, 1))
+    status_name <- paste0("sta", "tus")
+    codes <- c(yes = 1, no = 2)
+
+    set_val_labels(survey, status, codes)
+    expect_identical(val_labels(survey, status), codes)
+    set_val_labels(survey, "status", c(maybe = 3))
+    expect_identical(val_labels(survey, status), c(maybe = 3))
+
+    # The exact call from issue #133.
+    set_val_labels(survey, !!status_name, c(yes = 1))
+    expect_identical(val_labels(survey, status), c(yes = 1))
+
+    set_val_labels(survey, .(status_name), codes)
+    expect_identical(val_labels(survey, status), codes)
+
+    expect_null(val_labels(survey, stratum))
+})
+
+test_that("the positional labels argument evaluates in the caller", {
+    survey <- data.frame(status = c(1, 2))
+    status <- c(yes = 1, no = 2)
+
+    # `status` on the right is the caller's vector, not the column.
+    set_val_labels(survey, status, status)
+    expect_identical(val_labels(survey, status), c(yes = 1, no = 2))
+})
+
+test_that("every pre-existing setter convention still works", {
+    survey <- data.frame(status = c(1, 2), stratum = c(1, 1))
+    stratum_name <- "stratum"
+
+    # Tagged dots.
+    set_var_labels(survey, status = "Interview status")
+    expect_identical(var_label(survey, status), "Interview status")
+    set_val_labels(survey, status = c(yes = 1))
+    expect_identical(val_labels(survey, status), c(yes = 1))
+
+    # `!!name :=` and `.(name) :=` tags.
+    set_var_labels(survey, !!stratum_name := "Sampling stratum")
+    expect_identical(var_label(survey, stratum), "Sampling stratum")
+    set_var_labels(survey, .(stratum_name) := "Stratum again")
+    expect_identical(var_label(survey, stratum), "Stratum again")
+    set_val_labels(survey, !!stratum_name := c(urban = 1))
+    expect_identical(val_labels(survey, stratum), c(urban = 1))
+    set_val_labels(survey, .(stratum_name) := c(rural = 2))
+    expect_identical(val_labels(survey, stratum), c(rural = 2))
+
+    # `.labels`, alone and combined with tagged dots.
+    set_var_labels(survey, .labels = list(status = "From .labels"))
+    expect_identical(var_label(survey, status), "From .labels")
+    set_var_labels(
+        survey, status = "Tagged",
+        .labels = list(stratum = "Listed")
+    )
+    expect_identical(var_label(survey, status), "Tagged")
+    expect_identical(var_label(survey, stratum), "Listed")
+    set_val_labels(survey, .labels = list(status = c(no = 2)))
+    expect_identical(val_labels(survey, status), c(no = 2))
+
+    # The vector branch.
+    status <- c(1, 2)
+    status <- set_var_labels(status, "Vector label")
+    expect_identical(var_label(status), "Vector label")
+    status <- set_val_labels(status, yes = 1, no = 2)
+    expect_identical(val_labels(status), c(yes = 1, no = 2))
+})
+
+test_that("dots forwarded from a wrapper keep the tagged path", {
+    survey <- data.frame(status = c(1, 2))
+    label_through_wrapper <- function(data, ...) {
+        set_var_labels(data, ...)
+    }
+    label_through_wrapper(survey, status = "Forwarded")
+    expect_identical(var_label(survey, status), "Forwarded")
+})
+
+test_that("dots forwarded from a wrapper keep the positional shape", {
+    survey <- data.frame(status = c(1, 2))
+    codes_through_wrapper <- function(data, ...) {
+        set_val_labels(data, ...)
+    }
+    codes_through_wrapper(survey, "status", c(yes = 1))
+    expect_identical(val_labels(survey, status), c(yes = 1))
+})
+
+test_that("a computed first argument still errors as before", {
+    survey <- data.frame(status = c(1, 2))
+    expect_error(
+        set_val_labels(survey, paste0("sta", "tus"), c(yes = 1)),
+        "must have one non-empty name per update"
+    )
+    expect_error(
+        set_var_labels(survey, paste0("sta", "tus"), "Interview status"),
+        "must have one non-empty name per update"
+    )
+    expect_null(val_labels(survey, status))
+    expect_null(var_label(survey, status))
+})
+
+test_that("the positional shape validates the column and the labels", {
+    survey <- data.frame(status = c(1, 2))
+    expect_error(
+        set_var_labels(survey, absent, "Nope"), "Unknown column: absent"
+    )
+    expect_error(
+        set_val_labels(survey, status, c(1, 2)),
+        "must name every value-label code"
+    )
+})


### PR DESCRIPTION
Stacks on #130 and should merge after it (base: `perf-gen-strings`).

`gen(data, variable, ...)` and `repl(data, variable, ...)` teach that the first argument is the dataset and the second names the column. This PR makes that shape work across the four label functions, including the `set_val_labels(d, !!nm, c(yes = 1))` call from #133.

## What each function now accepts

- **`var_label(x, variable)` / `val_labels(x, variable)`** — optional second argument naming one column of a data frame; returns that column's label / labels vector. The name follows the `gen()` rule: bare symbol, string literal, `!!name`, or `.(name)`. An absent column errors with ``Column `x` does not exist``. Without `variable`, the vector and whole-data-frame forms are byte-identical to before.
- **`set_var_label(data, variable, label)`** — unchanged; additionally, `set_var_label(x, label)` on a bare vector sets the vector's label, mirroring `set_var_labels()`' non-data-frame branch.
- **`set_var_labels(data, variable, label)` / `set_val_labels(data, variable, labels)`** — new positional three-argument shape alongside the existing tagged-dots interface. The second argument (the labels value) is evaluated in the caller's environment.

## Precedence rule

The positional shape is recognized on the *defused* dots, before any evaluation, and only when all of these hold: `.labels` is `NULL`, `.data` is a data frame, and `...` is exactly two untagged, nonempty arguments whose first is syntactically a name — a bare symbol, one string literal, a `.()` call, or `!!name` (which unquotes to a string literal at capture). A symbol is taken as the column name literally, never resolved against caller variables. A first dot that is any other expression (e.g. `paste0("sta", "tus")`), and every tagged call, falls through to today's path and today's errors.

## No existing call changes meaning

Every call that succeeds today takes the existing code path unchanged: tagged dots, `!!nm := L`, `.(nm) := L`, `.labels = list(...)`, the vector branches, forwarded dots from a wrapper, and combinations. This is safe by construction — two untagged dots on a data frame have always been an error (column updates in `...` must be named), verified by probing before implementing (bare symbol → object-not-found; string/expression → "must have one non-empty name per update"; `!!nm` → "Can't use `!!` in a non-quoting function"; `.(nm)` → "could not find function `.`").

Also fixes a doc misplacement from the base branch: the `@rdname var_label` tag had landed on the internal `.is_runtime_name_tag` helper instead of `set_var_labels`, which would have corrupted the regenerated Rd page.

Docs: roxygen updated and `man/var_label.Rd` regenerated with roxygen2 8.1.0; only that page regenerated. `NAMESPACE`, `man/read_dta.Rd`, and `man/recode.Rd` are hand-maintained and untouched.

## Tests

`tests/testthat/test-label-dual-shape.R` pins both shapes of all four functions, the precedence rule, and every pre-existing convention.

Before: `[ FAIL 0 | WARN 0 | SKIP 0 | PASS 6291 ]`
After: `[ FAIL 0 | WARN 0 | SKIP 0 | PASS 6346 ]`