### PR TITLE
Own value-label tables by name and widen string formats in dta_append()

### DIFF
--- a/r-package/dtatools/R/dta-append.R
+++ b/r-package/dtatools/R/dta-append.R
@@ -33,12 +33,28 @@
 #' too wide to re-encode, say - is treated the same way.
 #'
 #' @section Metadata:
-#' Variable labels, value labels, formats, and variable-level notes
-#' come from the first source that contributes the variable.
-#' Combining is delegated to the package's own coercion rules, so two
-#' sources that give the same code different label text keep the first
-#' contributor's text and warn. Value-label tables that disagree only
-#' by covering different codes are merged.
+#' Variable labels, formats, and variable-level notes come from the
+#' first source that contributes the variable.
+#'
+#' Value-label tables are owned by table name, as in Stata. Sources are
+#' walked in order and the first to define a table name owns that
+#' definition; a later source's definition of the same name is
+#' discarded, not merged, even when it labels different codes. Each
+#' variable keeps the table name its first contributor assigned to it,
+#' taken from `value.label.name` or, when that is absent, the variable's
+#' own name, and its labels are the owning definition of that name. The
+#' owning definition may come from a different variable in a different
+#' source, and a name the first source does not define is taken from
+#' the first later source that does. A variable whose first contributor
+#' has no labels stays unlabelled.
+#'
+#' A display format follows the master's, with one exception that
+#' matches Stata: when a string's storage widens from `strN` to `strM`,
+#' the format takes the width of the new storage (`M`, or `9` when `M`
+#' is smaller or the result is `strL`) and keeps the master's
+#' justification flag, so `%-9s` on a `str9` that widens to `str20`
+#' becomes `%-20s`. A string whose storage does not widen, a `strL`, and
+#' a numeric promoted along the lattice keep the master's format.
 #'
 #' Stata does not define what happens to dataset-level notes on
 #' `append`, and it keeps the master's. `dataset_notes` therefore
@@ -235,6 +251,7 @@ dta_append <- function(sources, force = TRUE,
 
     prototypes <- vector("list", length(the_names))
     metadata_owners <- vector("list", length(the_names))
+    label_tables <- .append_value_label_tables(schemas)
     # A source is dropped for one variable when its storage cannot
     # meet the accumulated prototype; those rows take missing values.
     dropped <- vector("list", length(the_names))
@@ -277,7 +294,7 @@ dta_append <- function(sources, force = TRUE,
             prototype <- merged
         }
         prototypes[[plan_index]] <- .append_restore_owned_metadata(
-            prototype, metadata_owners[[plan_index]]
+            prototype, metadata_owners[[plan_index]], my_name, label_tables
         )
         dropped[[plan_index]] <- conflicting
         if (length(conflicting)) {
@@ -304,23 +321,118 @@ dta_append <- function(sources, force = TRUE,
     )
 }
 
-.append_restore_owned_metadata <- function(prototype, owner) {
+# Stata defines value-label tables at dataset scope and `append` keeps
+# the first definition of each table name; a later file's definition of
+# the same name is dropped with "(label xl already defined)". The
+# registry is keyed by table name, so walking sources in order and
+# keeping the first definition reproduces that. A variable that carries
+# labels but no `value.label.name` defines a table named after itself,
+# which is the name `save_dta()` gives it.
+.append_value_label_tables <- function(schemas) {
+    tables <- new.env(hash = TRUE, parent = emptyenv())
+    for (my_schema in schemas) {
+        schema <- my_schema$schema
+        column_names <- names(schema)
+        for (my_column in seq_along(schema)) {
+            value <- schema[[my_column]]
+            labels <- attr(value, "labels", exact = TRUE)
+            if (is.null(labels)) next
+            table_name <- .append_value_label_table_name(
+                value, column_names[[my_column]]
+            )
+            key <- paste0("x", enc2utf8(table_name))
+            if (!exists(key, tables, inherits = FALSE)) {
+                assign(key, labels, tables)
+            }
+        }
+    }
+    tables
+}
+
+.append_value_label_table_name <- function(value, column_name) {
+    table_name <- attr(value, "value.label.name", exact = TRUE)
+    if (is.character(table_name) && length(table_name) == 1L &&
+        !is.na(table_name) && nzchar(table_name)) {
+        return(table_name)
+    }
+    if (is.null(column_name) || is.na(column_name)) "" else column_name
+}
+
+.append_restore_owned_metadata <- function(prototype, owner, variable_name,
+                                           label_tables) {
     result <- .metadata_copy(prototype)
-    owned <- c(
-        "label", "value.label.name", "notes", "stata.note.numbers",
-        "stata.characteristics"
-    )
+    owned <- c("label", "notes", "stata.note.numbers", "stata.characteristics")
     for (my_name in owned) {
         attr(result, my_name) <- attr(owner, my_name, exact = TRUE)
     }
     owner_format <- attr(owner, "format.stata", exact = TRUE)
     if (!is.null(owner_format) || !inherits(prototype, "stata_temporal")) {
-        attr(result, "format.stata") <- owner_format
+        attr(result, "format.stata") <- .append_widened_string_format(
+            owner_format, owner, prototype
+        )
     }
-    if (is.null(attr(owner, "labels", exact = TRUE))) {
-        attr(result, "labels") <- NULL
+    # The variable keeps the table name its first contributor assigned
+    # and takes that table's owning definition, which may have come from
+    # another variable in an earlier source.
+    labels <- NULL
+    table_name <- NULL
+    if (!is.null(attr(owner, "labels", exact = TRUE))) {
+        table_name <- .append_value_label_table_name(owner, variable_name)
+        labels <- get0(
+            paste0("x", enc2utf8(table_name)), label_tables, inherits = FALSE
+        )
     }
-    result
+    attr(result, "labels") <- labels
+    attr(result, "value.label.name") <- if (
+        is.null(labels) || identical(table_name, variable_name)
+    ) {
+        NULL
+    } else {
+        table_name
+    }
+    .apply_haven_labelled_class(result, !is.null(labels))
+}
+
+# Stata keeps the master's display format through `append` except when
+# a string's storage widens, where it resets the width to the new
+# storage's default (the width, or 9 when that is smaller or the result
+# is strL) and keeps the master's justification flag. A format that is
+# not of the `%[-|~]Ns` shape is left alone.
+.append_widened_string_format <- function(owner_format, owner, prototype) {
+    if (!is.character(owner_format) || length(owner_format) != 1L ||
+        !inherits(prototype, "stata_string")) {
+        return(owner_format)
+    }
+    owner_storage <- attr(owner, "stata.string.storage", exact = TRUE)
+    result_storage <- attr(prototype, "stata.string.storage", exact = TRUE)
+    if (is.null(owner_storage) || is.null(result_storage) ||
+        identical(owner_storage, "strL") ||
+        identical(owner_storage, result_storage)) {
+        return(owner_format)
+    }
+    pattern <- "^%([-~]?)[0-9]+s$"
+    if (!grepl(pattern, owner_format)) return(owner_format)
+    flag <- sub(pattern, "\\1", owner_format)
+    width <- if (identical(result_storage, "strL")) {
+        9L
+    } else {
+        max(9L, .stata_string_storage_width(result_storage))
+    }
+    sprintf("%%%s%ds", flag, width)
+}
+
+# Value labels are resolved by table name after the storage prototype
+# is settled, so the coercion rules must not merge or warn about them
+# on the way.
+.append_without_value_labels <- function(value) {
+    if (is.null(attr(value, "labels", exact = TRUE)) &&
+        is.null(attr(value, "value.label.name", exact = TRUE))) {
+        return(value)
+    }
+    value <- .metadata_copy(value)
+    attr(value, "labels") <- NULL
+    attr(value, "value.label.name") <- NULL
+    .apply_haven_labelled_class(value, FALSE)
 }
 
 .append_name_occurrences <- function(the_names) {
@@ -344,6 +456,8 @@ dta_append <- function(sources, force = TRUE,
     if (inherits(right, .stata_metadata_vector_class)) {
         right <- .stata_metadata_vector_base(right)
     }
+    left <- .append_without_value_labels(left)
+    right <- .append_without_value_labels(right)
     left_storage <- dta_storage_type(left)
     right_storage <- dta_storage_type(right)
     left_declared <- !is.null(left_storage) &&

--- a/r-package/dtatools/man/dta_append.Rd
+++ b/r-package/dtatools/man/dta_append.Rd
@@ -71,12 +71,28 @@ too wide to re-encode, say - is treated the same way.
 
 \section{Metadata}{
 
-Variable labels, value labels, formats, and variable-level notes
-come from the first source that contributes the variable.
-Combining is delegated to the package's own coercion rules, so two
-sources that give the same code different label text keep the first
-contributor's text and warn. Value-label tables that disagree only
-by covering different codes are merged.
+Variable labels, formats, and variable-level notes come from the
+first source that contributes the variable.
+
+Value-label tables are owned by table name, as in Stata. Sources are
+walked in order and the first to define a table name owns that
+definition; a later source's definition of the same name is
+discarded, not merged, even when it labels different codes. Each
+variable keeps the table name its first contributor assigned to it,
+taken from \code{value.label.name} or, when that is absent, the variable's
+own name, and its labels are the owning definition of that name. The
+owning definition may come from a different variable in a different
+source, and a name the first source does not define is taken from
+the first later source that does. A variable whose first contributor
+has no labels stays unlabelled.
+
+A display format follows the master's, with one exception that
+matches Stata: when a string's storage widens from \code{strN} to \code{strM},
+the format takes the width of the new storage (\code{M}, or \code{9} when \code{M}
+is smaller or the result is \code{strL}) and keeps the master's
+justification flag, so \verb{\%-9s} on a \code{str9} that widens to \code{str20}
+becomes \verb{\%-20s}. A string whose storage does not widen, a \code{strL}, and
+a numeric promoted along the lattice keep the master's format.
 
 Stata does not define what happens to dataset-level notes on
 \code{append}, and it keeps the master's. \code{dataset_notes} therefore

--- a/r-package/dtatools/tests/testthat/test-dta-append.R
+++ b/r-package/dtatools/tests/testthat/test-dta-append.R
@@ -210,18 +210,170 @@ test_that("formats come from the first contributor after promotion", {
     expect_identical(attr(result$v, "format.stata"), "%8.0g")
 })
 
-test_that("value-label tables merge and the first contributor wins text", {
-    first <- tibble::tibble(v = dta_byte(c(1, 2)))
-    val_labels(first$v) <- c(yes = 1)
-    second <- tibble::tibble(v = dta_byte(c(2, 3)))
-    val_labels(second$v) <- c(no = 2)
+labelled_byte <- function(values, labels, table = NULL) {
+    result <- dta_byte(values)
+    val_labels(result) <- labels
+    if (!is.null(table)) attr(result, "value.label.name") <- table
+    result
+}
 
-    result <- dta_append(list(first, second))
-    expect_identical(val_labels(result$v), c(yes = 1, no = 2))
+test_that("the first source to define a value-label table owns it", {
+    # Stata's `append` keeps the master's `xl` and drops the using
+    # file's definition of the same name with "(label xl already
+    # defined)"; the two are never merged.
+    first <- tibble::tibble(v = labelled_byte(c(1, 2), c(yes = 1), "xl"))
+    second <- tibble::tibble(v = labelled_byte(c(2, 3), c(no = 2), "xl"))
+
+    expect_silent(result <- dta_append(list(first, second)))
+    expect_identical(val_labels(result$v), c(yes = 1))
+    expect_identical(attr(result$v, "value.label.name"), "xl")
+
+    # Conflicting text for a shared code is not a warning either: the
+    # later definition is discarded whole.
+    third <- tibble::tibble(v = labelled_byte(1, c(oui = 1), "xl"))
+    expect_silent(result <- dta_append(list(first, third)))
+    expect_identical(val_labels(result$v), c(yes = 1))
 
     unlabeled <- tibble::tibble(v = dta_byte(1))
     result <- dta_append(list(unlabeled, second))
     expect_null(val_labels(result$v))
+    expect_null(attr(result$v, "value.label.name"))
+})
+
+test_that("a variable takes the owning definition of its table name", {
+    # The shape from the MICS corpus: one source defines `labb` for
+    # `ma7m`, a later source assigns its own `labb` to other variables.
+    # Stata displays the first `labb` for all of them.
+    months <- c(January = 1, February = 2, March = 3)
+    yes_no <- c(yes = 1, no = 2)
+    first <- tibble::tibble(ma7m = labelled_byte(c(1, 3), months, "labb"))
+    second <- tibble::tibble(
+        ma6a2 = labelled_byte(1, yes_no, "labb"),
+        cm11c = labelled_byte(2, yes_no, "labb"),
+        y = labelled_byte(1, c(why = 1), "yl")
+    )
+
+    result <- dta_append(list(first, second))
+    for (my_name in c("ma7m", "ma6a2", "cm11c")) {
+        expect_identical(val_labels(result[[my_name]]), months, info = my_name)
+        expect_identical(
+            attr(result[[my_name]], "value.label.name"), "labb", info = my_name
+        )
+    }
+    # A table the master does not define is taken from the later
+    # source that does.
+    expect_identical(val_labels(result$y), c(why = 1))
+    expect_identical(attr(result$y, "value.label.name"), "yl")
+
+    # Every variable sharing `labb` now carries the same definition, so
+    # writing the result never falls back to per-variable table names.
+    path <- withr::local_tempfile(fileext = ".dta")
+    expect_no_warning(save_dta(result, path))
+    written <- read_dta(path)
+    expect_identical(val_labels(written$ma6a2), months)
+    expect_identical(attr(written$ma6a2, "value.label.name"), "labb")
+})
+
+test_that("unnamed labels define a table named after the variable", {
+    # `save_dta()` names an unnamed table after its variable, so the
+    # append treats an unnamed first contributor as owning that name.
+    first <- tibble::tibble(v = labelled_byte(1, c(one = 1)))
+    named_later <- tibble::tibble(
+        v = labelled_byte(2, c(two = 2), "vl"),
+        w = labelled_byte(2, c(deux = 2), "v")
+    )
+
+    result <- dta_append(list(first, named_later))
+    expect_identical(val_labels(result$v), c(one = 1))
+    expect_null(attr(result$v, "value.label.name"))
+    # `w` is assigned the table `v`, which the first source owns.
+    expect_identical(val_labels(result$w), c(one = 1))
+    expect_identical(attr(result$w, "value.label.name"), "v")
+
+    # The same rule from the other direction: an unnamed later
+    # contributor's table `v` is discarded when the master defines `v`.
+    owner <- tibble::tibble(w = labelled_byte(1, c(uno = 1), "v"))
+    result <- dta_append(list(owner, first))
+    expect_identical(val_labels(result$w), c(uno = 1))
+    expect_identical(val_labels(result$v), c(uno = 1))
+    expect_null(attr(result$v, "value.label.name"))
+})
+
+test_that("value-label ownership survives a file round trip", {
+    directory <- withr::local_tempdir()
+    first <- tibble::tibble(
+        x = labelled_byte(1, c(one = 1), "xl"),
+        u = dta_byte(1)
+    )
+    second <- tibble::tibble(
+        x = labelled_byte(2, c(two = 2), "xl"),
+        u = labelled_byte(2, c(two = 2), "ul")
+    )
+    master <- file.path(directory, "master.dta")
+    using <- file.path(directory, "using.dta")
+    save_dta(first, master)
+    save_dta(second, using)
+
+    result <- dta_append(list(master, using))
+    expect_identical(val_labels(result$x), c(one = 1))
+    expect_identical(attr(result$x, "value.label.name"), "xl")
+    expect_null(val_labels(result$u))
+})
+
+test_that("a widened string format takes the new width and keeps its flag", {
+    widen <- function(master_format, using_storage = "str20",
+                      using_format = NULL) {
+        first <- tibble::tibble(v = dta_string("ab", storage = "str2"))
+        attr(first$v, "format.stata") <- master_format
+        second <- tibble::tibble(v = dta_string("abc", storage = using_storage))
+        if (!is.null(using_format)) {
+            attr(second$v, "format.stata") <- using_format
+        }
+        result <- dta_append(list(first, second))
+        expect_identical(
+            attr(result$v, "stata.string.storage"), using_storage
+        )
+        attr(result$v, "format.stata")
+    }
+
+    # The using source's format is never taken.
+    expect_identical(widen("%9s", using_format = "%25s"), "%20s")
+    expect_identical(widen("%-9s", using_format = "%20s"), "%-20s")
+    expect_identical(widen("%9s", using_format = "%-30s"), "%20s")
+    expect_identical(widen("%~9s"), "%~20s")
+    # A master width wider than the new storage is still reset, and the
+    # width never drops below Stata's default of 9.
+    expect_identical(widen("%12s", using_storage = "str10"), "%10s")
+    expect_identical(widen("%12s", using_storage = "str5"), "%9s")
+    expect_identical(widen("%-12s", using_storage = "str5"), "%-9s")
+    # Widening to strL takes strL's default width.
+    expect_identical(widen("%-3s", using_storage = "strL"), "%-9s")
+})
+
+test_that("a string format is kept when storage does not widen", {
+    first <- tibble::tibble(v = dta_string("abcde", storage = "str12"))
+    attr(first$v, "format.stata") <- "%5s"
+    second <- tibble::tibble(v = dta_string("ab", storage = "str2"))
+    attr(second$v, "format.stata") <- "%20s"
+
+    result <- dta_append(list(first, second))
+    expect_identical(attr(result$v, "stata.string.storage"), "str12")
+    expect_identical(attr(result$v, "format.stata"), "%5s")
+
+    same <- tibble::tibble(v = dta_string("xy", storage = "str12"))
+    attr(same$v, "format.stata") <- "%-40s"
+    result <- dta_append(list(first, same))
+    expect_identical(attr(result$v, "format.stata"), "%5s")
+
+    long <- tibble::tibble(v = dta_string("xy", storage = "strL"))
+    attr(long$v, "format.stata") <- "%-15s"
+    result <- dta_append(list(long, second))
+    expect_identical(attr(result$v, "stata.string.storage"), "strL")
+    expect_identical(attr(result$v, "format.stata"), "%-15s")
+
+    unformatted <- tibble::tibble(v = dta_string("ab", storage = "str2"))
+    result <- dta_append(list(unformatted, first))
+    expect_null(attr(result$v, "format.stata"))
 })
 
 test_that("logical placeholders do not clear temporal structure", {


### PR DESCRIPTION
Fixes #146

`dta_append()` claims to stack sources the way Stata's `append using ..., force` does, but departed from it in two metadata rules. Both are verified against Stata MP 18.0.

## Rule 1: value-label tables are owned by table name

Stata defines value-label tables at dataset scope. On `append`, the first file to define a table name owns it and a later file's definition of the same name is dropped (`(label xl already defined)`), never merged. Each variable keeps the table name its first contributor assigned, and its label set is the owning definition of that name, which may come from a different variable in a different source (the MICS `labb` case: `ma7m` defines `labb` in the master, `ma6a2`/`ma6b2`/`cm11c` are assigned `labb` in a later source, and all display the master's months table). A name the master does not define is taken from the first later source that does. A variable with labels but no `value.label.name` defines a table named after itself, matching what `save_dta()` writes.

Previously `dta_append()` merged tables per variable through `vctrs::vec_ptype2`, giving `c(one = 1, two = 2)` where Stata keeps `c(one = 1)`, and leaving variables that share a table name with different sets, which `save_dta()` then renamed with "Conflicting value-label table mappings".

Implementation: `.append_common_prototype()` strips `labels`/`value.label.name` before coercion; `.append_value_label_tables()` builds a by-name registry by walking sources in order; `.append_restore_owned_metadata()` looks up the owner's table name in that registry and sets `value.label.name` only when it differs from the variable name.

## Rule 2: widened string storage resets the display format width

When a string's storage widens from `strN` to `strM`, Stata sets the format to `%Ms` (minimum 9; `%9s` when the result is `strL`) and keeps the master's justification flag (`-` or `~`). It does not take the using source's format. When storage does not widen, the master's format is kept unchanged; `strL` masters and numeric promotion keep the master's format (probed: `%~9s` on str2 -> str15 gives `%~15s`; `%20s` on str5 -> str10 gives `%10s`; `%-3s` on str3 -> strL gives `%-9s`; `%5.0f` on byte -> long stays `%5.0f`).

Implementation: `.append_widened_string_format()`, applied to the owner's format in `.append_restore_owned_metadata()`.

## Tests

`tests/testthat/test-dta-append.R`: 111 -> 159 expectations, all passing. The test "value-label tables merge and the first contributor wins text" asserted the merge and is rewritten as "the first source to define a value-label table owns it". Added: cross-variable table ownership (`labb`) including a `save_dta()` round trip with no rename warning; a table defined only by a later source; unnamed-labels-first-contributor in both directions; file-source round trip; string format widening with `%Ns`, `%-Ns`, `%~Ns`, a master wider than the new storage, and widening to strL; no change when storage does not widen, including strL master and an unformatted master; numeric format kept on promotion (already covered by "formats come from the first contributor after promotion").

Full suite: 7006 -> 7054 passing. One pre-existing error in `test-dibble-bracket.R` ("the autoprint skip does not outlive its top-level statement") fails identically on unmodified `main` in my environment (callr `Rscript` subprocess); unrelated to this change.

## Stata conformance

Built three `.dta` sources in Stata 18 exercising both rules (shared `xl` redefined in two later files, `labb` cross-variable, `pl` disjoint codes, `ul`/`yl`/`zl` defined only by later sources, string widening with `%9s`/`%-9s`/master-wider-than-storage, str3 -> strL, byte -> long with `%5.0f`, float -> double), appended them in Stata and saved the result. `dta_append()` on the same three files, written with `save_dta()`, was compared with `benchmarks/r-corpus-roundtrip/stata-compare.do` (args `stata-result.dta r-result.dta dibble 118`): **pass**. An attribute-level R comparison (`format.stata`, `labels`, `value.label.name`, `stata.string.storage`, variable label, storage type, `dta_identical()` on values) over every variable also matched, and `save_dta()` on the result emitted no table-name conflict warning.

## Docs

`dta_append()` roxygen "Metadata" section rewritten to state both rules; `man/dta_append.Rd` regenerated for that topic only (roxygen touched `dta_merge.Rd` too; that change was reverted as unrelated, see #132). The repository keeps no CHANGELOG/NEWS.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dataset appending so value-label tables consistently use the first contributing definition.
  * Preserved variable metadata from the first source, including labels, notes, formats, and label-table ownership.
  * Expanded string format widths when storage widens while retaining alignment.
  * Prevented temporary value-label conflicts and warnings during type conversion.
  * Preserved metadata and value-label behavior through `.dta` file round trips.

* **Documentation**
  * Clarified metadata precedence, value-label ownership, and string-format behavior when appending datasets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->