### PR TITLE
Regenerate man/ and add a roxygen drift check

### DIFF
--- a/r-package/dtatools/man/dta_merge.Rd
+++ b/r-package/dtatools/man/dta_merge.Rd
@@ -18,8 +18,8 @@ dta_merge(
 \item{x, y}{Data frames to merge, or file paths read with \code{\link[=read_dta]{read_dta()}} or
 \code{\link[=read_arrow]{read_arrow()}}, in any combination. \code{x} supplies the retained values for
 overlapping variables, dataset label, and dataset characteristics.
-Base data frames, tibbles, and data.tables are accepted without mutation;
-by default, the result follows the resolved \code{x} input's container.
+Base data frames, tibbles, and data.tables are accepted without mutation.
+By default, the result follows the resolved \code{x} input's container.
 Passing paths
 mirrors Stata's \verb{merge ... using filename} and keeps only the merged
 result in the caller's workspace. A path ending in \code{.arrow} is read with
@@ -61,6 +61,8 @@ bucket. Keys containing R \code{NaN} are rejected because \code{NaN} has no Stat
 missing identity; use \code{NA_real_} or \code{\link[=tagged_missing]{tagged_missing()}}.
 Character keys containing \code{NA_character_} are also rejected because Stata
 has only the empty string for a missing string; use \code{""} instead.
+Unmatched rows fill string columns with \code{""} for the same reason, while
+numeric columns fill with system missing.
 }
 \details{
 \code{x} plays the role of Stata's master dataset and \code{y} the using dataset.
@@ -107,7 +109,7 @@ substitutes one variable's mapping for another solely because names match.
 This is normally the expected result: Stata's collision can silently make a
 later label-based recode operate on unrelated text.
 
-Every merge generates a \verb{_merge} variable, a \code{stata_byte} column using
+Every merge generates a \verb{_merge} variable, a \code{dta_byte} column using
 Stata's \verb{_merge} codes with value labels \verb{x only (1)}, \verb{y only (2)}, and
 \code{matched (3)}. Merging errors if either input already has a \verb{_merge}
 column. The result keeps the dataset label and arbitrary characteristics

--- a/scripts/check-r-roxygen.sh
+++ b/scripts/check-r-roxygen.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+# Fail if man/ is out of sync with the roxygen blocks it is generated from.
+#
+# roxygen2 skips NAMESPACE and the two hand-maintained pages (man/read_dta.Rd,
+# man/recode.Rd) on its own, because none of them carries a roxygen2 header, so
+# this check leaves them alone without needing an explicit exclusion list.
+set -eu
+
+script_dir=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
+root=$(CDPATH='' cd -- "$script_dir/.." && pwd)
+package_root="$root/r-package/dtatools"
+
+if ! command -v Rscript >/dev/null 2>&1; then
+  echo "roxygen check: REQUIRED but Rscript is unavailable" >&2
+  exit 1
+fi
+
+if ! Rscript -e 'quit(status = !requireNamespace("roxygen2", quietly = TRUE))'; then
+  echo "roxygen check: REQUIRED but roxygen2 is unavailable" >&2
+  exit 1
+fi
+
+# Rd output is roxygen2-version-specific, so only compare against the pinned
+# version; a mismatched local install would report churn that is not drift.
+pinned=$(sed -n 's/^Config\/roxygen2\/version: //p' "$package_root/DESCRIPTION")
+installed=$(Rscript -e 'cat(as.character(utils::packageVersion("roxygen2")))')
+if test "$pinned" != "$installed"; then
+  echo "roxygen check: SKIP (roxygen2 $installed installed, DESCRIPTION pins $pinned)"
+  exit 0
+fi
+
+# load_code = "source" reads the R sources directly, so the check does not need
+# a compiled copy of the Rust bridge.
+(cd "$package_root" && Rscript -e 'roxygen2::roxygenise(".", load_code = "source")')
+
+if ! git -C "$root" diff --exit-code -- "r-package/dtatools/man"; then
+  echo "man/ is out of sync with the roxygen blocks; run roxygen2::roxygenise() in r-package/dtatools and commit the result" >&2
+  exit 1
+fi
+
+echo "roxygen check: PASS (man/ matches the roxygen blocks)"


### PR DESCRIPTION
Resolves #132.

`man/` no longer has the four missing pages the issue reported — `order_vars`, `rename_vars`, `reorder_dta_rows`, and `slice_dta_rows` were committed in the meantime, and `replace_values.Rd` is current. One page was still stale:

- `man/dta_merge.Rd` — prose edits and the `stata_byte` → `dta_byte` rename were never regenerated.

Regenerated with `roxygen2::roxygenise()` (roxygen2 8.1.0, matching the `DESCRIPTION` pin); verified identical output from both the pkgload and `load_code = "source"` paths. `NAMESPACE` is unchanged.

New `scripts/check-r-roxygen.sh` regenerates and fails on a non-empty `man/` diff, and runs in the `R package / ubuntu-latest` CI job. It:

- uses `load_code = "source"`, so it needs no compiled Rust bridge;
- skips itself if the installed roxygen2 differs from the `DESCRIPTION` pin, since Rd output is version-specific;
- preserves the two things the issue called out without an exclusion list: roxygen2 already refuses to touch `NAMESPACE`, `man/read_dta.Rd`, and `man/recode.Rd` because none carries a roxygen2 header.