### PR TITLE
Host dtatools releases in a CRAN-style GitHub Pages repository

### DIFF
--- a/.github/workflows/publish-r-repository.yml
+++ b/.github/workflows/publish-r-repository.yml
@@ -1,0 +1,52 @@
+name: Publish R package repository
+
+on:
+  workflow_run:
+    workflows: [Attach compiled R packages]
+    types: [completed]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: r-package-pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      # Use trusted default-branch scripts, never code from the triggering tag.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: main
+          persist-credentials: false
+      - uses: r-lib/actions/setup-r@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2.12.1
+        with:
+          r-version: release
+      - name: Download latest stable release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          tag="$(gh release view --repo "$GITHUB_REPOSITORY" --json tagName --jq .tagName)"
+          gh release download "$tag" --repo "$GITHUB_REPOSITORY" --pattern 'dtatools_*' --dir release-assets
+          Rscript --vanilla scripts/build-r-repository.R release-assets public "${tag#v}"
+      - uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4
+        with:
+          path: public
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy R repository
+        id: deployment
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4

--- a/.github/workflows/release-r-packages.yml
+++ b/.github/workflows/release-r-packages.yml
@@ -18,6 +18,8 @@ jobs:
       contents: read
     env:
       RUSTUP_TOOLCHAIN: ${{ matrix.rust_toolchain }}
+      # Match the minimum macOS version of the R 4.6 ARM64 distribution.
+      MACOSX_DEPLOYMENT_TARGET: '14.0'
     strategy:
       fail-fast: false
       matrix:
@@ -166,6 +168,15 @@ jobs:
         with:
           name: ${{ steps.package.outputs.artifact_name }}
           path: ${{ steps.package.outputs.asset }}
+          if-no-files-found: error
+          retention-days: 1
+
+      - name: Stage source for release
+        if: runner.os == 'Linux'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: r-package-source
+          path: release-build/source/dtatools_*.tar.gz
           if-no-files-found: error
           retention-days: 1
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,18 @@ cargo doc -p dta-tools --no-deps --open
 
 ## Compatibility
 
+Install the R package from the [dtatools package repository](https://jbearak.github.io/dta-parser/):
+
+```r
+install.packages("dtatools", repos = c(
+  dtatools = "https://jbearak.github.io/dta-parser",
+  CRAN = "https://cloud.r-project.org"
+))
+```
+
+See [installation and publishing details](docs/r-package-repository.md) for
+binary support, source requirements, and automatic release updates.
+
 Package-owned underscore identifiers use `dta_` and `_dta`. See the
 [naming migration](docs/dta-naming.md) for renamed classes, constants, and metadata fields.
 

--- a/docs/r-package-repository.md
+++ b/docs/r-package-repository.md
@@ -1,0 +1,77 @@
+# R package repository
+
+The CRAN-style repository at <https://jbearak.github.io/dta-parser/> hosts the
+latest stable `dtatools` release independently of CRAN.
+
+```r
+install.packages("dtatools", repos = c(
+  dtatools = "https://jbearak.github.io/dta-parser",
+  CRAN = "https://cloud.r-project.org"
+))
+```
+
+Keep CRAN in the repository list so R can install dependencies. To include
+dtatools in future `install.packages()` and `update.packages()` calls, add this
+to `~/.Rprofile`:
+
+```r
+options(repos = c(
+  dtatools = "https://jbearak.github.io/dta-parser",
+  CRAN = "https://cloud.r-project.org"
+))
+```
+
+## Available packages
+
+The package requires R >= 4.6.0. v0.8.0 includes source and binaries built with
+R 4.6.1. R selects Windows x86_64 and Apple Silicon macOS 14 or later binaries from the
+repository's R 4.6 directories. Intel Macs and Linux use source by default.
+Source installation needs Cargo and Rust >= 1.98.0, plus the platform's R build
+tools. Use `type = "source"` to request source explicitly.
+
+The Linux x86_64 binary is also hosted as a direct download linked from the
+repository page. It is an installed package from the GitHub Actions Ubuntu
+runner and requires compatible R and system libraries. Download it and use
+`R CMD INSTALL /path/to/archive.tar.gz` on a compatible system. It is not
+advertised as a portable binary through `install.packages()`.
+
+The source index is at `src/contrib/PACKAGES`. Binary indexes are at
+`bin/windows/contrib/4.6/PACKAGES` and
+`bin/macosx/sonoma-arm64/contrib/4.6/PACKAGES`, with a matching
+`bin/macosx/big-sur-arm64/contrib/4.6/PACKAGES` index for R builds using that path.
+Both macOS paths require macOS 14 or later, matching the
+[R 4.6 ARM64 distribution](https://cran.r-project.org/bin/macosx/).
+Each index also has compressed
+`PACKAGES.gz` and `PACKAGES.rds` forms, generated with R's
+[`tools::write_PACKAGES()`](https://stat.ethz.ch/R-manual/R-devel/library/tools/html/writePACKAGES.html).
+
+## Publishing
+
+Publish a GitHub release to run **Attach compiled R packages**. That workflow
+builds and smoke-tests all three binaries, checks the source archive, and
+attaches source and binary archives to the release. Its successful completion
+triggers **Publish R package repository**, which downloads the latest stable
+release, checks its version and required assets, generates indexes, and deploys
+them to GitHub Pages. A failed build leaves the deployed repository intact.
+
+The publishing workflow always selects GitHub's latest stable release, even
+when the binary workflow rebuilds an older tag. Prereleases are excluded.
+Pages hosts only the latest stable version; older assets stay on GitHub Releases.
+Set the intended release as latest when publishing a new stable version.
+
+To republish indexes after replacing release assets, run:
+
+```sh
+gh workflow run publish-r-repository.yml --repo jbearak/dta-parser
+```
+
+GitHub Pages must use GitHub Actions as its build source. Deployment uses the
+repository's `GITHUB_TOKEN` and the `github-pages` environment, with no personal
+access token or separate hosting repository. The npm workflow remains separate.
+
+To generate the repository locally with downloaded release assets:
+
+```sh
+gh release download v0.8.0 --pattern 'dtatools_*' --dir release-assets
+Rscript --vanilla scripts/build-r-repository.R release-assets public 0.8.0
+```

--- a/r-package/dtatools/README.md
+++ b/r-package/dtatools/README.md
@@ -328,6 +328,19 @@ SPSS formats.
 
 ## Installation
 
+Install from the [dtatools R package repository](https://jbearak.github.io/dta-parser/):
+
+```r
+install.packages("dtatools", repos = c(
+  dtatools = "https://jbearak.github.io/dta-parser",
+  CRAN = "https://cloud.r-project.org"
+))
+```
+
+Requires R 4.6 or later. Windows x86_64 and Apple Silicon macOS 14 or later
+have R 4.6 binaries. Other systems install from source and need Rust.
+See [repository details](../../docs/r-package-repository.md) for setup and updates.
+
 Published GitHub Releases contain compiled packages for Windows x86_64, Linux x86_64, and macOS ARM64. Open the [latest release](https://github.com/jbearak/dta-parser/releases/latest), choose the asset matching the R version, operating system, and architecture, and copy its URL:
 
 ```r

--- a/scripts/build-r-repository.R
+++ b/scripts/build-r-repository.R
@@ -1,0 +1,73 @@
+# Turn release assets into a CRAN-style repository. No contributed R packages needed.
+args <- commandArgs(trailingOnly = TRUE)
+stopifnot(length(args) == 3L)
+assets <- normalizePath(args[[1]], mustWork = TRUE)
+output <- args[[2]]
+version <- args[[3]]
+stopifnot(grepl("^[0-9]+[.][0-9]+[.][0-9]+$", version))
+if (dir.exists(output)) stop("Output directory must not already exist: ", output)
+dir.create(output, recursive = TRUE)
+
+stage <- function(asset, directory, type = NULL, filename = basename(asset)) {
+  destination <- file.path(output, directory)
+  dir.create(destination, recursive = TRUE, showWarnings = FALSE)
+  stopifnot(file.copy(asset, file.path(destination, filename)))
+  if (!is.null(type)) {
+    count <- tools::write_PACKAGES(destination, type = type, addFiles = TRUE)
+    stopifnot(count == 1L)
+    index <- read.dcf(file.path(destination, "PACKAGES"))
+    stopifnot(index[1, "Package"] == "dtatools", index[1, "Version"] == version)
+    for (name in c("PACKAGES", "PACKAGES.gz", "PACKAGES.rds")) {
+      stopifnot(file.exists(file.path(destination, name)))
+    }
+  }
+  file.path(directory, filename)
+}
+
+source <- file.path(assets, paste0("dtatools_", version, ".tar.gz"))
+stopifnot(file.exists(source))
+links <- stage(source, "src/contrib", "source")
+platforms <- c("windows-x86_64", "macos-arm64", "linux-x86_64")
+for (platform in platforms) {
+  extension <- switch(platform, `windows-x86_64` = "zip", `macos-arm64` = "tgz",
+                      `linux-x86_64` = "tar.gz")
+  pattern <- paste0("^dtatools_", gsub(".", "[.]", version, fixed = TRUE),
+                    "_R-([0-9]+[.][0-9]+)[.][0-9]+_", platform, "[.]",
+                    gsub(".", "[.]", extension, fixed = TRUE), "$")
+  asset <- list.files(assets, pattern = pattern, full.names = TRUE)
+  if (length(asset) != 1L) stop("Expected exactly one binary for ", platform)
+  r_minor <- sub(pattern, "\\1", basename(asset))
+  directory <- switch(platform,
+    `windows-x86_64` = paste0("bin/windows/contrib/", r_minor),
+    `macos-arm64` = paste0("bin/macosx/big-sur-arm64/contrib/", r_minor),
+    `linux-x86_64` = paste0("bin/linux/x86_64/", r_minor))
+  type <- switch(platform, `windows-x86_64` = "win.binary",
+                 `macos-arm64` = "mac.binary.big-sur-arm64", `linux-x86_64` = NULL)
+  filename <- if (is.null(type)) basename(asset) else paste0("dtatools_", version, ".", extension)
+  links <- c(links, stage(asset, directory, type, filename))
+  if (platform == "macos-arm64") {
+    # R 4.6 CRAN builds use sonoma-arm64; other R builds still use big-sur-arm64.
+    links <- c(links, stage(asset, paste0("bin/macosx/sonoma-arm64/contrib/", r_minor),
+                            "mac.binary.sonoma-arm64", filename))
+  }
+}
+
+writeLines(c(
+  '<!doctype html><html lang="en"><meta charset="utf-8">',
+  '<meta name="viewport" content="width=device-width, initial-scale=1">',
+  '<title>dtatools R package repository</title>',
+  '<h1>dtatools R package repository</h1>',
+  paste0('<p>Latest stable version: ', version, '. Requires R 4.6 or later.</p>'),
+  '<pre>install.packages("dtatools", repos = c(',
+  '  dtatools = "https://jbearak.github.io/dta-parser",',
+  '  CRAN = "https://cloud.r-project.org"',
+  '))</pre>',
+  '<p>Windows x86_64 and Apple Silicon macOS 14 or later binaries are available for the R minor version shown below. Other systems install from source and need Cargo and Rust 1.98.0 or later.</p>',
+  '<p>The Linux archive is an installed package built on the GitHub Actions Ubuntu runner. It needs a compatible R and system libraries; it is a direct download, not a portable Linux repository binary.</p>',
+  '<h2>Downloads</h2><ul>',
+  paste0('<li><a href="', links, '">', basename(links), '</a></li>'),
+  '</ul><p><a href="https://github.com/jbearak/dta-parser/releases">All releases</a> | <a href="https://github.com/jbearak/dta-parser/blob/main/docs/r-package-repository.md">Installation and publishing details</a></p>',
+  '</html>'
+), file.path(output, "index.html"))
+file.create(file.path(output, ".nojekyll"))
+cat("Built repository for dtatools", version, "in", output, "\n")


### PR DESCRIPTION
## Changes

Host the latest stable dtatools release at https://jbearak.github.io/dta-parser/ so users can install it with `install.packages()` and resolve dependencies from CRAN.

The release workflow now attaches the checked source archive alongside its three binaries. A separate workflow runs after successful attachment, builds source and Windows/macOS package indexes from the latest stable release, and deploys through GitHub Pages. Linux binaries remain available as direct downloads. Failed or incomplete releases do not replace the deployed repository.

Set the macOS build target to 14.0 and publish both Sonoma and Big Sur ARM64 repository paths for R 4.6 clients. Document installation, supported platforms, and manual index refreshes.

## Validation

- `actionlint` passed for both workflows.
- The v0.8.0 source archive passed `check-r-package-archive.sh`.
- Built indexes from the actual v0.8.0 release archives and verified R package discovery and downloads for source, Windows, and macOS.
