### PR TITLE
Document Stata divergences, by-reference mutation, and container behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ The TypeScript and Rust readers follow the same compatibility contract and are c
 
 - [Contributing](CONTRIBUTING.md) covers repository layout, development, testing, conformance, and releases.
 - [Benchmarks](benchmarks/README.md) covers methodology and links to dated TypeScript, Rust, R, haven, and Stata results.
+- R guides: [where dtatools diverges from Stata](docs/r-stata-divergences.md), [mutation by reference](docs/r-mutation-by-reference.md), and [containers](docs/r-containers.md) — what `gen()`, `repl()`, `:=`, and `mutate()` do on each table class.
 
 ## License
 

--- a/docs/r-containers.md
+++ b/docs/r-containers.md
@@ -1,0 +1,93 @@
+# Containers: what each operation does
+
+`dtatools` works with four table classes, and the same call can mean different things on each. This page states what changes in place, what returns a new object, and what column types result.
+
+| Container | What it is |
+| --- | --- |
+| **dibble** | A tibble that is a Stata dataset. Every numeric and string column carries Stata storage, every dataset operation on it returns a dibble, and it carries reference state from its creation. The default result of `read_dta()`, `read_arrow()`, and `dta_append()`. |
+| **tibble** | An ordinary `tbl_df`. Columns may carry Stata storage — the readers' columns do — but nothing enforces it. |
+| **data.frame** | A base data frame, with the same caveat. |
+| **data.table** | An ordinary data table, with keys, indexes, and its own `[` semantics. Available when the optional `data.table` package is installed. |
+
+Choose a reader's container with `output = ` on the call, or session-wide with `options(dtatools.output = )`. `as_dibble()`, `tibble::as_tibble()`, `as.data.frame()`, and `data.table::as.data.table()` convert. `save_arrow()` records which of the four its input was, and `read_arrow()` restores it by default.
+
+## Where the write lands
+
+*Reference* means the operation modifies the dataset itself, so every name bound to it sees the change and no assignment is needed. *Copy* means R's ordinary copy-on-modify: a new object comes back and the input is untouched. See [mutation by reference](./r-mutation-by-reference.md).
+
+| Operation | dibble | tibble | data.frame | data.table |
+| --- | --- | --- | --- | --- |
+| `gen(data, y = v)` | Reference | Reference; the tibble becomes a dibble and its columns are typed | Reference; stays a base data frame with bare existing columns | Reference; installs a physical column |
+| `repl(data, y = v, where = )` | Reference | Reference | Reference | Reference; invalidates keys and indexes on the changed column only |
+| `keep_vars()`, `drop_vars()`, `order_vars()`, `rename_vars()` | Reference | Reference | Reference | Reference |
+| `reorder_dta_rows(data, perm)` | Reference | Reference | Reference | Reference; drops the `sorted` marker and secondary indexes |
+| `data[i, y := v]` | Reference | Error | Error | data.table's own `:=`: reference, ignoring declared Stata storage |
+| `dplyr::mutate()` and the other verbs | Copy → dibble | Copy → tibble | Copy → data.frame | Copy → data.table |
+| `$<-`, `[[<-`, `[<-`, `names<-`, `dimnames<-`, `row.names<-` | **Reference** | Copy | Copy | Copy |
+| `var_label(data$x) <- `, `val_labels(data$x) <- `, `attr(data$x, ...) <- ` | **Reference** (they are `$<-` calls) | Copy | Copy | Copy |
+| `set_var_label()`, `set_dta_note()` and the other functional setters | Copy | Copy | Copy | Copy |
+| `slice_dta_rows(data, i)` | Copy → dibble | Copy → tibble | Copy → data.frame | Copy → data.table |
+| `data[i, ]`, `subset()`, `transform()`, `within()`, `head()`, `rbind()`, `cbind()` | Copy → dibble | Copy → tibble | Copy → data.frame | data.table's own behavior |
+| Joins, `bind_rows()` | Copy → dibble when the dibble is first | Copy → tibble | Copy → data.frame | Copy → data.table |
+| `copy_data()`, `tibble::as_tibble()` | Copy, independent | Copy, independent | Copy, independent | Copy, independent |
+
+One qualification on the tibble column: `gen()` on a plain tibble makes it a dibble, so from that call onward it follows the dibble column, replacement operators included. A base data frame keeps R's semantics for those operators however often `gen()` has run on it.
+
+Two rows deserve emphasis. `$<-` and its relatives are by reference **only** on a dibble; this is the one place where a dibble stops behaving like an ordinary tibble, and it is what makes `var_label(data$x) <- "Age"` reach every binding of the dataset. And `[i, y := v]` is a dibble form: on a data table the brackets are data.table's, with data.table's storage and promotion rules, and on the other two containers there is no `:=` to find. `gen()` and `repl()` are the spellings that mean the same thing on all four.
+
+Grouping works the same way everywhere: `by = ` groups in current row order, `bysort = ` sorts by reference and then groups, and a grouped tibble or dibble supplies its dplyr groups. The order of operations is Stata's — groups first, then row selection and values per group, with `.n` and `.N` as the within-group row number and count — rather than data.table's, which applies `i` before grouping.
+
+## What column type results
+
+Only a **dibble** types its columns. Every operation that adds or changes a column on a dibble gives a bare R vector a Stata storage type; the other three containers leave the value's own type alone, so a Stata storage type appears there only when the value already carried one — from a `dta_*()` constructor, from a reader, or from arithmetic on a column that had one.
+
+| Value produced by the expression | `gen()` and a new `:=` column | `mutate()`, `transform()`, `$<-` on a dibble | tibble, data.frame, data.table |
+| --- | --- | --- | --- |
+| Bare double | `float` — Stata's `generate` default; `double` under `options(dtatools.generate_type = "double")` | `double` | Bare double |
+| Bare integer | `long` | `long` | Bare integer |
+| Logical | Logical; `save_dta()` writes `byte` | Logical | Logical |
+| Character | Smallest fitting `str1`–`str2045`, or `strL` | Same | Bare character |
+| `Date` | `float`, declared a Stata date | Same | `Date` |
+| `POSIXct` | `double`, declared a Stata datetime | Same | `POSIXct` |
+| Factor | Factor; `save_dta()` writes a value-labelled `long` | Same | Factor |
+| `dta_byte()` … `dta_double()`, `dta_string()` | Its declared storage | Its declared storage | Its declared storage |
+| Arithmetic on a typed column | The storage the Stata lattice gives the result | Same | Same |
+| `haven_labelled` | Keeps its label metadata | Keeps its label metadata | Keeps its label metadata |
+| `difftime`, `bit64::integer64`, raw, list | Rejected by `gen()` | Passes through untyped; `save_dta()` refuses it | Unchanged |
+
+Overwriting a column that already has declared storage follows one rule on a dibble: keep that storage if every new value fits, otherwise take the narrowest storage that holds every value exactly — `byte`, `int`, `long`, `float`, `double`, or the smallest fitting `str#`. `mutate()`, `:=`, `transform()`, `within()`, and the replacement operators promote this way. `replace_values()` and `repl()` never promote; they reject a value the declared storage cannot hold. So does `[<-` applied to a Stata vector taken out of the dataset, as in `data$x[1] <- 1000L`, which is the vector's own strict assignment rather than a dataset operation.
+
+The full mapping, including the reasoning, is `?"stata-storage-defaults"`. The `gen()`/`mutate()` split is [ADR 0022](./adr/0022-give-gen-statas-generate-default.md) and is listed in [the divergences page](./r-stata-divergences.md#storage-types).
+
+## Worked comparison
+
+```r
+survey <- read_dta("survey.dta")          # a dibble
+tbl <- tibble::as_tibble(survey)          # a snapshot, ordinary tibble
+
+gen(survey, adjusted = income * 1.1)      # by reference; `adjusted` is float
+survey[income < 0, income := NA]          # by reference; prints nothing
+survey$region <- 1:nrow(survey)           # by reference; `region` is long
+var_label(survey$region) <- "Region"      # by reference; reaches the dataset
+
+tbl2 <- dplyr::mutate(tbl, adjusted = income * 1.1)   # a copy; `adjusted` is a bare double
+tbl$region <- 1:nrow(tbl)                             # a copy; nothing else sees it
+tbl[income < 0, income := NA]                         # error: tibbles have no `:=`
+
+gen(tbl, flag = income > 0)               # by reference — and `tbl` is now a dibble
+```
+
+The last line is the one to remember: `gen()` on a plain tibble attaches reference state and types the existing columns, so the tibble becomes a dibble at that point. `is_dibble()` reports it. A base data frame stays a base data frame, with reference state but bare existing columns.
+
+## Restrictions
+
+A dibble needs unique, non-empty column names, because its reference state indexes columns by name. The readers repair names first, so only `.name_repair = "minimal"` can produce names a dibble rejects; ask for `output = "tibble"` for such a read.
+
+Rowwise tibbles are rejected by `gen()` and `repl()`; `copy_data()` accepts them. Custom `data.table` subclasses are rejected by mutating and table-producing operations, because dtatools cannot know their invariants. A data table converted with `as_dibble()` is copied rather than shared — a dibble cannot hold data.table's self-reference — and its keys, indexes, and allocation capacity are left behind. Keys, indexes, allocation capacity, and `.internal.selfref` are runtime state and are never stored in `.arrow` files.
+
+## See also
+
+- [Mutation by reference](./r-mutation-by-reference.md)
+- [Where dtatools diverges from Stata](./r-stata-divergences.md)
+- [Stata vector operations](./r-stata-vector-operations.md) — the rules columns follow outside a dibble
+- `?dibble`, `?"dibble-bracket"`, `?"stata-storage-defaults"`, `?replace_values` in R

--- a/docs/r-mutation-by-reference.md
+++ b/docs/r-mutation-by-reference.md
@@ -1,0 +1,125 @@
+# Mutation by reference
+
+Most R code is copy-on-modify. `dtatools` deliberately is not, for the operations that translate Stata commands. This page explains what that means, why the package works this way, and what changes in your workflow as a result. No prior experience with pointers or `data.table` is assumed.
+
+## The R model you are used to
+
+In ordinary R, a name refers to a value, and changing a value through one name never affects another:
+
+```r
+a <- data.frame(x = 1:3)
+b <- a
+b$x <- b$x * 2
+
+a$x
+#> [1] 1 2 3
+```
+
+`b <- a` did not copy anything yet — R shares the data until one of the two is written to, and copies at that moment. This is *copy-on-modify*. It is why almost every R function takes a data frame and returns a new one, and why a function cannot change its caller's data:
+
+```r
+double_it <- function(d) {
+    d$x <- d$x * 2
+    d          # you must return it, and the caller must assign it
+}
+a <- double_it(a)
+```
+
+Stata works the other way. There is one dataset in memory, `replace x = x * 2` changes it, and nothing is assigned or returned. A translated Stata script written in ordinary R style would copy a multi-gigabyte dataset on every line.
+
+## What dtatools does instead
+
+A **dibble** — the container `read_dta()` returns — carries package-owned reference state. Operations that write through that state modify *the dataset itself*, so every name bound to it sees the change:
+
+```r
+survey <- read_dta("survey.dta")
+copy <- survey
+
+gen(survey, adjusted = income * 1.1)
+
+names(copy)          # `copy` has the new column too
+copy$adjusted[1]
+```
+
+Nothing was assigned. `gen()` returns the dataset invisibly, so `survey <- gen(survey, ...)` also works and is harmless, but it is misleading: the assignment is not what made the change, and writing it that way suggests the unmodified original still exists somewhere. It does not.
+
+The same holds inside a function, which is the payoff for a translated script:
+
+```r
+add_flags <- function(data) {
+    gen(data, poor = income < 1000)
+    repl(data, poor = NA, where = is_missing(income))
+    invisible(data)
+}
+
+add_flags(survey)    # `survey` now has `poor`
+```
+
+## Which operations write by reference
+
+By reference, on any supported container (dibble, tibble, base data frame, data table):
+
+- `gen()`, `replace_values()` / `repl()`
+- `keep_vars()`, `drop_vars()`, `order_vars()`, `rename_vars()`
+- `reorder_dta_rows()`
+
+By reference, on a dibble only:
+
+- `data[i, y := value]`, the bracket assignment shape
+- the replacement operators `$<-`, `[[<-`, `[<-`, `names<-`, `dimnames<-`, `row.names<-`
+- and therefore every metadata setter used in replacement form, because R spells `var_label(data$x) <- "Age"` as a `$<-` call: `var_label<-`, `val_labels<-`, and `attr<-` on `format.stata`, notes, or characteristics
+
+Not by reference — these return a new object and leave their input alone:
+
+- every dplyr verb (`mutate()`, `filter()`, `arrange()`, `select()`, `group_by()`, joins, `bind_rows()`)
+- base `subset()`, `transform()`, `within()`, `head()`, `rbind()`, `cbind()`, and `[` subsetting without `:=`
+- `slice_dta_rows()`, which returns the selected rows in a new table
+- the metadata setters called in functional form (`set_var_label()`, `set_dta_note()`, and friends), which return a changed copy
+- `copy_data()` and `tibble::as_tibble()`, whose whole purpose is to produce an independent object
+
+On a dibble those operations still return a dibble, so the two styles mix freely. A verb's result is a fresh dataset: a later `repl()` on it does not reach the input it came from, and a `repl()` on the input does not reach the result.
+
+## Why
+
+**Translation fidelity.** `replace x = 0 if y > 5` becomes `repl(data, x = 0, where = y > 5)` — one line, no assignment, no renaming of the dataset at each step. A script converted from Stata reads like the original.
+
+**Cost.** Copy-on-modify means a full dataset copy per modified column, and Stata scripts modify columns in long sequences. On the 5.2 GB, 5,972-column files this package is built for, that is the difference between a workflow that runs and one that does not. Writing through the reference also lets `gen()` and `repl()` patch a compact Stata column in its native storage — `byte` stays one byte per row — instead of materializing a double vector.
+
+**Metadata setters reach the dataset.** `var_label(data$x) <- "Age"` in ordinary R extracts a column, labels the copy, and writes it back into a copy of the data frame. On a dibble it labels the dataset's own column, so the label is there for every binding, including the caller's when this happens inside a function.
+
+## What changes in your workflow
+
+**Aliases are the same dataset.** `b <- a` gives you a second name for one dataset, not a snapshot. Column-only subsets share their column payloads, so a mutation reaches them too. Row subsets have new payloads and are independent. When you need an untouchable original, say so:
+
+```r
+original <- copy_data(survey)   # independent, keeps compact columns compact
+snapshot <- tibble::as_tibble(survey)   # a plain tibble with R's semantics
+```
+
+`copy_data()` deep-copies the columns, their compact backing, and mutable dataset metadata. It rejects columns or attributes holding environments, functions, bytecode, external pointers, or weak references, because those cannot be isolated by copying.
+
+**Functions do not need to return the dataset.** They may, invisibly, for chaining; the caller does not have to assign it. Conversely, passing a dibble to a function you did not write is a way to have it modified — pass `copy_data()` if that is not wanted.
+
+**There is no undo.** A mutation commits. Interrupting one is safe — compact columns keep rollback bytes until the write commits, so `Ctrl-C` restores the original payload — but a completed `repl()` cannot be reversed except by writing the old values back.
+
+**A `[` assignment does not print.** `[` always makes its result visible, so a bracket assignment at the console would print the whole dataset. As data.table does, dtatools skips the next top-level print of the mutated dataset, so `survey[income < 0, income := NA]` prints nothing and a bare `survey` on the next line prints as usual. The skip lasts only for the statement that made the assignment.
+
+**A few consumers need a snapshot.** A dibble is built with spare capacity for 256 more columns, and `gen()` appends into it in place, so the physical column list stays complete for everything that reads it. Past that capacity — and on a plain tibble that became a dibble at its first `gen()` — generated columns live in the attached reference state until an ordinary R assignment materializes a full copy. Code that bypasses S3 methods and reads a data frame's internal column-pointer array does not see those columns: `dplyr::bind_rows()`, `unclass()`, and direct attribute inspection are the ones to watch. Pass `tibble::as_tibble(data)` or `as.data.frame(data)` to such a consumer. Base extraction, the data mask, the core dplyr verbs, the package's writers, and the metadata helpers all see the complete dataset.
+
+**ALTREP columns from elsewhere are detached.** A generic ALTREP column created by base R or another package is converted to an ordinary vector before replacement, because its private caches cannot be safely invalidated. A standalone alias to that former column keeps the old values.
+
+## Compared with data.table
+
+If you know `data.table`, the model is familiar: `DT[, x := 1]` and `set()` modify in place, and `DT2 <- DT` gives a second name rather than a copy. dtatools' `:=` is deliberately the same shape. Three differences are worth knowing.
+
+The bracket shape belongs to the dibble. `data[i, y := value]` works on a dibble; on a data table it runs data.table's own `:=`, which knows nothing about declared Stata storage; on a tibble or data frame it is whatever error their `[` raises. `gen()` and `repl()` work on all four containers, so they are the portable spelling.
+
+The order of operations is Stata's, not data.table's. In `DT[i, j, by]`, data.table applies `i` first and groups only the surviving rows, so `.N` counts selected rows and a group emptied by `i` disappears. Here the groups are formed first, then `where` and the values are evaluated on each group's rows, so `.N` is the group's row count whatever `where` selects, and `where = .n == .N` marks each group's last row — which is what `bysort id: replace last = _n == _N` means in Stata.
+
+`.SD`, `.GRP`, and `.BY` are not provided, and `j` is not a general expression. Summaries stay with dplyr.
+
+## See also
+
+- [Containers](./r-containers.md) — what each operation does on a dibble, tibble, data frame, and data table, and the column types that result
+- [Where dtatools diverges from Stata](./r-stata-divergences.md)
+- `?dibble`, `?"dibble-bracket"`, `?replace_values`, `?copy_data` in R

--- a/docs/r-stata-divergences.md
+++ b/docs/r-stata-divergences.md
@@ -1,0 +1,99 @@
+# Where dtatools diverges from Stata
+
+`dtatools` treats Stata's behavior as the compatibility target: storage types, the 27 missing codes and their ordering, value labels, `merge`, `append`, `generate`, `replace`, and `by varlist:` all mean in R what they mean in Stata. This page records the places where it deliberately does something else, and why. Everything not listed here is either intended to match Stata or is a bug worth reporting.
+
+Divergences fall into three kinds. Some exist because R is a language of functions and values rather than a command language operating on one current dataset. Some exist because Stata's behavior is lossy or nondeterministic and a lossless or reproducible alternative is available. The rest are Stata edge cases where following Stata would silently produce a wrong answer.
+
+## Language shape
+
+R has no command prefixes, no `if`/`in` qualifiers, and no leading-underscore names, so the translated spellings differ even where the semantics do not.
+
+| Stata | dtatools | Why |
+| --- | --- | --- |
+| `_n`, `_N` | `.n`, `.N` in `values` and `where` | `_n` is not a valid R name. |
+| `mi(x)` | `is_mi(x)`, or `is_missing(x)` | The package prefixes predicates with `is_`; `is_mi()` keeps Stata's shorthand recognizable. |
+| `by varlist:` prefix | `by =` / `bysort =` arguments | R has no prefix syntax. The semantics are Stata's: groups are formed first, then `where` and the values are evaluated per group. |
+| `bysort id (date):` | `arrange()` or `reorder_dta_rows()`, then `by = id` | Parenthesized sort-only keys would need a second grammar inside an argument that otherwise names grouping columns. |
+| `generate x = exp if cond in 1/10` | `gen(data, x = exp, where = cond)` | `[in]` is a row-position selection, which `where` already accepts as numeric positions. |
+| `generate x = exp, before(y)` | `gen()` appends; use `order_vars()` | Placement is a separate concern from generation, and `order_vars()` already spells Stata's `order`. |
+| `generate x:lblname = exp` | `gen()` then `set_val_labels()` | Label authoring inside a generate expression has no natural R spelling. |
+| `note x: text`, `label var x "text"` | `set_dta_note()`, `set_var_label()` | See [notes and characteristics](./stata-notes-and-characteristics.md) and the [label metadata guide](./r-label-metadata.md). |
+
+Stata commands print a report — how many missing values `generate` produced, how many real changes `replace` made. dtatools functions do not print one. They signal problems as R conditions instead: an error where Stata would refuse, a warning where a conversion loses information.
+
+Stata commands modify the dataset in memory. dtatools splits this: `gen()`, `repl()`, `keep_vars()`, `drop_vars()`, `order_vars()`, `rename_vars()`, `reorder_dta_rows()`, and `:=` modify the dataset by reference, as Stata does, while the notes, characteristics, and metadata setters called in functional form return a changed copy. Called in replacement form on a dibble — `var_label(data$x) <- "Age"` — the metadata setters are by reference again. See [mutation by reference](./r-mutation-by-reference.md).
+
+## Storage types
+
+`?"stata-storage-defaults"` states the full mapping, and [containers](./r-containers.md#what-column-type-results) tabulates it. Three of its rules diverge from Stata.
+
+**`generate`'s default reaches only `gen()` and `:=`.** A bare double result from `gen(data, y = x * 2)` is stored as `float`, exactly as Stata's `generate` would, and `options(dtatools.generate_type = "double")` is the equivalent of `set type double`. But `dplyr::mutate()`, `transform()`, `within()`, and the replacement operators are R operations on a container, not translations of a Stata command, and they follow R's types: the same expression takes `float` through `gen()` and `double` through `mutate()`. Making `gen()` alone follow `generate` is what lets a translated Stata script keep the storage the original produced without restating `dta_float()` on every line; making the R verbs follow R types is what keeps `mutate()` from silently narrowing an R pipeline's doubles. See [ADR 0022](./adr/0022-give-gen-statas-generate-default.md).
+
+**Bare integer results are `long`, not `float`.** Stata's untyped `generate` produces `float` whatever the expression. An R integer vector comes from R rather than from a translated Stata line, and `float` cannot represent integers above 2^24, so `gen(data, y = 1L:n())` stores `long`.
+
+**Promotion goes to the narrowest storage that is exact, not up Stata's ladder.** When `mutate()`, `:=`, `transform()`, `within()`, or a replacement operator overwrites a typed column with values its storage cannot hold, the column takes the narrowest of `byte`, `int`, `long`, `float`, `double` that holds every new value exactly. Stata's `replace` promotes an overflowing `long` to `float`, where integers above 2^24 lose digits; dtatools goes to `double` instead. A silent loss of precision is not worth reproducing.
+
+`replace_values()` and `repl()` diverge further: they never promote at all, and reject a value the declared storage cannot hold. `replace` in Stata is the command that changes values in place, and a value that does not fit is normally a mistake in the translated logic rather than a request to widen the column. `:=` on an existing column promotes, because a user of the bracket shape expects `mutate()`'s behavior there.
+
+Two more mapping choices are R-side rather than Stata-side, and are stated here because they surprise Stata users. Logical columns stay logical rather than becoming `byte`, because R idioms on flags (`filter(data, flag)`, `where = flag`) need a logical; `save_dta()` writes them as `byte`. Factors stay factors and are written as value-labelled `long`.
+
+## Expressions and rows
+
+**An expression with a row selection is evaluated for every row, then selected.** Stata evaluates `generate x = exp if cond` only for the observations `cond` selects. dtatools evaluates `values` once against the whole dataset (or the whole group, under `by`/`bysort`) and then assigns to the selected rows. R expressions are vectorized over columns, and evaluating them twice — once to find the selection, once on a subset — would change the meaning of any aggregate in the expression. Where the difference matters, write the restriction into the expression as well as into `where`.
+
+**Rows a selection excludes hold Stata's missing.** This matches Stata: a numeric column generated under `where` holds system missing outside the selection, a string column holds `""`. `replace_values()` leaves excluded rows untouched, as `replace` does.
+
+**Strings have no `NA`.** Stata's only missing string is the empty string. `NA_character_` in a replacement value or an exported column becomes `""`, and the conversion is reported on export. Owned Stata string vectors reject `NA_character_` outright.
+
+## Merge
+
+`dta_merge()` follows Stata's `merge` in key identity — all 27 missing codes match only themselves — in requiring a declared `1:1`, `m:1`, or `1:m` relationship, in rejecting `m:m`, in the master-wins rule for overlapping variables, and in generating a value-labelled `_merge`. It diverges in three places. See [ADR 0009](./adr/0009-own-dta-identity-merge.md) and the [joins note](./r-joins-with-stata-columns.md).
+
+**Result order.** Stata re-sorts the merged dataset by the key variables. `dta_merge()` returns master rows in master order followed by unmatched using rows in using order. Key order would make every merge pay for a sort under Stata's ordering of 27 missing codes, and stable input order is the more useful default in an R pipeline. Sort afterwards when Stata's order is wanted.
+
+**Colliding value-label table names.** Stata stores named value-label definitions at dataset scope. When master and using define different mappings under the same name, Stata keeps master's definition and can then display it on a using-only variable — privacy labels on a month variable, for instance, which can silently misdirect a later recode written against label text. `dtatools` treats each variable's resolved code-to-text mapping as authoritative, so the using-only variable keeps its own labels. See [ADR 0016](./adr/0016-own-resolved-value-label-mappings.md) and the [label metadata guide](./r-label-metadata.md#compatibility-with-stata-merge). Correct accidental name collisions in the Stata source before comparing exact merge output.
+
+**Warnings where Stata is silent.** Overlapping non-key variables resolve master-first, as in Stata, but `dta_merge()` warns and names them, and it warns again when the two sides disagree on a variable's metadata.
+
+## Append
+
+`dta_append()` reproduces `append using ..., force`: the union of variables in first-appearance order, missing values where a source lacks a variable, string storage widened to the widest contributor, numeric storage promoted losslessly, and labels, formats, and variable notes taken from the first source that contributes the variable.
+
+**Sources are one list, not a master and a using.** Stata appends one or more using files to the dataset in memory. `dta_append(list(a, "b.dta", "c.arrow"))` resolves the schema union in a single pass instead of reallocating the result once per source.
+
+**Dataset-level notes are an explicit argument.** Stata does not define what `append` does with them and keeps the master's. `dataset_notes` defaults to `"first"` to match that, with `"all"` and `"none"` available because neither is obviously wrong.
+
+**`force` is an argument with a strict default.** A string/numeric conflict follows Stata's `force` — the first contributor's type wins, the conflicting rows hold missing, and a message names them — but `force = FALSE` makes it an error instead.
+
+## Reports and diagnostics
+
+**`labelbook(list_limit = )` lists a deterministic prefix.** Stata's `list(#)` shows a random subset of mappings. dtatools lists the first ones, so two runs of the same script produce the same report.
+
+**Reports are data, not printed output.** `codebook()` and `labelbook()` return structured results — underlying numeric codes, missing counts, notes, diagnostics, and Stata-style missingness implications — so callers need not parse a printed report. `tab()` returns a base `table` object rather than Stata's formatted `tabulate` output.
+
+**`recode()` is dplyr's interface, not Stata's command.** `dtatools::recode()` takes dplyr's replacement form and adds what dplyr loses: unmatched system and extended missing payloads survive, as do numeric classes, `haven_labelled`, `Date`, and `POSIXct`. Stata's `recode` rule syntax, including range rules, is not implemented. Value-label definitions are not rewritten when the codes they describe change.
+
+**`datasig()` is stronger than `datasignature`.** It is order-sensitive and covers names and order, storage types, labels, display formats, notes, and every value in row order, so it detects changes Stata's `datasignature` misses: values swapped within a variable, reordered observations, and values exchanged between same-type variables. The signatures are therefore not comparable with Stata's; a signature is a claim about content under `datasig()`'s own definition.
+
+**`factor_from_labels()` is one-way by design.** It keeps distinct source codes distinct even when their label text is identical, but it does not support reconstructing the numeric variable. Stata has no factor type; a reversible factor class would invite round-trips that cannot be honored. See [ADR 0004](./adr/0004-own-stata-missing-and-factor-helpers.md).
+
+## Files
+
+**The writer targets Stata 18 and 19 only.** It emits release 118, or 119 above 32,767 variables, and does not write older releases or the release 120/121 alias-variable layouts. Use haven for older releases.
+
+**Output is always little-endian.** Byte order has no effect on the values Stata exposes, and fixing it makes output deterministic across writer hosts.
+
+**Extensionless local names resolve to `.dta`**, as Stata's `use` and `save` do. On write, dtatools adds the extension with a warning rather than silently.
+
+**Pre-Unicode encoding is a choice, not a fact read from the file.** Releases before 118 record no code page, so the reader defaults to Windows-1252 and accepts explicit UTF-8, Windows-1252, and true ISO-8859-1 overrides.
+
+**Notes and characteristics on a variable named `_dta` are rejected on DTA export.** Arrow can hold them; DTA reserves that spelling for dataset scope, so changing their scope silently is not an option.
+
+See the [compatibility contract](./compatibility.md) for supported releases, encodings, and the reader's stricter row-window validation, which differs from haven rather than from Stata.
+
+## Divergences from R, not from Stata
+
+Two behaviors surprise R users rather than Stata users, and are documented elsewhere:
+
+- Stata missing codes are missing to `is.na()` and `is_missing()`, but vctrs equality must encode them as distinct comparable keys, so `vctrs::vec_detect_missing()` and completeness operations treat them as present, and dplyr's `na_matches` does not change their identity. See [Stata vector operations](./r-stata-vector-operations.md).
+- On a dibble the replacement operators write by reference, which is not R's copy-on-modify. See [mutation by reference](./r-mutation-by-reference.md) and [containers](./r-containers.md).

--- a/docs/r-stata-divergences.md
+++ b/docs/r-stata-divergences.md
@@ -33,7 +33,14 @@ Stata commands modify the dataset in memory. dtatools splits this: `gen()`, `rep
 
 **Promotion goes to the narrowest storage that is exact, not up Stata's ladder.** When `mutate()`, `:=`, `transform()`, `within()`, or a replacement operator overwrites a typed column with values its storage cannot hold, the column takes the narrowest of `byte`, `int`, `long`, `float`, `double` that holds every new value exactly. Stata's `replace` promotes an overflowing `long` to `float`, where integers above 2^24 lose digits; dtatools goes to `double` instead. A silent loss of precision is not worth reproducing.
 
-`replace_values()` and `repl()` diverge further: they never promote at all, and reject a value the declared storage cannot hold. `replace` in Stata is the command that changes values in place, and a value that does not fit is normally a mistake in the translated logic rather than a request to widen the column. `:=` on an existing column promotes, because a user of the bracket shape expects `mutate()`'s behavior there.
+`replace_values()` and `repl()` diverge further, and in the opposite direction: they never promote at all, and reject a value the declared storage cannot hold. Note that this is *stricter* than Stata, not a copy of it. Stata's `replace` widens the variable automatically and reports it — `replace x = 1000` on a `byte` prints `x was byte now int` — so a translated line that Stata accepts with a message is an error here:
+
+```r
+repl(data, x = 1000)      #> Stata byte storage cannot represent the value; use `dta_int()`
+data[, x := 1000]         #> promotes; `x` is now int
+```
+
+The intent ([ADR 0021](./adr/0021-make-dibbles-stata-typed-and-closed.md)) is to offer both contracts under two spellings: `repl()` holds a column to its declared storage, while `:=` and `mutate()` follow dplyr's rule that the right-hand side defines the column. There is no opt-in argument on `repl()`; widen the value (`repl(data, x = dta_int(1000))`), use `:=`, or declare wider storage when the column is created. One consequence worth knowing: a bare Arrow string read into a dibble carries the width of its dictionary, so `repl()` refuses a wider replacement string where it previously accepted one.
 
 Two more mapping choices are R-side rather than Stata-side, and are stated here because they surprise Stata users. Logical columns stay logical rather than becoming `byte`, because R idioms on flags (`filter(data, flag)`, `where = flag`) need a logical; `save_dta()` writes them as `byte`. Factors stay factors and are written as value-labelled `long`.
 

--- a/r-package/dtatools/README.md
+++ b/r-package/dtatools/README.md
@@ -91,7 +91,12 @@ data-table subclasses whose invariants dtatools cannot know.
 aliases and aliases of a target column observe the change. Call `copy_data()`
 first when the original dataset, its compact storage, and its metadata must
 remain independent. See `?replace_values` for selection, evaluation, formula,
-grouping, and Stata compatibility details.
+grouping, and Stata compatibility details, and
+[mutation by reference](../../docs/r-mutation-by-reference.md) for what writing
+by reference means and how it changes a workflow.
+[Containers](../../docs/r-containers.md) tabulates what `gen()`, `repl()`,
+`:=`, `mutate()`, and the replacement operators do on a dibble, tibble, data
+frame, and data table, and the column types each produces.
 
 `order_vars()` and `rename_vars()` mutate by reference too, as Stata's `order`
 and `rename` do: `order_vars()` moves the selected columns to the front and
@@ -721,6 +726,12 @@ Additional measurements and their provenance live in the repository's [dated ben
 
 The reader covers Stata 5 through 19. The writer targets Stata 18/19 and does
 not emit older formats. See the shared [compatibility contract](https://github.com/jbearak/dta-parser/blob/main/docs/compatibility.md) for exact format releases, encodings, missing-value behavior, and intentional differences from haven.
+
+`dtatools` takes Stata's behavior as its compatibility target.
+[Where dtatools diverges from Stata](../../docs/r-stata-divergences.md) lists
+the places it deliberately does something else — the `generate` default's
+reach, the promotion ladder, merge result order, colliding value-label table
+names, `labelbook`'s deterministic listing, and the rest — and why.
 
 ## Contributing
 


### PR DESCRIPTION
Adds three docs pages and links them from the root and R package READMEs. The R package README is already 731 lines, so these are separate pages rather than new sections there.

### `docs/r-stata-divergences.md`

Where dtatools deliberately does something other than what Stata does, and why, grouped by cause: R has no command prefixes or leading-underscore names; Stata's behavior is lossy or nondeterministic; or following Stata would silently produce a wrong answer.

Covers the translated spellings (`.n`/`.N`, `is_mi()`, `by=`/`bysort=`, no `before()`/`after()`, no printed report); `generate`'s float default reaching only `gen()` and `:=` and not `mutate()` (ADR 0022); bare integer results as `long`; promotion to the narrowest exact storage rather than Stata's `long` to `float` ladder; `replace_values()` never promoting at all; expressions evaluated for every row and then selected; merge result order, colliding value-label table names (ADR 0016), and warnings where Stata is silent; append's single source list and `dataset_notes`; `labelbook()`'s deterministic prefix against Stata's random subset; `datasig()` being stronger than `datasignature`; the writer's 18/19 and little-endian limits.

### `docs/r-mutation-by-reference.md`

Assumes no prior exposure to pointers or data.table. Starts from R's copy-on-modify, contrasts Stata's single dataset in memory, then gives an explicit three-way list of what writes by reference on any container, what writes by reference only on a dibble, and what returns a copy. Then the three reasons (translation fidelity, copy cost on multi-GB datasets, metadata setters reaching the dataset) and the workflow consequences: aliases, functions that need not return the dataset, no undo, the skipped autoprint after a bracket assignment, `copy_data()`, the 256-column capacity caveat for `bind_rows()` and `unclass()`, and a data.table comparison including the Stata-versus-data.table order of operations.

### `docs/r-containers.md`

The requested matrix. One table of reference-versus-copy across dibble, tibble, data.frame, and data.table for `gen()`, `repl()`, `:=`, the dplyr verbs, the replacement operators, the metadata setters in both forms, `keep_vars()` and friends, `slice_dta_rows()`/`reorder_dta_rows()`, and joins; a second table of the column type each value kind produces through `gen()`/`:=`, through `mutate()`/`$<-` on a dibble, and on the other three containers; then the overwrite and promotion rules and a worked example.

### Verification

Docs only, no code changes. The discriminating claims were checked against an installed build: `gen(d, k = 1)` gives `float`, `mutate(d, k2 = 1)` gives `double`, `[, k3 := 1]` gives `float`; `dta_byte` overflow promotes to `int` while `repl()` rejects; `gen()` on a base data frame types the new column `float` and leaves existing columns bare; `gen()` on a data.table and on a tibble both write by reference, and the tibble becomes a dibble.

One caveat worth a reviewer's eye: the system library holds 0.6.0, which predates ADR 0023, so `$<-` and `var_label(d$x) <-` did not reach aliases there. The pages describe main's behavior, taken from `dibble.R`'s roxygen, `.install_replacement`, and the six `S3method("...<-", dtatools_ref_data)` registrations in NAMESPACE, rather than from a run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance on container types, conversions, persistence, grouping, type handling, supported values, and operation-specific behavior.
  * Documented reference-based mutation, aliasing, snapshots, metadata updates, rollback behavior, and differences from related tools.
  * Added a guide to intentional differences between dtatools, Stata, and R.
  * Expanded package documentation with links to mutation, replacement, container, and compatibility guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->