### PR TITLE
Install dplyr for R release binaries

### DIFF
--- a/.github/workflows/release-r-packages.yml
+++ b/.github/workflows/release-r-packages.yml
@@ -82,7 +82,7 @@ jobs:
         shell: Rscript {0}
         run: |
           install.packages(
-            c("readr", "rlang", "tibble", "tidyselect"),
+            c("dplyr", "readr", "rlang", "tibble", "tidyselect"),
             repos = "https://cloud.r-project.org",
             Ncpus = 2L
           )


### PR DESCRIPTION
The 0.7.0 R binary build fails on all three platforms because `dtatools` requires `dplyr` but the release workflow does not install it. Add `dplyr` to the existing dependency setup so the tagged package can be built and attached to its release.

The missing-dependency failure was confirmed in all three release-job logs. Independent review and YAML validation pass. After merge, dispatch the fixed workflow for existing tag v0.7.0; no tag movement is needed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the release process to install the required R package dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->