### PR TITLE
Judge reference state by the dibble class

### DIFF
--- a/r-package/dtatools/R/mutate-data.R
+++ b/r-package/dtatools/R/mutate-data.R
@@ -437,7 +437,13 @@ gen <- function(data, ..., where = NULL, by = NULL, bysort = NULL) {
     result
 }
 
+# The `dtatools_ref_data` class is what makes the state authoritative,
+# because the mark sets both together. An in-place converter that rewrites
+# the class alone, as `data.table::setDT()` does, leaves the attribute on
+# an object the state no longer describes; honouring it there would have
+# the mutators read a column list that is no longer the object's own.
 .reference_state <- function(data) {
+    if (!inherits(data, "dtatools_ref_data")) return(NULL)
     state <- attr(data, ".dtatools_ref_state", exact = TRUE)
     if (is.environment(state)) state else NULL
 }

--- a/r-package/dtatools/tests/testthat/test-data-table-compatibility.R
+++ b/r-package/dtatools/tests/testthat/test-data-table-compatibility.R
@@ -290,3 +290,27 @@ test_that("dataset metadata setters keep data.table output ordinary", {
     result[, extra := 1]
     expect_identical(result$extra, c(1, 1))
 })
+
+test_that("setDT() on a read result drops the stale reference state", {
+    skip_if_not_installed("data.table")
+    .datatable.aware <- TRUE
+    path <- tempfile(fileext = ".dta")
+    on.exit(unlink(path), add = TRUE)
+    save_dta(data.frame(hh1 = dta_long(1:3)), path)
+
+    data <- read_dta(path, encoding = "UTF-8")
+    data.table::setDT(data)
+
+    # `setDT()` rewrites the class in place and leaves the mark behind,
+    # so the mutators must judge the object by its class alone.
+    expect_false(inherits(data, "dtatools_ref_data"))
+    expect_null(dtatools:::.reference_state(data))
+
+    gen(data, cluster = NA_real_)
+    expect_identical(names(data), c("hh1", "cluster"))
+    set_var_label(data, cluster, "Cluster ID")
+    expect_identical(var_label(data, cluster), "Cluster ID")
+    repl(data, cluster = hh1)
+    expect_identical(as.double(data$cluster), c(1, 2, 3))
+    expect_true(dtatools:::.ordinary_data_table(data))
+})

--- a/r-package/dtatools/tests/testthat/test-data-table-compatibility.R
+++ b/r-package/dtatools/tests/testthat/test-data-table-compatibility.R
@@ -299,6 +299,12 @@ test_that("setDT() on a read result drops the stale reference state", {
     save_dta(data.frame(hh1 = dta_long(1:3)), path)
 
     data <- read_dta(path, encoding = "UTF-8")
+    # The regression needs a real dibble going in, or the case below
+    # would pass without ever exercising a stale mark.
+    expect_true(inherits(data, "dtatools_ref_data"))
+    expect_true(is.environment(
+        attr(data, ".dtatools_ref_state", exact = TRUE)
+    ))
     data.table::setDT(data)
 
     # `setDT()` rewrites the class in place and leaves the mark behind,


### PR DESCRIPTION
Fixes #145.

## Cause

`data.table::setDT()` converts in place by rewriting the class vector. That drops `dtatools_ref_data` but leaves the `.dtatools_ref_state` environment attribute on the object. `.reference_state()` read the attribute directly, so every mutator took the reference-state path on an object whose columns the state no longer described:

- `gen()` appeared to add the column,
- the next `repl()` on it reported ``Column `cluster` does not exist``,
- `set_var_label()` failed with `attempt to set an attribute on NULL`.

## Fix

The mark sets the class and the attribute together (`C_dtatools_mark_reference_data`), so the class is the authority. `.reference_state()` is the single reader of the attribute in the package, so gating it on `inherits(data, "dtatools_ref_data")` makes every mutator fall back to the plain path for a converted object. This is the issue's first suggested option, and it matches what `is_dibble()` already does.

The one caller that inspects the state while the class is mid-assignment (`.set_stata_metadata_class()`) derives its `classes` vector from the object's own class attribute, so the object still carries the class there.

## Verification

The issue's reproduction now succeeds end to end. Re-binding the old predicate into the loaded namespace reproduces both reported errors exactly, confirming the new test is a genuine regression test:

```
gen names: hh1 cluster
set_var_label: attempt to set an attribute on NULL
repl: Column `cluster` does not exist
```

Full suite against the workspace tree: **FAIL 0 | PASS 7530**. The 2 warnings are pre-existing `Ops.Date` incompatible-methods noise on `main`.

Added `test-data-table-compatibility.R` coverage for the `read_dta` → `setDT` → `gen` → `set_var_label` → `repl` shape the issue names.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Reference state is now recognized only for objects explicitly marked as managed data.
  - Objects that contain similar state information but lack the required marker are treated as unmarked, preventing unintended metadata handling.

- **Tests**
  - Expanded compatibility coverage to verify that imported data is correctly marked and retains its expected reference state before conversion to a data table.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->