### PR TITLE
Collapse tagged missing operands to system missing in arithmetic

### DIFF
--- a/r-package/dtatools/R/stata-numeric.R
+++ b/r-package/dtatools/R/stata-numeric.R
@@ -49,6 +49,14 @@
 #' result's declared storage. Arithmetic results that are `NaN`, infinite, or
 #' outside Stata's double range become Stata system missing.
 #'
+#' Missing operands follow Stata. Any arithmetic operator, unary minus, and
+#' any `Math` or `Summary` function other than the rounding family yields
+#' system missing `.` where an operand is missing, whatever its tag: in Stata
+#' `.a + 1`, `-.a`, `.a + .b`, and `sqrt(.a)` are all `.`. The rounding
+#' functions `round()`, `signif()`, `floor()`, `ceiling()`, and `trunc()`
+#' return a tagged missing unchanged, as Stata's `round(.a)` is `.a`.
+#' Comparisons keep Stata's ordering of missing values and are unaffected.
+#'
 #' @param x For a constructor, a logical, integer, or double vector to encode.
 #'   For `stata_storage_type()`, a vector to inspect.
 #' @param .size A non-negative whole number of system missing values to
@@ -1012,7 +1020,39 @@ vec_cast.double.stata_numeric <- function(
     args <- vctrs::vec_recycle_common(left, right)
     operation <- getExportedValue("base", op)
     result <- suppressWarnings(operation(args[[1L]], args[[2L]]))
-    .stata_computed(result, minimum)
+    missing_operand <- is.na(args[[1L]]) | is.na(args[[2L]])
+    .stata_computed(.collapse_missing(result, missing_operand), minimum)
+}
+
+# Stata collapses a tagged missing operand to system missing `.` in
+# arithmetic. Base R operators happen to carry the tag through the NaN
+# payload, so replace every missing result position with plain `NA_real_`.
+# `where` defaults to the missing positions of `result` itself, which covers
+# cumulative functions and reductions as well as elementwise operations.
+.collapse_missing <- function(result, where = is.na(result)) {
+    if (!is.numeric(result) || !any(where)) {
+        return(result)
+    }
+    result[where] <- NA_real_
+    result
+}
+
+# Stata's rounding functions return a tagged missing unchanged:
+# `round(.a)` is `.a`.
+.stata_tag_preserving_math <- c(
+    "round", "signif", "floor", "ceiling", "trunc"
+)
+
+# Copy the missing values of `source` back into `result`, so a rounding
+# function returns each tagged missing unchanged even though base `round()`
+# and `signif()` discard the NaN payload.
+.restore_missing <- function(result, source) {
+    where <- is.na(source)
+    if (!is.numeric(result) || !any(where)) {
+        return(result)
+    }
+    result[where] <- source[where]
+    result
 }
 
 #' @export
@@ -1025,7 +1065,7 @@ vec_arith.stata_numeric.MISSING <- function(op, x, y, ...) {
     if (identical(op, "+")) return(x)
     if (identical(op, "!")) return(!.stata_data(x))
     if (!identical(op, "-")) vctrs::stop_incompatible_op(op, x, y)
-    result <- suppressWarnings(-.stata_data(x))
+    result <- .collapse_missing(suppressWarnings(-.stata_data(x)))
     .stata_computed(result, stata_storage_type(x))
 }
 
@@ -1065,6 +1105,11 @@ vec_math.stata_numeric <- function(.fn, .x, ...) {
     if (length(.x) == 0L && .fn %in% c("min", "max", "range")) {
         return(result)
     }
+    result <- if (.fn %in% .stata_tag_preserving_math) {
+        .restore_missing(result, .stata_data(.x))
+    } else {
+        .collapse_missing(result)
+    }
     .stata_computed(result, stata_storage_type(.x))
 }
 
@@ -1095,13 +1140,13 @@ Summary.stata_numeric <- function(..., na.rm = FALSE) {
     if (empty_extreme) {
         return(result)
     }
-    .stata_computed(result, minimum)
+    .stata_computed(.collapse_missing(result), minimum)
 }
 
 #' @export
 mean.stata_numeric <- function(x, ..., na.rm = FALSE) {
     result <- suppressWarnings(mean(.stata_data(x), ..., na.rm = na.rm))
-    .stata_computed(result, stata_storage_type(x))
+    .stata_computed(.collapse_missing(result), stata_storage_type(x))
 }
 
 #' @export

--- a/r-package/dtatools/README.md
+++ b/r-package/dtatools/README.md
@@ -403,7 +403,10 @@ rounds values to binary32.
 
 Subset assignment, `replace()`, `dplyr::if_else()`, and `dplyr::mutate()`
 retain declared storage. Arithmetic widens only when its result values require
-it. Base `ifelse()` strips the declaration because it takes attributes from the
+it. As in Stata, a missing operand makes the result system missing `.`
+whatever its tag (`.a + 1`, `-.a`, `.a + .b`, and `sqrt(.a)` are all `.`);
+only the rounding functions `round()`, `floor()`, `ceiling()`, and `trunc()`
+return a tagged missing unchanged. Comparisons are unaffected. Base `ifelse()` strips the declaration because it takes attributes from the
 condition; pass its result to a constructor to declare storage again. Encoding
 materializes doubles temporarily, so the memory reduction is steady-state
 rather than a reduction in peak memory during construction.

--- a/r-package/dtatools/README.md
+++ b/r-package/dtatools/README.md
@@ -405,7 +405,7 @@ Subset assignment, `replace()`, `dplyr::if_else()`, and `dplyr::mutate()`
 retain declared storage. Arithmetic widens only when its result values require
 it. As in Stata, a missing operand makes the result system missing `.`
 whatever its tag (`.a + 1`, `-.a`, `.a + .b`, and `sqrt(.a)` are all `.`);
-only the rounding functions `round()`, `floor()`, `ceiling()`, and `trunc()`
+only the rounding functions `round()`, `signif()`, `floor()`, `ceiling()`, and `trunc()`
 return a tagged missing unchanged. Comparisons are unaffected. Base `ifelse()` strips the declaration because it takes attributes from the
 condition; pass its result to a constructor to declare storage again. Encoding
 materializes doubles temporarily, so the memory reduction is steady-state

--- a/r-package/dtatools/man/stata_byte.Rd
+++ b/r-package/dtatools/man/stata_byte.Rd
@@ -84,6 +84,14 @@ storage type, then widen only when the computed values require it. This is
 value-dependent: integer overflow or a fractional result may change the
 result's declared storage. Arithmetic results that are \code{NaN}, infinite, or
 outside Stata's double range become Stata system missing.
+
+Missing operands follow Stata. Any arithmetic operator, unary minus, and
+any \code{Math} or \code{Summary} function other than the rounding family yields
+system missing \code{.} where an operand is missing, whatever its tag: in Stata
+\code{.a + 1}, \code{-.a}, \code{.a + .b}, and \code{sqrt(.a)} are all \code{.}. The rounding
+functions \code{round()}, \code{signif()}, \code{floor()}, \code{ceiling()}, and \code{trunc()}
+return a tagged missing unchanged, as Stata's \code{round(.a)} is \code{.a}.
+Comparisons keep Stata's ordering of missing values and are unaffected.
 }
 
 \examples{

--- a/r-package/dtatools/tests/testthat/test-stata-numeric.R
+++ b/r-package/dtatools/tests/testthat/test-stata-numeric.R
@@ -874,16 +874,87 @@ test_that("arithmetic promotes from operand storage according to result values",
     }
 })
 
-test_that("arithmetic preserves tags and returns bare logical comparisons", {
+test_that("arithmetic collapses tags and returns bare logical comparisons", {
     values <- stata_int(c(1, tagged_missing("a"), NA_real_))
     result <- values + 1
 
     expect_identical(stata_storage_type(result), "int")
     expect_identical(as.double(result)[1], 2)
-    expect_identical(missing_tag(result), c(NA_character_, "a", NA))
+    expect_identical(is.na(result), c(FALSE, TRUE, TRUE))
+    expect_identical(missing_tag(result), c(NA_character_, NA, NA))
     expect_identical(values == 1, c(TRUE, FALSE, FALSE))
     expect_null(stata_storage_type(values == 1))
     expect_identical(!stata_int(c(0, 1, NA_real_)), c(TRUE, FALSE, NA))
+})
+
+test_that("missing operands yield system missing whatever their tag", {
+    tagged <- stata_int(c(1L, tagged_missing("a")))
+    expect_identical(missing_tag(tagged), c(NA_character_, "a"))
+
+    year <- stata_int(tagged_missing("a")) - 1900
+    expect_true(is_missing(year))
+    expect_identical(missing_tag(year), NA_character_)
+
+    both_tagged <- stata_double(tagged_missing("a")) +
+        stata_double(tagged_missing("b"))
+    expect_true(is.na(both_tagged))
+    expect_identical(missing_tag(both_tagged), NA_character_)
+    expect_identical(
+        missing_tag(stata_double(tagged_missing("b")) + tagged_missing("a")),
+        NA_character_
+    )
+    expect_identical(
+        missing_tag(1 - stata_int(tagged_missing("a"))), NA_character_
+    )
+
+    negated <- -stata_int(c(1, tagged_missing("a")))
+    expect_identical(as.double(negated), c(-1, NA_real_))
+    expect_identical(missing_tag(negated), c(NA_character_, NA))
+
+    mixed <- stata_int(c(1, tagged_missing("a"), NA_real_, 5)) * 2
+    expect_identical(as.double(mixed), c(2, NA_real_, NA_real_, 10))
+    expect_identical(missing_tag(mixed), rep(NA_character_, 4L))
+    expect_identical(stata_storage_type(mixed), "int")
+
+    tagged_bytes <- stata_byte(c(2, tagged_missing("a"))) * stata_byte(3)
+    expect_identical(stata_storage_type(tagged_bytes), "byte")
+    expect_identical(
+        stata_storage_type(stata_byte(100) * stata_byte(3)), "int"
+    )
+    expect_identical(
+        stata_storage_type(stata_int(c(1, tagged_missing("a"))) / 2),
+        "float"
+    )
+})
+
+test_that("rounding keeps a missing tag and other math functions drop it", {
+    values <- stata_double(c(2.5, tagged_missing("a"), NA_real_))
+
+    for (rounding in c("round", "signif", "floor", "ceiling", "trunc")) {
+        rounded <- getExportedValue("base", rounding)(values)
+        expect_identical(
+            missing_tag(rounded), c(NA_character_, "a", NA), info = rounding
+        )
+    }
+    expect_identical(missing_tag(round(values, 1)), c(NA_character_, "a", NA))
+
+    for (dropping in c("sqrt", "exp", "log", "abs", "sign", "cumsum")) {
+        dropped <- getExportedValue("base", dropping)(values)
+        expect_identical(is.na(dropped), c(FALSE, TRUE, TRUE), info = dropping)
+        expect_identical(
+            missing_tag(dropped), rep(NA_character_, 3L), info = dropping
+        )
+    }
+
+    for (reduction in c("sum", "mean", "min", "max")) {
+        reduced <- getExportedValue("base", reduction)(values)
+        expect_true(is.na(reduced), info = reduction)
+        expect_identical(missing_tag(reduced), NA_character_, info = reduction)
+        expect_false(
+            is.na(getExportedValue("base", reduction)(values, na.rm = TRUE)),
+            info = reduction
+        )
+    }
 })
 
 test_that("computed results preserve Stata construction semantics", {
@@ -904,9 +975,13 @@ test_that("computed results preserve Stata construction semantics", {
 
         expect_identical(stata_storage_type(result), storage, info = storage)
         expect_identical(names(result), names(input), info = storage)
-        expect_identical(as.double(result), as.double(source), info = storage)
         expect_identical(
-            missing_tag(result), missing_tag(source), info = storage
+            as.double(result)[1], as.double(source)[1], info = storage
+        )
+        expect_identical(is.na(result), is.na(source), info = storage)
+        expect_identical(
+            unname(missing_tag(result)), rep(NA_character_, 4L),
+            info = storage
         )
         expect_true(
             dtatools:::.is_unmaterialized_numeric_altrep(result),


### PR DESCRIPTION
## Stata rule

Stata collapses any tagged missing operand of an arithmetic operator or ordinary function to system missing. Only the rounding family returns the tagged missing unchanged. Verified in Stata 18 (`stata -b do`):

| Expression | Stata result |
|---|---|
| `-.a` | `.` |
| `.a + 1` | `.` |
| `.a + .b` | `.` |
| `.a * 0` | `.` |
| `.a / 2`, `1 / .a`, `.a^2`, `mod(.a, 2)` | `.` |
| `round(.a)`, `round(.a, 10)` | `.a` |
| `floor(.a)`, `ceil(.a)`, `int(.a)`, `trunc(.a)` | `.a` |
| `abs(.a)`, `sign(.a)` | `.` |
| `sqrt(.a)`, `exp(.a)`, `ln(.a)`, `log10(.a)` | `.` |
| `sin(.a)`, `cos(.a)`, `tan(.a)`, `cloglog(.a)` | `.` |
| `min(.a, .b)`, `max(.a, .b)`, `max(.a, .)` | `.` |
| `max(.a, 1)` | `1` |
| `min(.a, ., 1)` | `1` |
| `sum(.a)` | `0` (sum() skips missing) |
| `+.a` | invalid syntax (unary plus does not exist in Stata) |

## What was wrong

`.stata_arith_base()` ran the base R operator on the raw double payloads and handed the result to `.stata_computed()`. A tagged missing lives in the NaN payload; base `+`, `-`, `*` carry that payload through on this platform, so `stata_int(.a) - 1900` gave `.a` and `.a + .b` gave `.a`. Nothing in the suite asserted that; it was an accident of IEEE payload propagation and was inconsistent (`round()` dropped the tag, `floor()` kept it).

## Changes (`R/stata-numeric.R`)

1. `.stata_arith_base()` (all binary `vec_arith` methods: `+ - * / ^ %% %/%`): after computing the result, every position where either recycled operand `is.na()` is set to plain `NA_real_` via the new `.collapse_missing()` helper, then passed to `.stata_computed()` as before. Storage promotion is unchanged.
2. `vec_arith.stata_numeric.MISSING` (unary minus): result collapsed the same way. Unary `+` still returns `x` unchanged; Stata has no unary plus, so there is nothing to match.
3. `vec_math.stata_numeric`: functions in `.stata_tag_preserving_math` (`round`, `signif`, `floor`, `ceiling`, `trunc`) copy each missing input back into the result so the tag survives, matching Stata's `round(.a) == .a`. Every other Math function collapses missing to system missing. `Summary.stata_numeric` (`sum`, `prod`, `min`, `max`, `range`) and `mean.stata_numeric` also collapse, so a reduction that returns missing returns system missing. `na.rm` semantics are unchanged: R's `max(x)` over a vector is a reduction with R's NA rules, not Stata's argument-list `max()`, so `max(c(.a, 1))` is still `NA` without `na.rm = TRUE`; what changed is only that the returned missing carries no tag.

Comparison code is untouched.

## Docs

Roxygen on `stata_byte` (the arithmetic section) and README now state the rule. `man/stata_byte.Rd` regenerated with roxygen2 8.1.0; the known noise (`dta_append.Rd`, `dta_merge.Rd`, new `order_vars.Rd` etc.) reverted/deleted. No NEWS.md in the package.

## Tests

`tests/testthat/test-stata-numeric.R`:
- New: `stata_int(.a) - 1900` is system missing with `missing_tag()` NA; `.a + .b` (both orders, and with a bare tagged double) is system missing; `-x` on a tagged value; `c(1, .a, NA, 5) * 2` gives `c(2, ., ., 10)` with no tags; `stata_byte * stata_byte` stays `byte` (and still promotes on overflow); rounding family keeps the tag; `sqrt`, `exp`, `log`, `abs`, `sign`, `cumsum` drop it; `sum`, `mean`, `min`, `max` return untagged missing.
- Changed: "arithmetic preserves tags and returns bare logical comparisons" asserted the accidental behavior (`missing_tag(values + 1)` == `c(NA, "a", NA)`); renamed to "arithmetic collapses tags ..." and now expects no tag. "computed results preserve Stata construction semantics" compared `missing_tag(source + 0)` to the source's tags; it now checks missingness positions and that tags are gone.

`stata_int(c(1L, tagged_missing("a")))` accepts a tagged value directly, so tests build vectors that way.

Full suite: `FAIL 0 ERROR 0 WARN 0 SKIP 0 PASS 6629`

## Downstream

Once fertility_surveys pins this, its `stata_arithmetic`/`dta_arithmetic` operand wrapper in `R/mics/bh_vars/cm_birth.R` is no longer needed and can be deleted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized missing-value results for arithmetic, negation, mathematical functions, summaries, and means to system missing (`.`).
  * Preserved tagged missing values in rounding functions, including `signif()`, `round()`, `floor()`, `ceiling()`, and `trunc()`.
  * Kept comparison behavior and Stata missing-value ordering unchanged.

* **Documentation**
  * Clarified missing-value behavior across arithmetic, math, summary, rounding, and comparison operations.

* **Tests**
  * Expanded coverage for tagged missing values across numeric operations, reductions, rounding, and comparisons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->