### PR TITLE
Read a run-time column name with .(name)

### DIFF
--- a/r-package/dtatools/DESCRIPTION
+++ b/r-package/dtatools/DESCRIPTION
@@ -18,7 +18,7 @@ Depends: R (>= 4.5.0)
 Imports:
     dplyr (>= 1.1.0),
     readr (>= 2.2.0),
-    rlang,
+    rlang (>= 1.0.0),
     stats,
     tibble,
     tidyselect,

--- a/r-package/dtatools/R/labels.R
+++ b/r-package/dtatools/R/labels.R
@@ -641,23 +641,10 @@ set_var_label <- function(data, variable, label) {
         .is_runtime_name_call(argument[[2L]])
 }
 
-# The `!!!x` splice spelling parses as three nested `!` calls. Returns the
-# spliced operand, or NULL when the expression is not a splice.
-.splice_operand <- function(expression) {
-    bang <- function(e) {
-        is.call(e) && length(e) == 2L && identical(e[[1L]], quote(`!`))
-    }
-    if (!bang(expression) || !bang(expression[[2L]]) ||
-        !bang(expression[[2L]][[2L]])) {
-        return(NULL)
-    }
-    expression[[2L]][[2L]][[2L]]
-}
-
 # `.(name) := value` in the plural setters. rlang rejects a call on the
 # left of `:=` before it evaluates anything, so the tags are resolved here
 # first: each `.()` left-hand side becomes an ordinary argument name, then
-# `rlang::dots_list()` runs on the rewritten call and keeps its own
+# `rlang::dots_list()` runs on the rewritten argument and keeps its own
 # handling of `!!!`, `:=`, homonyms and empty arguments unchanged.
 #
 # Dots forwarded from an enclosing function belong to that function's
@@ -665,11 +652,11 @@ set_var_label <- function(data, variable, label) {
 # environment cannot be right for every argument. `rlang::enquos0()`
 # captures each dot's own expression and environment without injection
 # processing, which also lets a `.()` call survive on the left of `:=`.
-# Every argument is evaluated in its own environment here and enters the
-# rebuilt call as a bound value; `!!!x` keeps its splice spelling around
-# the bound operand so `rlang::dots_list()` still splices it.
-.dots_list_with_runtime_names <- function(quoted, environment, plain,
-                                          quosures) {
+# Each argument is then handed to its own `rlang::dots_list()` call,
+# evaluated in its own frame, so `!!!` and `:=` inside it behave exactly
+# as they do on the ordinary path. `.homonyms = "keep"` makes the
+# per-argument results concatenate without loss.
+.dots_list_with_runtime_names <- function(quoted, plain, quosures) {
     if (!any(vapply(as.list(quoted), .is_runtime_name_tag, logical(1L)))) {
         # No `.()` tag, so nothing needs rewriting. Taking the ordinary
         # path here keeps every existing call byte-identical in behavior,
@@ -680,43 +667,28 @@ set_var_label <- function(data, variable, label) {
     quosures <- quosures()
     labels <- names(quosures)
     if (is.null(labels)) labels <- rep("", length(quosures))
-    bindings <- new.env(parent = environment)
-    arguments <- vector("list", length(quosures))
+    pieces <- vector("list", length(quosures))
     for (index in seq_along(quosures)) {
         quosure <- quosures[[index]]
         if (rlang::quo_is_missing(quosure)) {
-            arguments[[index]] <- quote(expr = )
-            next
+            stop(sprintf("Argument %d can't be empty.", index), call. = FALSE)
         }
         expression <- rlang::quo_get_expr(quosure)
         frame <- rlang::quo_get_env(quosure)
-        name <- sprintf(".dtatools_dot_%d", index)
-        symbol <- as.name(name)
-        splice <- .splice_operand(expression)
+        label <- labels[[index]]
         if (.is_runtime_name_tag(expression)) {
-            labels[[index]] <- .runtime_name_call_value(
-                expression[[2L]], frame
-            )
-            assign(name, eval(expression[[3L]], frame), envir = bindings)
-            arguments[[index]] <- symbol
-        } else if (!is.null(splice)) {
-            assign(name, eval(splice, frame), envir = bindings)
-            arguments[[index]] <- call("!", call("!", call("!", symbol)))
-        } else if (is.call(expression) && length(expression) == 3L &&
-                   identical(expression[[1L]], quote(`:=`))) {
-            assign(name, eval(expression[[3L]], frame), envir = bindings)
-            arguments[[index]] <- call(":=", expression[[2L]], symbol)
-        } else {
-            assign(name, eval(expression, frame), envir = bindings)
-            arguments[[index]] <- symbol
+            label <- .runtime_name_call_value(expression[[2L]], frame)
+            expression <- expression[[3L]]
         }
+        # The function object heads the call, because a constant's
+        # quosure carries the empty environment, where `::` is unbound.
+        call <- as.call(c(
+            list(rlang::dots_list), stats::setNames(list(expression), label),
+            list(.homonyms = "keep", .ignore_empty = "none")
+        ))
+        pieces[[index]] <- eval(call, frame)
     }
-    names(arguments) <- labels
-    call <- as.call(c(
-        quote(rlang::dots_list), arguments,
-        list(.homonyms = "keep", .ignore_empty = "none")
-    ))
-    eval(call, bindings)
+    do.call(c, pieces)
 }
 
 # `!!name` before rlang's quasiquotation runs: the parsed call
@@ -769,7 +741,7 @@ set_var_labels <- function(.data, ..., .labels = NULL) {
         )
     } else {
         .dots_list_with_runtime_names(
-            quoted, parent.frame(),
+            quoted,
             function() {
                 rlang::dots_list(
                     ..., .homonyms = "keep", .ignore_empty = "none"
@@ -821,7 +793,7 @@ set_val_labels <- function(.data, ..., .labels = NULL) {
         )
     } else {
         .dots_list_with_runtime_names(
-            quoted, parent.frame(),
+            quoted,
             function() {
                 rlang::dots_list(
                     ..., .homonyms = "keep", .ignore_empty = "none"

--- a/r-package/dtatools/R/labels.R
+++ b/r-package/dtatools/R/labels.R
@@ -29,10 +29,12 @@
 #' tidy-evaluation escape, as in
 #' `set_var_label(data, !!name, "Cluster number")`; no `rlang::inject()`
 #' wrapper is required, and `rlang::sym()` is optional, so the older
-#' `!!rlang::sym(name)` spelling remains equivalent. There is no `.data`
-#' pronoun for this argument, because it names a target rather than reading a
-#' column. `set_var_labels()` and `set_val_labels()` take a programmatic named
-#' list through `.labels` instead, and `keep_vars()`, `drop_vars()`, and
+#' `!!rlang::sym(name)` spelling remains equivalent. A `.(name)` call reaches
+#' the same place: `set_var_label(data, .(name), "Cluster number")`. There is
+#' no `.data` pronoun for this argument, because it names a target rather
+#' than reading a column. `set_var_labels()` and `set_val_labels()` name a
+#' runtime column with a `.(name) := value` tag in `...` or a programmatic
+#' named list through `.labels`, and `keep_vars()`, `drop_vars()`, and
 #' `rename_vars()` take `tidyselect::all_of()` or `.names`.
 #'
 #' The data-frame forms of `set_var_label()`, `set_var_labels()`, and
@@ -85,12 +87,14 @@
 #' @param value New label metadata. Data-frame replacement forms require a
 #'   named list or `NULL`.
 #' @param .data A vector or data frame to update.
-#' @param ... Named column updates for a data frame. For a vector, supply one
-#'   variable label or one or more named value-label codes.
+#' @param ... Named column updates for a data frame. A column named at run
+#'   time takes a `.(name) := value` tag. For a vector, supply one variable
+#'   label or one or more named value-label codes.
 #' @param .labels A programmatic label value for a vector, or a named list of
 #'   column updates for a data frame.
 #' @param variable One unquoted column name, or one nonempty, non-missing
-#'   character string, which is what `!!name` unquotes to.
+#'   character string, which is what `!!name` unquotes to and what a
+#'   `.(name)` call supplies in place.
 #' @param label One variable label, or `NULL` to remove it.
 #' @return Getters return the metadata described above. Replacement functions
 #'   and `set_*()` functions return the updated vector or data frame. Data-frame
@@ -565,49 +569,92 @@ set_var_label <- function(data, variable, label) {
     .apply_variable_label_updates(access, updates)
 }
 
-#' @rdname var_label
-#' @export
 .is_runtime_name_tag <- function(argument) {
     is.call(argument) && length(argument) == 3L &&
         identical(argument[[1L]], quote(`:=`)) &&
         .is_runtime_name_call(argument[[2L]])
 }
 
+# The `!!!x` splice spelling parses as three nested `!` calls. Returns the
+# spliced operand, or NULL when the expression is not a splice.
+.splice_operand <- function(expression) {
+    bang <- function(e) {
+        is.call(e) && length(e) == 2L && identical(e[[1L]], quote(`!`))
+    }
+    if (!bang(expression) || !bang(expression[[2L]]) ||
+        !bang(expression[[2L]][[2L]])) {
+        return(NULL)
+    }
+    expression[[2L]][[2L]][[2L]]
+}
+
 # `.(name) := value` in the plural setters. rlang rejects a call on the
 # left of `:=` before it evaluates anything, so the tags are resolved here
-# first: each `.()` left-hand side is evaluated in the caller's environment
-# and becomes an ordinary argument name, then `rlang::dots_list()` runs on
-# the rewritten call and keeps its own handling of `!!`, `!!!`, homonyms
-# and empty arguments unchanged.
-.dots_list_with_runtime_names <- function(quoted, environment, plain) {
-    arguments <- as.list(quoted)
-    if (!any(vapply(arguments, .is_runtime_name_tag, logical(1L)))) {
+# first: each `.()` left-hand side becomes an ordinary argument name, then
+# `rlang::dots_list()` runs on the rewritten call and keeps its own
+# handling of `!!!`, `:=`, homonyms and empty arguments unchanged.
+#
+# Dots forwarded from an enclosing function belong to that function's
+# caller, not to the setter's immediate caller, so a single evaluation
+# environment cannot be right for every argument. `rlang::enquos0()`
+# captures each dot's own expression and environment without injection
+# processing, which also lets a `.()` call survive on the left of `:=`.
+# Every argument is evaluated in its own environment here and enters the
+# rebuilt call as a bound value; `!!!x` keeps its splice spelling around
+# the bound operand so `rlang::dots_list()` still splices it.
+.dots_list_with_runtime_names <- function(quoted, environment, plain,
+                                          quosures) {
+    if (!any(vapply(as.list(quoted), .is_runtime_name_tag, logical(1L)))) {
         # No `.()` tag, so nothing needs rewriting. Taking the ordinary
         # path here keeps every existing call byte-identical in behavior,
         # including dots forwarded from an enclosing function, whose
         # promises belong to that caller rather than to this frame.
         return(plain())
     }
-    names(arguments) <- if (is.null(names(arguments))) {
-        rep("", length(arguments))
-    } else {
-        names(arguments)
+    quosures <- quosures()
+    labels <- names(quosures)
+    if (is.null(labels)) labels <- rep("", length(quosures))
+    bindings <- new.env(parent = environment)
+    arguments <- vector("list", length(quosures))
+    for (index in seq_along(quosures)) {
+        quosure <- quosures[[index]]
+        if (rlang::quo_is_missing(quosure)) {
+            arguments[[index]] <- quote(expr = )
+            next
+        }
+        expression <- rlang::quo_get_expr(quosure)
+        frame <- rlang::quo_get_env(quosure)
+        name <- sprintf(".dtatools_dot_%d", index)
+        symbol <- as.name(name)
+        splice <- .splice_operand(expression)
+        if (.is_runtime_name_tag(expression)) {
+            labels[[index]] <- .runtime_name_call_value(
+                expression[[2L]], frame
+            )
+            assign(name, eval(expression[[3L]], frame), envir = bindings)
+            arguments[[index]] <- symbol
+        } else if (!is.null(splice)) {
+            assign(name, eval(splice, frame), envir = bindings)
+            arguments[[index]] <- call("!", call("!", call("!", symbol)))
+        } else if (is.call(expression) && length(expression) == 3L &&
+                   identical(expression[[1L]], quote(`:=`))) {
+            assign(name, eval(expression[[3L]], frame), envir = bindings)
+            arguments[[index]] <- call(":=", expression[[2L]], symbol)
+        } else {
+            assign(name, eval(expression, frame), envir = bindings)
+            arguments[[index]] <- symbol
+        }
     }
-    for (index in seq_along(arguments)) {
-        argument <- arguments[[index]]
-        if (!.is_runtime_name_tag(argument)) next
-        names(arguments)[[index]] <- .runtime_name_call_value(
-            argument[[2L]], environment
-        )
-        arguments[[index]] <- argument[[3L]]
-    }
+    names(arguments) <- labels
     call <- as.call(c(
         quote(rlang::dots_list), arguments,
         list(.homonyms = "keep", .ignore_empty = "none")
     ))
-    eval(call, environment)
+    eval(call, bindings)
 }
 
+#' @rdname var_label
+#' @export
 set_var_labels <- function(.data, ..., .labels = NULL) {
     dots <- .dots_list_with_runtime_names(
         substitute(...()), parent.frame(),
@@ -615,7 +662,8 @@ set_var_labels <- function(.data, ..., .labels = NULL) {
             rlang::dots_list(
                 ..., .homonyms = "keep", .ignore_empty = "none"
             )
-        }
+        },
+        function() rlang::enquos0(...)
     )
     if (!is.data.frame(.data)) {
         if (!is.null(.labels) && length(dots) > 0L) {
@@ -656,7 +704,8 @@ set_val_labels <- function(.data, ..., .labels = NULL) {
             rlang::dots_list(
                 ..., .homonyms = "keep", .ignore_empty = "none"
             )
-        }
+        },
+        function() rlang::enquos0(...)
     )
     if (!is.data.frame(.data)) {
         if (!is.null(.labels) && length(dots) > 0L) {

--- a/r-package/dtatools/R/mutate-data.R
+++ b/r-package/dtatools/R/mutate-data.R
@@ -43,14 +43,21 @@
 #' scalar, and one nonempty, non-missing string is accepted in the `variable`
 #' position. A literal `gen(data, "adjusted", value)` names a column the same
 #' way. An empty string, `NA`, a character vector of length other than one, a
-#' call such as `a + 1`, `...`, and a missing argument are errors.
+#' call other than `.()`, `...`, and a missing argument are errors.
 #'
-#' In the `values` and `where` expressions a runtime name is reached through
-#' the mask's `.data` pronoun instead: `values = .data[[name]]` and
+#' `.(name)` is the one spelling that works in every position. It is
+#' evaluated where it sits, so it can stand inside a larger expression the
+#' way `!!` cannot: `values = income + .(name)` reads the column that `name`
+#' holds. The argument is evaluated in the caller's environment, never in
+#' the data mask, so a column sharing the variable's name cannot shadow it,
+#' and it must be one nonempty, non-missing string.
+#'
+#' In the `values` and `where` expressions a runtime name is also reached
+#' through the mask's `.data` pronoun: `values = .data[[name]]` and
 #' `where = !is_missing(.data[[name]])`. Note the asymmetry, which is the
 #' surprising part: `.data[[name]]` works in `values` and `where` but not in
 #' the `variable` position, because `variable` names a target rather than
-#' reading a column. Use `!!name` there.
+#' reading a column. Use `!!name` or `.(name)` there.
 #'
 #' `values` and `where` use a data mask built from the dataset before the
 #' mutation. Columns win over objects in the calling environment; use `.env`
@@ -134,8 +141,9 @@
 #' @param data An ungrouped data frame or tibble to mutate. `copy_data()` also
 #'   accepts grouped and rowwise tibbles.
 #' @param variable Exactly one unquoted target name, or one nonempty,
-#'   non-missing character string, which is what `!!name` unquotes to. An
-#'   empty string, `NA`, a character vector of length other than one, a call,
+#'   non-missing character string, which is what `!!name` unquotes to and
+#'   what a `.(name)` call supplies in place. An empty string, `NA`, a
+#'   character vector of length other than one, a call other than `.()`,
 #'   `...`, and a missing argument are errors.
 #' @param values A value expression or one-sided formula. It may reference a
 #'   column whose name is a string through the mask's `.data` pronoun.

--- a/r-package/dtatools/README.md
+++ b/r-package/dtatools/README.md
@@ -510,23 +510,37 @@ confirm_var(survey, "missing", on_failure = "false")
 `gen()`, `repl()`, `replace_values()`, and `set_var_label()` capture their
 variable-name argument the way Stata's `generate` and `replace` do, so the name
 is normally written unquoted. When the name is only known at run time, unquote
-it with rlang's `!!` operator. These functions capture with `rlang::enquo()`,
-which already applies quasiquotation, so no `rlang::inject()` wrapper is
-needed. Inside the `values` and `where` expressions, the `.data` pronoun reads
-a column whose name is a string; it does not work in the name position, which
-names a target rather than reading a column.
+it with rlang's `!!` operator or write `.(name)`. These functions capture with
+`rlang::enquo()`, which already applies quasiquotation, so no `rlang::inject()`
+wrapper is needed. Inside the `values` and `where` expressions, `.(name)` and
+the `.data` pronoun both read a column whose name is a string; `!!` and
+`.data[[name]]` do not work in the name position, which names a target rather
+than reading a column, while `.(name)` works everywhere and may sit inside a
+larger expression.
 
 ```r
-target_name <- "cluster"
-source_name <- "wm1"
+target_name <- "income"
+source_name <- "identifier"
 
 repl(survey, !!target_name, .data[[source_name]])
 repl(survey, !!target_name, 0, where = is_missing(.data[[source_name]]))
 gen(survey, !!paste0(target_name, "_flag"), .data[[source_name]] > 0)
-set_var_label(survey, !!target_name, "Cluster number")
+set_var_label(survey, !!target_name, "Total income")
+
+# `.(name)` is evaluated where it sits, in the caller's environment
+repl(survey, .(target_name), .(source_name) + 1)
 
 # `!!rlang::sym(name)` is the equivalent older spelling and still works
 repl(survey, !!rlang::sym(target_name), 1)
+```
+
+`set_var_labels()` and `set_val_labels()` update columns by name in `...`.
+A column named at run time takes a `.(name) := value` tag there, or supply a
+named list through `.labels`:
+
+```r
+set_var_labels(survey, .(target_name) := "Total income", identifier = "ID")
+set_val_labels(survey, .(source_name) := c(low = 1, high = 2))
 ```
 
 Use the installed help for exact behavior and examples:

--- a/r-package/dtatools/README.md
+++ b/r-package/dtatools/README.md
@@ -513,10 +513,10 @@ is normally written unquoted. When the name is only known at run time, unquote
 it with rlang's `!!` operator or write `.(name)`. These functions capture with
 `rlang::enquo()`, which already applies quasiquotation, so no `rlang::inject()`
 wrapper is needed. Inside the `values` and `where` expressions, `.(name)` and
-the `.data` pronoun both read a column whose name is a string; `!!` and
-`.data[[name]]` do not work in the name position, which names a target rather
-than reading a column, while `.(name)` works everywhere and may sit inside a
-larger expression.
+the `.data` pronoun both read a column whose name is a string. In the name
+position, which names a target rather than reading a column, `!!name` and
+`.(name)` work but `.data[[name]]` does not. `.(name)` is the one spelling that
+works everywhere, and it may sit inside a larger expression.
 
 ```r
 target_name <- "income"

--- a/r-package/dtatools/man/replace_values.Rd
+++ b/r-package/dtatools/man/replace_values.Rd
@@ -20,8 +20,9 @@ copy_data(data)
 accepts grouped and rowwise tibbles.}
 
 \item{variable}{Exactly one unquoted target name, or one nonempty,
-non-missing character string, which is what \code{!!name} unquotes to. An
-empty string, \code{NA}, a character vector of length other than one, a call,
+non-missing character string, which is what \code{!!name} unquotes to and
+what a \code{.(name)} call supplies in place. An empty string, \code{NA}, a
+character vector of length other than one, a call other than \code{.()},
 \code{...}, and a missing argument are errors.}
 
 \item{values}{A value expression or one-sided formula. It may reference a
@@ -79,14 +80,21 @@ in a string. No \code{rlang::inject()} wrapper is needed, because
 scalar, and one nonempty, non-missing string is accepted in the \code{variable}
 position. A literal \code{gen(data, "adjusted", value)} names a column the same
 way. An empty string, \code{NA}, a character vector of length other than one, a
-call such as \code{a + 1}, \code{...}, and a missing argument are errors.
+call other than \code{.()}, \code{...}, and a missing argument are errors.
 
-In the \code{values} and \code{where} expressions a runtime name is reached through
-the mask's \code{.data} pronoun instead: \code{values = .data[[name]]} and
+\code{.(name)} is the one spelling that works in every position. It is
+evaluated where it sits, so it can stand inside a larger expression the
+way \verb{!!} cannot: \code{values = income + .(name)} reads the column that \code{name}
+holds. The argument is evaluated in the caller's environment, never in
+the data mask, so a column sharing the variable's name cannot shadow it,
+and it must be one nonempty, non-missing string.
+
+In the \code{values} and \code{where} expressions a runtime name is also reached
+through the mask's \code{.data} pronoun: \code{values = .data[[name]]} and
 \code{where = !is_missing(.data[[name]])}. Note the asymmetry, which is the
 surprising part: \code{.data[[name]]} works in \code{values} and \code{where} but not in
 the \code{variable} position, because \code{variable} names a target rather than
-reading a column. Use \code{!!name} there.
+reading a column. Use \code{!!name} or \code{.(name)} there.
 
 \code{values} and \code{where} use a data mask built from the dataset before the
 mutation. Columns win over objects in the calling environment; use \code{.env}

--- a/r-package/dtatools/man/var_label.Rd
+++ b/r-package/dtatools/man/var_label.Rd
@@ -39,14 +39,16 @@ set_val_labels(.data, ..., .labels = NULL)
 named list or \code{NULL}.}
 
 \item{variable}{One unquoted column name, or one nonempty, non-missing
-character string, which is what \code{!!name} unquotes to.}
+character string, which is what \code{!!name} unquotes to and what a
+\code{.(name)} call supplies in place.}
 
 \item{label}{One variable label, or \code{NULL} to remove it.}
 
 \item{.data}{A vector or data frame to update.}
 
-\item{...}{Named column updates for a data frame. For a vector, supply one
-variable label or one or more named value-label codes.}
+\item{...}{Named column updates for a data frame. A column named at run
+time takes a \code{.(name) := value} tag. For a vector, supply one variable
+label or one or more named value-label codes.}
 
 \item{.labels}{A programmatic label value for a vector, or a named list of
 column updates for a data frame.}
@@ -90,10 +92,12 @@ non-missing string. A name known only at run time therefore needs only the
 tidy-evaluation escape, as in
 \code{set_var_label(data, !!name, "Cluster number")}; no \code{rlang::inject()}
 wrapper is required, and \code{rlang::sym()} is optional, so the older
-\code{!!rlang::sym(name)} spelling remains equivalent. There is no \code{.data}
-pronoun for this argument, because it names a target rather than reading a
-column. \code{set_var_labels()} and \code{set_val_labels()} take a programmatic named
-list through \code{.labels} instead, and \code{keep_vars()}, \code{drop_vars()}, and
+\code{!!rlang::sym(name)} spelling remains equivalent. A \code{.(name)} call reaches
+the same place: \code{set_var_label(data, .(name), "Cluster number")}. There is
+no \code{.data} pronoun for this argument, because it names a target rather
+than reading a column. \code{set_var_labels()} and \code{set_val_labels()} name a
+runtime column with a \code{.(name) := value} tag in \code{...} or a programmatic
+named list through \code{.labels}, and \code{keep_vars()}, \code{drop_vars()}, and
 \code{rename_vars()} take \code{tidyselect::all_of()} or \code{.names}.
 
 The data-frame forms of \code{set_var_label()}, \code{set_var_labels()}, and

--- a/r-package/dtatools/tests/testthat/test-name-strings.R
+++ b/r-package/dtatools/tests/testthat/test-name-strings.R
@@ -244,6 +244,27 @@ test_that("`.()` tags coexist with splices and `:=` names", {
         set_var_labels(data, .(tag) := "x", a = "y"),
         "must not contain duplicate column names"
     )
+    expect_identical(var_label(data$a), "First")
+    expect_identical(var_label(data$b), "Second")
+    expect_identical(var_label(data$c), "Third")
+})
+
+test_that("`.()` tags keep a spliced value's own frame and reject empties", {
+    data <- data.frame(a = c(1, 2), b = c(3, 4))
+    tag <- "a"
+    relabel <- function(data, ...) set_var_labels(data, ...)
+    from_caller <- function(data) {
+        second <- "b"
+        spliced <- list(b = "Spliced")
+        relabel(data, .(tag) := "Tagged", !!second := "Named")
+        relabel(data, .(tag) := "Tagged", !!!spliced)
+    }
+    from_caller(data)
+    expect_identical(var_label(data$a), "Tagged")
+    expect_identical(var_label(data$b), "Spliced")
+
+    expect_error(set_var_labels(data, .(tag) := "x", ), "can't be empty")
+    expect_identical(var_label(data$a), "Tagged")
 })
 
 test_that("forwarded dots keep their own frames alongside a `.()` tag", {

--- a/r-package/dtatools/tests/testthat/test-name-strings.R
+++ b/r-package/dtatools/tests/testthat/test-name-strings.R
@@ -174,3 +174,90 @@ test_that("a string target leaves a compact column unmaterialized", {
     )
     expect_equal(as.double(data$compact), c(10, 3))
 })
+
+test_that("`.()` names the target and reads columns at run time", {
+    data <- data.frame(income = c(10, 20), hh1 = c(5, 6))
+    target <- "income"
+    origin <- "hh1"
+
+    repl(data, .(target), .(origin) + 1)
+    expect_equal(as.double(data$income), c(6, 7))
+
+    repl(data, .(target), 0, where = .(origin) > 5)
+    expect_equal(as.double(data$income), c(6, 0))
+
+    # `.()` sits inside a larger expression, which `!!` cannot do.
+    gen(data, .(paste0(target, "_flag")), .(origin) * 2 + income)
+    expect_equal(as.double(data$income_flag), c(16, 12))
+})
+
+test_that("`.()` rejects invalid runtime names", {
+    data <- data.frame(income = c(10, 20))
+    expect_error(
+        repl(data, .(1), 0),
+        "takes one nonempty, non-missing string"
+    )
+    expect_error(
+        repl(data, .(c("a", "b")), 0),
+        "takes one nonempty, non-missing string"
+    )
+    expect_error(
+        repl(data, .("income", "extra"), 0),
+        "takes one nonempty, non-missing string"
+    )
+    absent <- "absent"
+    expect_error(repl(data, income, .(absent)), "does not exist")
+    expect_identical(names(data), "income")
+})
+
+test_that("`set_var_label()` accepts a `.()` runtime name", {
+    data <- data.frame(income = c(10, 20))
+    target <- "income"
+    set_var_label(data, .(target), "Income")
+    expect_identical(var_label(data$income), "Income")
+})
+
+test_that("`.()` tags name columns in the plural label setters", {
+    data <- data.frame(a = c(1, 2), b = c(3, 4))
+    first <- "a"
+    set_var_labels(data, .(first) := "First", b = "Second")
+    expect_identical(var_label(data$a), "First")
+    expect_identical(var_label(data$b), "Second")
+
+    second <- "b"
+    set_val_labels(data, .(second) := c(yes = 3, no = 4))
+    expect_identical(val_labels(data$b), c(yes = 3, no = 4))
+})
+
+test_that("`.()` tags coexist with splices and `:=` names", {
+    data <- data.frame(a = c(1, 2), b = c(3, 4), c = c(5, 6))
+    tag <- "a"
+    others <- list(b = "Second")
+    third <- "c"
+    set_var_labels(data, .(tag) := "First", !!!others, !!third := "Third")
+    expect_identical(var_label(data$a), "First")
+    expect_identical(var_label(data$b), "Second")
+    expect_identical(var_label(data$c), "Third")
+
+    # Overlapping updates still fail atomically alongside a tag.
+    expect_error(
+        set_var_labels(data, .(tag) := "x", a = "y"),
+        "must not contain duplicate column names"
+    )
+})
+
+test_that("forwarded dots keep their own frames alongside a `.()` tag", {
+    relabel <- function(data, ...) set_var_labels(data, ...)
+    revalue <- function(data, ...) set_val_labels(data, ...)
+    from_caller <- function(data) {
+        tag_name <- "a"
+        caller_label <- "From the caller"
+        relabel(data, .(tag_name) := "Tagged", b = caller_label)
+        revalue(data, .(tag_name) := c(low = 1))
+    }
+    data <- data.frame(a = c(1, 2), b = c(3, 4))
+    from_caller(data)
+    expect_identical(var_label(data$a), "Tagged")
+    expect_identical(var_label(data$b), "From the caller")
+    expect_identical(val_labels(data$a), c(low = 1))
+})


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for runtime column names using `.(name)` across data transformations and variable/value label setters.
  * Runtime names now work in target, value, and `where` expressions, including embedded expressions and spliced arguments.
  * Label getters can now retrieve metadata for a specified column.
  * Label setters support vector inputs and positional data-frame usage.
  * Added validation for missing, empty, or invalid runtime names.

* **Documentation**
  * Expanded guidance and examples for dynamic names, label updates, and `.data[[name]]` usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->