### PR TITLE
docs: clarify slice_dta_rows versus bracket subsetting

### DIFF
--- a/r-package/dtatools/R/slice-dta-rows.R
+++ b/r-package/dtatools/R/slice-dta-rows.R
@@ -11,6 +11,13 @@
 #' logical, and character locations are supported, as are repeated and missing
 #' locations. Character locations match row names.
 #'
+#' For a dibble with at least ten rows, `slice_dta_rows(survey, 1:10)` and
+#' `survey[1:10, ]` both return the first ten rows with all columns, preserving
+#' Stata metadata and leaving `survey` unchanged. Brackets use ordinary tibble
+#' subsetting; `slice_dta_rows()` batches compact Stata numeric columns in native
+#' code to reduce per-column overhead. Use brackets for everyday subsetting;
+#' consider `slice_dta_rows()` when slicing wide Stata datasets.
+#'
 #' @param data An ordinary base data frame, tibble, data.table, or
 #'   [dibble][dibble()]. Other data-frame subclasses are not supported.
 #' @param rows A row subscript accepted by [vctrs::vec_as_location()].

--- a/r-package/dtatools/README.md
+++ b/r-package/dtatools/README.md
@@ -131,6 +131,13 @@ reorder_dta_rows(survey, order(survey$id))
 first_ten <- slice_dta_rows(survey, 1:10)
 ```
 
+For a dibble with at least ten rows, `slice_dta_rows(survey, 1:10)` and
+`survey[1:10, ]` both return the first ten rows with all columns, preserving
+Stata metadata and leaving `survey` unchanged. Brackets use ordinary tibble
+subsetting; `slice_dta_rows()` batches compact Stata numeric columns in native
+code to reduce per-column overhead. Use brackets for everyday subsetting;
+consider `slice_dta_rows()` when slicing wide Stata datasets.
+
 ## Why use dtatools?
 
 Repository benchmarks compare `dtatools` with haven across a large survey corpus and one especially wide file:

--- a/r-package/dtatools/man/slice_dta_rows.Rd
+++ b/r-package/dtatools/man/slice_dta_rows.Rd
@@ -31,4 +31,11 @@ metadata.
 \code{rows} follows \code{\link[vctrs:vec_as_location]{vctrs::vec_as_location()}} semantics. Positive, negative,
 logical, and character locations are supported, as are repeated and missing
 locations. Character locations match row names.
+
+For a dibble with at least ten rows, \code{slice_dta_rows(survey, 1:10)} and
+\code{survey[1:10, ]} both return the first ten rows with all columns, preserving
+Stata metadata and leaving \code{survey} unchanged. Brackets use ordinary tibble
+subsetting; \code{slice_dta_rows()} batches compact Stata numeric columns in native
+code to reduce per-column overhead. Use brackets for everyday subsetting;
+consider \code{slice_dta_rows()} when slicing wide Stata datasets.
 }


### PR DESCRIPTION
The row-slicing documentation explained native gathering without directly comparing the helper to ordinary brackets. Add a side-by-side explanation of `slice_dta_rows(survey, 1:10)` and `survey[1:10, ]` to the README and function help.

The text states that both select the same rows and columns from a dibble, preserve Stata metadata, and leave the input unchanged. It explains the helper's reduced per-column overhead and when to consider it for wide Stata datasets.

Validation: regenerated the Rd help with roxygen2, ran `scripts/check-r-roxygen.sh`, and checked `git diff --check`. Documentation only; no runtime behavior changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added guidance comparing `slice_dta_rows()` with bracket subsetting for dibbles.
  - Clarified shared output behavior, metadata preservation, and that the input remains unchanged.
  - Documented native batching for compact Stata numeric columns and when to use each approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->