### PR TITLE
Fix macOS R binary linkage across R distributions

### DIFF
--- a/.github/workflows/release-r-packages.yml
+++ b/.github/workflows/release-r-packages.yml
@@ -131,6 +131,13 @@ jobs:
           echo "asset=release-build/binary/$asset_name" >> "$GITHUB_OUTPUT"
           echo "artifact_name=r-package-$ASSET_PLATFORM" >> "$GITHUB_OUTPUT"
 
+      - name: Check portable macOS R linkage
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          sh scripts/check-macos-r-linkage.sh \
+            release-build/library/dtatools/libs/dtatools.so
+
       - name: Smoke test installed package
         shell: Rscript {0}
         run: |

--- a/r-package/dtatools/configure
+++ b/r-package/dtatools/configure
@@ -13,3 +13,10 @@ sed \
   -e "s|@RUST_SYSTEM_LIBS@|$rust_system_libs|g" \
   -e "s|@RUST_NAMESPACE@|$rust_namespace|g" \
   src/Makevars.in > src/Makevars
+
+if [ "$(uname -s)" = Darwin ]; then
+  # R's macOS linker flags already enable dynamic lookup. Resolve R
+  # symbols from the host process instead of loading a second runtime
+  # when a framework-built binary is used with Homebrew R (or vice versa).
+  printf '\noverride LIBR =\n' >> src/Makevars
+fi

--- a/scripts/check-macos-r-linkage.sh
+++ b/scripts/check-macos-r-linkage.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -eu
+
+# R symbols must bind to the host process, not another R distribution.
+library=${1:?usage: check-macos-r-linkage.sh path/to/dtatools.so}
+dependencies=$(otool -L "$library")
+if printf '%s\n' "$dependencies" | tail -n +2 | \
+    grep -E 'libR[.]dylib|R[.]framework' >/dev/null; then
+    printf 'Binary links directly to an R runtime:\n%s\n' "$dependencies" >&2
+    exit 1
+fi


### PR DESCRIPTION
The v0.8.0 macOS binary crashed under Homebrew R because it loaded CRAN framework R through an absolute libR dependency. Clear LIBR on macOS so R symbols use the host runtime through the existing dynamic-lookup linker flags. Add a release check rejecting direct R-runtime dependencies.

Validation: the check rejects the original release binary and accepts the rebuild. The rebuilt binary passes the full installed-package test suite under both framework R 4.6.1 and Homebrew R 4.6.1.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved macOS R package compatibility by ensuring packages use the existing R runtime correctly.
  - Added validation to detect portable-linking issues in macOS builds before release.

- **Chores**
  - Strengthened release checks for macOS packages to help prevent runtime loading and distribution problems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->