### PR TITLE
Repair mutation and typing defects from the dibble audit

### DIFF
--- a/r-package/dtatools/R/dibble.R
+++ b/r-package/dtatools/R/dibble.R
@@ -318,6 +318,7 @@ NULL
     binding <- if (simple_target) {
         .capture_mutation_binding(target_expr, parent.frame(), value = x)
     } else NULL
+    destination <- if (is.null(binding)) target_expr else binding
     original_x <- x
     if (.has_column_overlay(x)) {
         x <- .prepare_column_operation(x, length(.reference_names(x)))
@@ -340,12 +341,18 @@ NULL
             assignment$values, where, generate = !exists,
             selection = selection, promote = TRUE
         )
+        # Each completed assignment must reach its destination before another
+        # RHS runs or fails, including when its column list was reallocated.
+        destination <- .rebind_mutation(
+            original_x, x, destination, parent.frame()
+        )
+        original_x <- x
     }
     # `[` forces its result visible after dispatch, so `invisible()` alone
     # would autoprint the dataset after every assignment. Recorded after
     # the last write so a failed assignment still shows its error only.
     .suppress_bracket_autoprint(x)
-    .return_mutation(original_x, x, if (is.null(binding)) target_expr else binding, parent.frame())
+    invisible(x)
 }
 
 # Reads `j` as one or more `:=` assignments, or `NULL` when `j` is

--- a/r-package/dtatools/R/dta-append.R
+++ b/r-package/dtatools/R/dta-append.R
@@ -96,6 +96,20 @@ dta_append <- function(sources, force = TRUE,
     plan <- .append_build_plan(schemas, force)
     filled <- .append_fill_columns(schemas, plan)
 
+    source_names <- names(filled$columns)
+    repaired_names <- vctrs::vec_as_names(
+        source_names, repair = .name_repair, repair_arg = ".name_repair"
+    )
+    for (index in which(source_names != repaired_names)) {
+        column <- filled$columns[[index]]
+        if (!is.null(attr(column, "labels", exact = TRUE)) &&
+            is.null(attr(column, "value.label.name", exact = TRUE))) {
+            column <- .metadata_copy(column)
+            attr(column, "value.label.name") <- source_names[[index]]
+            filled$columns[[index]] <- column
+        }
+    }
+    names(filled$columns) <- repaired_names
     result <- vctrs::new_data_frame(
         filled$columns, n = filled$row_count
     )
@@ -109,7 +123,7 @@ dta_append <- function(sources, force = TRUE,
         .stored_output_container(schemas[[1L]]$schema)
     }
     result <- .as_stata_metadata_frame(
-        .finalize_output_container(result, output, .name_repair, stored)
+        .finalize_output_container(result, output, "minimal", stored)
     )
     .complete_output_container(result, output, stored)
 }

--- a/r-package/dtatools/R/dta-append.R
+++ b/r-package/dtatools/R/dta-append.R
@@ -105,7 +105,11 @@ dta_append <- function(sources, force = TRUE,
         if (!is.null(attr(column, "labels", exact = TRUE)) &&
             is.null(attr(column, "value.label.name", exact = TRUE))) {
             column <- .metadata_copy(column)
-            attr(column, "value.label.name") <- source_names[[index]]
+            attr(column, "value.label.name") <- if (nzchar(source_names[[index]])) {
+                source_names[[index]]
+            } else {
+                repaired_names[[index]]
+            }
             filled$columns[[index]] <- column
         }
     }

--- a/r-package/dtatools/R/mutate-data.R
+++ b/r-package/dtatools/R/mutate-data.R
@@ -1514,7 +1514,7 @@ gen <- function(data, ..., where = NULL, by = NULL, bysort = NULL) {
 # `selected` is a `.grouped_selection()` result; when given, `where` is
 # not evaluated again.
 .grouped_mutation <- function(where, values, columns, groups, row_count,
-                              selected = NULL) {
+                              selected = NULL, drop_unselected = FALSE) {
     view <- .mutation_group_view(columns)
     count <- length(groups$rows)
     row_pieces <- vector("list", count)
@@ -1551,6 +1551,10 @@ gen <- function(data, ..., where = NULL, by = NULL, bysort = NULL) {
         } else {
             positions <- as.integer(group_rows)
         }
+        if (drop_unselected && length(positions) == 0L) {
+            kept[[index]] <- FALSE
+            next
+        }
         piece <- switch(mode,
             scalar = vctrs::vec_recycle(evaluated, length(positions)),
             row = vctrs::vec_slice(evaluated, positions),
@@ -1565,6 +1569,7 @@ gen <- function(data, ..., where = NULL, by = NULL, bysort = NULL) {
     # nothing. A dataset with rows always has at least one nonempty group.
     row_pieces <- row_pieces[kept]
     value_pieces <- value_pieces[kept]
+    if (!length(value_pieces)) return(list(rows = integer(), values = NULL))
     all_rows <- unlist(row_pieces, use.names = FALSE)
     gathered <- .mutation_gather_values(value_pieces)
     if (anyDuplicated(all_rows) > 0L) {
@@ -1792,7 +1797,7 @@ gen <- function(data, ..., where = NULL, by = NULL, bysort = NULL) {
     if (!is.null(groups)) {
         gathered <- .grouped_mutation(
             where, values, original$columns, groups, original$nrow,
-            selected = selection$group_rows
+            selected = selection$group_rows, drop_unselected = !generate
         )
         selected <- gathered$rows
         evaluated <- gathered$values
@@ -1892,7 +1897,14 @@ gen <- function(data, ..., where = NULL, by = NULL, bysort = NULL) {
             if (report_promotion) {
                 .report_storage_promotion(target$name, column, promoted)
             }
-            .set_data_column_at(access, target$location, promoted)
+            commit <- function() {
+                .set_data_column_at(access, target$location, promoted)
+            }
+            if (.ordinary_data_table(data)) {
+                .data_table_replace_commit(data, target$name, commit)
+            } else {
+                commit()
+            }
             if (grouped_input) .regroup_after_replacement(data, state)
             return(invisible(data))
         }
@@ -3193,12 +3205,14 @@ transmute.dtatools_ref_data <- function(.data, ...) {
 # The hook is a `(` call around each expression, evaluated in an
 # environment where `(` is the typer; `(` is the one call head R's
 # deparser does not show as a function, so `mutate(d, x + 1)` still names
-# its column `x + 1` once the parentheses are stripped, and dplyr's
-# "In argument" bullets are rewritten the same way. Symbols, `.data`
+# its column `x + 1` through the one-column frame below, and dplyr's
+# "In argument" bullets are relabelled. Existing-column symbols, `.data`
 # references, and `NULL` are left alone: they select or remove columns
-# rather than compute them. `across()`, `if_any()`, and `if_all()` are
-# left for dplyr to expand, and their columns are typed after the verb as
-# every other changed column is.
+# rather than compute them. Caller-backed symbols and `across()` results
+# are typed before later expressions use them. An unnamed vector is returned
+# as a one-column frame under its original expression name, so dplyr sees
+# collisions and overwrites during mask evaluation, before closing the result.
+# `if_any()` and `if_all()` return logicals and keep dplyr's expansion.
 .typed_mask_verb <- function(data, generic, dots, arguments, caller) {
     # The call is evaluated where `generic` names the dplyr function, so
     # dplyr reports errors as "Error in `mutate()`" rather than against
@@ -3218,7 +3232,6 @@ transmute.dtatools_ref_data <- function(.data, ...) {
     result <- .relabel_mask_conditions(
         eval(call, environment), wrapped$labels
     )
-    result <- .unwrap_mask_names(result, wrapped$renames)
     .close_dibble(
         data, .retype_changed_columns(result, before, caller), caller
     )
@@ -3227,13 +3240,13 @@ transmute.dtatools_ref_data <- function(.data, ...) {
 .wrap_mask_expressions <- function(dots, before, caller) {
     names <- rlang::names2(dots)
     labels <- character()
-    renames <- character()
     for (index in seq_along(dots)) {
         quosure <- dots[[index]]
-        if (!.mask_expression_typable(quosure)) next
+        if (!.mask_expression_typable(quosure, before)) next
         name <- names[[index]]
         typer <- .mask_value_typer(
-            before, caller, if (nzchar(name)) name else NULL
+            before, caller, if (nzchar(name)) name else NULL,
+            .mask_expression_label(quosure)
         )
         environment <- new.env(parent = rlang::quo_get_env(quosure))
         environment[["("]] <- typer
@@ -3246,18 +3259,18 @@ transmute.dtatools_ref_data <- function(.data, ...) {
             labels[[paste0(name, " = ", outer)]] <- paste0(name, " = ", inner)
         } else {
             labels[[outer]] <- inner
-            renames[[outer]] <- inner
         }
         dots[[index]] <- wrapped
     }
-    list(dots = dots, labels = labels, renames = renames)
+    list(dots = dots, labels = labels)
 }
 
-.mask_expression_typable <- function(quosure) {
-    if (rlang::quo_is_missing(quosure) || rlang::quo_is_null(quosure) ||
-        rlang::quo_is_symbol(quosure)) {
+.mask_expression_typable <- function(quosure, before) {
+    if (rlang::quo_is_missing(quosure) || rlang::quo_is_null(quosure)) {
         return(FALSE)
     }
+    if (rlang::quo_is_symbol(quosure) &&
+        rlang::as_name(quosure) %in% names(before)) return(FALSE)
     expression <- rlang::quo_get_expr(quosure)
     if (!is.call(expression)) return(TRUE)
     if (rlang::is_call(expression, c("$", "[["), n = 2L) &&
@@ -3265,7 +3278,7 @@ transmute.dtatools_ref_data <- function(.data, ...) {
         return(FALSE)
     }
     !rlang::is_call(
-        expression, c("across", "if_any", "if_all"), ns = c("", "dplyr")
+        expression, c("if_any", "if_all"), ns = c("", "dplyr")
     )
 }
 
@@ -3282,7 +3295,9 @@ transmute.dtatools_ref_data <- function(.data, ...) {
 # overwrites a column promotes from that column; an unnamed data frame
 # result is unpacked by dplyr, so each of its columns is typed against
 # the column of the same name.
-.mask_value_typer <- function(before, caller, name) {
+.mask_value_typer <- function(before, caller, name, label) {
+    force(name)
+    force(label)
     function(value) {
         if (is.null(value)) return(NULL)
         if (is.data.frame(value)) {
@@ -3296,8 +3311,12 @@ transmute.dtatools_ref_data <- function(.data, ...) {
             }
             return(value)
         }
-        .typed_mask_value(value, if (is.null(name)) NULL else before[[name]],
-                          caller)
+        target <- if (is.null(name)) label else name
+        result <- .typed_mask_value(value, before[[target]], caller)
+        if (!is.null(name)) return(result)
+        vctrs::new_data_frame(
+            stats::setNames(list(result), target), n = vctrs::vec_size(result)
+        )
     }
 }
 
@@ -3337,19 +3356,6 @@ transmute.dtatools_ref_data <- function(.data, ...) {
             invokeRestart("muffleWarning")
         }
     )
-}
-
-# An unnamed expression names its column `(x + 1)`; it becomes `x + 1`.
-.unwrap_mask_names <- function(result, renames) {
-    for (index in seq_along(renames)) {
-        outer <- names(renames)[[index]]
-        inner <- renames[[index]]
-        current <- names(result)
-        if (outer %in% current && !(inner %in% current)) {
-            result <- dplyr::rename(result, !!inner := !!outer)
-        }
-    }
-    result
 }
 
 .typed_reference_replacement <- function(data, result, caller) {

--- a/r-package/dtatools/R/mutate-data.R
+++ b/r-package/dtatools/R/mutate-data.R
@@ -3354,14 +3354,28 @@ transmute.dtatools_ref_data <- function(.data, ...) {
         for (field in c("message", "body")) {
             text <- condition[[field]]
             if (!is.character(text)) next
-            for (index in seq_along(labels)) {
-                text <- gsub(
-                    paste0("`", names(labels)[[index]], "`"),
-                    paste0("`", labels[[index]], "`"),
-                    text, fixed = TRUE
-                )
-            }
-            condition[[field]] <- text
+            from <- paste0("In argument: `", names(labels), "`.")
+            to <- paste0("In argument: `", labels, "`.")
+            condition[[field]] <- vapply(text, function(message) {
+                if (is.na(message)) return(message)
+                # Warnings can arrive with their cause already rendered into
+                # the message. Rewrite only the generated annotation before
+                # that cause, never the user's warning text below it.
+                lines <- strsplit(paste0(message, "\n"), "\n", fixed = TRUE)[[1L]]
+                for (index in seq_along(lines)) {
+                    line <- lines[[index]]
+                    if (startsWith(line, "Caused by ")) break
+                    prefix <- if (startsWith(line, "\u2139 ")) "\u2139 " else
+                        if (startsWith(line, "i ")) "i " else ""
+                    annotation <- substring(line, nchar(prefix) + 1L)
+                    replacement <- match(annotation, from)
+                    if (!is.na(replacement)) {
+                        lines[[index]] <- paste0(prefix, to[[replacement]])
+                    }
+                }
+                paste(lines, collapse = "\n")
+            }, character(1), USE.NAMES = FALSE)
+            names(condition[[field]]) <- names(text)
         }
         condition
     }

--- a/r-package/dtatools/R/mutate-data.R
+++ b/r-package/dtatools/R/mutate-data.R
@@ -1925,7 +1925,10 @@ gen <- function(data, ..., where = NULL, by = NULL, bysort = NULL) {
             as.integer(.native_data_column_location(access, target$location)),
             column, rows, replacement
         )
-        column <- if (.ordinary_data_table(data)) {
+        # The native patcher still validates strict scalar replacements for
+        # an empty selection; do not invalidate lookup state without a write.
+        column <- if (.ordinary_data_table(data) &&
+                      .mutation_selected_count(rows, original$nrow) > 0L) {
             .data_table_replace_commit(data, target$name, patch)
         } else {
             patch()

--- a/r-package/dtatools/R/mutate-data.R
+++ b/r-package/dtatools/R/mutate-data.R
@@ -1911,6 +1911,12 @@ gen <- function(data, ..., where = NULL, by = NULL, bysort = NULL) {
         replacement <- .cast_replacement(
             values, column, rows, value_mode
         )
+        # No selected group supplied a value. vctrs accepts NULL here, but
+        # the native patcher requires a vector even for an empty selection.
+        if (is.null(replacement) &&
+            .mutation_selected_count(rows, original$nrow) == 0L) {
+            return(invisible(data))
+        }
     }
 
     if (!generate) {
@@ -1953,8 +1959,9 @@ gen <- function(data, ..., where = NULL, by = NULL, bysort = NULL) {
     suspendInterrupts({
         result <- patch()
         if (is.null(result)) return(NULL)
-        if (target %in% key_columns) data.table::setkeyv(data, NULL)
-        if (any(affected_indexes)) {
+        key_changed <- target %in% key_columns
+        if (key_changed) data.table::setkeyv(data, NULL)
+        if (key_changed || any(affected_indexes)) {
             retained <- index_columns[!affected_indexes]
             data.table::setindexv(data, NULL)
             for (columns in retained) data.table::setindexv(data, columns)
@@ -1971,8 +1978,9 @@ gen <- function(data, ..., where = NULL, by = NULL, bysort = NULL) {
     )
     suspendInterrupts({
         result <- patch()
-        if (target %in% key_columns) data.table::setkeyv(data, NULL)
-        if (any(affected_indexes)) {
+        key_changed <- target %in% key_columns
+        if (key_changed) data.table::setkeyv(data, NULL)
+        if (key_changed || any(affected_indexes)) {
             retained <- index_columns[!affected_indexes]
             data.table::setindexv(data, NULL)
             for (columns in retained) data.table::setindexv(data, columns)
@@ -3300,19 +3308,29 @@ transmute.dtatools_ref_data <- function(.data, ...) {
     force(label)
     function(value) {
         if (is.null(value)) return(NULL)
+        # rlang's mask top holds the live column bindings, including earlier
+        # clauses. Read only the target; caller bindings must not supply it.
+        mask <- rlang::env_get(parent.frame(), ".top_env", default = NULL)
+        prior <- function(target) {
+            if (is.environment(mask)) {
+                rlang::env_get(mask, target, default = NULL)
+            } else {
+                before[[target]]
+            }
+        }
         if (is.data.frame(value)) {
             if (!is.null(name)) return(value)
             columns <- names(value)
             for (index in seq_along(columns)) {
                 value[[index]] <- .typed_mask_value(
-                    .subset2(value, index), before[[columns[[index]]]],
+                    .subset2(value, index), prior(columns[[index]]),
                     caller
                 )
             }
             return(value)
         }
         target <- if (is.null(name)) label else name
-        result <- .typed_mask_value(value, before[[target]], caller)
+        result <- .typed_mask_value(value, prior(target), caller)
         if (!is.null(name)) return(result)
         vctrs::new_data_frame(
             stats::setNames(list(result), target), n = vctrs::vec_size(result)

--- a/r-package/dtatools/R/reserve-columns.R
+++ b/r-package/dtatools/R/reserve-columns.R
@@ -129,7 +129,14 @@ reserve_columns <- function(data, n = getOption("dtatools.alloccol", 5000L)) {
 }
 
 .return_mutation <- function(before, result, target, env) {
-    if (.same_mutation_object(before, result)) return(invisible(result))
+    .rebind_mutation(before, result, target, env)
+    invisible(result)
+}
+
+# Return the captured destination with its expected container advanced only
+# after a successful rebind. Bracket assignments reuse it for their next commit.
+.rebind_mutation <- function(before, result, target, env) {
+    if (.same_mutation_object(before, result)) return(target)
     if (is.symbol(target)) {
         current <- get0(as.character(target), envir = env, inherits = TRUE)
         if (.same_mutation_object(current, before)) {
@@ -149,7 +156,7 @@ reserve_columns <- function(data, n = getOption("dtatools.alloccol", 5000L)) {
                           inherits = TRUE)
         if (!.same_mutation_object(container, target$original_container)) {
             warning("Mutation target changed during evaluation; assign the returned table.", call. = FALSE)
-            return(invisible(result))
+            return(target)
         }
         current <- if (target$head == "$") {
             do.call(`$`, list(container, target$key))
@@ -157,9 +164,13 @@ reserve_columns <- function(data, n = getOption("dtatools.alloccol", 5000L)) {
         if (.same_mutation_object(current, before)) {
             destination <- as.call(list(as.name(target$head), target$container, target$key))
             eval(as.call(list(quote(`<-`), destination, result)), envir = target$env)
+            target$original_container <- get0(
+                as.character(target$container), envir = target$env,
+                inherits = TRUE
+            )
         } else {
             warning("Mutation target changed during evaluation; assign the returned table.", call. = FALSE)
         }
     }
-    invisible(result)
+    target
 }

--- a/r-package/dtatools/R/stata-string.R
+++ b/r-package/dtatools/R/stata-string.R
@@ -4,7 +4,8 @@
 #' declaration survives supported vector operations. Stata strings use `""`
 #' for missing values, so `NA_character_` is rejected here and in subset
 #' assignment; a vctrs coercion into a Stata string, as a join's padding or
-#' `vec_c()` performs, spells `NA` as `""`. Replacement within the vector
+#' `vec_c()` performs, spells `NA` as `""`. Subsetting and restoration also
+#' use `""` for missing or out-of-range padding. Replacement within the vector
 #' must fit the declared width, while extending it, as base `rbind()` does,
 #' widens the declaration to the common storage.
 #'
@@ -94,7 +95,9 @@ vec_proxy.stata_string <- function(x, ...) .stata_string_data(x)
 #' @export
 vec_restore.stata_string <- function(x, to, ...) {
     storage <- attr(to, "stata.string.storage", exact = TRUE)
-    .new_stata_string(as.character(x), storage, to)
+    value <- as.character(x)
+    if (!.is_unmaterialized_dictstring(value) && anyNA(value)) value[is.na(value)] <- ""
+    .new_stata_string(value, storage, to)
 }
 
 #' @export
@@ -102,6 +105,7 @@ vec_restore.stata_string <- function(x, to, ...) {
     if (length(list(...))) stop("Stata string vectors do not support array subscripts", call. = FALSE)
     data <- .stata_string_data(x)
     result <- if (missing(i)) data[] else data[i]
+    if (!.is_unmaterialized_dictstring(result) && anyNA(result)) result[is.na(result)] <- ""
     .new_stata_string(result, attr(x, "stata.string.storage", exact = TRUE), x)
 }
 

--- a/r-package/dtatools/man/dta_string.Rd
+++ b/r-package/dtatools/man/dta_string.Rd
@@ -20,7 +20,8 @@ Creates an owned Stata string vector whose fixed-width or \code{strL} storage
 declaration survives supported vector operations. Stata strings use \code{""}
 for missing values, so \code{NA_character_} is rejected here and in subset
 assignment; a vctrs coercion into a Stata string, as a join's padding or
-\code{vec_c()} performs, spells \code{NA} as \code{""}. Replacement within the vector
+\code{vec_c()} performs, spells \code{NA} as \code{""}. Subsetting and restoration also
+use \code{""} for missing or out-of-range padding. Replacement within the vector
 must fit the declared width, while extending it, as base \code{rbind()} does,
 widens the declaration to the common storage.
 }

--- a/r-package/dtatools/tests/testthat/test-data-table-compatibility.R
+++ b/r-package/dtatools/tests/testthat/test-data-table-compatibility.R
@@ -320,3 +320,32 @@ test_that("setDT() on a read result drops the stale reference state", {
     expect_identical(as.double(data$cluster), c(1, 2, 3))
     expect_true(dtatools:::.ordinary_data_table(data))
 })
+
+test_that("promotion invalidates affected data-table keys and indexes", {
+    skip_if_not_installed("data.table")
+    .datatable.aware <- TRUE
+    keyed <- data.table::data.table(x = dta_byte(1:3), y = 11:13)
+    data.table::setkeyv(keyed, "x")
+    alias <- keyed
+    suppressMessages(repl(keyed, x = 1000, where = x == 1))
+    expect_null(data.table::key(keyed))
+    expect_null(data.table::key(alias))
+    expect_identical(keyed[list(1000), on = "x"]$y, 11L)
+    expect_identical(dta_storage_type(keyed$x), "int")
+
+    indexed <- data.table::data.table(
+        x = dta_byte(c(3, 1, 2)), y = 11:13, z = c(3, 1, 2)
+    )
+    data.table::setindexv(indexed, "x")
+    data.table::setindexv(indexed, "z")
+    suppressMessages(repl(indexed, x = 1000, where = x == 1))
+    expect_identical(data.table::indices(indexed), "z")
+    expect_identical(indexed[x == 1000]$y, 12L)
+    expect_identical(indexed[z == 1]$y, 12L)
+
+    strings <- data.table::data.table(x = dta_string(c("a", "b")), y = 1:2)
+    data.table::setkeyv(strings, "x")
+    suppressMessages(repl(strings, x = "wide", where = 1L))
+    expect_null(data.table::key(strings))
+    expect_identical(strings[list("wide"), on = "x"]$y, 1L)
+})

--- a/r-package/dtatools/tests/testthat/test-data-table-compatibility.R
+++ b/r-package/dtatools/tests/testthat/test-data-table-compatibility.R
@@ -349,3 +349,23 @@ test_that("promotion invalidates affected data-table keys and indexes", {
     expect_null(data.table::key(strings))
     expect_identical(strings[list("wide"), on = "x"]$y, 1L)
 })
+
+test_that("clearing a replaced data-table key preserves unrelated indexes", {
+    skip_if_not_installed("data.table")
+    .datatable.aware <- TRUE
+    for (replacement in c(5, 1000)) {
+        data <- data.table::data.table(x = dta_byte(1:3), z = c(3L, 1L, 2L))
+        data.table::setkeyv(data, "x")
+        data.table::setindexv(data, "z")
+        suppressMessages(repl(data, x = replacement, where = 1L))
+        expect_null(data.table::key(data))
+        expect_identical(data.table::indices(data), "z")
+        expect_identical(as.integer(data[z == 3L]$x), as.integer(replacement))
+        data.table::setkeyv(data, "x")
+        data.table::setindexv(data, "z")
+        suppressMessages(repl(data, x = replacement, where = x == 2))
+        expect_null(data.table::key(data))
+        expect_identical(data.table::indices(data), "z")
+        expect_identical(as.integer(data[z == 1L]$x), as.integer(replacement))
+    }
+})

--- a/r-package/dtatools/tests/testthat/test-data-table-compatibility.R
+++ b/r-package/dtatools/tests/testthat/test-data-table-compatibility.R
@@ -369,3 +369,24 @@ test_that("clearing a replaced data-table key preserves unrelated indexes", {
         expect_identical(as.integer(data[z == 1L]$x), as.integer(replacement))
     }
 })
+
+
+test_that("strict zero-row replacement preserves data-table lookup state", {
+    skip_if_not_installed("data.table")
+    .datatable.aware <- TRUE
+    for (typed in c(FALSE, TRUE)) {
+        data <- data.table::data.table(
+            x = if (typed) dta_byte(1:3) else 1:3, z = c(3L, 1L, 2L)
+        )
+        data.table::setkeyv(data, "x")
+        data.table::setindexv(data, "z")
+        alias <- data
+        for (selected in list(FALSE, integer())) {
+            repl(data, x = 5L, where = selected, promote = FALSE)
+            expect_identical(data.table::key(data), "x")
+            expect_identical(data.table::indices(data), "z")
+            expect_identical(data.table::key(alias), "x")
+            expect_identical(as.integer(data$x), 1:3)
+        }
+    }
+})

--- a/r-package/dtatools/tests/testthat/test-dibble-bracket.R
+++ b/r-package/dtatools/tests/testthat/test-dibble-bracket.R
@@ -312,3 +312,53 @@ test_that("the autoprint skip does not outlive its top-level statement", {
         )
     }
 })
+
+test_that("each bracket assignment rebinds before the next expression", {
+    withr::local_options(dtatools.alloccol = 0L)
+    targets <- list(quote(data), quote(box$data), quote(box[[index]]),
+                    quote(get("data")), quote(get0("data")))
+    for (target in targets) {
+        data <- dibble(x = 1:2)
+        alias <- data
+        box <- list(data = data, other = dibble(other = 3:4))
+        index <- "data"
+        # Read the original destination from the next RHS, not the data mask.
+        observe <- function() length(names(eval(target)))
+        call <- substitute(TARGET[, `:=`(y = 1L, z = observe(), bad = stop("boom"))],
+                           list(TARGET = target))
+        expect_error(suppressWarnings(eval(call)), "boom")
+        result <- eval(target)
+        expect_identical(names(result), c("x", "y", "z"))
+        expect_identical(as.integer(result$z), rep(2L, 2))
+        expect_identical(names(alias), "x")
+        expect_identical(as.integer(alias$x), 1:2)
+        expect_identical(length(unclass(result)), 3L)
+    }
+})
+
+test_that("bracket rebinding keeps its captured destination across assignments", {
+    withr::local_options(dtatools.alloccol = 0L)
+    box <- list(data = dibble(x = 1:2), other = dibble(other = 3:4))
+    index <- "data"
+    values <- function() { index <<- "other"; 1L }
+    suppressWarnings(box[[index]][, `:=`(y = values(), z = y + 1L)])
+    expect_identical(names(box$data), c("x", "y", "z"))
+    expect_identical(names(box$other), "other")
+    expect_identical(as.integer(box$data$z), c(2L, 2L))
+
+    original <- box$data <- dibble(x = 1:2)
+    replacement <- list(data = original, sibling = 99L)
+    change <- function() { box <<- replacement; 1L }
+    warnings <- character()
+    result <- withCallingHandlers(
+        box$data[, `:=`(y = change(), z = y + 1L)],
+        warning = function(w) {
+            warnings <<- c(warnings, conditionMessage(w))
+            invokeRestart("muffleWarning")
+        }
+    )
+    expect_true(any(grepl("target changed", warnings)))
+    expect_identical(box, replacement)
+    expect_identical(names(box$data), "x")
+    expect_identical(names(result), c("x", "y", "z"))
+})

--- a/r-package/dtatools/tests/testthat/test-dibble.R
+++ b/r-package/dtatools/tests/testthat/test-dibble.R
@@ -1722,3 +1722,28 @@ test_that("unnamed computations use their natural names in the mask", {
     expect_identical(nrow(result), 1L)
     expect_identical(as.character(result$x), "")
 })
+
+test_that("mask promotion sees prior clauses' storage and metadata", {
+    narrow <- dta_byte(1:2)
+    var_label(narrow) <- "old"
+    wide <- dta_double(1:2)
+    var_label(wide) <- "new"
+    data <- dibble(x = narrow)
+    values <- c(1, 2)
+    result <- dplyr::mutate(data, x = wide, x = values, seen = var_label(x))
+    expect_identical(dta_storage_type(result$x), "double")
+    expect_identical(var_label(result$x), "new")
+    expect_identical(as.character(result$seen), c("new", "new"))
+    result <- dplyr::mutate(data, x = wide,
+        dplyr::across(x, ~ as.double(.x)), seen = var_label(x))
+    expect_identical(dta_storage_type(result$x), "double")
+    expect_identical(as.character(result$seen), c("new", "new"))
+    result <- dplyr::mutate(data, x = wide,
+        tibble::tibble(x = values), seen = var_label(x))
+    expect_identical(dta_storage_type(result$x), "double")
+    expect_identical(as.character(result$seen), c("new", "new"))
+    # A removal also removes the old column's metadata from later typing.
+    result <- dplyr::mutate(data, x = NULL, x = values)
+    expect_identical(dta_storage_type(result$x), "double")
+    expect_null(var_label(result$x))
+})

--- a/r-package/dtatools/tests/testthat/test-dibble.R
+++ b/r-package/dtatools/tests/testthat/test-dibble.R
@@ -1213,7 +1213,7 @@ test_that("subsetting keeps compact dictionary strings compact", {
     # hold, so that subset materializes as R's `[` would.
     beyond <- data$s[c(1L, 9L)]
     expect_false(compact(beyond))
-    expect_identical(as.character(beyond), c("aa", NA))
+    expect_identical(as.character(beyond), c("aa", ""))
     expect_identical(as.character(data$s[[3L]]), "aa")
     expect_identical(as.character(data$s), c("aa", "bb", "aa", "cc", "bb"))
 
@@ -1658,4 +1658,67 @@ test_that("serialized legacy dibbles retain typing and closure", {
     gen(ordinary, y = 1)
     expect_identical(dtatools:::.reference_state(ordinary)$dibble, FALSE)
     expect_false(is_dibble(unserialize(serialize(ordinary, NULL))))
+})
+
+test_that("across results are typed before later mask expressions", {
+    data <- dibble(g = c(1L, 1L), x = c("a", "b"))
+    for (input in list(data, dplyr::group_by(data, g), dplyr::rowwise(data))) {
+        result <- dplyr::mutate(
+            input, dplyr::across(x, ~ NA_character_), missing = x == ""
+        )
+        expect_identical(as.character(result$x), c("", ""))
+        expect_identical(result$missing, c(TRUE, TRUE))
+    }
+    result <- dplyr::mutate(data, dplyr::across(x, ~ NA_character_),
+                            missing = x == "", .by = g)
+    expect_identical(result$missing, c(TRUE, TRUE))
+    result <- dplyr::summarise(data, dplyr::across(x, ~ NA_character_),
+                              missing = x == "")
+    expect_identical(result$missing, TRUE)
+    result <- dplyr::reframe(data, dplyr::across(x, ~ NA_character_),
+                            missing = x == "")
+    expect_identical(result$missing, TRUE)
+    result <- dplyr::mutate(
+        data, dplyr::across(x, list(text = ~ NA_character_), .names = "{.col}_{.fn}"),
+        missing = x_text == ""
+    )
+    expect_identical(result$missing, c(TRUE, TRUE))
+})
+
+test_that("caller-backed symbols are typed on entry to the data mask", {
+    data <- dibble(x = 1:2)
+    values <- c(NA_real_, 1)
+    strings <- c(NA_character_, "")
+    result <- dplyr::mutate(data, y = values, z = y > 0,
+                            text = strings, missing = text == "")
+    expect_identical(result$z, c(TRUE, TRUE))
+    expect_identical(result$missing, c(TRUE, TRUE))
+    expect_identical(dta_storage_type(result$y), "double")
+    expect_identical(nrow(dplyr::distinct(data, strings)), 1L)
+    expect_identical(nrow(dplyr::group_keys(dplyr::group_by(data, strings))), 1L)
+    x <- c(NA_real_, 1)
+    result <- dplyr::mutate(data, y = x, z = y > 0)
+    expect_identical(as.integer(result$y), 1:2)
+    expect_identical(result$z, c(TRUE, TRUE))
+})
+
+test_that("unnamed computations use their natural names in the mask", {
+    data <- dibble(x = 1:2, `x + 1` = 0L)
+    result <- dplyr::mutate(data, x + 1, later = `x + 1` * 10)
+    expect_identical(names(result), c("x", "x + 1", "later"))
+    expect_identical(as.integer(result$`x + 1`), 2:3)
+    expect_identical(as.integer(result$later), c(20L, 30L))
+    result <- dplyr::mutate(data, x + 1, `x + 1` = 9L)
+    expect_identical(names(result), c("x", "x + 1"))
+    expect_identical(as.integer(result$`x + 1`), c(9L, 9L))
+    result <- dplyr::summarise(data, sum(x), `sum(x)` = 9L)
+    expect_identical(names(result), "sum(x)")
+    expect_identical(as.integer(result$`sum(x)`), 9L)
+    result <- dplyr::mutate(data, tibble::tibble(y = c(NA_real_, 1)), z = y > 0)
+    expect_identical(result$z, c(TRUE, TRUE))
+    expect_identical(names(result), c("x", "x + 1", "y", "z"))
+    result <- dplyr::distinct(dibble(x = 1:2),
+        dplyr::across(x, ~ dplyr::if_else(.x == 1, NA_character_, "")))
+    expect_identical(nrow(result), 1L)
+    expect_identical(as.character(result$x), "")
 })

--- a/r-package/dtatools/tests/testthat/test-dibble.R
+++ b/r-package/dtatools/tests/testthat/test-dibble.R
@@ -1747,3 +1747,42 @@ test_that("mask promotion sees prior clauses' storage and metadata", {
     expect_identical(dta_storage_type(result$x), "double")
     expect_null(var_label(result$x))
 })
+
+test_that("mask warning labels leave caller-binding messages unchanged", {
+    for (unicode in c(TRUE, FALSE)) {
+        withr::local_options(cli.unicode = unicode)
+        for (delayed in c(FALSE, TRUE)) {
+            env <- new.env(parent = environment())
+            env$input <- dibble(x = 1:2)
+            user_text <- paste0(
+                "user supplied `(values)` literally\n",
+                "In argument: `(values)`.\n"
+            )
+            env$user_text <- user_text
+            if (delayed) {
+                delayedAssign("values", {
+                    warning(user_text, call. = FALSE)
+                    1:2
+                }, eval.env = env, assign.env = env)
+            } else {
+                getter <- function(value) {
+                    warning(user_text, call. = FALSE)
+                    1:2
+                }
+                environment(getter) <- env
+                makeActiveBinding("values", getter, env)
+            }
+            message <- NULL
+            withCallingHandlers(
+                eval(quote(dplyr::mutate(input, values)), env),
+                warning = function(w) {
+                    message <<- conditionMessage(w)
+                    invokeRestart("muffleWarning")
+                }
+            )
+            expect_match(message, "In argument: `values`.", fixed = TRUE)
+            expect_match(message, "user supplied `(values)` literally", fixed = TRUE)
+            expect_match(message, "In argument: `(values)`.", fixed = TRUE)
+        }
+    }
+})

--- a/r-package/dtatools/tests/testthat/test-dta-append.R
+++ b/r-package/dtatools/tests/testthat/test-dta-append.R
@@ -675,3 +675,21 @@ test_that("append name repair preserves implicit label-table identity", {
     expect_null(attr(unchanged$v, "value.label.name"))
     expect_null(attr(source$v, "value.label.name"))
 })
+
+
+test_that("append gives blank implicit label names a stable repaired identity", {
+    value <- dta_byte(1:2)
+    val_labels(value) <- c(one = 1, two = 2)
+    source <- vctrs::new_data_frame(stats::setNames(list(value), ""))
+    for (output in c("dibble", "tibble", "data.table")) {
+        if (output == "data.table") skip_if_not_installed("data.table")
+        result <- suppressMessages(dta_append(source, output = output))
+        table_name <- names(result)[[1L]]
+        expect_identical(attr(result[[1L]], "value.label.name"), table_name)
+        repeated <- dta_append(result, output = output,
+            .name_repair = function(names) paste0("renamed_", names))
+        expect_identical(attr(repeated[[1L]], "value.label.name"), table_name)
+        expect_identical(val_labels(repeated[[1L]]), c(one = 1, two = 2))
+    }
+    expect_null(attr(source[[1L]], "value.label.name"))
+})

--- a/r-package/dtatools/tests/testthat/test-dta-append.R
+++ b/r-package/dtatools/tests/testthat/test-dta-append.R
@@ -647,3 +647,31 @@ test_that("a character source holding NA obeys force like the pieces path", {
         "incompatible storage"
     )
 })
+
+test_that("append name repair preserves implicit label-table identity", {
+    value <- dta_byte(1)
+    val_labels(value) <- c(one = 1)
+    shared <- value
+    attr(shared, "value.label.name") <- "v"
+    source <- tibble::tibble(v = value, w = shared)
+    for (output in c("dibble", "tibble", "data.table")) {
+        if (output == "data.table") skip_if_not_installed("data.table")
+        calls <- 0L
+        repair <- function(names) { calls <<- calls + 1L; toupper(names) }
+        result <- dta_append(source, output = output, .name_repair = repair)
+        expect_identical(calls, 1L)
+        expect_identical(names(result), c("V", "W"))
+        expect_identical(attr(result$V, "value.label.name"), "v")
+        expect_identical(attr(result$W, "value.label.name"), "v")
+        expect_identical(val_labels(result$V), c(one = 1))
+        path <- tempfile(fileext = ".dta")
+        save_dta(result, path)
+        restored <- read_dta(path)
+        expect_identical(attr(restored$V, "value.label.name"), "v")
+        expect_identical(attr(restored$W, "value.label.name"), "v")
+        unlink(path)
+    }
+    unchanged <- dta_append(source)
+    expect_null(attr(unchanged$v, "value.label.name"))
+    expect_null(attr(source$v, "value.label.name"))
+})

--- a/r-package/dtatools/tests/testthat/test-mutate-data.R
+++ b/r-package/dtatools/tests/testthat/test-mutate-data.R
@@ -2860,3 +2860,17 @@ test_that("unselected replacement groups do not contribute value types", {
     expect_identical(dta_storage_type(data$x), "byte")
     expect_identical(as.integer(data$x), c(1L, 6L))
 })
+
+test_that("strict grouped zero-selection replacement is a no-op", {
+    for (value in list(dta_byte(1:2), dta_int(1:2), dta_long(1:2),
+                       dta_float(1:2), dta_double(1:2), dta_string(c("a", "b")))) {
+        data <- dibble(g = 1:2, x = value)
+        alias <- data
+        replacement <- if (is.character(value)) "z" else 5L
+        expect_no_error(replace_values(data, x = replacement, where = FALSE,
+                                      by = g, promote = FALSE))
+        expect_identical(as.vector(data$x), as.vector(value))
+        expect_identical(dta_storage_type(data$x), dta_storage_type(value))
+        expect_identical(data, alias)
+    }
+})

--- a/r-package/dtatools/tests/testthat/test-mutate-data.R
+++ b/r-package/dtatools/tests/testthat/test-mutate-data.R
@@ -2843,3 +2843,20 @@ test_that("promotion never narrows the integers a column can hold", {
     )
     expect_equal(as.double(data$x), c(3e9, 3e9))
 })
+
+test_that("unselected replacement groups do not contribute value types", {
+    data <- dibble(grp = 1:2, x = dta_byte(1:2))
+    expect_no_error(repl(data, x = if (as.integer(grp[[1]]) == 1L) "bad" else 5L,
+                         where = FALSE, by = grp))
+    expect_identical(as.integer(data$x), 1:2)
+    expect_identical(dta_storage_type(data$x), "byte")
+    expect_no_error(repl(data, x = if (as.integer(grp[[1]]) == 1L) "bad" else 5L,
+                         where = grp == 2L, by = grp))
+    expect_identical(as.integer(data$x), c(1L, 5L))
+    expect_identical(dta_storage_type(data$x), "byte")
+    expect_no_error(repl(data,
+        x = if (as.integer(grp[[1]]) == 1L) dta_double(1000) else dta_byte(6),
+        where = grp == 2L, by = grp))
+    expect_identical(dta_storage_type(data$x), "byte")
+    expect_identical(as.integer(data$x), c(1L, 6L))
+})

--- a/r-package/dtatools/tests/testthat/test-stata-string.R
+++ b/r-package/dtatools/tests/testthat/test-stata-string.R
@@ -113,3 +113,28 @@ test_that("Stata restoration drops unknown attributes once", {
     expect_null(attr(empty, "mystery", exact = TRUE))
     expect_s3_class(empty, "stata_string")
 })
+
+test_that("Stata string subset and restore padding use empty missing strings", {
+    for (storage in c("str3", "strL")) {
+        value <- dta_string(c(a = "a", b = "bb"), storage)
+        attr(value, "label") <- "Text"
+        attr(value, "format.stata") <- "%9s"
+        results <- list(
+            value[c(1L, 3L, NA_integer_)],
+            value[c("a", "absent", NA_character_)],
+            value[c(TRUE, NA, TRUE)],
+            vctrs::vec_slice(value, c(1L, NA_integer_, NA_integer_)),
+            vctrs::vec_restore(c("a", NA_character_, NA_character_), value)
+        )
+        for (result in results) {
+            expect_identical(unname(as.character(result)), c("a", "", ""))
+            expect_identical(dta_storage_type(result), storage)
+            expect_identical(attr(result, "label"), "Text")
+            expect_identical(attr(result, "format.stata"), "%9s")
+        }
+        expect_identical(names(results[[1L]]), c("a", "", ""))
+        expect_identical(as.character(vctrs::vec_init(value, 2L)), c("", ""))
+        expect_length(value[integer()], 0L)
+        expect_error(value[1L] <- NA_character_, "NA_character_")
+    }
+})


### PR DESCRIPTION
This completes the current-main audit requested by #149 after #159, #161, and #163. Four repair commits address fourteen findings in mutation, dplyr mask typing, string padding, append metadata, and diagnostics.

- Rebind each successful bracket assignment before the next runs, preserving completed work on later errors and captured extraction/get targets.
- Normalize Stata string subset/restore padding to empty strings and invalidate affected data.table lookup state on promotion.
- Type caller-symbol and across results before later mask expressions use them; preserve natural expression names and promote repeated clauses against current mask metadata.
- Exclude unselected replacement groups from common-type negotiation, preserve strict empty-group no-ops, and retain implicit append label-table identity after name repair.
- Preserve unrelated secondary indexes when a key is cleared and preserve originating warning text when restoring generated expression labels.

Each finding has regression coverage. Deferred mixed arithmetic lattice, metadata setter, and existing Rust/check warnings remain outside this audit.

Validation: fresh R 4.6.1 install; full testthat suite passes with 717 blocks, 8,947 assertions, zero failures/errors/skips, and 99 baseline warnings. Focused tests and roxygen consistency pass. Both persistent correctness and systems reviewers are clean on 5918d54dd217b684f547ad41c8e7ed8e0af4be42.

Systems measurements found roughly 10–12.5 ms additional overhead per across(identity) call over 100 columns, independent of tested row count. Column payload addresses remain unchanged and no column-sized R allocation occurs. The reviewer accepted the overhead required to type results before subsequent expressions consume them.

The requested `codex -m gpt-5.6-sol -c model_reasoning_effort=xhigh review` completed five rounds plus a same-session adjudication, ending with no actionable findings on the reviewed head. The initial twelve accepted findings were fixed in three separate repair-round commits. A fourth commit addresses two CodeRabbit findings: stable label-table names after blank-name repair and unchanged data.table keys/indexes on strict empty selections. Both persistent reviewers inspected the complete diff after every commit and are clean after five rounds. The fifth CLI round is clean on the CodeRabbit follow-up. CodeRabbit confirmed both fixes and withdrew its scalar missing-string extraction claim after reproduction showed the base subscript error; both internal reviewers and the CLI independently confirmed that disposition.

One cosmetic limitation was explicitly adjudicated and withdrawn by the CLI reviewer: dplyr's retained warning history may show the equivalent wrapped `(values)` expression although the emitted warning shows `values`. Cause text and behavior are unchanged; changing dplyr's private warning cache or symbol evaluation was judged disproportionate.

Closes #149.
