### PR TITLE
Make dibble note and characteristic setters mutate by reference

### DIFF
--- a/docs/r-containers.md
+++ b/docs/r-containers.md
@@ -26,7 +26,8 @@ Choose a reader's container with `output = ` on the call, or session-wide with `
 | `dplyr::mutate()` and the other verbs | Copy → dibble | Copy → tibble | Copy → data.frame | Copy → data.table |
 | `$<-`, `[[<-`, `[<-`, `names<-`, `dimnames<-`, `row.names<-` | **Reference** | Copy | Copy | Copy |
 | `var_label(data$x) <- `, `val_labels(data$x) <- `, `attr(data$x, ...) <- ` | **Reference** (they are `$<-` calls) | Copy | Copy | Copy |
-| `set_var_label()`, `set_dta_note()` and the other functional setters | Copy | Copy | Copy | Copy |
+| `set_var_label()`, `set_var_labels()`, `set_val_labels()` on a data frame | Reference | Reference | Reference | Reference |
+| `set_dta_note()`, `add_dta_note()`, `drop_dta_notes()`, `renumber_dta_notes()`, `set_dta_characteristic()`, `drop_dta_characteristics()` | Reference | Copy | Copy | Copy |
 | `slice_dta_rows(data, i)` | Copy → dibble | Copy → tibble | Copy → data.frame | Copy → data.table |
 | `data[i, ]`, `subset()`, `transform()`, `within()`, `head()`, `rbind()`, `cbind()` | Copy → dibble | Copy → tibble | Copy → data.frame | data.table's own behavior |
 | Joins, `bind_rows()` | Copy → dibble when the dibble is first | Copy → tibble | Copy → data.frame | Copy → data.table |

--- a/r-package/dtatools/R/dta-metadata.R
+++ b/r-package/dtatools/R/dta-metadata.R
@@ -4,16 +4,18 @@
 #' Notes retain their Stata numbers, including gaps. Numeric `note*` keys are
 #' reserved for the note API and never appear in characteristic results.
 #'
-#' Setters return a copy of `x`. Supply `variable` as one column name or
+#' On a dibble, setters modify `x` by reference and return it invisibly, so
+#' every binding sees the change, including calls inside functions. On other
+#' data frames and vectors, setters return a copy of `x`. Use [copy_data()]
+#' first when a dibble's metadata changes should be independent.
+#' Supply `variable` as one column name or
 #' one-based position to work at variable scope. A missing variable is an
 #' error. Empty note text and characteristic values are retained; `NULL`
 #' removes a note or characteristic. Adding a note uses one more than the
 #' highest existing number, matching Stata's next-number behavior.
 #'
 #' `renumber_dta_notes()` preserves the current number order and assigns
-#' consecutive numbers beginning at `start`. R differs from Stata's command
-#' language by returning the changed object instead of modifying a dataset in
-#' place.
+#' consecutive numbers beginning at `start`.
 #'
 #' Arrow can retain metadata on a variable named `_dta`. DTA reserves that
 #' target spelling for dataset metadata, so `save_dta()` rejects notes or
@@ -44,7 +46,7 @@
 #' @param names Characteristic names to drop. `NULL` drops all characteristics.
 #' @return `dta_notes()` and `dta_characteristics()` return named character
 #'   vectors. Singular getters return one string or `NULL`. Mutation helpers
-#'   return the changed object.
+#'   return the changed object, invisibly for dibbles.
 #' @examples
 #' survey <- data.frame(age = c(20, 30))
 #' survey <- set_dta_note(survey, 2, "Cleaned after interview")
@@ -265,11 +267,11 @@ drop_dta_characteristics <- function(x, names = NULL, variable = NULL) {
 
 .dta_update_target <- function(x, variable, update) {
     if (is.data.frame(x)) .reject_data_table_subclass(x, "x")
-    # A reference dataset is edited through its snapshot: copying the
-    # marked object would share one reference state between the input
-    # and the result, so a later `gen()` on either would write to both.
-    # A dibble is re-marked afterwards; the result is a new object either
-    # way.
+    # Stage metadata and restoration classes on a snapshot before writing
+    # into the recorded dibble. Base attribute assignment on the dibble
+    # itself would copy its physical table and lose reserved capacity.
+    state <- if (is_dibble(x)) .reference_state(x) else NULL
+    if (!is.null(state$object)) x <- state$object
     source <- x
     if (inherits(x, "dtatools_ref_data")) x <- .reference_snapshot(x)
     target <- .dta_metadata_target(x, variable)
@@ -279,8 +281,28 @@ drop_dta_characteristics <- function(x, names = NULL, variable = NULL) {
         .as_dta_metadata_frame(changed)
     } else {
         result <- .metadata_copy(x)
-        result[[target$index]] <- changed
+        result[[target$index]] <- .as_dta_metadata_vector(changed)
         .as_dta_metadata_frame(result)
+    }
+    if (!is.null(state)) {
+        if (is.null(target$index)) {
+            for (name in .dta_metadata_attribute_names) {
+                .Call(
+                    C_dtatools_set_attribute, source, name,
+                    attr(result, name, exact = TRUE)
+                )
+            }
+        } else {
+            .set_data_column_at(
+                .column_access(source), target$index, result[[target$index]]
+            )
+        }
+        state$classes <- class(result)
+        .Call(
+            C_dtatools_set_attribute, source, "class",
+            unique(c("dtatools_ref_data", state$classes))
+        )
+        return(invisible(source))
     }
     .close_dibble(source, result)
 }

--- a/r-package/dtatools/man/dta_notes.Rd
+++ b/r-package/dtatools/man/dta_notes.Rd
@@ -54,7 +54,7 @@ one-based position in a data frame.}
 \value{
 \code{dta_notes()} and \code{dta_characteristics()} return named character
 vectors. Singular getters return one string or \code{NULL}. Mutation helpers
-return the changed object.
+return the changed object, invisibly for dibbles.
 }
 \description{
 These helpers expose the metadata stored in Stata characteristic records.
@@ -62,16 +62,18 @@ Notes retain their Stata numbers, including gaps. Numeric \verb{note*} keys are
 reserved for the note API and never appear in characteristic results.
 }
 \details{
-Setters return a copy of \code{x}. Supply \code{variable} as one column name or
+On a dibble, setters modify \code{x} by reference and return it invisibly, so
+every binding sees the change, including calls inside functions. On other
+data frames and vectors, setters return a copy of \code{x}. Use \code{\link[=copy_data]{copy_data()}}
+first when a dibble's metadata changes should be independent.
+Supply \code{variable} as one column name or
 one-based position to work at variable scope. A missing variable is an
 error. Empty note text and characteristic values are retained; \code{NULL}
 removes a note or characteristic. Adding a note uses one more than the
 highest existing number, matching Stata's next-number behavior.
 
 \code{renumber_dta_notes()} preserves the current number order and assigns
-consecutive numbers beginning at \code{start}. R differs from Stata's command
-language by returning the changed object instead of modifying a dataset in
-place.
+consecutive numbers beginning at \code{start}.
 
 Arrow can retain metadata on a variable named \verb{_dta}. DTA reserves that
 target spelling for dataset metadata, so \code{save_dta()} rejects notes or

--- a/r-package/dtatools/tests/testthat/test-dibble.R
+++ b/r-package/dtatools/tests/testthat/test-dibble.R
@@ -423,17 +423,17 @@ test_that("slice_dta_rows accepts the default read container", {
     expect_identical(as.double(plain$y), c(2, 3))
 })
 
-test_that("dataset-scoped metadata setters give a dibble its own state", {
+test_that("dataset-scoped metadata setters return the same dibble", {
     data <- read_dta(fixture("auto_v118.dta"))
     changed <- set_dta_note(data, 1, "note")
     expect_true(is_dibble(changed))
     expect_identical(dta_notes(changed), c(`1` = "note"))
     gen(changed, y = 1)
     expect_true("y" %in% names(changed))
-    expect_false("y" %in% names(data))
+    expect_true("y" %in% names(data))
     gen(data, z = 2)
-    expect_false("z" %in% names(changed))
-    expect_identical(dta_notes(data), dta_notes(read_dta(fixture("auto_v118.dta"))))
+    expect_true("z" %in% names(changed))
+    expect_identical(dta_notes(data), c(`1` = "note"))
 })
 
 test_that("slicing a grouped dibble keeps dataset metadata", {
@@ -1102,7 +1102,7 @@ test_that("a derived dibble owns its columns", {
         rename = dplyr::rename(source, id = x),
         group_by = dplyr::group_by(source, flag),
         bind_cols = dplyr::bind_cols(source, dibble(z = 4:6)),
-        noted = add_dta_note(source, "a note", variable = "s")
+        noted_copy = add_dta_note(copy_data(source), "a note", variable = "s")
     )
     for (name in names(derived)) {
         piece <- derived[[name]]

--- a/r-package/dtatools/tests/testthat/test-dta-metadata.R
+++ b/r-package/dtatools/tests/testthat/test-dta-metadata.R
@@ -590,3 +590,133 @@ test_that("DTA and Arrow round trips retain dataset and projected variable metad
         dta_characteristics(data, "x")
     )
 })
+
+test_that("metadata helpers edit dibbles through function parameters and aliases", {
+    for (variable in list(NULL, "x", 1L)) {
+        data <- dibble(x = c("a", "b"), flag = c(TRUE, FALSE))
+        alias <- data
+        independent <- copy_data(data)
+        column <- data$x
+        address <- rlang::obj_address(data)
+        apply <- function(fun, ...) {
+            edit <- function(x) fun(x, ..., variable = variable)
+            result <- withVisible(edit(data))
+            expect_false(result$visible)
+            expect_identical(rlang::obj_address(result$value), address)
+            expect_identical(rlang::obj_address(data), address)
+            expect_identical(dta_notes(alias, variable), dta_notes(data, variable))
+            expect_identical(
+                dta_characteristics(alias, variable),
+                dta_characteristics(data, variable)
+            )
+        }
+        apply(set_dta_note, 4L, "four")
+        expect_identical(dta_notes(alias, variable), c(`4` = "four"))
+        apply(add_dta_note, "five")
+        expect_identical(dta_notes(alias, variable), c(`4` = "four", `5` = "five"))
+        apply(set_dta_note, 4L, "")
+        apply(renumber_dta_notes, 2L)
+        expect_identical(dta_notes(alias, variable), c(`2` = "", `3` = "five"))
+        apply(drop_dta_notes, 2L)
+        expect_identical(dta_notes(alias, variable), c(`3` = "five"))
+        apply(set_dta_note, 3L, NULL)
+        expect_length(dta_notes(alias, variable), 0L)
+        apply(add_dta_note, "one")
+        apply(drop_dta_notes)
+        expect_length(dta_notes(alias, variable), 0L)
+
+        apply(set_dta_characteristic, "source", "survey")
+        expect_identical(dta_characteristics(alias, variable), c(source = "survey"))
+        apply(set_dta_characteristic, "source", "")
+        expect_identical(dta_characteristics(alias, variable), c(source = ""))
+        apply(set_dta_characteristic, "source", NULL)
+        expect_length(dta_characteristics(alias, variable), 0L)
+        apply(set_dta_characteristic, "source", "survey")
+        apply(set_dta_characteristic, "role", "id")
+        apply(drop_dta_characteristics, "source")
+        expect_identical(dta_characteristics(alias, variable), c(role = "id"))
+        apply(drop_dta_characteristics)
+        expect_length(dta_characteristics(alias, variable), 0L)
+        expect_false(inherits(data, "dtatools_dta_metadata"))
+
+        apply(set_dta_note, 1L, "retained")
+        subset <- data[1L, ]
+        expect_identical(dta_notes(subset, variable), c(`1` = "retained"))
+        expect_length(dta_notes(independent, variable), 0L)
+        expect_length(dta_characteristics(independent, variable), 0L)
+        expect_length(dta_notes(column), 0L)
+        expect_length(dta_characteristics(column), 0L)
+        generate <- function(x) gen(x, added = 1)
+        expect_silent(generate(data))
+        expect_identical(names(alias), c("x", "flag", "added"))
+        expect_identical(as.double(alias$added), c(1, 1))
+        expect_true(is_dibble(alias))
+    }
+})
+
+test_that("metadata helpers keep copy semantics on ordinary tables and vectors", {
+    for (make in list(data.frame, tibble::tibble)) {
+        for (variable in list(NULL, "x")) {
+            original <- make(x = 1:2)
+            noted <- set_dta_note(original, 4L, "four", variable)
+            expect_length(dta_notes(original, variable), 0L)
+            added <- add_dta_note(noted, "five", variable)
+            expect_identical(dta_notes(noted, variable), c(`4` = "four"))
+            renumbered <- renumber_dta_notes(added, 1L, variable)
+            expect_identical(dta_notes(added, variable), c(`4` = "four", `5` = "five"))
+            dropped <- drop_dta_notes(renumbered, variable = variable)
+            expect_identical(dta_notes(renumbered, variable), c(`1` = "four", `2` = "five"))
+            expect_length(dta_notes(dropped, variable), 0L)
+            marked <- set_dta_characteristic(original, "source", "survey", variable)
+            expect_length(dta_characteristics(original, variable), 0L)
+            removed <- drop_dta_characteristics(marked, variable = variable)
+            expect_identical(dta_characteristics(marked, variable), c(source = "survey"))
+            expect_length(dta_characteristics(removed, variable), 0L)
+        }
+    }
+    original <- 1:2
+    noted <- set_dta_note(original, 1L, "note")
+    expect_length(dta_notes(original), 0L)
+    expect_identical(dta_notes(noted), c(`1` = "note"))
+})
+
+test_that("failed dibble metadata edits leave all bindings unchanged", {
+    data <- dibble(x = 1:2)
+    set_dta_note(data, 9999L, "last")
+    set_dta_note(data, 1L, "first")
+    set_dta_characteristic(data, "source", "survey", "x")
+    before <- copy_data(data)
+    expect_error(add_dta_note(data, "overflow"), "9,999")
+    expect_error(renumber_dta_notes(data, 9999L), "9,999")
+    expect_error(set_dta_note(data, 1L, NA_character_), "non-missing")
+    expect_error(set_dta_characteristic(data, "note1", "bad"), "numeric")
+    expect_error(drop_dta_notes(data, variable = "missing"), "does not exist")
+    expect_identical(as.data.frame(data), as.data.frame(before))
+})
+
+test_that("dibble metadata edits preserve other scopes and grouping", {
+    data <- dplyr::group_by(dibble(x = 1:2, flag = c(TRUE, FALSE)), flag)
+    alias <- data
+    groups <- dplyr::group_data(data)
+    set_dta_note(data, 1L, "dataset")
+    set_dta_note(data, 2L, "variable", "flag")
+    set_dta_characteristic(data, "source", "survey")
+    set_dta_characteristic(data, "role", "group", "flag")
+    snapshot <- copy_data(data)
+    drop_dta_notes(data)
+    drop_dta_characteristics(data)
+    expect_s3_class(alias, "dtatools_dta_metadata")
+    expect_identical(dta_notes(alias, "flag"), c(`2` = "variable"))
+    expect_identical(dta_characteristics(alias, "flag"), c(role = "group"))
+    expect_identical(dplyr::group_vars(alias), "flag")
+    expect_identical(dplyr::group_data(alias), groups)
+    drop_dta_notes(data, variable = "flag")
+    expect_s3_class(alias, "dtatools_dta_metadata")
+    drop_dta_characteristics(data, variable = "flag")
+    expect_false(inherits(alias, "dtatools_dta_metadata"))
+    expect_false(inherits(alias$flag, "dtatools_dta_metadata_vector"))
+    expect_identical(dta_notes(snapshot), c(`1` = "dataset"))
+    expect_identical(dta_notes(snapshot, "flag"), c(`2` = "variable"))
+    expect_identical(dta_characteristics(snapshot), c(source = "survey"))
+    expect_identical(dta_characteristics(snapshot, "flag"), c(role = "group"))
+})


### PR DESCRIPTION
Notes and characteristics set on a dibble now reach every alias and the caller of a function, even when the return value is discarded. The setters previously edited a snapshot and returned a separate dibble.

The shared update helper stages metadata changes, then installs attributes or the changed column into the recorded dibble and returns it invisibly. It preserves reserved column capacity and updates metadata restoration classes when keys are added or removed. Other containers retain copy semantics. The help page and container guide now describe these behaviors; the guide also corrects the existing label setters' reference semantics on all data frames.

Regression coverage includes all six mutation helpers, dataset and variable scopes, aliases, function parameters, invisible returns, subsequent column generation, copy isolation, grouping, and rejected edits.

Validation:
- Reproduced #178 before the fix and verified it passes afterwards.
- Metadata and dibble tests pass after two local review passes and fixes.
- `R CMD build` and `R CMD check --no-manual`: 9,749 passing assertions, zero failures or skips. The check reports three warnings and two notes from the unchanged native build and vendored dependencies, including the local macOS deployment-target mismatch.
- Generated-documentation and source-archive checks pass.

Closes #178.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Metadata setters now update dibble objects in place and return them invisibly.
  * Metadata changes to other data frames and vectors continue to produce independent copies.
  * Added support and guidance for creating independent dibble metadata with `copy_data()`.

* **Bug Fixes**
  * Preserved metadata consistency across aliases, subsetting, generated columns, grouping, and failed edits.
  * Improved metadata removal and class cleanup behavior.

* **Documentation**
  * Clarified reference and copy behavior for container metadata setters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->