### PR TITLE
Error when a masked symbol is both a column and a caller object

### DIFF
--- a/r-package/dtatools/R/mutate-data.R
+++ b/r-package/dtatools/R/mutate-data.R
@@ -75,10 +75,20 @@
 #' reading a column. Use `!!name` or `.(name)` there.
 #'
 #' `values` and `where` use a data mask built from the dataset before the
-#' mutation. Columns win over objects in the calling environment; use `.env`
-#' for an environment value when names collide. A stored or inline one-sided
-#' formula evaluates its right-hand side in the same data mask and uses the
-#' formula environment as its fallback. Two-sided formulas are rejected.
+#' mutation. Columns win over objects in the calling environment. When a
+#' bare symbol in either expression is both a column and an object bound
+#' anywhere from the calling frame up to the global environment, the call
+#' is an error rather than a silent choice: write `.data$name` for the
+#' column or `.env$name` for the object. Bindings in attached packages and
+#' base are not consulted, so a column named `pi` or `T` is not flagged;
+#' an object that is a function does not count, so a script named after
+#' the column it builds is not flagged either; and the right-hand side of
+#' `$`, the body of `.()`, and function positions are never treated as
+#' column reads.
+#' `options(dtatools.shadow_check = FALSE)` disables the check. A stored or
+#' inline one-sided formula evaluates its right-hand side in the same data
+#' mask and uses the formula environment as its fallback. Two-sided
+#' formulas are rejected.
 #'
 #' `where = NULL` selects every row. A logical result must have size one or the
 #' dataset row count; missing logical values do not select a row. Numeric row
@@ -703,6 +713,84 @@ gen <- function(data, ..., where = NULL) {
     TRUE
 }
 
+# A bare symbol in `values` or `where` resolves to a column first and to
+# the calling environment second, so a local that happens to share a
+# column's name is shadowed without a word. When one symbol is bound in
+# both places the expression is ambiguous to a reader as well as to the
+# evaluator, so it is an error naming the two spellings that are not.
+# The environment search runs from the capture frame up to and including
+# the global environment, not into attached packages or base, so column
+# names like `pi` or `T` do not trip it, and a binding that is a function
+# does not count, since a masked symbol reads a vector. `options(
+# dtatools.shadow_check = FALSE)` turns the check off.
+.SHADOW_CHECK_SKIP <- c(".data", ".env", ".")
+
+.masked_symbols <- function(expression, found = character()) {
+    if (is.symbol(expression)) {
+        name <- as.character(expression)
+        if (nzchar(name) && !(name %in% .SHADOW_CHECK_SKIP)) {
+            found <- c(found, name)
+        }
+        return(found)
+    }
+    if (!is.call(expression)) return(found)
+    head <- expression[[1L]]
+    if (identical(head, quote(.))) return(found)
+    if (identical(head, quote(`$`)) || identical(head, quote(`@`))) {
+        return(.masked_symbols(expression[[2L]], found))
+    }
+    if (identical(head, quote(`~`))) return(found)
+    if (identical(head, quote(`function`))) return(found)
+    for (index in seq.int(2L, length.out = length(expression) - 1L)) {
+        argument <- expression[[index]]
+        if (identical(argument, quote(expr = ))) next
+        found <- .masked_symbols(argument, found)
+    }
+    if (is.call(head)) found <- .masked_symbols(head, found)
+    found
+}
+
+# A function binding is skipped: a masked symbol reads a vector, and a
+# recode script is often named after the column it builds.
+.bound_in_caller_chain <- function(name, environment) {
+    while (!identical(environment, emptyenv())) {
+        if (exists(name, envir = environment, inherits = FALSE)) {
+            return(!is.function(get(name, envir = environment,
+                                    inherits = FALSE)))
+        }
+        if (identical(environment, globalenv())) return(FALSE)
+        environment <- parent.env(environment)
+    }
+    FALSE
+}
+
+.check_shadowed_symbols <- function(expression, columns, environment) {
+    if (!is.environment(environment)) return(invisible(NULL))
+    if (!isTRUE(getOption("dtatools.shadow_check", TRUE))) {
+        return(invisible(NULL))
+    }
+    symbols <- unique(.masked_symbols(expression))
+    if (length(symbols) == 0L) return(invisible(NULL))
+    is_column <- if (is.environment(columns)) {
+        vapply(
+            symbols, exists, logical(1L),
+            envir = columns, inherits = FALSE, USE.NAMES = FALSE
+        )
+    } else {
+        symbols %in% names(columns)
+    }
+    for (name in symbols[is_column]) {
+        if (.bound_in_caller_chain(name, environment)) {
+            stop(sprintf(paste(
+                "`%s` is both a column and an object in the calling",
+                "environment; write `.data$%s` for the column or",
+                "`.env$%s` for the object"
+            ), name, name, name), call. = FALSE)
+        }
+    }
+    invisible(NULL)
+}
+
 .eval_plain_mutation <- function(expression, columns, environment) {
     if (!is.environment(columns)) {
         return(eval(expression, columns, environment))
@@ -719,6 +807,12 @@ gen <- function(data, ..., where = NULL) {
     # columns masking the expression environment. Skipping the rlang data
     # mask there removes the dominant per-call cost of `gen()`/`repl()`.
     if (is.null(environment)) {
+        if (rlang::is_quosure(expression)) {
+            .check_shadowed_symbols(
+                rlang::quo_get_expr(expression), columns,
+                rlang::quo_get_env(expression)
+            )
+        }
         if (rlang::is_quosure(expression) &&
             .plain_mutation_expression(rlang::quo_get_expr(expression))) {
             return(.eval_plain_mutation(
@@ -726,8 +820,11 @@ gen <- function(data, ..., where = NULL) {
                 rlang::quo_get_env(expression)
             ))
         }
-    } else if (.plain_mutation_expression(expression)) {
-        return(.eval_plain_mutation(expression, columns, environment))
+    } else {
+        .check_shadowed_symbols(expression, columns, environment)
+        if (.plain_mutation_expression(expression)) {
+            return(.eval_plain_mutation(expression, columns, environment))
+        }
     }
     reader_environment <- if (!is.null(environment)) {
         environment

--- a/r-package/dtatools/R/mutate-data.R
+++ b/r-package/dtatools/R/mutate-data.R
@@ -718,6 +718,8 @@ gen <- function(data, ..., where = NULL) {
 # column's name is shadowed without a word. When one symbol is bound in
 # both places the expression is ambiguous to a reader as well as to the
 # evaluator, so it is an error naming the two spellings that are not.
+# `.mutate_data()` runs it on `where` before building the fused
+# comparison plan, since that plan reads columns without evaluating.
 # The environment search runs from the capture frame up to and including
 # the global environment, not into attached packages or base, so column
 # names like `pi` or `T` do not trip it, and a binding that is a function
@@ -741,6 +743,9 @@ gen <- function(data, ..., where = NULL) {
     }
     if (identical(head, quote(`~`))) return(found)
     if (identical(head, quote(`function`))) return(found)
+    if (identical(head, quote(`::`)) || identical(head, quote(`:::`))) {
+        return(found)
+    }
     for (index in seq.int(2L, length.out = length(expression) - 1L)) {
         argument <- expression[[index]]
         if (identical(argument, quote(expr = ))) next
@@ -1129,6 +1134,12 @@ gen <- function(data, ..., where = NULL) {
     access <- NULL
     column <- NULL
 
+    if (!rlang::quo_is_missing(where)) {
+        .check_shadowed_symbols(
+            rlang::quo_get_expr(where), original$columns,
+            rlang::quo_get_env(where)
+        )
+    }
     fused <- if (generate) NULL else {
         .fused_comparison_plan(where, original$columns, original$nrow)
     }

--- a/r-package/dtatools/README.md
+++ b/r-package/dtatools/README.md
@@ -534,6 +534,23 @@ repl(survey, .(target_name), .(source_name) + 1)
 repl(survey, !!rlang::sym(target_name), 1)
 ```
 
+Inside `values` and `where`, columns win over objects in the calling
+environment. A bare symbol that is both a column and an object bound anywhere
+from the calling frame up to the global environment is an error, because
+either reading is defensible and the wrong one fails silently. Write
+`.data$name` for the column or `.env$name` for the object:
+
+```r
+rows <- survey$income < 9000
+repl(survey, income, 0, where = rows)        # error if `rows` is a column
+repl(survey, income, 0, where = .env$rows)   # the local, unambiguously
+```
+
+Bindings in attached packages and base are not consulted, so a column named
+`pi` or `T` is not flagged, and a function binding does not count, so a
+recode script named after the column it builds is not flagged either.
+`options(dtatools.shadow_check = FALSE)` turns the check off.
+
 `set_var_labels()` and `set_val_labels()` update columns by name in `...`.
 A column named at run time takes a `.(name) := value` tag there, or supply a
 named list through `.labels`:

--- a/r-package/dtatools/man/replace_values.Rd
+++ b/r-package/dtatools/man/replace_values.Rd
@@ -113,10 +113,20 @@ the \code{variable} position, because \code{variable} names a target rather than
 reading a column. Use \code{!!name} or \code{.(name)} there.
 
 \code{values} and \code{where} use a data mask built from the dataset before the
-mutation. Columns win over objects in the calling environment; use \code{.env}
-for an environment value when names collide. A stored or inline one-sided
-formula evaluates its right-hand side in the same data mask and uses the
-formula environment as its fallback. Two-sided formulas are rejected.
+mutation. Columns win over objects in the calling environment. When a
+bare symbol in either expression is both a column and an object bound
+anywhere from the calling frame up to the global environment, the call
+is an error rather than a silent choice: write \code{.data$name} for the
+column or \code{.env$name} for the object. Bindings in attached packages and
+base are not consulted, so a column named \code{pi} or \code{T} is not flagged;
+an object that is a function does not count, so a script named after
+the column it builds is not flagged either; and the right-hand side of
+\code{$}, the body of \code{.()}, and function positions are never treated as
+column reads.
+\code{options(dtatools.shadow_check = FALSE)} disables the check. A stored or
+inline one-sided formula evaluates its right-hand side in the same data
+mask and uses the formula environment as its fallback. Two-sided
+formulas are rejected.
 
 \code{where = NULL} selects every row. A logical result must have size one or the
 dataset row count; missing logical values do not select a row. Numeric row

--- a/r-package/dtatools/tests/testthat/test-mutate-data.R
+++ b/r-package/dtatools/tests/testthat/test-mutate-data.R
@@ -2168,6 +2168,24 @@ test_that("a symbol bound as both column and object is an error", {
     expect_error(repl(data, x, 9, where = ~ rows), message)
     expect_identical(data$x, c(1, 2, 3))
 
+    # The fused comparison path, which reads columns without evaluating
+    # the expression, is checked too.
+    fused <- data.frame(
+        x = stata_byte(c(1, 2, 3)), rows = stata_byte(c(0, 0, 0))
+    )
+    expect_error(repl(fused, x, 9, where = rows == 0), message)
+    expect_error(repl(fused, x, 9, where = x == rows), message)
+    cutoff <- 2
+    fused$cutoff <- stata_byte(c(0, 0, 0))
+    expect_error(repl(fused, x, 9, where = x > cutoff), "`cutoff` is both")
+    expect_identical(as.double(fused$x), c(1, 2, 3))
+
+    # Namespace qualifiers are not column reads.
+    data <- data.frame(x = c(1, 2, 3), stats = c(0, 0, 0))
+    stats <- 5
+    repl(data, x, stats::median(x))
+    expect_identical(data$x, c(2, 2, 2))
+
     # Both explicit spellings pass, and each reads what it names.
     repl(data, x, 9, where = .env$rows)
     expect_identical(data$x, c(9, 2, 9))

--- a/r-package/dtatools/tests/testthat/test-mutate-data.R
+++ b/r-package/dtatools/tests/testthat/test-mutate-data.R
@@ -2155,3 +2155,72 @@ test_that("mutation dots must be one target pair and at most one where", {
     expect_error(gen(data, .(1) := 1), "nonempty")
     expect_identical(data, data.frame(x = 1:2, y = 3:4))
 })
+
+test_that("a symbol bound as both column and object is an error", {
+    data <- data.frame(x = c(1, 2, 3), rows = c(0, 0, 0))
+    rows <- c(TRUE, FALSE, TRUE)
+    message <- "`rows` is both a column and an object"
+
+    expect_error(repl(data, x, 9, where = rows), message)
+    expect_error(repl(data, x, rows), message)
+    expect_error(gen(data, y, x + rows), message)
+    expect_error(repl(data, x, 9, where = rows == 0), message)
+    expect_error(repl(data, x, 9, where = ~ rows), message)
+    expect_identical(data$x, c(1, 2, 3))
+
+    # Both explicit spellings pass, and each reads what it names.
+    repl(data, x, 9, where = .env$rows)
+    expect_identical(data$x, c(9, 2, 9))
+    repl(data, x, 5, where = .data$rows == 0)
+    expect_identical(data$x, c(5, 5, 5))
+    repl(data, x, .data$rows + 1)
+    expect_identical(data$x, c(1, 1, 1))
+    repl(data, x, .env$rows)
+    expect_identical(data$x, c(1, 0, 1))
+
+    # `.()` is evaluated in the caller's environment, never as a column read.
+    name <- "x"
+    data <- data.frame(x = c(1, 2), name = c("a", "b"))
+    repl(data, x, .(name) + 1)
+    expect_identical(data$x, c(2, 3))
+
+    # Function positions and `$` right-hand sides are not column reads.
+    data <- data.frame(x = c(1, 2), sum = c(0, 0), value = c(5, 6))
+    sum <- 3
+    holder <- list(value = 7)
+    repl(data, x, sum(value))
+    expect_identical(data$x, c(11, 11))
+    repl(data, x, holder$value)
+    expect_identical(data$x, c(7, 7))
+
+    # Bindings in base and attached packages are not consulted.
+    data <- data.frame(x = c(1, 2), pi = c(3, 3), T = c(1, 1))
+    repl(data, x, pi + T)
+    expect_identical(data$x, c(4, 4))
+
+    # A function binding does not count: a script may share its column's name.
+    data <- data.frame(x = c(1, 2), income = c(5, 6))
+    income <- function(data) repl(data, x, income * 2)
+    income(data)
+    expect_identical(data$x, c(10, 12))
+
+    # The check follows the capture frame up to the global environment.
+    data <- data.frame(x = c(1, 2), offset = c(10, 20))
+    outer <- function(data) {
+        offset <- 1
+        inner <- function(data) repl(data, x, x + offset)
+        inner(data)
+    }
+    expect_error(outer(data), "`offset` is both a column")
+    no_local <- function(data) repl(data, x, x + offset)
+    no_local(data)
+    expect_identical(data$x, c(11, 22))
+
+    # The option turns the check off, and columns win as before.
+    data <- data.frame(x = c(1, 2, 3), rows = c(0, 0, 0))
+    rows <- c(TRUE, FALSE, TRUE)
+    withr::with_options(list(dtatools.shadow_check = FALSE), {
+        repl(data, x, rows)
+    })
+    expect_identical(data$x, c(0, 0, 0))
+})


### PR DESCRIPTION
In `values` and `where`, a bare symbol resolves to a column first and to the calling environment second, so a local that happens to share a column's name was shadowed silently. Every such site in a caller had to remember `.env$`.

This makes the ambiguous case an error naming the two spellings that are not ambiguous:

```
`rows` is both a column and an object in the calling environment; write `.data$rows` for the column or `.env$rows` for the object
```

Scope of the check:

- Runs on every `values` and `where` expression before evaluation, on both the plain-eval fast path and the rlang mask path, so the fused comparison path sees it too.
- Walks from the capture frame up to and including the global environment, not into attached packages or base, so columns named `pi` or `T` are not flagged.
- A binding that is a function does not count: a masked symbol reads a vector, and a recode script is commonly named after the column it builds (`cm_lastbirth <- function(data, ...)` inside which `cm_lastbirth` is a column).
- `.()` bodies, the right-hand side of `$`/`@`, formula bodies, function definitions, and function-call heads are not treated as column reads.
- `options(dtatools.shadow_check = FALSE)` turns it off.

Verified downstream on fertility_surveys against all 209 MICS surveys. The check fired on three scripts that bound `x <- data[[x_name]]` and then used `x` bare in `where`; those aliases read the same column either way, so they were deleted rather than spelled `.env$`. With that, Tier A 2247/0, fleet 209/209, Tier B 207/209 (unchanged).

Suite: 6529/0 (base 6501).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added warnings for ambiguous names in `values` and `where` expressions when they match both data columns and caller-scope objects.
  * Added guidance to use `.data` or `.env` to explicitly select the intended value.
  * Added an option to disable shadowing checks when needed.

* **Documentation**
  * Documented shadowing behavior, exceptions, configuration, and supported expression contexts.

* **Bug Fixes**
  * Improved detection across formulas, nested environments, and combined filtering and mutation expressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->