### PR TITLE
Document that gen copies labels from a bare column

### DIFF
--- a/docs/r-stata-divergences.md
+++ b/docs/r-stata-divergences.md
@@ -19,6 +19,7 @@ R has no command prefixes, no `if`/`in` qualifiers, and no leading-underscore na
 | `generate x = exp if cond in 1/10` | `gen(data, x = exp, where = cond)` | `[in]` is a row-position selection, which `where` already accepts as numeric positions. |
 | `generate x = exp, before(y)` | `gen()` appends; use `order_vars()` | Placement is a separate concern from generation, and `order_vars()` already spells Stata's `order`. |
 | `generate x:lblname = exp` | `gen()` then `set_val_labels()` | Label authoring inside a generate expression has no natural R spelling. |
+| `generate y = x` then `label variable`, `label copy`, `label values` | `gen(data, y = x)` alone | A bare column reference copies the variable label and value labels along with the values, because in R the labels are attributes of the vector. Stata's `generate` copies values only. An arithmetic expression, `gen(data, y = x + 0)`, and `repl()` produce an unlabelled result, as in Stata. |
 | `note x: text`, `label var x "text"` | `set_dta_note()`, `set_var_label()` | See [notes and characteristics](./stata-notes-and-characteristics.md) and the [label metadata guide](./r-label-metadata.md). |
 
 Stata commands report how many missing values `generate` produced and how many real changes `replace` made. dtatools omits those counts; `repl()` reports storage promotion. They signal problems as R conditions instead: an error where Stata would refuse, a warning where a conversion loses information.


### PR DESCRIPTION
Adds a row to the Language shape table in `docs/r-stata-divergences.md`.

In Stata, `generate y = x` copies values only; carrying the variable label and value labels over takes `label variable`, `label copy`, and `label values` as well, which is why wrapper programs like `aww_copy_var` exist in downstream projects. In dtatools, `gen(data, y = x)` from a bare column reference brings both kinds of label along, because they are attributes of the R vector. An arithmetic expression such as `gen(data, y = x + 0)` and `repl()` produce an unlabelled result, matching Stata.

Verified against dtatools 0.7.1 before writing the row:

```r
d <- dibble(x = c(1, 2))
set_var_label(d, x, "lab")
set_val_labels(d, .labels = list(x = c(a = 1, b = 2)))
gen(d, y = x);     var_label(d$y)  # "lab"; val_labels carried too
gen(d, z = x + 0); var_label(d$z)  # NULL
repl(d, y = x);    var_label(d$y)  # NULL
```

Prompted by fertility_surveys `R/copy_var.R`, whose header now points out that the wrapper survives only for line-for-line correspondence with the `.do` tree.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified label behavior for generated columns: direct column copies retain variable and value labels, while arithmetic expressions and replacements produce unlabelled results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->