### PR TITLE
Declare Raven NSE contracts for egen, dta_*, metadata setters and dibble `[`

### DIFF
--- a/r-package/dtatools/NEWS.md
+++ b/r-package/dtatools/NEWS.md
@@ -1,3 +1,13 @@
+# dtatools 0.8.0.9000
+
+* The Raven sidecar `inst/raven/nse.toml` now declares the captured
+  arguments of egen, the dta_* summary and group helpers, set_var_format,
+  set_var_formats, set_var_labels, set_val_labels, var_label, val_labels,
+  order_vars and rename_vars, and carries a `[subset]` table naming the
+  dibble constructors and converters so Raven treats `[` with `:=` on a
+  dibble as data-masking. Callers no longer see undefined-variable
+  warnings for bare column names passed to these functions.
+
 # dtatools 0.8.0
 
 * Dplyr is optional. Package-native operations and recoding work independently;

--- a/r-package/dtatools/inst/raven/nse.toml
+++ b/r-package/dtatools/inst/raven/nse.toml
@@ -9,6 +9,16 @@
 
 schema = 1
 
+# `[` on a dibble is data-masking, as data.table's is: `d[age > 30, ...]`
+# and `d[, new := old + 1]` read column names, not variables. `:=` alone
+# already marks a call as NSE; this table covers the row selector and any
+# dibble Raven can trace to one of these constructors, and lets a bare
+# `dibble(...)` count while dtatools is in play. Converters are the
+# by-reference functions whose first argument is a dibble from then on.
+[subset]
+constructors = ["dibble", "as_dibble", "read_dta", "read_arrow", "copy_data"]
+converters = ["reserve_columns"]
+
 # gen(survey, adjusted = income + 5) and gen(survey, adjusted, income + 5):
 # the target and its values arrive in `...`, optionally followed by `where`,
 # and every dot is quoted and evaluated against the data mask, as is a named
@@ -47,12 +57,123 @@ formals = ["data", "..."]
 captured = []
 captured_dots = true
 
+# egen(survey, total_income = dta_total(income), where = eligible,
+# by = household): like gen(), the target and its calculation arrive in
+# `...` and are evaluated against the data mask, as is a named `where`;
+# `by` and `bysort` are quoted column names. `rows`, `type`, `before` and
+# `after` are literal controls.
+[[function]]
+name = "egen"
+formals = ["data", "...", "where", "by", "bysort", "rows", "type", "before", "after"]
+captured = ["where", "by", "bysort"]
+captured_dots = true
+
+# The dta_* calculations are only ever written inside an egen() or dibble
+# `:=` call, where their `x` is a column expression. Declaring `x` (or the
+# dots) captured keeps Raven from resolving it as a variable at the call
+# site. `missing` and the dta_group_id() controls are literal.
+[[function]]
+name = "dta_mean"
+formals = ["x"]
+captured = ["x"]
+
+[[function]]
+name = "dta_min"
+formals = ["x", "missing"]
+captured = ["x"]
+
+[[function]]
+name = "dta_max"
+formals = ["x", "missing"]
+captured = ["x"]
+
+[[function]]
+name = "dta_total"
+formals = ["x", "missing"]
+captured = ["x"]
+
+[[function]]
+name = "dta_row_max"
+formals = ["..."]
+captured = []
+captured_dots = true
+
+[[function]]
+name = "dta_row_total"
+formals = ["...", "missing"]
+captured = []
+captured_dots = true
+
+[[function]]
+name = "dta_group_id"
+formals = ["...", "missing", "autotype", "label", "label_name", "truncate"]
+captured = []
+captured_dots = true
+
+[[function]]
+name = "dta_group_tag"
+formals = ["...", "missing"]
+captured = []
+captured_dots = true
+
 # set_var_label(survey, age, "Age"): `variable` is quoted and resolved as one
 # column name. `data` and `label` are evaluated normally.
 [[function]]
 name = "set_var_label"
 formals = ["data", "variable", "label"]
 captured = ["variable"]
+
+# set_var_format(survey, age, "%8.0g") and set_var_formats(survey,
+# age = "%8.0g"): `variable` and the tagged dots are quoted column names.
+# set_var_labels() and set_val_labels() take the same shape, so
+# set_val_labels(survey, age = c(Young = 1)) names a column, not a variable.
+[[function]]
+name = "set_var_format"
+formals = ["data", "variable", "format"]
+captured = ["variable"]
+
+[[function]]
+name = "set_var_formats"
+formals = [".data", "...", ".formats"]
+captured = []
+captured_dots = true
+
+[[function]]
+name = "set_var_labels"
+formals = [".data", "...", ".labels"]
+captured = []
+captured_dots = true
+
+[[function]]
+name = "set_val_labels"
+formals = [".data", "...", ".labels"]
+captured = []
+captured_dots = true
+
+# var_label(survey, age) and val_labels(survey, age): `variable` is quoted.
+[[function]]
+name = "var_label"
+formals = ["x", "variable"]
+captured = ["variable"]
+
+[[function]]
+name = "val_labels"
+formals = ["x", "variable"]
+captured = ["variable"]
+
+# order_vars(survey, id, age) and rename_vars(survey, age_years = age): the
+# dots are column selections and renames, like keep_vars() and drop_vars().
+[[function]]
+name = "order_vars"
+formals = ["data", "..."]
+captured = []
+captured_dots = true
+
+[[function]]
+name = "rename_vars"
+formals = ["data", "...", ".names"]
+captured = []
+captured_dots = true
 
 # tab(mtcars, cyl, gear): `x` and the dots are quoted column expressions. The
 # explicit `data` argument, and the literal controls after the dots, are not.

--- a/r-package/dtatools/tests/testthat/test-raven-nse.R
+++ b/r-package/dtatools/tests/testthat/test-raven-nse.R
@@ -5,7 +5,8 @@
 
 # Minimal reader for the subset of TOML the declaration file uses: `[[function]]
 # table headers, `key = "string"`, `key = true/false`, and string arrays written
-# either on one line or across several. Comments and blank lines are dropped.
+# either on one line or across several, plus the `[subset]` table read by a
+# second helper. Comments and blank lines are dropped.
 # Deliberately not a general TOML parser -- it only has to read a file this
 # package writes.
 read_nse_declarations <- function(path) {
@@ -75,8 +76,64 @@ expected_policy <- list(
     set_var_label = list(captured = "variable", captured_dots = FALSE),
     tab = list(captured = "x", captured_dots = TRUE),
     read_dta = list(captured = "col_select", captured_dots = FALSE),
-    read_arrow = list(captured = "col_select", captured_dots = FALSE)
+    read_arrow = list(captured = "col_select", captured_dots = FALSE),
+    egen = list(captured = c("where", "by", "bysort"), captured_dots = TRUE),
+    dta_mean = list(captured = "x", captured_dots = FALSE),
+    dta_min = list(captured = "x", captured_dots = FALSE),
+    dta_max = list(captured = "x", captured_dots = FALSE),
+    dta_total = list(captured = "x", captured_dots = FALSE),
+    dta_row_max = list(captured = character(), captured_dots = TRUE),
+    dta_row_total = list(captured = character(), captured_dots = TRUE),
+    dta_group_id = list(captured = character(), captured_dots = TRUE),
+    dta_group_tag = list(captured = character(), captured_dots = TRUE),
+    set_var_format = list(captured = "variable", captured_dots = FALSE),
+    set_var_formats = list(captured = character(), captured_dots = TRUE),
+    set_var_labels = list(captured = character(), captured_dots = TRUE),
+    set_val_labels = list(captured = character(), captured_dots = TRUE),
+    var_label = list(captured = "variable", captured_dots = FALSE),
+    val_labels = list(captured = "variable", captured_dots = FALSE),
+    order_vars = list(captured = character(), captured_dots = TRUE),
+    rename_vars = list(captured = character(), captured_dots = TRUE)
 )
+
+# The `[subset]` table declares which exported functions produce a dibble,
+# so Raven treats `d[i, j]` on their result as data-masking. Every name it
+# lists must stay exported, and the constructors must really return one.
+expected_subset <- list(
+    constructors = c("dibble", "as_dibble", "read_dta", "read_arrow",
+                     "copy_data"),
+    converters = "reserve_columns"
+)
+
+read_subset_declaration <- function(path) {
+    lines <- readLines(path, warn = FALSE)
+    lines <- trimws(sub("(^|\\s)#.*$", "", lines))
+    lines <- lines[nzchar(lines)]
+    start <- match("[subset]", lines)
+    if (is.na(start)) return(NULL)
+    body <- lines[seq(start + 1L, length(lines))]
+    stop_at <- grep("^\\[", body)
+    if (length(stop_at)) body <- body[seq_len(stop_at[[1L]] - 1L)]
+    result <- list()
+    for (line in body) {
+        parts <- regmatches(line, regexpr("=", line), invert = TRUE)[[1]]
+        quoted <- unlist(regmatches(parts[[2]], gregexpr('"[^"]*"', parts[[2]])))
+        result[[trimws(parts[[1]])]] <- gsub('"', "", quoted, fixed = TRUE)
+    }
+    result
+}
+
+test_that("the [subset] table names exported dibble constructors", {
+    declared <- read_subset_declaration(declaration_path())
+    expect_identical(declared$constructors, expected_subset$constructors)
+    expect_identical(declared$converters, expected_subset$converters)
+    exported <- getNamespaceExports("dtatools")
+    expect_true(all(unlist(declared) %in% exported))
+    expect_true(is_dibble(dibble(x = 1)))
+    expect_true(is_dibble(as_dibble(data.frame(x = 1))))
+    expect_true(is_dibble(copy_data(dibble(x = 1))))
+    expect_true(is_dibble(reserve_columns(dibble(x = 1), 1)))
+})
 
 test_that("every declared function is exported by the package", {
     declarations <- read_nse_declarations(declaration_path())

--- a/r-package/dtatools/tools/native-test-manifest.json
+++ b/r-package/dtatools/tools/native-test-manifest.json
@@ -4335,7 +4335,7 @@
         },
         {
           "path": "tests/testthat/test-raven-nse.R",
-          "sha256": "9e96c06aac46aa578d12720f98f8a6ad7790bbc19bc67aff47a02aa42c8fc410"
+          "sha256": "a762cad391dba4a9f0a0dbd0160427f4934400cafa4a96b9d297fe3e2034eeda"
         }
       ],
       "blocks": [
@@ -5649,10 +5649,18 @@
         },
         {
           "file": "test-raven-nse.R",
+          "test": "the [subset] table names exported dibble constructors",
+          "occurrence": 1,
+          "skip": "forbid",
+          "min_pass": 7,
+          "warnings": 0
+        },
+        {
+          "file": "test-raven-nse.R",
           "test": "every declared function is exported by the package",
           "occurrence": 1,
           "skip": "forbid",
-          "min_pass": 10,
+          "min_pass": 27,
           "warnings": 0
         },
         {
@@ -5660,7 +5668,7 @@
           "test": "the declaration file still carries the expected policy",
           "occurrence": 1,
           "skip": "forbid",
-          "min_pass": 19,
+          "min_pass": 53,
           "warnings": 0
         },
         {
@@ -5668,7 +5676,7 @@
           "test": "declared formals match the function signatures",
           "occurrence": 1,
           "skip": "forbid",
-          "min_pass": 9,
+          "min_pass": 26,
           "warnings": 0
         },
         {
@@ -5676,7 +5684,7 @@
           "test": "captured arguments name real formals",
           "occurrence": 1,
           "skip": "forbid",
-          "min_pass": 9,
+          "min_pass": 26,
           "warnings": 0
         },
         {


### PR DESCRIPTION
## Why

`inst/raven/nse.toml` covered only `gen`, `repl`, `replace_values`, `keep_vars`, `drop_vars`, `set_var_label`, `tab`, `read_dta` and `read_arrow`. Every other exported function that quotes a column name (`egen()` with `where=`/`by=`, `dta_max(x)` and the other `dta_*` summary and group helpers, `set_var_format()`, `set_var_formats()`, `set_var_labels()`, `set_val_labels()`, `var_label()`, `val_labels()`, `order_vars()`, `rename_vars()`) made Raven report the bare column name as an undefined variable in calling code.

## What

- Add `[[function]]` declarations for the 17 missing exports (26 total). Captured formals follow each function's `enquo`/`ensym`/`enquos` usage; `...` is marked `captured_dots` where the dots are quoted.
- Add a `[subset]` table naming the dibble constructors (`dibble`, `as_dibble`, `read_dta`, `read_arrow`, `copy_data`) and converter (`reserve_columns`) so Raven treats `data[, col := value]` on a dibble as data-masking. Raven 0.20.1 ignores the unknown table; Raven main (jbearak/raven@4b4366d2, 2026-09-06) honors it.
- `set_dta_metadata()` is deliberately not declared: it collects arguments through `rlang::dots_list()` and evaluates them normally.
- Extend `tests/testthat/test-raven-nse.R`: every declared function must be exported and its captured formals must exist; the `[subset]` names must be exported and must produce objects for which `is_dibble()` is TRUE.
- NEWS entry under 0.8.0.9000.

## Measured

`raven check` on Guttmacher/fertility_surveys, swapping only the installed sidecar:

| raven | shipped sidecar | this sidecar |
|---|---|---|
| 0.20.1 (release) | 51 warnings | 12 warnings, all `data[, col := ...]` on a dibble |
| main @ 4694bdf7 (built locally) | 39 warnings | 0 warnings |

`devtools::test(filter = "raven-nse")`: 139 pass, 0 fail.
