### PR TITLE
Fix npm provenance repository metadata

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,7 +8,7 @@ name: Publish to npm
 #   Package page → Settings → "Trusted Publisher" → add a GitHub Actions
 #   publisher with:
 #     - Organization or user: jbearak
-#     - Repository:           dta-tools
+#     - Repository:           dta-parser
 #     - Workflow filename:    publish.yml
 #     - Environment:          release   (must match the job's environment)
 #   That links this exact workflow to the package; GitHub's OIDC token is

--- a/typescript/dta-parser/README.md
+++ b/typescript/dta-parser/README.md
@@ -90,7 +90,7 @@ descriptors cannot redirect later file reads. `DtaFile` resolves selected
 `strL` values and validates their object references. Numeric `note*` keys and
 Stata's `_lang_list` and `_lang_c` language-control keys are reserved.
 
-Automatic text decoding uses Windows-1252 for pre-Unicode files and UTF-8 for Unicode files. Callers can override it with UTF-8, Windows-1252, or ISO-8859-1. See the repository's [compatibility contract](https://github.com/jbearak/dta-tools/blob/main/docs/compatibility.md) for exact releases and language differences.
+Automatic text decoding uses Windows-1252 for pre-Unicode files and UTF-8 for Unicode files. Callers can override it with UTF-8, Windows-1252, or ISO-8859-1. See the repository's [compatibility contract](https://github.com/jbearak/dta-parser/blob/main/docs/compatibility.md) for exact releases and language differences.
 
 ## Main exports
 
@@ -152,7 +152,7 @@ options accept `chunk_rows`, which bounds decoded output between cancellation
 checks; one compressed buffer decode remains synchronous.
 
 See the repository's
-[Arrow compatibility contract](https://github.com/jbearak/dta-tools/blob/main/docs/compatibility.md#arrow-read-compatibility)
+[Arrow compatibility contract](https://github.com/jbearak/dta-parser/blob/main/docs/compatibility.md#arrow-read-compatibility)
 for supported types, profile versions, validation, and compression coverage.
 The readers do not write files. Zstandard decoding includes MIT-licensed code
 derived from [fzstd](https://github.com/101arrowz/fzstd); its license is retained
@@ -160,9 +160,9 @@ in the distributed bundles.
 
 ## Project links
 
-- [Repository](https://github.com/jbearak/dta-tools)
-- [Contributing](https://github.com/jbearak/dta-tools/blob/main/CONTRIBUTING.md)
-- [Benchmarks](https://github.com/jbearak/dta-tools/tree/main/benchmarks)
+- [Repository](https://github.com/jbearak/dta-parser)
+- [Contributing](https://github.com/jbearak/dta-parser/blob/main/CONTRIBUTING.md)
+- [Benchmarks](https://github.com/jbearak/dta-parser/tree/main/benchmarks)
 
 ## License
 

--- a/typescript/dta-parser/package.json
+++ b/typescript/dta-parser/package.json
@@ -7,7 +7,7 @@
   "author": "Jonathan Marc Bearak",
   "repository": {
     "type": "git",
-    "url": "https://github.com/jbearak/dta-tools.git",
+    "url": "https://github.com/jbearak/dta-parser.git",
     "directory": "typescript/dta-parser"
   },
   "main": "./dist/cjs/index.cjs",


### PR DESCRIPTION
npm rejected the 0.7.0 publication because package.json identified `jbearak/dta-tools` while GitHub Actions provenance identified `jbearak/dta-parser`. Correct the package repository URL and the adjacent trusted-publisher setup comment so the existing publication workflow can verify provenance.

Independent review and package dry run pass. After merge, rerun the existing workflow manually from main to publish the still-unpublished npm version 0.7.0; the existing Git tag remains unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the documented repository references to point to the current `dta-parser` repository.
  - Updated npm publishing metadata to reflect the correct repository location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->